### PR TITLE
[tests]configure nyc to report coverage on all source files

### DIFF
--- a/packages/cpp/.yo-rc.json
+++ b/packages/cpp/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/cpp/src/package.spec.ts
+++ b/packages/cpp/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("cpp package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/editor/.yo-rc.json
+++ b/packages/editor/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/editor/src/package.spec.ts
+++ b/packages/editor/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("editor package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/java/.yo-rc.json
+++ b/packages/java/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/java/src/package.spec.ts
+++ b/packages/java/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("java package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/languages/.yo-rc.json
+++ b/packages/languages/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/languages/src/package.spec.ts
+++ b/packages/languages/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("languages package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/monaco/.yo-rc.json
+++ b/packages/monaco/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/monaco/src/package.spec.ts
+++ b/packages/monaco/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("monaco package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/navigator/.yo-rc.json
+++ b/packages/navigator/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/navigator/src/package.spec.ts
+++ b/packages/navigator/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("navigator package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/nyc.json
+++ b/packages/nyc.json
@@ -11,5 +11,6 @@
     ],
     "extension": [
         ".ts"
-    ]
+    ],
+    "all": true
 }

--- a/packages/preferences-api/.yo-rc.json
+++ b/packages/preferences-api/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/preferences-api/src/package.spec.ts
+++ b/packages/preferences-api/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("preferences-api package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/python/.yo-rc.json
+++ b/packages/python/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/python/src/package.spec.ts
+++ b/packages/python/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("python package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/terminal/.yo-rc.json
+++ b/packages/terminal/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/terminal/src/package.spec.ts
+++ b/packages/terminal/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("terminal package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/workspace/.yo-rc.json
+++ b/packages/workspace/.yo-rc.json
@@ -1,5 +1,5 @@
 {
   "generator-theia": {
-    "testSupport": false
+    "testSupport": true
   }
 }

--- a/packages/workspace/src/package.spec.ts
+++ b/packages/workspace/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, wihout having any actual unit tests in it.
+   This way a coverage report will be genarated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("workspace package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});


### PR DESCRIPTION
This is so we get the most accurate test coverage report possible.
Before this, nyc was configured to only report coverage for source
files that are touched by the tests. So a file that is not tested
at all would not be reported, instead of reporting that it's 0%
covered. Also, for those packages that do not have any unit tests,
it was necessary to add a bogus one just to that mocha doesn't
fail the tests.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>