### PR TITLE
Fix electron types version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@phosphor/virtualdom": "^0.1.1",
     "@phosphor/widgets": "^0.1.7",
     "@types/bunyan": "0.0.36",
-    "@types/electron": "^1.4.33",
+    "@types/electron": "1.4.38",
     "@types/express": "^4.0.35",
     "@types/fs-extra": "^2.1.0",
     "@types/glob": "^5.0.30",


### PR DESCRIPTION
Upgrade to the electon types 1.6.10 is breaking the build fix it to version 1.4.38 for now.

```
iving erros like:

src/application/electron-browser/clipboard/electron-clipboard-service.ts(8,27): error TS7016: Could not find a declaration file for module 'electron'. '/home/eantotr/ownCloud/work/theia/node_modules/electron/index.js' implicitly has an 'any' type.
src/application/electron-browser/menu/menu-plugin.ts(11,27): error TS7016: Could not find a declaration file for module 'electron'. '/home/eantotr/ownCloud/work/theia/node_modules/electron/index.js' implicitly has an 'any' type.
src/application/electron-browser/menu/menu-plugin.ts(23,20): error TS2503: Cannot find namespace 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(23,20): error TS4055: Return type of public method from exported class has or is using private name 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(32,36): error TS2503: Cannot find namespace 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(32,36): error TS4055: Return type of public method from exported class has or is using private name 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(39,35): error TS2503: Cannot find namespace 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(39,94): error TS2503: Cannot find namespace 'Electron'.
src/application/electron-browser/menu/menu-plugin.ts(88,28): error TS2503: Cannot find namespace 'Electron'.

```
Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>

