### PR TITLE
chokidar filesystem watcher: Consider EACCES as insufficient permission

### DIFF
--- a/packages/filesystem/src/node/chokidar-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/chokidar-filesystem-watcher.ts
@@ -59,7 +59,7 @@ export class ChokidarFileSystemWatcherServer implements FileSystemWatcherServer 
                 resolve(watcherId);
             });
             watcher.on('error', error => {
-                if (this.isWatchingError(error) && error.code === 'EPERM') {
+                if (this.isWatchingError(error) && (error.code === 'EPERM' || error.code === 'EACCES')) {
                     this.logger.warn(`Cannot watch file changes due to insufficient permissions. Skipping: ${error.filename}.`);
                 } else {
                     this.logger.error(`Watching error:`, error);


### PR DESCRIPTION
When the user does not have sufficient permission to watch a file, errno
can sometimes be EACCES.  This is what I see right now when Theia tries
to watch a file that belongs to another user and the mode is 700:

2017-11-01T19:44:48.106Z] ERROR: Theia/5483 on elxacz23q12:
    Watching error: [ { Error: watch /tmp/wp/roots EACCES
        at _errnoException (util.js:1021:11)
        at FSWatcher.start (fs.js:1383:19)
        at Object.fs.watch (fs.js:1409:11)
        at createFsWatchInstance (/home/emaisin/src/theia/node_modules/chokidar/lib/nodefs-handler.js:37:15)
        at setFsWatchListener (/home/emaisin/src/theia/node_modules/chokidar/lib/nodefs-handler.js:80:15)
        at FSWatcher.NodeFsHandler._watchWithNodeFs (/home/emaisin/src/theia/node_modules/chokidar/lib/nodefs-handler.js:228:14)
        at FSWatcher.NodeFsHandler._handleFile (/home/emaisin/src/theia/node_modules/chokidar/lib/nodefs-handler.js:255:21)
        at FSWatcher.<anonymous> (/home/emaisin/src/theia/node_modules/chokidar/lib/nodefs-handler.js:473:21)
        at FSReqWrap.oncomplete (fs.js:154:5)
        code: 'EACCES',
        errno: 'EACCES',
        syscall: 'watch /tmp/wp/roots',
        filename: '/tmp/wp/roots' } ]

This patch makes it so that if we see this errno, we will print the same
error message as when we see EPERM.  It doesn't really change anything
in the behavior, just what we print.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>