### PR TITLE
Close ContextMenu

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -13,6 +13,7 @@ import { CommandContribution, CommandRegistry, Command } from '../common/command
 import { MessageService } from '../common/message-service';
 import { ApplicationShell } from './shell';
 import * as browser from './browser';
+import { MAINAREA_TABBAR_CONTEXT_MENU } from './shell';
 
 export namespace CommonMenus {
 
@@ -72,6 +73,24 @@ export namespace CommonCommands {
     export const PREVIOUS_TAB: Command = {
         id: 'core.previousTab',
         label: 'Switch to previous tab'
+    };
+
+    export const CLOSE_TAB: Command = {
+        id: 'core.close.tab',
+        label: 'Close'
+    };
+    export const CLOSE_OTHER_TABS: Command = {
+        id: 'core.close.other.tabs',
+        label: 'Close Others'
+    };
+
+    export const CLOSE_RIGHT_TABS: Command = {
+        id: 'core.close.right.tabs',
+        label: 'Close to the Right'
+    };
+    export const CLOSE_ALL_TABS: Command = {
+        id: 'core.close.all.tabs',
+        label: 'Close All'
     };
 
 }
@@ -149,6 +168,29 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 commandId: CommonCommands.PASTE.id,
                 order: '2'
             });
+
+        // Tab ContextMenu
+        registry.registerSubmenu([], MAINAREA_TABBAR_CONTEXT_MENU, '');
+        registry.registerMenuAction([MAINAREA_TABBAR_CONTEXT_MENU], {
+            commandId: CommonCommands.CLOSE_TAB.id,
+            label: CommonCommands.CLOSE_TAB.label,
+            order: '0'
+        });
+        registry.registerMenuAction([MAINAREA_TABBAR_CONTEXT_MENU], {
+            commandId: CommonCommands.CLOSE_OTHER_TABS.id,
+            label: CommonCommands.CLOSE_OTHER_TABS.label,
+            order: '1'
+        });
+        registry.registerMenuAction([MAINAREA_TABBAR_CONTEXT_MENU], {
+            commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
+            label: CommonCommands.CLOSE_RIGHT_TABS.label,
+            order: '2'
+        });
+        registry.registerMenuAction([MAINAREA_TABBAR_CONTEXT_MENU], {
+            commandId: CommonCommands.CLOSE_ALL_TABS.id,
+            label: CommonCommands.CLOSE_ALL_TABS.label,
+            order: '3'
+        });
     }
 
     registerCommands(commandRegistry: CommandRegistry): void {
@@ -193,6 +235,26 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
             isEnabled: () => this.shell.hasSelectedTab(),
             execute: () => this.shell.activatePreviousTab()
+        });
+
+        commandRegistry.registerCommand(CommonCommands.CLOSE_TAB);
+        commandRegistry.registerHandler(CommonCommands.CLOSE_TAB.id, {
+            execute: () => this.shell.closeTab()
+        });
+
+        commandRegistry.registerCommand(CommonCommands.CLOSE_OTHER_TABS);
+        commandRegistry.registerHandler(CommonCommands.CLOSE_OTHER_TABS.id, {
+            execute: () => this.shell.closeOtherTabs()
+        });
+
+        commandRegistry.registerCommand(CommonCommands.CLOSE_RIGHT_TABS);
+        commandRegistry.registerHandler(CommonCommands.CLOSE_RIGHT_TABS.id, {
+            execute: () => this.shell.closeRightTabs()
+        });
+
+        commandRegistry.registerCommand(CommonCommands.CLOSE_ALL_TABS);
+        commandRegistry.registerHandler(CommonCommands.CLOSE_ALL_TABS.id, {
+            execute: () => this.shell.closeAllTabs()
         });
     }
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -11,7 +11,7 @@ import { KeybindingContribution, KeybindingRegistry } from '../common/keybinding
 import { KeyCode, Key, Modifier } from '../common/keys';
 import { CommandContribution, CommandRegistry, Command } from '../common/command';
 import { MessageService } from '../common/message-service';
