### PR TITLE
Update node-pty to 0.7.0 and remove workarounds

### DIFF
--- a/packages/process/extension.package.json
+++ b/packages/process/extension.package.json
@@ -4,7 +4,7 @@
   "description": "Theia process support.",
   "dependencies": {
     "@theia/core": "0.1.1",
-    "node-pty": "^0.6.10"
+    "node-pty": "^0.7.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -27,15 +27,12 @@ describe('TerminalProcess', function () {
 
     it('test error on non existent path', function () {
 
-        /* FIXME need to pass empty options because of issue #115 in node-pty
-        this should be fixed in next release of node-pty */
-
         /* Strangly linux returns exited with code 1 when using a non existant path but windows throws an error.
         This would need to be investigated more.  */
         if (isWindows) {
-            return expect(() => terminalProcessFactory({ command: '/non-existent', options: {} })).to.throw();
+            return expect(() => terminalProcessFactory({ command: '/non-existent' })).to.throw();
         } else {
-            const terminalProcess = terminalProcessFactory({ command: '/non-existant', options: {} });
+            const terminalProcess = terminalProcessFactory({ command: '/non-existant' });
             const p = new Promise(resolve => {
                 terminalProcess.onExit(event => {
                     if (event.code > 0) { resolve(); }
@@ -49,23 +46,17 @@ describe('TerminalProcess', function () {
 
     it('test exit', function () {
         const args = ['--version'];
-        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args, options: {} });
+        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
         const p = new Promise((resolve, reject) => {
             terminalProcess.onError(error => {
                 reject();
                 terminalProcess.dispose();
             });
             terminalProcess.onExit(event => {
-                /* FIXME windows has not exit code  because of issue #75 in node-pty
-                this should be fixed in next release of node-pty */
-                if (isWindows) {
+                if (event.code === 0) {
                     resolve();
                 } else {
-                    if (event.code === 0) {
-                        resolve();
-                    } else {
-                        reject();
-                    }
+                    reject();
                 }
                 terminalProcess.dispose();
             });
@@ -75,7 +66,7 @@ describe('TerminalProcess', function () {
     });
 
     it('test dispose', function () {
-        const terminalProcess = terminalProcessFactory({ command: process.execPath, options: {} });
+        const terminalProcess = terminalProcessFactory({ command: process.execPath });
         const p = new Promise((resolve, reject) => {
             terminalProcess.dispose();
             terminalProcess.onExit(event => resolve());
@@ -85,7 +76,7 @@ describe('TerminalProcess', function () {
 
     it('test pipe stream', function () {
         const args = ['--version'];
-        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args, options: {} });
+        const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
 
         const outStream = new stream.PassThrough();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4724,11 +4724,7 @@ mv@^2.1.1, mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
-
-nan@^2.3.0, nan@^2.3.3:
+nan@^2.3.0, nan@^2.3.3, nan@^2.6.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -4825,11 +4821,11 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-pty@^0.6.10:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.6.10.tgz#b7d355bb2002d16e14c3c353e58c48f7ee131a67"
+node-pty@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.0.tgz#993038692d3a2921811a152658fc7dc211323ac2"
   dependencies:
-    nan "2.5.0"
+    nan "^2.6.2"
 
 node-status-codes@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This version contains fixes for #115 and #75 of node-pty. This allows us
to remove a few workarounds.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>