### PR TITLE
GH-631: Handled insufficient file permission issue gracefully

### DIFF
--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -95,6 +95,11 @@ export interface FileSystem extends Disposable {
      */
     getRoots(): Promise<FileStat[]>;
 
+    /**
+     * Returns a promise the resolves to a file stat representing the current user's home directory.
+     */
+    getCurrentUserHome(): Promise<FileStat>;
+
 }
 
 /**

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -780,6 +780,24 @@ describe("NodeFileSystem", () => {
 
     });
 
+    describe("#14 roots", async () => {
+
+        it("should not throw error", async () => {
+            expect(await createFileSystem().getRoots()).to.be.not.empty;
+        });
+
+    });
+
+    describe("#15 currentUserHome", async () => {
+
+        it("should exist", async () => {
+            const actual = (await createFileSystem().getCurrentUserHome()).uri.toString();
+            const expected = FileUri.create(os.homedir()).toString();
+            expect(expected).to.be.equal(actual);
+        });
+
+    });
+
     function createFileSystem(): FileSystem {
         return new FileSystemNode();
     }

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -314,7 +314,7 @@ export class FileSystemNode implements FileSystem {
             return this.doCreateFileStat(uri, stats);
         } catch (error) {
             if (isErrnoException(error)) {
-                if (error.code === "ENOENT" || error.code === "EACCES" || error.code === 'EBUSY') {
+                if (error.code === "ENOENT" || error.code === "EACCES" || error.code === 'EBUSY' || error.code === 'EPERM') {
                     return undefined;
                 }
             }
@@ -332,29 +332,16 @@ export class FileSystemNode implements FileSystem {
     }
 
     protected doCreateDirectoryStat(uri: URI, path: string, stat: fs.Stats, depth: number): FileStat {
-        try {
-            const files = fs.readdirSync(path);
-            const hasChildren = files.length > 0;
-            const children = hasChildren ? depth > 0 ? this.doGetChildren(uri, files, depth) : undefined : [];
-            return {
-                uri: uri.toString(),
-                lastModification: stat.mtime.getTime(),
-                isDirectory: true,
-                hasChildren,
-                children
-            };
-        } catch (error) {
-            if (isErrnoException(error) && error.code === 'EPERM') {
-                return {
-                    uri: uri.toString(),
-                    lastModification: -1,
-                    isDirectory: true,
-                    children: [],
-                    hasChildren: false
-                };
-            }
-            throw error;
-        }
+        const files = fs.readdirSync(path);
+        const hasChildren = files.length > 0;
+        const children = hasChildren ? depth > 0 ? this.doGetChildren(uri, files, depth) : undefined : [];
+        return {
+            uri: uri.toString(),
+            lastModification: stat.mtime.getTime(),
+            isDirectory: true,
+            hasChildren,
+            children
+        };
     }
 
     protected doGetChildren(uri: URI, files: string[], depth: number): FileStat[] {

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -314,7 +314,7 @@ export class FileSystemNode implements FileSystem {
             return this.doCreateFileStat(uri, stats);
         } catch (error) {
             if (isErrnoException(error)) {
-                if (error.code === "ENOENT" || error.code === "EACCES") {
+                if (error.code === "ENOENT" || error.code === "EACCES" || error.code === 'EBUSY') {
                     return undefined;
                 }
             }
@@ -332,16 +332,29 @@ export class FileSystemNode implements FileSystem {
     }
 
     protected doCreateDirectoryStat(uri: URI, path: string, stat: fs.Stats, depth: number): FileStat {
-        const files = fs.readdirSync(path);
-        const hasChildren = files.length > 0;
-        const children = hasChildren ? depth > 0 ? this.doGetChildren(uri, files, depth) : undefined : [];
-        return {
-            uri: uri.toString(),
-            lastModification: stat.mtime.getTime(),
-            isDirectory: true,
-            hasChildren,
-            children
-        };
+        try {
+            const files = fs.readdirSync(path);
+            const hasChildren = files.length > 0;
+            const children = hasChildren ? depth > 0 ? this.doGetChildren(uri, files, depth) : undefined : [];
+            return {
+                uri: uri.toString(),
+                lastModification: stat.mtime.getTime(),
+                isDirectory: true,
+                hasChildren,
+                children
+            };
+        } catch (error) {
+            if (isErrnoException(error) && error.code === 'EPERM') {
+                return {
+                    uri: uri.toString(),
+                    lastModification: -1,
+                    isDirectory: true,
+                    children: [],
+                    hasChildren: false
+                };
+            }
+            throw error;
+        }
     }
 
     protected doGetChildren(uri: URI, files: string[], depth: number): FileStat[] {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -48,7 +48,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
 
     protected showFileDialog(): void {
         this.workspaceService.tryRoot.then(async resolvedRoot => {
-            const root = resolvedRoot || (await this.fileSystem.getRoots())[0];
+            const root = resolvedRoot || await this.fileSystem.getCurrentUserHome();
             if (root) {
                 const rootUri = new URI(root.uri).parent;
                 const rootStat = await this.fileSystem.getFileStat(rootUri.toString());


### PR DESCRIPTION
Task: #631.
Closes #631.

 - Do not throw an error while scanning the directories and any descendant file resource cannot be read due to insufficient permissions.
 - From now on, workspace root selector dialog proposes home folder.
 - Transformed file-watcher errors into warnings if those are due to `EPERM.
 - Added `getCurrentUserHome()` to FS.