### PR TITLE
[quality] add more rules to dev.tslint.json (fixes #356)

### DIFF
--- a/packages/strict.tslint.json
+++ b/packages/strict.tslint.json
@@ -1,0 +1,145 @@
+{
+  "defaultSeverity": "warning",
+  "extends": "./dev.tslint.json",
+  "rules": {
+    "array-type": [
+      true,
+      "array"
+    ],
+    "arrow-return-shorthand": true,
+    "await-promise": true,
+    "adjacent-overload-signatures": true,
+    "align": [
+      true
+    ],
+    "arrow-parens": true,
+    "ban": true,
+    "callable-types": true,
+    "completed-docs": [
+      true
+    ],
+    "cyclomatic-complexity": [
+      true
+    ],
+    "eofline": true,
+    "file-header": [
+      true
+    ],
+    "import-blacklist": true,
+    "import-spacing": true,
+    "interface-name": true,
+    "interface-over-type-literal": true,
+    "jsdoc-format": true,
+    "label-position": true,
+    "linebreak-style": [
+      true,
+      "LF"
+    ],
+    "max-classes-per-file": [
+      false
+    ],
+    "max-file-line-count": [
+      false
+    ],
+    "member-ordering": [
+      true
+    ],
+    "member-access": true,
+    "new-parens": true,
+    "no-angle-bracket-type-assertion": true,
+    "no-any": true,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-boolean-literal-compare": true,
+    "no-conditional-assignment": true,
+    "no-consecutive-blank-lines": [
+      true
+    ],
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "log",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-default-export": true,
+    "no-duplicate-super": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-floating-promises": true,
+    "no-for-in-array": true,
+    "no-import-side-effect": true,
+    "no-inferrable-types": true,
+    "no-inferred-empty-object-type": true,
+    "no-internal-module": true,
+    "no-invalid-template-strings": true,
+    "no-invalid-this": true,
+    "no-magic-numbers": true,
+    "no-mergeable-namespace": true,
+    "no-missing-visibility-modifiers": true,
+    "no-misused-new": true,
+    "no-namespace": false,
+    "no-null-keyword": true,
+    "no-parameter-properties": false,
+    "no-reference": true,
+    "no-reference-import": true,
+    "no-require-imports": true,
+    "no-shadowed-variable": true,
+    "no-sparse-arrays": true,
+    "no-string-literal": true,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-unbound-method": true,
+    "no-unnecessary-callback-wrapper": true,
+    "no-unnecessary-initializer": true,
+    "no-unnecessary-qualifier": true,
+    "no-unsafe-any": true,
+    "no-unsafe-finally": true,
+    "no-use-before-declare": true,
+    "no-var-requires": true,
+    "no-void-expression": true,
+    "object-literal-key-quotes": [
+      true,
+      "as-needed"
+    ],
+    "object-literal-shorthand": true,
+    "object-literal-sort-keys": true,
+    "one-variable-per-declaration": true,
+    "only-arrow-functions": [
+      true,
+      "allow-declarations",
+      "allow-named-functions"
+    ],
+    "ordered-imports": [
+      true
+    ],
+    "prefer-for-of": true,
+    "prefer-function-over-method": false,
+    "prefer-method-signature": true,
+    "prefer-template": true,
+    "strict-type-predicates": true,
+    "promise-function-async": true,
+    "restrict-plus-operands": true,
+    "space-before-function-paren": [
+      true,
+      "never"
+    ],
+    "strict-boolean-expressions": true,
+    "switch-default": true,
+    "typedef": [
+      true,
+      "parameter",
+      "property-declaration",
+      "member-variable-declaration"
+    ],
+    "typeof-compare": true,
+    "unified-signatures": true,
+    "use-isnan": true
+  }
+}


### PR DESCRIPTION
These are development rules that will highlight violations directly
in vscode, making it easy to notice and fix. The scope of the
contained rules is on-purpose much wider than the base rules in
tslint.json.

Note: I think we want to disable some of the rules contained in this PR, the trick is agreeing which ones we think will benefit Theia on the whole. 