### PR TITLE
Allow any number of websocket servers

### DIFF
--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -53,6 +53,10 @@ export class BackendApplication {
                 this.logger.info(`Theia app listening on port ${server.address().port}.`);
                 resolve(server);
             });
+
+            /* Allow any number of websocket servers.  */
+            server.setMaxListeners(0);
+
             for (const contrib of this.contributionsProvider.getContributions()) {
                 if (contrib.onStart) {
                     contrib.onStart(server);


### PR DESCRIPTION
Since starting a websocket server adds a listener on the 'upgrade' event of the
http server we need to increase the default 10 listener limit on
net.Server.

This patch just removes this limit so that we can have any number of
websocket servers.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>