### PR TITLE
[contextmenu] Added onHide callback to context menu.

### DIFF
--- a/packages/core/src/browser/context-menu-renderer.ts
+++ b/packages/core/src/browser/context-menu-renderer.ts
@@ -13,5 +13,5 @@ export function toAnchor(anchor: HTMLElement | { x: number, y: number }): Anchor
 
 export const ContextMenuRenderer = Symbol("ContextMenuRenderer");
 export interface ContextMenuRenderer {
-    render(path: string, anchor: Anchor): void;
+    render(path: string, anchor: Anchor, onHide?: () => void): void;
 }

--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -15,9 +15,12 @@ export class BrowserContextMenuRenderer implements ContextMenuRenderer {
     constructor( @inject(BrowserMainMenuFactory) private menuFactory: BrowserMainMenuFactory) {
     }
 
-    render(path: string, anchor: Anchor): void {
+    render(path: string, anchor: Anchor, onHide?: () => void): void {
         const contextMenu = this.menuFactory.createContextMenu(path);
         const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor;
+        if (onHide) {
+            contextMenu.aboutToClose.connect(() => onHide());
+        }
         contextMenu.open(x, y);
     }
 

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -15,9 +15,12 @@ export class ElectronContextMenuRenderer implements ContextMenuRenderer {
     constructor( @inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
     }
 
-    render(path: string, anchor: Anchor): void {
+    render(path: string, anchor: Anchor, onHide?: () => void): void {
         const menu = this.menuFactory.createContextMenu(path);
         menu.popup();
+        if (onHide) {
+            onHide();
+        }
     }
 
 }

--- a/packages/monaco/src/browser/monaco-context-menu.ts
+++ b/packages/monaco/src/browser/monaco-context-menu.ts
@@ -24,7 +24,7 @@ export class MonacoContextMenuService implements IContextMenuService {
         // If it is the general context menu, we want to delegate to our menu registry entirely and ignore the actually passed actions.
         // Unfortunately checking the existence of certain properties seems to be the best way to tell, what kind of context menu is requested.
         if (delegate.hasOwnProperty("getKeyBinding")) {
-            this.contextMenuRenderer.render(EDITOR_CONTEXT_MENU_ID, anchor);
+            this.contextMenuRenderer.render(EDITOR_CONTEXT_MENU_ID, anchor, () => delegate.onHide(false));
         } else {
             delegate.getActions().then(actions => {
                 const commands = new CommandRegistry();
@@ -46,6 +46,7 @@ export class MonacoContextMenuService implements IContextMenuService {
                         command: commandId
                     });
                 }
+                menu.aboutToClose.connect(() => delegate.onHide(false));
                 menu.open(anchor.x, anchor.y);
             });
         }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -116,6 +116,11 @@ declare module monaco.editor {
          * Returns the actions for the menu
          */
         getActions(): monaco.Promise<IAction[]>
+
+        /**
+         * Needs to be called with the context menu closes again.
+         */
+        onHide(wasCancelled: boolean): void
     }
 
     export interface IAction {


### PR DESCRIPTION
... since monaco needs to reset some properties when the context menu gets closed. (fixes #482)

Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>