### PR TITLE
GH-625: Passed the workspace root from the frontend to backend.

### DIFF
--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -6,6 +6,7 @@
 */
 import { Git, Repository } from '../common';
 import { injectable, inject } from "inversify";
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 @injectable()
 export class GitRepositoryProvider {
@@ -13,16 +14,16 @@ export class GitRepositoryProvider {
     protected selectedRepository: Repository;
 
     constructor(
-        @inject(Git) protected readonly git: Git
-    ) {
-
-    }
+        @inject(Git) protected readonly git: Git,
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+    ) { }
 
     async getSelected(): Promise<Repository> {
         if (this.selectedRepository) {
             return this.selectedRepository;
         } else {
-            return this.git.repositories().then(r => this.selectedRepository = r[0]);
+            const root = await this.workspaceService.root;
+            return this.git.repositories(root.uri).then(r => this.selectedRepository = r[0]);
         }
     }
 

--- a/packages/git/src/browser/git-resource.ts
+++ b/packages/git/src/browser/git-resource.ts
@@ -9,6 +9,7 @@ import { injectable, inject } from "inversify";
 import { Git, Repository } from '../common';
 import { Resource, ResourceResolver } from "@theia/core";
 import URI from "@theia/core/lib/common/uri";
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 export const GIT_RESOURCE_SCHEME = 'gitrev';
 
@@ -27,7 +28,8 @@ export class GitResource implements Resource {
 export class GitResourceResolver implements ResourceResolver {
 
     constructor(
-        @inject(Git) protected readonly git: Git
+        @inject(Git) protected readonly git: Git,
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
     ) { }
 
     resolve(uri: URI): Resource | Promise<Resource> {
@@ -43,8 +45,9 @@ export class GitResourceResolver implements ResourceResolver {
     }
 
     async getRepository(uri: URI): Promise<Repository> {
+        const root = await this.workspaceService.root;
         const uriWithoutScheme = uri.withoutScheme();
-        const repos = await this.git.repositories();
+        const repos = await this.git.repositories(root.uri);
         // We sort by length so that we visit the nested repositories first.
         // We do not want to get the repository A instead of B if we have:
         // repository A, another repository B inside A and a resource A/B/C.ext.

--- a/packages/git/src/browser/git-widget.ts
+++ b/packages/git/src/browser/git-widget.ts
@@ -19,6 +19,7 @@ import { h } from '@phosphor/virtualdom/lib';
 import { DiffUris } from '@theia/editor/lib/browser/diff-uris';
 import { FileIconProvider } from '@theia/filesystem/lib/browser/icons/file-icons';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
 @injectable()
 export class GitWidget extends VirtualWidget {
@@ -44,7 +45,8 @@ export class GitWidget extends VirtualWidget {
         @inject(ResourceProvider) protected readonly resourceProvider: ResourceProvider,
         @inject(MessageService) protected readonly messageService: MessageService,
         @inject(FileIconProvider) protected readonly iconProvider: FileIconProvider,
-        @inject(CommandService) protected readonly commandService: CommandService) {
+        @inject(CommandService) protected readonly commandService: CommandService,
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService) {
         super();
         this.id = 'theia-gitContainer';
         this.title.label = 'Git';
@@ -58,7 +60,8 @@ export class GitWidget extends VirtualWidget {
     }
 
     async initialize(): Promise<void> {
-        this.repositories = await this.git.repositories();
+        const root = await this.workspaceService.root;
+        this.repositories = await this.git.repositories(root.uri);
         this.repository = await this.gitRepositoryProvider.getSelected();
         this.gitWatcher.dispose();
         this.watcherDisposable = await this.gitWatcher.watchGitChanges(this.repository);

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -118,10 +118,9 @@ export namespace Git {
             /**
              * The desired destination path (given as a URI) for the cloned repository.
              * If the path does not exist it will be created. Cloning into an existing
-             * directory is only allowed if the directory is empty. If not specified,
-             * then the workspace root will be used as the destination.
+             * directory is only allowed if the directory is empty.
              */
-            readonly localUri?: string;
+            readonly localUri: string;
 
             /**
              * The branch to checkout after the clone has completed. If not given,
@@ -336,12 +335,12 @@ export interface Git {
      * @param remoteUrl the URL of the remote.
      * @param options the clone options.
      */
-    clone(remoteUrl: string, options?: Git.Options.Clone): Promise<Repository>;
+    clone(remoteUrl: string, options: Git.Options.Clone): Promise<Repository>;
 
     /**
-     * Resolves to an array of repositories discovered in the workspace.
+     * Resolves to an array of repositories discovered in the workspace given with the workspace root URI.
      */
-    repositories(): Promise<Repository[]>;
+    repositories(workspaceRootUri: string): Promise<Repository[]>;
 
     /**
      * Returns with the working directory status of the given Git repository.

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -27,8 +27,10 @@ describe('git', async () => {
             await initRepository(path.join(root, 'A'));
             await initRepository(path.join(root, 'B'));
             await initRepository(path.join(root, 'C'));
-            const git = await createGit(root);
-            const repositories = await git.repositories();
+            const git = await createGit();
+            const workspace = await createWorkspace(root);
+            const workspaceRootUri = await workspace.getRoot();
+            const repositories = await git.repositories(workspaceRootUri!);
             expect(repositories.map(r => path.basename(FileUri.fsPath(r.localUri))).sort()).to.deep.equal(['A', 'B', 'C']);
 
         });
@@ -44,8 +46,10 @@ describe('git', async () => {
             await initRepository(path.join(root, 'BASE', 'A'));
             await initRepository(path.join(root, 'BASE', 'B'));
             await initRepository(path.join(root, 'BASE', 'C'));
-            const git = await createGit(path.join(root, 'BASE'));
-            const repositories = await git.repositories();
+            const git = await createGit();
+            const workspace = await createWorkspace(path.join(root, 'BASE'));
+            const workspaceRootUri = await workspace.getRoot();
+            const repositories = await git.repositories(workspaceRootUri!);
             expect(repositories.map(r => path.basename(FileUri.fsPath(r.localUri))).sort()).to.deep.equal(['A', 'B', 'BASE', 'C']);
 
         });
@@ -62,8 +66,10 @@ describe('git', async () => {
             await initRepository(path.join(root, 'BASE', 'WS_ROOT', 'A'));
             await initRepository(path.join(root, 'BASE', 'WS_ROOT', 'B'));
             await initRepository(path.join(root, 'BASE', 'WS_ROOT', 'C'));
-            const git = await createGit(path.join(root, 'BASE', 'WS_ROOT'));
-            const repositories = await git.repositories();
+            const git = await createGit();
+            const workspace = await createWorkspace(path.join(root, 'BASE', 'WS_ROOT'));
+            const workspaceRootUri = await workspace.getRoot();
+            const repositories = await git.repositories(workspaceRootUri!);
             const repositoryNames = repositories.map(r => path.basename(FileUri.fsPath(r.localUri)));
             expect(repositoryNames.shift()).to.equal('BASE'); // The first must be the container repository.
             expect(repositoryNames.sort()).to.deep.equal(['A', 'B', 'C']);
@@ -214,8 +220,7 @@ describe('git', async () => {
 });
 
 async function createGit(fsRoot: string = ''): Promise<DugiteGit> {
-    const workspace = await createWorkspace(fsRoot);
-    return new DugiteGit(workspace);
+    return new DugiteGit();
 }
 
 async function createWorkspace(fsRoot: string): Promise<WorkspaceServer> {


### PR DESCRIPTION
When either listing the discovered repositories or when trying to
clone a repository. Adjusted the frontend code and the tests to
the new Git API. With these changes, multiple clients can use the
same backend.

Closes #625.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>