### PR TITLE
Clarify and simplify contribution rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,19 @@ functionality for IDE-like applications, like a file system or a navigator
 view, most functionality doesn't necessarily need to be put into the core
 repository but can be developed separately.
 
+* [How Can I Contribute?](#how-can-i-contribute)
+  * [Asking Questions](#asking-questions)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Reporting Feature Requests](#reporting-feature-requests)
+  * [Pull Requests](#pull-requests)
+* [Contributions](#contributions)
+  * [Reviewing](#reviewing)
+  * [Signing off](#signing-off)
+  * [Landing](#signing-off)
+* [Becoming a Committer](#becoming-a-committer)
+* [Coding Guidelines](#coding-guidelines)
+* [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin-11)
+
 ## How Can I Contribute?
 
 In the following some of the typical ways of contribution are described.
@@ -42,63 +55,66 @@ an issue. Simply choose the issue you would want to work on, and tell everyone
 that you are willing to do so and how you would approach it. The team will be
 happy to guide you and give feedback.
 
+## Contributions
+
+All contributions to the project must be through pull requests. This applies to all changes to documentation, code, binary files, etc. Even long term committers must use pull requests.
+
+No pull request can be merged without being reviewed.
+
+### Reviewing
+
+For non-trivial contributions, pull requests should sit for at least 24 hours to ensure that committers in other timezones have time to review. Trivial pull requests may be landed after a shorter delay.
+
+The default for each contribution is that it is accepted once no committer has an objection. Once all issues brought by committers are addressed it can be signed-off and landed by any committer.
+
+### Signing off
+
+Committers sign-off on a pull request by explicitly stating their approval in the PR text or associated comment stream.
+
+All pull requests submitted by individuals who are not committers must be signed-off on by an existing committer before the PR can be landed. The sponsoring committer becomes responsible for the PR.
+
+Pull requests from an existing committer must be signed-off on by at least one other committer.
+
+### Landing
+
+When Landing a pull request, a committer may modify the original commit message to include the following additional meta information regarding the change process:
+
+- A `PR-URL:` line that references the full GitHub URL of the original Pull Request being merged so it's easy to trace a commit back to the conversation that lead up to that change.
+- A `Fixes: X` line as appropriate, where X includes the full GitHub URL for an issue, and/or the complete or abbreviated hash identifier and commit message if the commit fixes a bug in a previous commit. Multiple Fixes: lines may be added if appropriate.
+
+## Becoming a Committer
+
+All contributors who land a non-trivial contribution should be on-boarded in a timely manner and added as a committer. The invitation to become a committer must include a copy of the project Developer’s Certificate of Origin ([DCO]((#developers-certificate-of-origin-11))). Assuming the individual accepts the invitation, they are granted commit-access to the project.
+
+Committers are expected to follow this policy and continue to send pull requests, go through proper review, and have other committers sign-off and land their pull requests.
+
 ## Coding Guidelines
 
 We follow the coding guidelines described
 [here](https://github.com/theia-ide/theia/wiki/Coding-Guidelines).
 
-## Sign your work
-
-The sign-off is a simple line at the end of the explanation for the patch. Your
-signature certifies that you wrote the patch or otherwise have the right to
-pass it on as an open-source patch. The rules are pretty simple: if you can
-certify the below (from
-[developercertificate.org](http://developercertificate.org/)):
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-Developer's Certificate of Origin 1.1
+## Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
 
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
 
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
 
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-Then you just add a line to every git commit message:
-
-    Signed-off-by: Joe Smith <joe.smith@email.com>
-
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
-
-If you set your `user.name` and `user.email` git configs, you can sign your
-commit automatically with `git commit -s`.
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.


### PR DESCRIPTION
The changes are inspired by Node.js Foundation's contribution policy:
- https://nodejs.org/en/get-involved/development/
- https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951

They use the DCO as well instead of the CLA to avoid the bureaucracy, but treat it in the wider sense, particularly the contribution sign-off.

The main change is that a contributor does not need to use git to sign-off commits, but each contribution should be signed off by an existing committer by approving a PR. If you reread the DCO you should see that the third point allows it.

So there are no requirements for contributors who are not committers and committers agree to this rules by accepting the invitation to become a committer.