### PR TITLE
Pin electron version to 1.6.8 to avoid conflicts with @types/electron

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1-alpha.1",
   "license": "Apache-2.0",
   "dependencies": {
-    "electron": "^1.6.2",
+    "electron": "1.6.8",
     "monaco-css": "^1.3.1",
     "monaco-editor": "^0.8.3",
     "monaco-editor-core": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/ws": "0.0.38",
     "@types/xterm": "^2.0.2",
     "chokidar": "^1.6.1",
-    "electron": "^1.6.2",
+    "electron": "1.6.8",
     "express": "^4.15.2",
     "fs-extra": "^2.1.2",
     "glob": "^7.1.1",


### PR DESCRIPTION
This fixes the build.

See issue #161

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>