### PR TITLE
Don't require a workspace root to start a terminal

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -42,11 +42,9 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(TerminalCommands.NEW);
-        this.workspaceService.root.then(() => {
-            commands.registerHandler(TerminalCommands.NEW.id, {
-                isEnabled: () => true,
-                execute: () => this.newTerminal()
-            });
+        commands.registerHandler(TerminalCommands.NEW.id, {
+            isEnabled: () => true,
+            execute: () => this.newTerminal()
         });
     }
 

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -95,9 +95,10 @@ export class TerminalWidget extends BaseWidget {
 
     public async start(): Promise<void> {
         this.registerResize();
-        const root = await this.workspaceService.root;
+        const root = await this.workspaceService.tryRoot;
+        const rootURI = root !== undefined ? root.uri : undefined;
         this.terminalId = await this.shellTerminalServer.create(
-            { rootURI: root.uri, cols: this.cols, rows: this.rows });
+            { rootURI, cols: this.cols, rows: this.rows });
 
         /* An error has occurred in the backend.  */
         if (this.terminalId === -1) {

--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject, named } from 'inversify';
-import * as process from 'process';
+import * as os from 'os';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { TerminalProcess, TerminalProcessOptions, ProcessManager } from '@theia/process/lib/node';
 import { isWindows } from "@theia/core/lib/common";
@@ -29,7 +29,7 @@ function getRootPath(rootURI?: string): string {
         const uri = new URI(rootURI);
         return FileUri.fsPath(uri);
     } else {
-        return process.cwd();
+        return os.homedir();
     }
 }
 


### PR DESCRIPTION
If no workspace is selected, use the user home directory as cwd.

Fixes: #659

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>