### PR TITLE
Language Server: add go language server implementation

### DIFF
--- a/examples/browser/src/backend/main.ts
+++ b/examples/browser/src/backend/main.ts
@@ -15,6 +15,7 @@ import { messagingModule } from "theia-core/lib/messaging/node";
 import { nodeLanguagesModule } from 'theia-core/lib/languages/node';
 import { nodeJavaModule } from 'theia-core/lib/java/node';
 import { nodePythonModule } from 'theia-core/lib/languages/python/node/node-python-module';
+import { nodeGoModule } from 'theia-core/lib/languages/go/node/node-go-module';
 import terminalBackendModule from 'theia-core/lib/terminal/node/terminal-backend-module'
 
 // FIXME introduce default error handler contribution
@@ -42,6 +43,7 @@ container.load(nodeLanguagesModule);
 container.load(terminalBackendModule);
 container.load(nodeJavaModule);
 container.load(nodePythonModule);
+container.load(nodeGoModule);
 container.bind(BackendApplicationContribution).to(StaticServer);
 const application = container.get(BackendApplication);
 application.start();

--- a/src/languages/go/node/go-contribution.ts
+++ b/src/languages/go/node/go-contribution.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from "inversify";
+import { LanguageContribution, IConnection, createServerProcess, forward } from "../../node";
+
+export type ConfigurationType = 'config_win' | 'config_mac' | 'config_linux';
+export const configurations = new Map<typeof process.platform, ConfigurationType>();
+configurations.set('darwin', 'config_mac');
+configurations.set('win32', 'config_win');
+configurations.set('linux', 'config_linux');
+
+
+/**
+ * IF you have go on your machine, `go-langserver` can be installed with the following command:
+ * `go get github.com/sourcegraph/go-langserver`
+ */
+@injectable()
+export class GoContribution implements LanguageContribution {
+
+    readonly description = {
+        id: 'go',
+        name: 'Go',
+        documentSelector: ['go'],
+        fileEvents: [
+            '**/*.go'
+        ]
+    }
+
+    listen(clientConnection: IConnection): void {
+        const command = 'go-langserver';
+        const args: string[] = [
+        ];
+        try {
+            const serverConnection = createServerProcess(this.description.name, command, args);
+            forward(clientConnection, serverConnection);
+        } catch (err) {
+            console.error(err)
+            console.error("Error starting go language server.")
+            console.error("Please make sure it is installed on your system.")
+            console.error("Use the following command: 'go get github.com/sourcegraph/go-langserver'")
+        }
+    }
+
+}

--- a/src/languages/go/node/go-contribution.ts
+++ b/src/languages/go/node/go-contribution.ts
@@ -10,9 +10,6 @@ import { LanguageContribution, IConnection, createServerProcess, forward } from 
 
 export type ConfigurationType = 'config_win' | 'config_mac' | 'config_linux';
 export const configurations = new Map<typeof process.platform, ConfigurationType>();
-configurations.set('darwin', 'config_mac');
-configurations.set('win32', 'config_win');
-configurations.set('linux', 'config_linux');
 
 
 /**

--- a/src/languages/go/node/node-go-module.ts
+++ b/src/languages/go/node/node-go-module.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from "inversify";
+import { LanguageContribution } from "../../node";
+import { GoContribution } from './go-contribution';
+
+export const nodeGoModule = new ContainerModule(bind => {
+    bind<LanguageContribution>(LanguageContribution).to(GoContribution).inSingletonScope();
+});


### PR DESCRIPTION
Howdy!  Stumbled across a blog post describing this and got pretty excited.  I've added Go language server support by copying the python pattern.  It works nicely, from what I can tell.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.