### PR TITLE
Fix the windows terminal cwd path

### DIFF
--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -11,6 +11,7 @@ import { ILogger } from '@theia/core/lib/common/logger';
 import { TerminalProcess, TerminalProcessOptions, ProcessManager } from '@theia/process/lib/node';
 import { isWindows } from "@theia/core/lib/common";
 import URI from "@theia/core/lib/common/uri";
+import { FileUri } from "@theia/core/lib/node/file-uri";
 
 export const ShellProcessFactory = Symbol("ShellProcessFactory");
 export type ShellProcessFactory = (options: ShellProcessOptions) => ShellProcess;
@@ -26,7 +27,7 @@ export interface ShellProcessOptions {
 function getRootPath(rootURI?: string): string {
     if (rootURI) {
         const uri = new URI(rootURI);
-        return uri.path.toString();
+        return FileUri.fsPath(uri);
     } else {
         return process.cwd();
     }


### PR DESCRIPTION
Before this patch the URI path was taken directly rather than being
converted to an proper os path.

This patch fixes this by calling FileUri.fsPath(uri).

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>