-import { FrontendApplication } from './frontend-application';
+import { ApplicationShell } from './shell';
 import * as browser from './browser';
 
 export namespace CommonMenus {
@@ -87,7 +87,7 @@ export const supportPaste = browser.isNative || (!browser.isChrome && document.q
 export class CommonFrontendContribution implements MenuContribution, CommandContribution, KeybindingContribution {
 
     constructor(
-        @inject(FrontendApplication) protected readonly app: FrontendApplication,
+        @inject(ApplicationShell) protected readonly shell: ApplicationShell,
         @inject(MessageService) protected readonly messageService: MessageService
     ) { }
 
@@ -187,12 +187,12 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         commandRegistry.registerCommand(CommonCommands.REPLACE);
 
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB, {
-            isEnabled: () => this.app.shell.hasSelectedTab(),
-            execute: () => this.app.shell.activateNextTab()
+            isEnabled: () => this.shell.hasSelectedTab(),
+            execute: () => this.shell.activateNextTab()
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
-            isEnabled: () => this.app.shell.hasSelectedTab(),
-            execute: () => this.app.shell.activatePreviousTab()
+            isEnabled: () => this.shell.hasSelectedTab(),
+            execute: () => this.shell.activatePreviousTab()
         });
     }
 

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -27,7 +27,7 @@ import { QuickOpenService, QuickCommandService, QuickCommandFrontendContribution
 import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import { ShellLayoutRestorer } from './shell-layout-restorer';
-import { ApplicationShell, ApplicationShellOptions } from './shell';
+import { ApplicationShell, ApplicationShellOptions, DockPanelRenderer, DockPanelTabBarRenderer } from './shell';
 
 import '../../src/browser/style/index.css';
 import 'font-awesome/css/font-awesome.min.css';
@@ -38,6 +38,9 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(ApplicationShellOptions).toConstantValue({});
     bind(ApplicationShell).toSelf().inSingletonScope();
+
+    bind(DockPanelRenderer).toSelf();
+    bind(DockPanelTabBarRenderer).toSelf();
 
     bindContributionProvider(bind, OpenHandler);
     bind(DefaultOpenerService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -27,6 +27,7 @@ import { QuickOpenService, QuickCommandService, QuickCommandFrontendContribution
 import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import { ShellLayoutRestorer } from './shell-layout-restorer';
+import { ApplicationShell, ApplicationShellOptions } from './shell';
 
 import '../../src/browser/style/index.css';
 import 'font-awesome/css/font-awesome.min.css';
@@ -34,6 +35,9 @@ import 'font-awesome/css/font-awesome.min.css';
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplication).toSelf().inSingletonScope();
     bindContributionProvider(bind, FrontendApplicationContribution);
+
+    bind(ApplicationShellOptions).toConstantValue({});
+    bind(ApplicationShell).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, OpenHandler);
     bind(DefaultOpenerService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -27,7 +27,7 @@ import { QuickOpenService, QuickCommandService, QuickCommandFrontendContribution
 import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import { ShellLayoutRestorer } from './shell-layout-restorer';
-import { ApplicationShell, ApplicationShellOptions, DockPanelRenderer, DockPanelTabBarRenderer } from './shell';
+import { ApplicationShell, ApplicationShellOptions, DockPanelRenderer, DockPanelTabBarRenderer, DockPanelTabBarRendererFactory } from './shell';
 
 import '../../src/browser/style/index.css';
 import 'font-awesome/css/font-awesome.min.css';
@@ -40,6 +40,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(ApplicationShell).toSelf().inSingletonScope();
 
     bind(DockPanelRenderer).toSelf();
+    bind(DockPanelTabBarRendererFactory).toAutoFactory(DockPanelTabBarRenderer);
     bind(DockPanelTabBarRenderer).toSelf();
 
     bindContributionProvider(bind, OpenHandler);

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -47,8 +47,6 @@ export interface FrontendApplicationContribution {
 @injectable()
 export class FrontendApplication {
 
-    protected _shell: ApplicationShell | undefined;
-
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
         @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry,
@@ -56,14 +54,12 @@ export class FrontendApplication {
         @inject(ILogger) protected readonly logger: ILogger,
         @inject(ShellLayoutRestorer) protected readonly layoutRestorer: ShellLayoutRestorer,
         @inject(ContributionProvider) @named(FrontendApplicationContribution)
-        protected readonly contributions: ContributionProvider<FrontendApplicationContribution>
+        protected readonly contributions: ContributionProvider<FrontendApplicationContribution>,
+        @inject(ApplicationShell) protected readonly _shell: ApplicationShell,
     ) { }
 
     get shell(): ApplicationShell {
-        if (this._shell) {
-            return this._shell;
-        }
-        throw new Error('The application has not been started yet.');
+        return this._shell;
     }
 
     /**
@@ -75,19 +71,11 @@ export class FrontendApplication {
      * - display the application shell
      */
     async start(): Promise<void> {
-        if (this._shell) {
-            throw new Error('The application is already running.');
-        }
-        this._shell = this.createShell();
         this.startContributions();
         await this.layoutRestorer.initializeLayout(this, this.contributions.getContributions());
         this.ensureLoaded().then(() =>
             this.attachShell()
         );
-    }
-
-    protected createShell(): ApplicationShell {
-        return new ApplicationShell();
     }
 
     protected attachShell(): void {

--- a/packages/core/src/browser/shell.ts
+++ b/packages/core/src/browser/shell.ts
@@ -7,6 +7,7 @@
 
 import { ArrayExt, each, find, toArray } from "@phosphor/algorithm";
 import { ISignal, Signal } from "@phosphor/signaling";
+import { injectable } from 'inversify';
 
 import {
     BoxLayout,
@@ -20,6 +21,8 @@ import {
     Title,
     Widget
 } from "@phosphor/widgets";
+
+export const ApplicationShellOptions = Symbol("ApplicationShellOptions");
 
 /**
  * The class name added to AppShell instances.
@@ -59,6 +62,7 @@ export interface DockLayoutData extends DockPanel.ILayoutConfig {
 /**
  * The application shell.
  */
+@injectable()
 export class ApplicationShell extends Widget {
     /**
      * Construct a new application shell.


### PR DESCRIPTION
I have this crazy problem with inversify

With the last commit (not working ? )

I get:

```
index.js:46 Error: Missing required @inject or @multiInject annotation in: argument 5 in class FrontendApplication.
    at _createSubRequests (planner.js:107)
    at Object.plan (planner.js:126)
    at container.js:239
    at Container._get (container.js:232)
    at Container.get (container.js:191)
    at start (index.js:21)
    at <anonymous>
```

This goes away if I comment out `  @inject(FrontendApplication) protected readonly app: FrontendApplication,`  in shell-command-contribution.ts

I'm really don't get what is going on here... help is appreciated

@akosyakov  could you please take a look ?

I'll try to debug this more, @epatpol  had similar issues in a different context too.