### PR TITLE
Loosen up version constraints 

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -54,7 +54,7 @@
     "write-json-file": "^2.2.0"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -110,7 +110,7 @@ export class ApplicationPackage {
         return raw ? this.newExtensionPackage(raw) : undefined;
     }
 
-    newExtensionPackage(raw: PublishedNodePackage): ExtensionPackage {
+    protected newExtensionPackage(raw: PublishedNodePackage): ExtensionPackage {
         return new ExtensionPackage(raw, this.registry);
     }
 

--- a/dev-packages/application-package/src/extension-package.spec.ts
+++ b/dev-packages/application-package/src/extension-package.spec.ts
@@ -5,27 +5,31 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import * as semver from 'semver';
 import * as assert from 'assert';
 import { NpmRegistry } from './npm-registry';
 import { RawExtensionPackage, ExtensionPackage } from './extension-package';
 
-const testOutdated = (expectation: boolean, name: string, version: string) =>
-    it.skip(name + '@' + version, async () => {
+const testOutdated = (expectation: (extensionPackage: ExtensionPackage) => boolean | Promise<boolean>, name: string, version: string) =>
+    it(name + '@' + version, async () => {
         const registry = new NpmRegistry();
         const rawExtension = await RawExtensionPackage.view(registry, name, version);
         assert.ok(rawExtension);
 
         const extensionPackage = new ExtensionPackage(rawExtension!, registry);
         const outdated = await extensionPackage.isOutdated();
-        assert.equal(expectation, outdated);
+        assert.equal(await expectation(extensionPackage), outdated);
     });
 
 describe("extension-package", () => {
 
     describe("isOutdated", () => {
-        testOutdated(false, '@theia/core', 'next');
-        testOutdated(false, '@theia/core', 'latest');
-        testOutdated(true, '@theia/core', '0.1.0');
+        testOutdated(async extensionPackage => {
+            const latestVersion = await extensionPackage.getLatestVersion();
+            return latestVersion ? semver.gt(latestVersion, extensionPackage.raw.version) : false;
+        }, '@theia/core', 'next');
+        testOutdated(() => false, '@theia/core', 'latest');
+        testOutdated(() => true, '@theia/core', '0.1.0');
     });
 
 });

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -194,7 +194,11 @@ export namespace RawExtensionPackage {
                         return next;
                     }
                 }
-                return this.tags['latest'];
+                const latest = this.tags['latest'];
+                if (this.registry.config.next || !semver.prerelease(latest)) {
+                    return latest;
+                }
+                return undefined;
             }
             return undefined;
         }

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -19,11 +19,9 @@ export interface Extension {
 
 export class ExtensionPackage {
     constructor(
-        protected readonly raw: PublishedNodePackage & Partial<RawExtensionPackage>,
+        readonly raw: PublishedNodePackage & Partial<RawExtensionPackage>,
         protected readonly registry: NpmRegistry
-    ) {
-        this.raw = raw;
-    }
+    ) { }
 
     get name(): string {
         return this.raw.name;

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -31,6 +31,6 @@
     "docs": "echo 'skip'"
   },
   "dependencies": {
-    "@theia/application-package": "0.2.0"
+    "@theia/application-package": "^0.2.0"
   }
 }

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -3,26 +3,26 @@
   "name": "@theia/example-browser",
   "version": "0.2.0",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/cpp": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/extension-manager": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/git": "0.2.0",
