### PR TITLE
Fix terminal initial size

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -63,12 +63,9 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
     }
 
     protected async newTerminal(): Promise<void> {
-        const newTerminal = await this.widgetManager.getOrCreateWidget(TERMINAL_WIDGET_FACTORY_ID, <TerminalWidgetFactoryOptions>{
+        await this.widgetManager.getOrCreateWidget(TERMINAL_WIDGET_FACTORY_ID, <TerminalWidgetFactoryOptions>{
             created: new Date().toString()
         });
-
-        this.app.shell.addToMainArea(newTerminal);
-        this.app.shell.activateMain(newTerminal.id);
     }
 
 }

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -14,6 +14,7 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { ITerminalServer, terminalPath } from '../common/terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
 import { IShellTerminalServer, shellTerminalPath } from '../common/shell-terminal-protocol';
+import { FrontendApplication } from '@theia/core/lib/browser';
 
 import '../../src/browser/terminal.css';
 import 'xterm/dist/xterm.css';
@@ -38,7 +39,12 @@ export default new ContainerModule(bind => {
                 ...options
             });
             const result = child.get(TerminalWidget);
+            const app = ctx.container.get(FrontendApplication);
+
+            app.shell.addToMainArea(result);
+            app.shell.activateMain(result.id);
             result.start();
+
             return result;
         }
     }));

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -75,8 +75,6 @@ export class TerminalWidget extends BaseWidget {
         this.term.on('title', (title: string) => {
             this.title.label = title;
         });
-
-        this.registerResize();
     }
 
     protected registerResize(): void {
@@ -96,6 +94,7 @@ export class TerminalWidget extends BaseWidget {
     }
 
     public async start(): Promise<void> {
+        this.registerResize();
         const root = await this.workspaceService.root;
         this.terminalId = await this.shellTerminalServer.create(
             { rootURI: root.uri, cols: this.cols, rows: this.rows });

--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -19,4 +19,6 @@
 .terminal-container {
     padding-top: calc(var(--theia-code-padding)*3) !important;
     padding-left: calc(var(--theia-code-padding)*3) !important;
+    width:100%;
+    height:100%;
 }


### PR DESCRIPTION
This patch fixes the terminal initialize since, before this patch the
initial geometry calculated by (this.term as any).proposeGeometry() was
undefined causing default values to be used for the terminal size.

This was caused by a call to getComputedStyle on the parent element before
the element was actually in the DOM.

This patch makes it so that the widget is added to the DOM and only after
this is done the terminal is started and its geometry is calculated.

Fixes: #294

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>