### PR TITLE
Make it possible to export container dependant variables

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -18,6 +18,11 @@ export const FrontendApplicationContribution = Symbol("FrontendApplicationContri
 export interface FrontendApplicationContribution {
 
     /**
+     * Called on application startup before onStart is called.
+     */
+    initialize?(): void;
+
+    /**
      * Called when the application is started.
      */
     onStart?(app: FrontendApplication): void;
@@ -96,6 +101,17 @@ export class FrontendApplication {
     }
 
     protected startContributions(): void {
+
+        for (const contribution of this.contributions.getContributions()) {
+            if (contribution.initialize) {
+                try {
+                    contribution.initialize();
+                } catch (err) {
+                    this.logger.error(err.toString());
+                }
+            }
+        }
+
         /**
          * FIXME:
          * - decouple commands & menus

--- a/packages/core/src/browser/logger-frontend-module.ts
+++ b/packages/core/src/browser/logger-frontend-module.ts
@@ -7,11 +7,19 @@
 
 import { ContainerModule, Container } from 'inversify';
 import { ILoggerServer, loggerPath } from '../common/logger-protocol';
-import { ILogger, Logger, LoggerFactory, LoggerOptions } from '../common/logger';
+import { ILogger, Logger, LoggerFactory, LoggerOptions, setRootLogger } from '../common/logger';
 import { LoggerWatcher } from '../common/logger-watcher';
 import { WebSocketConnectionProvider } from './messaging';
+import { FrontendApplicationContribution } from './frontend-application';
 
 export const loggerFrontendModule = new ContainerModule(bind => {
+    bind(FrontendApplicationContribution).toDynamicValue(ctx =>
+        ({
+            initialize() {
+                setRootLogger(ctx.container.get<ILogger>(ILogger));
+            }
+        }));
+
     bind(ILogger).to(Logger).inSingletonScope();
     bind(LoggerWatcher).toSelf().inSingletonScope();
     bind(ILoggerServer).toDynamicValue(ctx => {

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -18,6 +18,14 @@ export enum LogLevel {
     TRACE = 10
 }
 
+/* This is to be initialized from container composition root.
+It can be used outside of the inversify context.  */
+export let logger: ILogger;
+
+export function setRootLogger(alogger: ILogger) {
+    logger = alogger;
+}
+
 export type Log = (message: string, ...params: any[]) => void;
 export type Loggable = (log: Log) => void;
 

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -41,13 +41,21 @@ export class BackendApplication {
 
         for (const contribution of this.contributionsProvider.getContributions()) {
             if (contribution.initialize) {
-                contribution.initialize();
+                try {
+                    contribution.initialize();
+                } catch (err) {
+                    this.logger.error(err.toString());
+                }
             }
         }
 
         for (const contribution of this.contributionsProvider.getContributions()) {
             if (contribution.configure) {
-                contribution.configure(this.app);
+                try {
+                    contribution.configure(this.app);
+                } catch (err) {
+                    this.logger.error(err.toString());
+                }
             }
         }
     }
@@ -69,7 +77,11 @@ export class BackendApplication {
 
             for (const contrib of this.contributionsProvider.getContributions()) {
                 if (contrib.onStart) {
-                    contrib.onStart(server);
+                    try {
+                        contrib.onStart(server);
+                    } catch (err) {
+                        this.logger.error(err.toString());
+                    }
                 }
             }
         });

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -12,6 +12,7 @@ import { ILogger, ContributionProvider } from '../common';
 
 export const BackendApplicationContribution = Symbol("BackendApplicationContribution");
 export interface BackendApplicationContribution {
+    initialize?(): void;
     configure?(app: express.Application): void;
     onStart?(server: http.Server): void;
 }
@@ -37,6 +38,13 @@ export class BackendApplication {
                 }
             }
         });
+
+        for (const contribution of this.contributionsProvider.getContributions()) {
+            if (contribution.initialize) {
+                contribution.initialize();
+            }
+        }
+
         for (const contribution of this.contributionsProvider.getContributions()) {
             if (contribution.configure) {
                 contribution.configure(this.app);

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -7,13 +7,22 @@
 
 import { ContainerModule, Container } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from "../common/messaging";
-import { ILogger, LoggerFactory, LoggerOptions, Logger } from '../common/logger';
+import { ILogger, LoggerFactory, LoggerOptions, Logger, setRootLogger } from '../common/logger';
 import { ILoggerServer, ILoggerClient, loggerPath, LoggerServerOptions } from '../common/logger-protocol';
 import { BunyanLoggerServer } from './bunyan-logger-server';
 import { LoggerWatcher } from '../common/logger-watcher';
+import { BackendApplicationContribution } from './backend-application';
+
 import * as yargs from 'yargs';
 
 export const loggerBackendModule = new ContainerModule(bind => {
+    bind(BackendApplicationContribution).toDynamicValue(ctx =>
+        ({
+            initialize() {
+                setRootLogger(ctx.container.get<ILogger>(ILogger));
+            }
+        }));
+
     bind(ILogger).to(Logger).inSingletonScope().whenTargetIsDefault();
     bind(LoggerWatcher).toSelf().inSingletonScope();
     bind(ILoggerServer).to(BunyanLoggerServer).inSingletonScope();


### PR DESCRIPTION
This patch introduces the initialize function inside a module, this
function is called with the root container of the application at
application startup.

This enables the logger module to export a logger object fetched via
container.get<ILogger>(ILogger) such that this new logger object can be
exported to code that does not use injection.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>