### PR TITLE
GH-231: Fixed `express-serve-static-core` version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/bunyan": "0.0.36",
     "@types/electron": "1.4.38",
     "@types/express": "^4.0.35",
+    "@types/express-serve-static-core": "4.0.46",
     "@types/fs-extra": "^2.1.0",
     "@types/glob": "^5.0.30",
     "@types/touch": "0.0.1",


### PR DESCRIPTION
This was required to work around a typing issue.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>