### PR TITLE
Retry the tests 3 times if they fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ before_install:
 install: yarn
 script: 
   - if [ ${TRAVIS_OS_NAME} = "linux" ]; then 
-      yarn test ;
+      travis_retry yarn test ;
     else
-      yarn test:theia ;
+      travis_retry yarn test:theia ;
     fi
 notifications:
   webhooks:


### PR DESCRIPTION
This is done to avoid timeout problems on the CI platform failing the
build from time to time.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>