-    "@theia/go": "0.2.0",
-    "@theia/java": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/markers": "0.2.0",
-    "@theia/monaco": "0.2.0",
-    "@theia/navigator": "0.2.0",
-    "@theia/preferences": "0.2.0",
-    "@theia/process": "0.2.0",
-    "@theia/python": "0.2.0",
-    "@theia/terminal": "0.2.0",
-    "@theia/typescript": "0.2.0",
-    "@theia/file-search": "0.2.0",
-    "@theia/workspace": "0.2.0",
-    "@theia/metrics": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/cpp": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/extension-manager": "^0.2.0",
+    "@theia/file-search": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/git": "^0.2.0",
+    "@theia/go": "^0.2.0",
+    "@theia/java": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/markers": "^0.2.0",
+    "@theia/metrics": "^0.2.0",
+    "@theia/monaco": "^0.2.0",
+    "@theia/navigator": "^0.2.0",
+    "@theia/preferences": "^0.2.0",
+    "@theia/process": "^0.2.0",
+    "@theia/python": "^0.2.0",
+    "@theia/terminal": "^0.2.0",
+    "@theia/typescript": "^0.2.0",
+    "@theia/workspace": "^0.2.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",
@@ -39,6 +39,6 @@
     "coverage": "yarn coverage:compile && yarn test && yarn coverage:remap && yarn coverage:report:lcov && yarn coverage:report:html"
   },
   "devDependencies": {
-    "@theia/cli": "0.2.0"
+    "@theia/cli": "^0.2.0"
   }
 }

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -6,26 +6,26 @@
     "target": "electron"
   },
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/cpp": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/extension-manager": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/git": "0.2.0",
-    "@theia/go": "0.2.0",
-    "@theia/java": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/markers": "0.2.0",
-    "@theia/monaco": "0.2.0",
-    "@theia/navigator": "0.2.0",
-    "@theia/preferences": "0.2.0",
-    "@theia/process": "0.2.0",
-    "@theia/python": "0.2.0",
-    "@theia/terminal": "0.2.0",
-    "@theia/typescript": "0.2.0",
-    "@theia/file-search": "0.2.0",
-    "@theia/workspace": "0.2.0",
-    "@theia/metrics": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/cpp": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/extension-manager": "^0.2.0",
+    "@theia/file-search": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/git": "^0.2.0",
+    "@theia/go": "^0.2.0",
+    "@theia/java": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/markers": "^0.2.0",
+    "@theia/metrics": "^0.2.0",
+    "@theia/monaco": "^0.2.0",
+    "@theia/navigator": "^0.2.0",
+    "@theia/preferences": "^0.2.0",
+    "@theia/process": "^0.2.0",
+    "@theia/python": "^0.2.0",
+    "@theia/terminal": "^0.2.0",
+    "@theia/typescript": "^0.2.0",
+    "@theia/workspace": "^0.2.0"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",
@@ -38,6 +38,6 @@
     "test:ui": "wdio wdio.conf.js"
   },
   "devDependencies": {
-    "@theia/cli": "0.2.0"
+    "@theia/cli": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rebuild:electron:debug": "DEBUG=electron-rebuild && yarn rebuild:electron",
     "watch": "lerna run watch --scope \"@theia/!(example-)*\" --parallel",
     "publish": "yarn && yarn test && yarn publish:latest",
-    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --exact --skip-git",
+    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git",
     "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes"
   },
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/cpp/package.json
+++ b/packages/cpp/package.json
@@ -3,12 +3,12 @@
   "version": "0.2.0",
   "description": "Theia - Cpp Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/monaco": "0.2.0",
