### PR TITLE
Increase timeout to 5 secs for tests that depend on a process

### DIFF
--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -22,6 +22,7 @@ const expect = chai.expect;
 
 describe('RawProcess', function () {
 
+    this.timeout(5000);
     const rawProcessFactory = testContainer.get<RawProcessFactory>(RawProcessFactory);
 
     it('test error on non existent path', function () {

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -23,6 +23,7 @@ const expect = chai.expect;
 
 describe('TerminalProcess', function () {
 
+    this.timeout(5000);
     const terminalProcessFactory = testContainer.get<TerminalProcessFactory>(TerminalProcessFactory);
 
     it('test error on non existent path', function () {

--- a/packages/terminal/src/node/shell-terminal-server.spec.ts
+++ b/packages/terminal/src/node/shell-terminal-server.spec.ts
@@ -19,6 +19,8 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe('ShellServer', function () {
+
+    this.timeout(5000);
     const shellTerminalServer = testContainer.get<IShellTerminalServer>(IShellTerminalServer);
 
     it('test shell terminal create', function () {

--- a/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
@@ -24,6 +24,7 @@ const expect = chai.expect;
 
 describe('Terminal Backend Contribution', function () {
 
+    this.timeout(5000);
     let server: http.Server;
     let shellTerminalServer: IShellTerminalServer;
 

--- a/packages/terminal/src/node/terminal-server.spec.ts
+++ b/packages/terminal/src/node/terminal-server.spec.ts
@@ -23,6 +23,7 @@ const expect = chai.expect;
 
 describe('TermninalServer', function () {
 
+    this.timeout(5000);
     const terminalServer = testContainer.get<ITerminalServer>(ITerminalServer);
     const terminalWatcher = testContainer.get<TerminalWatcher>(TerminalWatcher);
 


### PR DESCRIPTION
The default 2 seconds was sometimes to slow for tests that require a
process to be started or a terminal to be started.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>