### PR TITLE
Fix resize for terminal id 0

### DIFF
--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -83,7 +83,7 @@ export class TerminalWidget extends BaseWidget {
         this.rows = initialGeometry.rows;
 
         this.term.on('resize', size => {
-            if (!this.terminalId) {
+            if (this.terminalId === undefined) {
                 return;
             }
             this.cols = size.cols


### PR DESCRIPTION
The terminalId can be 0 so check for undefined when trying to register the
resize handler rather than use the not operator.

Fixes #463

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>