### PR TITLE
C++ extension preferences framework

### DIFF
--- a/packages/cpp/extension.package.json
+++ b/packages/cpp/extension.package.json
@@ -7,7 +7,8 @@
     "@theia/languages": "^0.1.1",
     "@theia/editor": "^0.1.1",
     "@theia/monaco": "^0.1.1",
-    "@theia/filesystem": "^0.1.1"
+    "@theia/filesystem": "^0.1.1",
+    "@theia/preferences": "^0.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cpp/src/browser/cpp-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-client-contribution.ts
@@ -5,8 +5,8 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { injectable, inject } from "inversify";
-import { BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory } from '@theia/languages/lib/browser';
+import { injectable } from "inversify";
+import { BaseLanguageClientContribution } from '@theia/languages/lib/browser';
 import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME } from '../common';
 
 @injectable()
@@ -14,14 +14,6 @@ export class CppClientContribution extends BaseLanguageClientContribution {
 
     readonly id = CPP_LANGUAGE_ID;
     readonly name = CPP_LANGUAGE_NAME;
-
-    constructor(
-        @inject(Workspace) protected readonly workspace: Workspace,
-        @inject(Languages) protected readonly languages: Languages,
-        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
-    ) {
-        super(workspace, languages, languageClientFactory)
-    }
 
     protected get documentSelector() {
         return [

--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -15,7 +15,6 @@ import { TextDocumentItemRequest } from "./cpp-protocol";
 import { TextDocumentIdentifier } from "@theia/languages/lib/common";
 import { EDITOR_CONTEXT_MENU_ID } from "@theia/editor/lib/browser";
 
-
 /**
  * Switch between source/header file
  */
@@ -32,7 +31,6 @@ export const FILE_OPEN_PATH = (path: string): Command => <Command>{
 export class CppCommandContribution implements CommandContribution, MenuContribution {
 
     constructor(
-        // @inject(SelectionService) protected readonly selectionService: SelectionService,
         @inject(CppClientContribution) protected readonly clientContribution: CppClientContribution,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         protected readonly selectionService: SelectionService

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -11,8 +11,10 @@ import { CppCommandContribution } from './cpp-commands';
 
 import { LanguageClientContribution } from "@theia/languages/lib/browser";
 import { CppClientContribution } from "./cpp-client-contribution";
+import { bindCppPreferences } from "../common";
 
 export default new ContainerModule(bind => {
+    bindCppPreferences(bind);
     bind(CommandContribution).to(CppCommandContribution).inSingletonScope();
     bind(MenuContribution).to(CppCommandContribution).inSingletonScope();
 

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -6,18 +6,22 @@
  */
 
 import { ContainerModule } from "inversify";
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { CommandContribution, KeybindingContribution, KeybindingContext } from '@theia/core/lib/common';
 import { CppCommandContribution } from './cpp-commands';
 
 import { LanguageClientContribution } from "@theia/languages/lib/browser";
 import { CppClientContribution } from "./cpp-client-contribution";
 import { bindCppPreferences } from "../common";
+import { CppKeybindingContribution, CppKeybindingContext } from "./cpp-keybinding";
 
 export default new ContainerModule(bind => {
     bindCppPreferences(bind);
     bind(CommandContribution).to(CppCommandContribution).inSingletonScope();
-    bind(MenuContribution).to(CppCommandContribution).inSingletonScope();
+    bind(CppKeybindingContext).toSelf().inSingletonScope();
+    bind(KeybindingContext).toDynamicValue(context => context.container.get(CppKeybindingContext));
+    bind(KeybindingContribution).to(CppKeybindingContribution).inSingletonScope();
 
     bind(CppClientContribution).toSelf().inSingletonScope();
     bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppClientContribution));
+
 });

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { EditorManager } from "@theia/editor/lib/browser"
+import {
+    KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier
+} from "@theia/core/lib/common";
+
+@injectable()
+export class CppKeybindingContext implements KeybindingContext {
+    constructor( @inject(EditorManager) protected readonly editorService: EditorManager) { }
+
+    id = 'cpp.keybinding.context';
+
+    isEnabled(arg?: Keybinding) {
+        return this.editorService && !!this.editorService.activeEditor &&
+            (this.editorService.activeEditor.editor.document.uri.endsWith(".cpp") || this.editorService.activeEditor.editor.document.uri.endsWith(".h"));
+    }
+
+}
+
+@injectable()
+export class CppKeybindingContribution implements KeybindingContribution {
+
+    constructor(
+        @inject(CppKeybindingContext) protected readonly cppKeybindingContext: CppKeybindingContext
+    ) { }
+
+    registerKeyBindings(registry: KeybindingRegistry): void {
+        [
+            {
+                commandId: 'switch_source_header',
+                context: this.cppKeybindingContext,
+                keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M3] })
+            }
+        ].forEach(binding => {
+            registry.registerKeyBinding(binding);
+        });
+
+    }
+
+}

--- a/packages/cpp/src/common/cpp-preferences.ts
+++ b/packages/cpp/src/common/cpp-preferences.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces } from "inversify";
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceService,
+    PreferenceContribution,
+    PreferenceSchema
+} from '@theia/preferences/lib/common';
+
+export const CppConfigSchema: PreferenceSchema = {
+    "type": "object",
+    "properties": {
+        "cpp.clangdCompileCommandsPath": {
+            "type": "string",
+            "description": "clangd path for compile_commands.json"
+        }
+    }
+}
+
+export interface CppConfiguration {
+    'cpp.clangdCompileCommandsPath': string
+}
+
+export const defaultCppConfiguration: CppConfiguration = {
+    'cpp.clangdCompileCommandsPath': "-compileCommands=/home/ewilenr/theiaEclipse/eclipse/git/llvm/build"
+}
+
+export const CppPreferences = Symbol('CppPreferences');
+export type CppPreferences = PreferenceProxy<CppConfiguration>;
+
+export function createCppPreferences(preferences: PreferenceService): CppPreferences {
+    return createPreferenceProxy(preferences, defaultCppConfiguration, CppConfigSchema);
+}
+
+export function bindCppPreferences(bind: interfaces.Bind): void {
+    bind(CppPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get(PreferenceService);
+        return createCppPreferences(preferences);
+    });
+
+    bind(PreferenceContribution).toConstantValue({ schema: CppConfigSchema });
+}

