### PR TITLE
GH-483: Go to Definition does not jump to correct file offset

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -147,8 +147,10 @@ export class EditorManagerImpl implements EditorManager {
 
     protected getSelection(selection: RecursivePartial<Range>): Range | Position | undefined {
         const { start, end } = selection;
-        if (start && start.line && start.character) {
-            if (end && end.line && end.character) {
+        if (start && start.line !== undefined && start.line >= 0 &&
+            start.character !== undefined && start.character >= 0) {
+            if (end && end.line !== undefined && end.line >= 0 &&
+                end.character !== undefined && end.character >= 0) {
                 return selection as Range;
             }
             return start as Position;


### PR DESCRIPTION
There was an incorrect check that was preventing anything at either
line 0 or character 0 to go through.

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>