### PR TITLE
[coverage] generate lcov file for each package

### DIFF
--- a/packages/nyc.json
+++ b/packages/nyc.json
@@ -7,7 +7,8 @@
         "src/**/*.spec.ts"
     ],
     "reporter": [
-        "html"
+        "html",
+        "lcov"
     ],
     "extension": [
         ".ts"


### PR DESCRIPTION
Adding "lcov" reporter to nyc.json so that coverage files
(lcov.info) are generated when the tests are run.