### PR TITLE
Language Server: add go language server integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
         "packages/cpp/coverage/lcov.info",
         "packages/editor/coverage/lcov.info",
         "packages/filesystem/coverage/lcov.info",
+        "packages/go/coverage/lcov.info",
         "packages/java/coverage/lcov.info",
         "packages/languages/coverage/lcov.info",
         "packages/monaco/coverage/lcov.info",

--- a/examples/browser/.yo-rc.json
+++ b/examples/browser/.yo-rc.json
@@ -15,7 +15,8 @@
       "@theia/monaco": "../../packages/monaco",
       "@theia/java": "../../packages/java",
       "@theia/python": "../../packages/python",
-      "@theia/cpp": "../../packages/cpp"
+      "@theia/cpp": "../../packages/cpp",
+      "@theia/go": "../../packages/go"
     },
     "node_modulesPath": "../../node_modules"
   }

--- a/examples/browser/theia.package.json
+++ b/examples/browser/theia.package.json
@@ -14,7 +14,8 @@
     "@theia/monaco": "^0.1.1",
     "@theia/java": "^0.1.1",
     "@theia/python": "^0.1.1",
-    "@theia/cpp": "^0.1.1"
+    "@theia/cpp": "^0.1.1",
+    "@theia/go": "^0.1.1"
   },
   "scripts": {
     "clean": "rimraf lib && rimraf errorShots",

--- a/examples/electron/.yo-rc.json
+++ b/examples/electron/.yo-rc.json
@@ -15,7 +15,8 @@
       "@theia/monaco": "../../packages/monaco",
       "@theia/java": "../../packages/java",
       "@theia/python": "../../packages/python",
-      "@theia/cpp": "../../packages/cpp"
+      "@theia/cpp": "../../packages/cpp",
+      "@theia/go": "../../packages/go"
     },
     "node_modulesPath": "../../node_modules"
   }

--- a/examples/electron/theia.package.json
+++ b/examples/electron/theia.package.json
@@ -7,6 +7,7 @@
     "@theia/cpp": "^0.1.1",
     "@theia/editor": "^0.1.1",
     "@theia/filesystem": "^0.1.1",
+    "@theia/go": "^0.1.1",
     "@theia/java": "^0.1.1",
     "@theia/languages": "^0.1.1",
     "@theia/monaco": "^0.1.1",

--- a/packages/go/.yo-rc.json
+++ b/packages/go/.yo-rc.json
@@ -1,0 +1,5 @@
+{
+  "generator-theia": {
+    "testSupport": true
+  }
+}

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -1,0 +1,6 @@
+# Theia - Go Extension
+
+See [here](https://github.com/theia-ide/theia) for a detailed documentation.
+
+## License
+[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/go/compile.tsconfig.json
+++ b/packages/go/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/go/extension.package.json
+++ b/packages/go/extension.package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@theia/go",
+  "version": "0.1.1",
+  "description": "Theia - Go Extension",
+  "dependencies": {
+    "@theia/core": "^0.1.1",
+    "@theia/languages": "^0.1.1",
+    "@theia/editor": "^0.1.1",
+    "@theia/monaco": "^0.1.1",
+    "@theia/filesystem": "^0.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [{
+    "frontend": "lib/browser/go-frontend-module",
+    "backend": "lib/node/go-backend-module"
+  }]
+}

--- a/packages/go/src/browser/go-client-contribution.ts
+++ b/packages/go/src/browser/go-client-contribution.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory } from '@theia/languages/lib/browser';
+import { GO_LANGUAGE_ID, GO_LANGUAGE_NAME } from '../common';
+
+@injectable()
+export class GoClientContribution extends BaseLanguageClientContribution {
+
+    readonly id = GO_LANGUAGE_ID;
+    readonly name = GO_LANGUAGE_NAME;
+
+    constructor(
+        @inject(Workspace) protected readonly workspace: Workspace,
+        @inject(Languages) protected readonly languages: Languages,
+        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
+    ) {
+        super(workspace, languages, languageClientFactory)
+    }
+
+    protected get documentSelector() {
+        return [
+            'go'
+        ];
+    }
+
+    protected get globPatterns() {
+        return [
+            '**/*.go'
+        ];
+    }
+
+
+}

--- a/packages/go/src/browser/go-frontend-module.ts
+++ b/packages/go/src/browser/go-frontend-module.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from "inversify";
+
+import { LanguageClientContribution } from "@theia/languages/lib/browser";
+import { GoClientContribution } from "./go-client-contribution";
+
+export default new ContainerModule(bind => {
+    bind(GoClientContribution).toSelf().inSingletonScope();
+    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(GoClientContribution));
+});

--- a/packages/go/src/browser/index.ts
+++ b/packages/go/src/browser/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export * from './go-frontend-module';

--- a/packages/go/src/common/index.ts
+++ b/packages/go/src/common/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export const GO_LANGUAGE_ID = 'go';
+export const GO_LANGUAGE_NAME = 'Go';

--- a/packages/go/src/node/go-backend-module.ts
+++ b/packages/go/src/node/go-backend-module.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from "inversify";
+import { LanguageServerContribution } from "@theia/languages/lib/node";
+import { GoContribution } from './go-contribution';
+
+export default new ContainerModule(bind => {
+    bind(LanguageServerContribution).to(GoContribution).inSingletonScope();
+});

--- a/packages/go/src/node/go-contribution.ts
+++ b/packages/go/src/node/go-contribution.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from "inversify";
+import { BaseLanguageServerContribution, IConnection } from "@theia/languages/lib/node";
+import { GO_LANGUAGE_ID, GO_LANGUAGE_NAME } from '../common';
+
+/**
+ * IF you have go on your machine, `go-langserver` can be installed with the following command:
+ * `go get github.com/sourcegraph/go-langserver`
+ */
+@injectable()
+export class GoContribution extends BaseLanguageServerContribution {
+
+    readonly id = GO_LANGUAGE_ID;
+    readonly name = GO_LANGUAGE_NAME;
+
+    start(clientConnection: IConnection): void {
+        // TODO: go-langserver has to be on PATH, this should be a preference.
+        const command = 'go-langserver';
+        const args: string[] = [];
+        const serverConnection = this.createProcessStreamConnection(command, args);
+        this.forward(clientConnection, serverConnection);
+    }
+
+    protected onDidFailSpawnProcess(error: Error): void {
+        super.onDidFailSpawnProcess(error);
+        console.error("Error starting go language server.");
+        console.error("Please make sure it is installed on your system.");
+        console.error("Use the following command: 'go get github.com/sourcegraph/go-langserver'");
+    }
+}

--- a/packages/go/src/node/index.ts
+++ b/packages/go/src/node/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export * from './go-backend-module';

--- a/packages/go/src/package.spec.ts
+++ b/packages/go/src/package.spec.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("go package", () => {
+
+    it("support code coverage statistics", () => {
+        return true;
+    })
+});

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -50,6 +50,9 @@
             ],
             "@theia/python/lib/*": [
                 "python/src/*"
+            ],
+            "@theia/go/lib/*": [
+                "go/src/*"
             ]
         }
     },


### PR DESCRIPTION
This is based on https://github.com/theia-ide/theia/pull/141
This adds support for "go-langserver". At this moment, it is possible
to "Go to definition".

For best results, GOPATH needs to be set, see:
https://github.com/sourcegraph/go-langserver/issues/185

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>