### PR TITLE
[coverage] add vscode configs to use vscode extension vscode-lcov in …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,26 @@
     "search.exclude": {
         "**/node_modules": true,
         "**/lib": true
-    }
+    },
+    "lcov.path": [
+        "packages/core/coverage/lcov.info",
+        "packages/cpp/coverage/lcov.info",
+        "packages/editor/coverage/lcov.info",
+        "packages/filesystem/coverage/lcov.info",
+        "packages/java/coverage/lcov.info",
+        "packages/languages/coverage/lcov.info",
+        "packages/monaco/coverage/lcov.info",
+        "packages/navigator/coverage/lcov.info",
+        "packages/preferences-api/coverage/lcov.info",
+        "packages/preferences/coverage/lcov.info",
+        "packages/python/coverage/lcov.info",
+        "packages/terminal/coverage/lcov.info",
+        "packages/workspace/coverage/lcov.info"
+    ],
+    "lcov.watch": [
+        {
+            "pattern": "**/*.spec.ts",
+            "command": "yarn test:theia"
+        }
+    ]
 }


### PR DESCRIPTION
…Theia

fixes #374

See issue for information about how to enable the coverage decorations and watcher