### PR TITLE
GH-795: From now on, browser window is shown when it is fully rendered.

### DIFF
--- a/dev-packages/application-package/src/generator/frontend-generator.ts
+++ b/dev-packages/application-package/src/generator/frontend-generator.ts
@@ -96,7 +96,8 @@ if (cluster.isMaster) {
         const { fork }  = require('child_process');
         // Check whether we are in bundled application or development mode.
         const devMode = process.defaultApp || /node_modules[\\/]electron[\\/]/.test(process.execPath);
-        const mainWindow = new electron.BrowserWindow({ width: 1024, height: 728 });
+        const mainWindow = new electron.BrowserWindow({ width: 1024, height: 728, show: false });
+        mainWindow.on('ready-to-show', () => mainWindow.show());
         const mainPath = path.join(__dirname, '..', 'backend', 'main');
         const loadMainWindow = function(port) {
             mainWindow.loadURL(\`file://\${path.join(__dirname, '../../lib/index.html')}?port=\${port}\`);


### PR DESCRIPTION
The browser window will be shown only when it is has been rendered and
it can be displayed without a visual flash.

Closes #795.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>