### PR TITLE
Add node 8 to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- '8'
 - '7'
 - '6'
 git:


### PR DESCRIPTION
We support node 8 now, so this patch adds it to the CI process.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>