### PR TITLE
Add basic metrics to theia

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -21,7 +21,8 @@
     "@theia/terminal": "0.2.0",
     "@theia/typescript": "0.2.0",
     "@theia/file-search": "0.2.0",
-    "@theia/workspace": "0.2.0"
+    "@theia/workspace": "0.2.0",
+    "@theia/metrics": "0.2.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -24,7 +24,8 @@
     "@theia/terminal": "0.2.0",
     "@theia/typescript": "0.2.0",
     "@theia/file-search": "0.2.0",
-    "@theia/workspace": "0.2.0"
+    "@theia/workspace": "0.2.0",
+    "@theia/metrics": "0.2.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -1,0 +1,8 @@
+# Theia Metrics Extensions
+
+This extension provides metrics for theia using the prometheus API.
+
+See [here](https://github.com/theia-ide/theia) for a detailed documentation.
+
+## License
+[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/metrics/compile.tsconfig.json
+++ b/packages/metrics/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@theia/metrics",
+  "version": "0.2.0",
+  "description": "Theia - Metrics Extension",
+  "dependencies": {
+    "@theia/core": "0.2.0",
+    "prom-client": "^10.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "backend": "lib/node/metrics-backend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test",
+    "docs": "theiaext docs"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "0.2.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/metrics/src/node/metrics-backend-contribution.ts
+++ b/packages/metrics/src/node/metrics-backend-contribution.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import * as http from 'http';
+import * as express from 'express';
+import { ILogger } from "@theia/core/lib/common";
+import { BackendApplicationContribution } from '@theia/core/lib/node';
+import * as prom from 'prom-client';
+
+@injectable()
+export class MetricsBackendContribution implements BackendApplicationContribution {
+    constructor(
+        @inject(ILogger) protected readonly logger: ILogger) {
+    }
+
+    configure(app: express.Application) {
+        app.get('/metrics', (req, res) => {
+            res.send(prom.register.metrics().toString());
+        });
+    }
+
+    onStart(server: http.Server): void {
+        const collectDefaultMetrics = prom.collectDefaultMetrics;
+
+        // Probe every 5th second.
+        collectDefaultMetrics({ timeout: 5000 });
+    }
+}

--- a/packages/metrics/src/node/metrics-backend-module.ts
+++ b/packages/metrics/src/node/metrics-backend-module.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from 'inversify';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { MetricsBackendContribution } from './metrics-backend-contribution';
+
+export default new ContainerModule(bind => {
+    bind(BackendApplicationContribution).to(MetricsBackendContribution);
+});

--- a/packages/metrics/src/package.spec.ts
+++ b/packages/metrics/src/package.spec.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("metrics package", () => {
+
+    it("should support code coverage statistics", () => true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,6 +714,10 @@ binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
+bintrees@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
+
 bl@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
@@ -5410,6 +5414,12 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+prom-client@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-10.2.0.tgz#a6250a4ea5032b0bed0cb57a2463f1472e6095ee"
+  dependencies:
+    tdigest "^0.1.1"
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -6502,6 +6512,12 @@ tar@^2.0.0, tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+tdigest@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
+  dependencies:
+    bintrees "1.0.1"
 
 temp-dir@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This patch adds basic metrics to theia using prometheus.
See: https://github.com/siimon/prom-client for more information.

Fixes: #680

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>