### PR TITLE
Quick fix for Enter on the numpad to open files (#260)

### DIFF
--- a/src/application/browser/tree/tree-widget.ts
+++ b/src/application/browser/tree/tree-widget.ts
@@ -230,6 +230,7 @@ export class TreeWidget extends VirtualWidget {
         this.addKeyListener(this.node, Key.ARROW_UP, () => this.handleUp());
         this.addKeyListener(this.node, Key.ARROW_DOWN, () => this.handleDown());
         this.addKeyListener(this.node, Key.ENTER, () => this.handleEnter());
+        this.addKeyListener(this.node, Key.NUMPAD_ENTER, () => this.handleEnter());
         this.addEventListener(this.node, 'contextmenu', e => this.handleContextMenuEvent(this.model.root, e));
         this.addEventListener(this.node, 'click', e => this.handleClickEvent(this.model.root, e));
     }

--- a/src/application/common/keys.ts
+++ b/src/application/common/keys.ts
@@ -133,6 +133,7 @@ export namespace Key {
     }
 
     export const ENTER: Key = { code: "Enter", keyCode: 13 };
+    export const NUMPAD_ENTER: Key = { code: "NumpadEnter", keyCode: 13 };
     export const SPACE: Key = { code: "Space", keyCode: 32 };
     export const TAB: Key = { code: "Tab", keyCode: 9 };
     export const DELETE: Key = { code: "Delete", keyCode: 46 };


### PR DESCRIPTION
Add a new Key for NumpadEnter. Add a new listener for it in the Tree.
A more generic solution is needed for not having to handle Enter
twice everywhere.

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>