### PR TITLE
Temporarly skip extension-package outdated test

### DIFF
--- a/dev-packages/application-package/src/extension-package.spec.ts
+++ b/dev-packages/application-package/src/extension-package.spec.ts
@@ -10,7 +10,7 @@ import { NpmRegistry } from './npm-registry';
 import { RawExtensionPackage, ExtensionPackage } from './extension-package';
 
 const testOutdated = (expectation: boolean, name: string, version: string) =>
-    it(name + '@' + version, async () => {
+    it.skip(name + '@' + version, async () => {
         const registry = new NpmRegistry();
         const rawExtension = await RawExtensionPackage.view(registry, name, version);
         assert.ok(rawExtension);


### PR DESCRIPTION
With this test enabled, the build breaks if we publish a version that is
more recent than next.

So each time we publish a new version this will fail.

This needs to be refactored, but this patch skips the tests to allow tests
to pass until this is properly fixed.

See #739 for more information.

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>