### PR TITLE
Refs #719: terminal: Read and use CSS properties from page

### DIFF
--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -5,17 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-.terminal {
-    background-color: var(--theia-layout-color1) !important;
-    font-family: var(--theia-code-font-family) !important;
-    font-size: var(--theia-code-font-size) !important;
-    color: var(--theia-ui-font-color0) !important;
-}
-
-.terminal .xterm-viewport {
-    background-color: var(--theia-layout-color1) !important;
-}
-
 .terminal-container {
     padding-top: calc(var(--theia-code-padding)*3) !important;
     padding-left: calc(var(--theia-code-padding)*3) !important;


### PR DESCRIPTION
Before upgrading the xterm.js version in

  Refs #516: Upgrade xterm.js to v3 branch
  af29995c1dc3f95e6a45ecc88a864704dad8df0a

it was possible to set the font family, font size, foreground color and
backround color simply by setting a css  properties on .terminal (& al),
because the terminals were implemented with plain text in divs.  In the
new version, they are implemented by drawing on canvases, which doesn't
take into account CSS properties.  Instead, we need to pass values those
values to the Terminal constructor.

To achieve this without duplicating the definitions of those properties
(already defined in our CSS), the terminal widget now looks up the
values of the custom CSS properties (e.g. --theia-code-font-family)
defined on the :root element (<html>).  I added some validation such
that if those properties are renamed or their format changes, the
terminal will fail to initialize and we'll know right away.

The CSS properties on .terminal can now be removed, since they don't
have an impact anymore.