### PR TITLE
[layout restorer] Keep order of widgets in side bars (fixes #665).

### DIFF
--- a/packages/core/src/browser/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell-layout-restorer.ts
@@ -126,7 +126,9 @@ export class ShellLayoutRestorer implements FrontendApplicationContribution, Com
         const result = JSON.parse(layoutData, (property: string, value) => {
             if (this.isWidgetsProperty(property)) {
                 const widgets: Widget[] = [];
-                for (const desc of (value as WidgetDescription[])) {
+                const descs = (value as WidgetDescription[]);
+                for (let i = 0; i < descs.length; i++) {
+                    const desc = descs[i];
                     const promise = this.widgetManager.getOrCreateWidget(desc.constructionOptions.factoryId, desc.constructionOptions.options)
                         .then(widget => {
                             if (widget) {
@@ -135,7 +137,7 @@ export class ShellLayoutRestorer implements FrontendApplicationContribution, Com
                                         widget.restoreState(desc.innerWidgetState);
                                     }
                                 }
-                                widgets.push(widget);
+                                widgets[i] = widget;
                             }
                         }).catch(err => {
                             this.logger.warn(`Couldn't restore widget for ${desc}. Error : ${err} `);

--- a/packages/core/src/browser/shell.ts
+++ b/packages/core/src/browser/shell.ts
@@ -584,8 +584,11 @@ namespace Private {
             if (layoutData) {
                 this.collapse();
                 if (layoutData.widgets) {
-                    for (let i = 0; i < layoutData.widgets.length; i++) {
-                        this.addWidget(layoutData.widgets[i], i);
+                    let index = 0;
+                    for (const widget of layoutData.widgets) {
+                        if (widget) {
+                            this.addWidget(widget, index++);
+                        }
                     }
                 }
                 if (layoutData.activeWidgets) {


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>