### PR TITLE
GH-738: Fixed cluster issue when running a packaged electron app.

### DIFF
--- a/dev-packages/application-package/src/generator/backend-generator.ts
+++ b/dev-packages/application-package/src/generator/backend-generator.ts
@@ -59,9 +59,11 @@ module.exports = (port, host) => Promise.resolve()${this.compileBackendModuleImp
     }
 
     protected compileMain(backendModules: Map<string, string>): string {
-        return ` // @ts-check
+        return `// @ts-check
 const serverPath = require('path').resolve(__dirname, 'server');
-module.exports = require('@theia/core/lib/node/cluster/main').default(serverPath);
+module.exports = require('@theia/core/lib/node/cluster/main').default(serverPath).then(function (address) {
+    process.send(address.port.toString());
+});
 `;
     }
 

--- a/dev-packages/application-package/src/generator/backend-generator.ts
+++ b/dev-packages/application-package/src/generator/backend-generator.ts
@@ -61,9 +61,13 @@ module.exports = (port, host) => Promise.resolve()${this.compileBackendModuleImp
     protected compileMain(backendModules: Map<string, string>): string {
         return `// @ts-check
 const serverPath = require('path').resolve(__dirname, 'server');
-module.exports = require('@theia/core/lib/node/cluster/main').default(serverPath).then(function (address) {
-    process.send(address.port.toString());
+const address = require('@theia/core/lib/node/cluster/main').default(serverPath);
+address.then(function (address) {
+    if (process && process.send) {
+        process.send(address.port.toString());
+    }
 });
+module.exports = address;
 `;
     }
 


### PR DESCRIPTION
The cluster module works by forking a Node.js process and passing
the current `argv` to it. If the application is bundled together,
then the cluster module will not get the correct `argv`.
(See:
https://github.com/electron/electron/issues/6337#issuecomment-230183287)

Closes #738.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

TODOs: (Verified with 1a3e09c0a77d2650a1036eafaa087543b8526da7 with [`dedupe`](https://github.com/theia-ide/theia/issues/752#issuecomment-339943269) before calling `webpack`)
 - [x] Verify in the browser with `yarn start`.
 - [x] Verify in the browser by launching it from VS Code.
 - [x] Verify in electron with `yarn start`.
 - [x] Verify in electron by launching it from VS Code.
 - [x] Verify in electron with published packaged by launching it from VS Code.
 - [x] Verify in the browser with published packaged by launching it from VS Code.
 - [x] Verify in bundled electron application.