### PR TITLE
Refs #516: Upgrade xterm.js to v3 branch

### DIFF
--- a/dev-packages/application-package/src/generator/webpack-generator.ts
+++ b/dev-packages/application-package/src/generator/webpack-generator.ts
@@ -70,6 +70,19 @@ module.exports = {
                 loader: 'ignore-loader'
             },
             {
+                /* Get rid of :
+
+                   @theia/example-electron: WARNING in /home/emaisin/src/theia/~/xterm/lib/addons/attach/index.html
+                   @theia/example-electron: Module parse failed: /home/emaisin/src/theia/node_modules/xterm/lib/addons/attach/index.html Unexpected token (1:0)
+                   @theia/example-electron: You may need an appropriate loader to handle this file type.
+
+                   See: https://github.com/theia-ide/theia/pull/688#issuecomment-338289418
+                */
+
+                test: /node_modules\\/xterm\\/lib\\/addons\\/attach\\/index\\.html/,
+                loader: 'ignore-loader',
+            },
+            {
                 // see https://github.com/theia-ide/theia/issues/556
                 test: /source-map-support/,
                 loader: 'ignore-loader'

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -8,7 +8,7 @@
     "@theia/process": "^0.1.1",
     "@theia/workspace": "^0.1.1",
     "@types/xterm": "^2.0.3",
-    "xterm": "^2.8.1"
+    "xterm": "theia-ide/xterm.js#v3-built"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -17,7 +17,7 @@ import { IShellTerminalServer, shellTerminalPath } from '../common/shell-termina
 import { FrontendApplication } from '@theia/core/lib/browser';
 
 import '../../src/browser/terminal.css';
-import 'xterm/dist/xterm.css';
+import 'xterm/lib/xterm.css';
 
 export default new ContainerModule(bind => {
     bind(TerminalWidget).toSelf().inTransientScope();

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -39,7 +39,7 @@ export interface TerminalWidgetFactoryOptions extends Partial<TerminalWidgetOpti
 export class TerminalWidget extends BaseWidget {
 
     private terminalId: number | undefined
-    private term: Xterm
+    private term: Xterm.Terminal
     private cols: number = 80
     private rows: number = 40
     private endpoint: Endpoint
@@ -68,9 +68,8 @@ export class TerminalWidget extends BaseWidget {
         this.title.closable = true
         this.addClass("terminal-container")
 
-        this.term = new Xterm({
+        this.term = new Xterm.Terminal({
             cursorBlink: true,
-            theme: 'dark'
         });
 
         this.term.open(this.node);
@@ -88,6 +87,11 @@ export class TerminalWidget extends BaseWidget {
             if (this.terminalId === undefined) {
                 return;
             }
+
+            if (!size) {
+                return;
+            }
+
             this.cols = size.cols;
             this.rows = size.rows;
             this.shellTerminalServer.resize(this.terminalId, this.cols, this.rows);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7329,9 +7329,9 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-xterm@^2.8.1:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-2.9.2.tgz#ec3e7c636ba67af4a7026be2cff7bdf08e56400a"
+xterm@theia-ide/xterm.js#v3-built:
+  version "2.9.1"
+  resolved "https://codeload.github.com/theia-ide/xterm.js/tar.gz/e2aca68c8d5a64320d26b889d2c8d3f4510d4805"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
There were many tmux-related fixes in the v3 branch (the next major
version, they are currently at 2.x.y).  This patch updates the
dependencies of the terminal module such that it uses the latest
unstable/unreleased/development version of xterm.js, branch v3.

We can point the dependency in the package.json directly to a github
repo (that's what theia-ide/xterm.js does).  However, running "yarn"
just checks out the repo, it doesn't build it.  Therefore, I created a
fork of xterm.js in the theia-ide organization, created a new branch
(v3-built), built it (npm install) and checked in the result (the lib/
directory).  We can use that branch as a dependency.

Some minor changes in the terminal module were needed due to API
changes.