### PR TITLE
Add some basic preferences for the monaco editor

### DIFF
--- a/src/editor/browser/editor-frontend-module.ts
+++ b/src/editor/browser/editor-frontend-module.ts
@@ -15,8 +15,12 @@ import { EditorManagerImpl, EditorManager } from './editor-manager';
 import { EditorRegistry } from './editor-registry';
 import { EditorCommandHandlers } from "./editor-command";
 import { EditorKeybindingContribution, EditorKeybindingContext } from "./editor-keybinding";
+import { bindEditorPreferences } from '../../editor/browser/editor-preferences'
+
 
 export default new ContainerModule(bind => {
+    bindEditorPreferences(bind);
+
     bind(EditorRegistry).toSelf().inSingletonScope();
     bind(EditorManager).to(EditorManagerImpl).inSingletonScope();
     bind(OpenHandler).toDynamicValue(context => context.container.get(EditorManager));

--- a/src/editor/browser/editor-preferences.ts
+++ b/src/editor/browser/editor-preferences.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces } from "inversify";
+import {
+    createPreferenceProxy,
+    PreferenceContribution,
+    PreferenceProxy,
+    PreferenceService,
+} from '../../preferences/common';
+
+export interface EditorConfiguration {
+    'editor.tabSize': number,
+    'editor.lineNumbers': 'on' | 'off'
+    'editor.renderWhitespace': 'none' | 'boundary' | 'all'
+}
+
+export const defaultEditorConfiguration: EditorConfiguration = {
+    'editor.tabSize': 4,
+    'editor.lineNumbers': 'on',
+    'editor.renderWhitespace': 'none'
+
+}
+
+export const EditorPreferences = Symbol('EditorPreferences');
+export type EditorPreferences = PreferenceProxy<EditorConfiguration>;
+
+export function createEditorPreferences(preferences: PreferenceService): EditorPreferences {
+    return createPreferenceProxy(preferences, defaultEditorConfiguration);
+}
+
+export function bindEditorPreferences(bind: interfaces.Bind): void {
+    bind(EditorPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get(PreferenceService);
+        return createEditorPreferences(preferences);
+    });
+
+    bind(PreferenceContribution).toConstantValue({
+        preferences: [{
+            name: 'editor.tabSize',
+            defaultValue: defaultEditorConfiguration['editor.tabSize'],
+            description: "Configure the tab size in the monaco editor"
+        },
+        {
+            name: 'editor.lineNumbers',
+            defaultValue: defaultEditorConfiguration['editor.lineNumbers'],
+            description: "Control the rendering of line numbers"
+        },
+        {
+            name: 'editor.renderWhitespace',
+            defaultValue: defaultEditorConfiguration['editor.lineNumbers'],
+            description: "Control the rendering of whitespaces in the editor"
+        }]
+    });
+}

--- a/src/editor/browser/index.ts
+++ b/src/editor/browser/index.ts
@@ -13,3 +13,4 @@ export * from './editor-command';
 export * from './editor-menu';
 export * from './editor-keybinding';
 export * from './editor-frontend-module';
+export * from './editor-preferences';

--- a/src/monaco/browser/monaco-editor-provider.ts
+++ b/src/monaco/browser/monaco-editor-provider.ts
@@ -21,6 +21,8 @@ import { PreferenceChangedEvent } from "../../preferences/common/preference-prot
 @injectable()
 export class MonacoEditorProvider {
 
+    toDispose = new DisposableCollection();
+
     constructor(
         @inject(MonacoEditorService) protected readonly editorService: MonacoEditorService,
         @inject(MonacoModelResolver) protected readonly monacoModelResolver: MonacoModelResolver,
@@ -65,14 +67,13 @@ export class MonacoEditorProvider {
                     }
                 );
 
-                let toDispose = new DisposableCollection();
 
-                toDispose.push(this.editorPreferences.onPreferenceChanged(e => {
+                this.toDispose.push(this.editorPreferences.onPreferenceChanged(e => {
                     this.handlePreferenceEvent(e, editor);
                 }))
 
                 editor.onDispose(() => {
-                    toDispose.dispose();
+                    this.toDispose.dispose();
                     reference.dispose()
                 });
 


### PR DESCRIPTION
This adds the possibility of changing the tabSize and showing/hiding the
lineNumbers by modifying the .theia/settings.json file.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>