### PR TITLE
Fix use of "cp" on Windows (partly fixes #307)

### DIFF
--- a/generator-theia/src/common/app-package-generator.ts
+++ b/generator-theia/src/common/app-package-generator.ts
@@ -46,7 +46,7 @@ export class AppPackageGenerator extends AbstractGenerator {
                 "cold:start": "yarn run clean && yarn run start",
                 "build": "yarn run build:frontend && yarn run build:backend",
                 "build:frontend": "webpack",
-                "build:backend": `cp ${this.srcGen()}/frontend/index.html lib`,
+                "build:backend": `shx cp ${this.srcGen()}/frontend/index.html lib`,
                 "watch": "yarn run build:frontend && webpack --watch",
                 ...scripts,
                 ...this.model.pck.scripts
@@ -61,6 +61,7 @@ export class AppPackageGenerator extends AbstractGenerator {
                 "css-loader": "^0.28.1",
                 "file-loader": "^0.11.1",
                 "source-map-loader": "^0.2.1",
+                "shx": "^0.2.2",
                 "url-loader": "^0.5.8",
                 "font-awesome-webpack": "0.0.5-beta.2",
                 "less": "^2.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,6 +2174,10 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+
 es6-promise@^4.0.5:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
@@ -6296,6 +6300,22 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shelljs@^0.7.3:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shx@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.2.2.tgz#0a304d020b0edf1306ad81570e80f0346df58a39"
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.7.3"
 
 sigmund@~1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Since the command doesn't exist, use "shx" to replace it.
shx is a wrapper around ShellJS which is "Portable Unix shell
commands for Node.js"

Signed-off-by: Marc-André Laperle <marc-andre.laperle@ericsson.com>