### PR TITLE
GH-190: Fixed copy/cut/paste keybinding issue on Linux.

### DIFF
--- a/src/monaco/browser/monaco-keybinding.ts
+++ b/src/monaco/browser/monaco-keybinding.ts
@@ -188,7 +188,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                 modifiers: []
             }
             // CTRL + COMMAND
-            if ((isOSX && keyCode & KeyMod.CtrlCmd) || keyCode & KeyMod.WinCtrl) {
+            if ((keyCode & KeyMod.CtrlCmd) || (keyCode & KeyMod.WinCtrl)) {
                 sequence.modifiers!.push(Modifier.M1);
             }
             // SHIFT


### PR DESCRIPTION
The `M1` (Ctrl/Cmd) modifier was not appended to the keycode on Liunx.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>