### PR TITLE
Reuse environment so that JRE can be found via the system path

### DIFF
--- a/examples/browser/Dockerfile
+++ b/examples/browser/Dockerfile
@@ -28,6 +28,9 @@
 #    Note that you may get an "Error forwarding request." error after clicking
 #    on the 3000 link. Please wait a few seconds before trying again as Theia
 #    may not have completely finished starting up yet.
+#
+# Note: If you want Java language support you will need to extend this image yourself
+# by adding a JDK to the image and making sure it is accessible via the system PATH.
 
 FROM node:7.10
 RUN useradd --create-home theia

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -65,15 +65,14 @@ export class JavaContribution extends BaseLanguageServerContribution {
             const outSocket = this.accept(outServer);
 
             this.logInfo('logs at ' + path.resolve(workspacePath, '.metadata', '.log'));
+            const env = Object.create(process.env);
+            env.STDIN_HOST = inServer.address().address;
+            env.STDIN_PORT = inServer.address().port;
+            env.STDOUT_HOST = outServer.address().address;
+            env.STDOUT_PORT = outServer.address().port;
             this.createProcessSocketConnection(inSocket, outSocket, command, args, {
-                env: {
-                    'STDIN_HOST': inServer.address().address,
-                    'STDIN_PORT': inServer.address().port,
-                    'STDOUT_HOST': outServer.address().address,
-                    'STDOUT_PORT': outServer.address().port
-                }
+                env: env
             }).then(serverConnection => this.forward(clientConnection, serverConnection));
         });
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Tim deBoer <deboer@ca.ibm.com>