### PR TITLE
GH-754: Fixed the file URI creation for the AMD loader.

### DIFF
--- a/packages/monaco/src/electron-browser/monaco-electron-module.ts
+++ b/packages/monaco/src/electron-browser/monaco-electron-module.ts
@@ -5,17 +5,30 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import * as path from "path";
 import { ContainerModule } from "inversify";
-import { FileUri } from "@theia/core/lib/node/file-uri";
 import { loadVsRequire, loadMonaco } from "../browser/monaco-loader";
 
 export { ContainerModule };
 
 const s = <any>self;
 
+/**
+ * We cannot use `FileUri#create` because URIs with file scheme cannot be properly decoded via the AMD loader.
+ * So if you have a FS path on Windows: `C:\Users\foo`, then you will get a URI `file:///c%3A/Users/foo` which
+ * will be converted into the `c%3A/Users/foo` FS path on Windows by the AMD loader.
+ */
+const uriFromPath = (filePath: string) => {
+    let pathName = path.resolve(filePath).replace(/\\/g, '/');
+    if (pathName.length > 0 && pathName.charAt(0) !== '/') {
+        pathName = '/' + pathName;
+    }
+    return encodeURI('file://' + pathName);
+};
+
 export default loadVsRequire(global)
     .then(vsRequire => {
-        const baseUrl = FileUri.create(__dirname).toString();
+        const baseUrl = uriFromPath(__dirname);
         vsRequire.config({ baseUrl });
 
         // workaround monaco-css not understanding the environment


### PR DESCRIPTION
The `decodeURI` cannot handle the `file:///c%3A/foo` URIs (C:\foo)
inside the AMD loader. It will be converted into an incorrect
`c%3A/foo` path which obviously does not exist on Windows.

This should fix the broken electron application on Windows.

Closes #754.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

The underlying idea was taken from the [Monaco-electron example](https://github.com/Microsoft/monaco-editor-samples/blob/6a3a3edd5e8ef6f0e1a5748a19a6ded0d4b5a9d3/sample-electron/index.html#L28).