### PR TITLE
file-dependency-updater: use awaitWriteFinish

### DIFF
--- a/config/file-dependency-updater/index.js
+++ b/config/file-dependency-updater/index.js
@@ -32,7 +32,19 @@ const nodeModules = "node_modules";
                 const targetPath = path.join(currentRoot, nodeModules, dependency, fileLocation);
                 if (fs.existsSync(targetPath) && fs.statSync(targetPath).isDirectory()) {
                     const sourcePath = path.join(upstreamRoot, fileLocation);
-                    chokidar.watch(sourcePath, { ignored: /(^|[\/\\])\../, alwaysStat: true, ignoreInitial: true }).on("all", function (event, filePath, stat) {
+                    console.log("Adding a watch on", sourcePath);
+
+                    chokidar.watch(sourcePath, {
+                        ignored: /(^|[\/\\])\../,
+                        alwaysStat: true,
+                        ignoreInitial: true,
+                        awaitWriteFinish: {
+                            /* To avoid getting change events before files are
+                             * completely written, wait until they are stable for
+                             * 100ms second before firing the event. */
+                            stabilityThreshold: 100,
+                        },
+                    }).on("all", function (event, filePath, stat) {
                         const relativeFilePath = path.relative(sourcePath, filePath);
                         const targetFilePath = path.resolve(targetPath, relativeFilePath);
                         if (stat) { // add, addDir, change 


### PR DESCRIPTION
When tsc writes a file, it first truncates it (open with O_TRUNC) and
then writes to it.  Chokidar gives us a single change event, sometimes
before the write.  This makes us copy an empty file (or possbibly
incomplete, if multiple writes are required).

The solution favored by chokidar seems to be to use awaitWriteFinish
[1], which acts like a "debouncer".  It waits until the file is stable
for a certain time before reporting the change event.

I put a delay of 1 second to be extra safe, but we could perhaps reduce
it.  It will at least allow us to confirm if the solution works.

[1] https://github.com/paulmillr/chokidar/issues/365

Refs #125