--- a/packages/cpp/src/common/cpp-preferences.ts
+++ b/packages/cpp/src/common/cpp-preferences.ts
@@ -20,16 +20,26 @@ export const CppConfigSchema: PreferenceSchema = {
         "cpp.clangdCompileCommandsPath": {
             "type": "string",
             "description": "clangd path for compile_commands.json"
+        },
+        "cpp.clangdPath": {
+            "type": "string",
+            "description": "Literal command to start Clangd with. Can contain any relative or absolute path to clangd executable."
+        },
+        "cpp.clangdCommandArgs": {
+            "type": "string",
+            "description": "Literal command to start Clangd with. Can contain any relative or absolute path to clangd executable."
         }
     }
 }
 
 export interface CppConfiguration {
-    'cpp.clangdCompileCommandsPath': string
+    'cpp.clangdCompileCommandsPath': string,
+    'cpp.clangdPath': string
 }
 
 export const defaultCppConfiguration: CppConfiguration = {
-    'cpp.clangdCompileCommandsPath': "-compileCommands=/home/ewilenr/theiaEclipse/eclipse/git/llvm/build"
+    'cpp.clangdCompileCommandsPath': "-compile-commands-dir=/home/ewilenr/theiaEclipse/eclipse/git/llvm/build",
+    'cpp.clangdPath': "/home/ewilenr/theiaEclipse/eclipse/git/llvm/build/bin/compile_commands.json"
 }
 
 export const CppPreferences = Symbol('CppPreferences');

--- a/packages/cpp/src/common/index.ts
+++ b/packages/cpp/src/common/index.ts
@@ -7,3 +7,4 @@
 
 export const CPP_LANGUAGE_ID = 'cpp';
 export const CPP_LANGUAGE_NAME = 'C/C++';
+export * from './cpp-preferences'

--- a/packages/cpp/src/node/cpp-backend-module.ts
+++ b/packages/cpp/src/node/cpp-backend-module.ts
@@ -8,7 +8,9 @@
 import { ContainerModule } from "inversify";
 import { LanguageServerContribution } from "@theia/languages/lib/node";
 import { CppContribution } from './cpp-contribution';
+import { bindCppPreferences } from "../common/";
 
 export default new ContainerModule(bind => {
+    bindCppPreferences(bind);
     bind(LanguageServerContribution).to(CppContribution).inSingletonScope();
 });

--- a/packages/cpp/src/node/cpp-contribution.ts
+++ b/packages/cpp/src/node/cpp-contribution.ts
@@ -10,7 +10,7 @@ import { BaseLanguageServerContribution, IConnection } from "@theia/languages/li
 import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME } from '../common';
 import { CppPreferences } from "../common";
 import { Message, isRequestMessage } from 'vscode-ws-jsonrpc';
-import { InitializeParams, InitializeRequest } from 'vscode-languageserver/lib/protocol';
+import { InitializeParams, InitializeRequest } from 'vscode-languageserver-protocol';
 
 @injectable()
 export class CppContribution extends BaseLanguageServerContribution {
@@ -42,10 +42,16 @@ export class CppContribution extends BaseLanguageServerContribution {
     }
 
     public start(clientConnection: IConnection): void {
-        // TODO: clangd has to be on PATH, this should be a preference.
-        console.log(this.cppPreferences["cpp.clangdCompileCommandsPath"]);
-        const command = 'clangd';
-        const args: string[] = [this.cppPreferences["cpp.clangdCompileCommandsPath"]];
+        let command: any = '';
+        let args: string[] = [];
+        if (this.cppPreferences["cpp.clangdPath"] === "") {
+            command = (this.cppPreferences["cpp.clangdPath"] + '/clangd');
+            args = [];
+        } else {
+            command = 'clangd';
+            args = []; // [this.cppPreferences["cpp.clangdCompileCommandsPath"]];
+        }
+
         const serverConnection = this.createProcessStreamConnection(command, args);
         this.forward(clientConnection, serverConnection);
     }


### PR DESCRIPTION
Basic framework for C++ prefs in which I created one preference to be sent to clangd as a command line arg. This framework should be used for every preference in this extension's scope.