-    "@theia/preferences": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/monaco": "^0.2.0",
+    "@theia/preferences": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -44,7 +44,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "description": "Theia - Editor Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/preferences": "0.2.0",
-    "@theia/workspace": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/preferences": "^0.2.0",
+    "@theia/workspace": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +40,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/extension-manager/package.json
+++ b/packages/extension-manager/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "description": "Theia - Extension Manager",
   "dependencies": {
-    "@theia/application-package": "0.2.0",
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0",
+    "@theia/application-package": "^0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
     "@types/sanitize-html": "^1.13.31",
     "@types/showdown": "^1.7.1",
     "sanitize-html": "^1.14.1",
@@ -45,7 +45,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/extension-manager/src/node/node-extension-server.ts
+++ b/packages/extension-manager/src/node/node-extension-server.ts
@@ -54,9 +54,11 @@ export class NodeExtensionServer implements ExtensionServer {
         const extensions = [];
         for (const raw of packages) {
             if (PublishedNodePackage.is(raw)) {
-                const extensionPackage = manager.pck.newExtensionPackage(raw);
-                const extension = this.toRawExtension(extensionPackage);
-                extensions.push(extension);
+                const extensionPackage = await manager.pck.findExtensionPackage(raw.name);
+                if (extensionPackage) {
+                    const extension = this.toRawExtension(extensionPackage);
+                    extensions.push(extension);
+                }
             }
         }
         return extensions;

--- a/packages/extension-manager/src/node/node-extension-server.ts
+++ b/packages/extension-manager/src/node/node-extension-server.ts
@@ -92,7 +92,7 @@ export class NodeExtensionServer implements ExtensionServer {
             if (!latestVersion) {
                 return;
             }
-            if (manager.pck.setDependency(extension, latestVersion)) {
+            if (manager.pck.setDependency(extension, `^${latestVersion}`)) {
                 this.notifyDidChange({
                     name: extension,
                     installed: true
@@ -151,7 +151,7 @@ export class NodeExtensionServer implements ExtensionServer {
             if (!latestVersion) {
                 return;
             }
-            if (manager.pck.setDependency(extension, latestVersion)) {
+            if (manager.pck.setDependency(extension, `^${latestVersion}`)) {
                 this.notifyDidChange({
                     name: extension,
                     outdated: false

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "description": "Theia - FileSystem Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/preferences-api": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/preferences-api": "^0.2.0",
     "@types/chokidar": "^1.7.0",
     "@types/fs-extra": "^4.0.2",
     "@types/touch": "0.0.1",
@@ -49,7 +49,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -3,11 +3,11 @@
   "version": "0.2.0",
   "description": "Theia - Git Integration",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/preferences-api": "0.2.0",
-    "@theia/workspace": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/preferences-api": "^0.2.0",
+    "@theia/workspace": "^0.2.0",
     "abs": "^1.3.8",
     "dugite-extra": "0.0.1-alpha.13",
     "findit2": "^2.2.3"
@@ -46,7 +46,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -3,11 +3,11 @@
   "version": "0.2.0",
   "description": "Theia - Go Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/monaco": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/monaco": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -43,7 +43,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -3,15 +3,15 @@
   "version": "0.2.0",
   "description": "Theia - Java Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/monaco": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/monaco": "^0.2.0",
     "@types/glob": "^5.0.30",
     "glob": "^7.1.2"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0",
+    "@theia/ext-scripts": "^0.2.0",
     "gulp": "^3.9.1",
     "gulp-decompress": "^2.0.1",
     "gulp-download": "0.0.1"

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Theia - Languages Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
+    "@theia/core": "^0.2.0",
     "vscode-base-languageclient": "^0.0.1-alpha.3",
     "vscode-languageserver": "^3.4.0"
   },
@@ -41,7 +41,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/markers/package.json
+++ b/packages/markers/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "description": "Theia - Markers Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -39,7 +39,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Theia - Metrics Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
+    "@theia/core": "^0.2.0",
     "prom-client": "^10.2.0"
   },
   "publishConfig": {
@@ -39,7 +39,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -3,14 +3,14 @@
   "version": "0.2.0",
   "description": "Theia - Monaco Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/editor": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/markers": "0.2.0",
-    "@theia/outline-view": "0.2.0",
-    "@theia/preferences": "0.2.0",
-    "@theia/workspace": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/editor": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/markers": "^0.2.0",
+    "@theia/outline-view": "^0.2.0",
+    "@theia/preferences": "^0.2.0",
+    "@theia/workspace": "^0.2.0",
     "monaco-css": "^1.3.3",
     "monaco-html": "^1.3.2",
     "monaco-json": "^1.3.2",
@@ -51,7 +51,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "description": "Theia - Navigator Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/workspace": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/workspace": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +40,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/outline-view/package.json
+++ b/packages/outline-view/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Theia - Outline View Extension",
   "dependencies": {
-    "@theia/core": "0.2.0"
+    "@theia/core": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -38,7 +38,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/preferences-api/package.json
+++ b/packages/preferences-api/package.json
@@ -5,7 +5,7 @@
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
   "dependencies": {
-    "@theia/core": "0.2.0"
+    "@theia/core": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -35,7 +35,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.0",
   "description": "Theia - Preferences Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/preferences-api": "0.2.0",
-    "@theia/workspace": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/preferences-api": "^0.2.0",
+    "@theia/workspace": "^0.2.0",
     "ajv": "^5.2.2",
     "jsonc-parser": "^1.0.0"
   },
@@ -44,7 +44,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "Theia process support.",
   "dependencies": {
-    "@theia/core": "0.2.0",
+    "@theia/core": "^0.2.0",
     "node-pty": "^0.7.0"
   },
   "publishConfig": {
@@ -39,7 +39,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/python/package.json
+++ b/packages/python/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "description": "Theia - Python Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/languages": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/languages": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +40,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -3,10 +3,10 @@
   "version": "0.2.0",
   "description": "Theia - Terminal Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0",
-    "@theia/process": "0.2.0",
-    "@theia/workspace": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0",
+    "@theia/process": "^0.2.0",
+    "@theia/workspace": "^0.2.0",
     "@types/xterm": "^2.0.3",
     "xterm": "theia-ide/xterm.js#v3-built"
   },
@@ -44,7 +44,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "description": "Theia - Typescript Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/languages": "0.2.0",
-    "@theia/monaco": "0.2.0",
+    "@theia/core": "^0.2.0",
+    "@theia/languages": "^0.2.0",
+    "@theia/monaco": "^0.2.0",
     "monaco-typescript": "^2.2.0",
     "typescript-language-server": "^0.1.4"
   },
@@ -43,7 +43,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -3,8 +3,8 @@
   "version": "0.2.0",
   "description": "Theia - Workspace Extension",
   "dependencies": {
-    "@theia/core": "0.2.0",
-    "@theia/filesystem": "0.2.0"
+    "@theia/core": "^0.2.0",
+    "@theia/filesystem": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"
@@ -40,7 +40,7 @@
     "docs": "theiaext docs"
   },
   "devDependencies": {
-    "@theia/ext-scripts": "0.2.0"
+    "@theia/ext-scripts": "^0.2.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"


### PR DESCRIPTION
This PR makes it possible to update Theia extensions within 0.2.x range. i.e. avoids duplicate package on install. I am going to make 0.2.1 release to apply ranges after the PR is merged. Ability to update to a new major version will be handled by another PR. I will open an issue for it.

It also:
- fixes outdated tests;
- ensures that shown versions are the same in the extension list and the extension detail view;
- and ignore the latest version if it contains prereleased tags (happens for new packages).