### PR TITLE
Issue #538, remove some warnings about the loaders when compiling theia.

### DIFF
--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -47,6 +47,10 @@ module.exports = {
                 loader: 'url-loader?limit=10000&mimetype=image/svg+xml'
             },
             {
+                test: /node_modules.+xterm.+\.map$/,
+                loader: 'ignore-loader'
+            },
+            {
                 test: /\.js$/,
                 enforce: 'pre',
                 loader: 'source-map-loader'

--- a/examples/electron/webpack.config.js
+++ b/examples/electron/webpack.config.js
@@ -41,6 +41,10 @@ module.exports = {
                 loader: 'url-loader?limit=10000&mimetype=image/svg+xml'
             },
             {
+                test: /node_modules.+xterm.+\.map$/,
+                loader: 'ignore-loader'
+            },
+            {
                 test: /\.js$/,
                 enforce: 'pre',
                 loader: 'source-map-loader'


### PR DESCRIPTION
When executing webpack, it put warnings about the loader to handle
some files type.

Signed-off-by: Jacques Bouthillier <Jacques.bouthillier@ericsson.com>