### PR TITLE
Fix browser example yarn start on windows

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -40,7 +40,7 @@ function shell(command: string, args: string[]): Promise<string> {
 }
 async function bunyan(childProcess: cp.ChildProcess): Promise<string> {
     const bunyanPath = resolveBin('bunyan');
-    const bunyanProcess = cp.spawn(bunyanPath, [], { cwd, env, stdio: ['pipe', 1, 2, 'ipc'] });
+    const bunyanProcess = cp.spawn(bunyanPath, [], { cwd, env, stdio: ['pipe', 1, 2] });
     childProcess.stdout.pipe(bunyanProcess.stdin);
     childProcess.stderr.pipe(bunyanProcess.stdin);
     return promisify(bunyanProcess);


### PR DESCRIPTION
This patch removes the unneeded ipc channel when spawning bunyan, this
made windows fail.

Fixes: #587

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>