### PR TITLE
GH-784: Fixed issue with the `argv` when forking a new process.

### DIFF
--- a/dev-packages/application-package/src/generator/frontend-generator.ts
+++ b/dev-packages/application-package/src/generator/frontend-generator.ts
@@ -112,7 +112,7 @@ if (cluster.isMaster) {
                 electron.app.exit(1);
             });
         } else {
-            const cp = fork(mainPath, process.argv, { stdio: [0, 1, 2, 'ipc'] });
+            const cp = fork(mainPath);
             cp.on('message', function (message) {
                 loadMainWindow(message);
             });

--- a/packages/core/src/browser/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell-layout-restorer.ts
@@ -136,10 +136,8 @@ export class ShellLayoutRestorer implements CommandContribution {
                         const promise = this.widgetManager.getOrCreateWidget(desc.constructionOptions.factoryId, desc.constructionOptions.options)
                             .then(widget => {
                                 if (widget) {
-                                    if (desc.innerWidgetState) {
-                                        if (StatefulWidget.is(widget) && desc.innerWidgetState) {
-                                            widget.restoreState(desc.innerWidgetState);
-                                        }
+                                    if (StatefulWidget.is(widget) && desc.innerWidgetState !== undefined) {
+                                        widget.restoreState(desc.innerWidgetState);
                                     }
                                     widgets[i] = widget;
                                 }

--- a/packages/core/src/browser/tree/tree-widget.ts
+++ b/packages/core/src/browser/tree/tree-widget.ts
@@ -329,10 +329,20 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
     }
 
     storeState(): object {
-        return this.deflateForStorage(this.model.root!);
+        if (this.model.root) {
+            return {
+                root: this.deflateForStorage(this.model.root)
+            };
+        } else {
+            return {};
+        }
     }
+
     restoreState(oldState: object): void {
-        this.model.root = this.inflateFromStorage(oldState);
+        // tslint:disable-next-line:no-any
+        if ((oldState as any).root) {
+            this.model.root = this.inflateFromStorage(oldState);
+        }
     }
 
 }


### PR DESCRIPTION
When running a bundled electron application, the `argv` got messed up,
so that the default workspace server thought the workspace root is set.

Also, do not try to restore the layout if the internal widget state is
an empty layout object.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>