### PR TITLE
[workspace] Improved Recently Used Workspace Handling

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -25,10 +25,10 @@ export class QuickFileOpenService implements QuickOpenModel {
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
         @inject(FileSearchService) protected readonly fileSearchService: FileSearchService
     ) {
-        workspaceService.root.then(root => this.wsRoot = root);
+        workspaceService.tryRoot.then(root => this.wsRoot = root);
     }
 
-    private wsRoot: FileStat;
+    private wsRoot: FileStat | undefined;
 
     isEnabled(): boolean {
         return this.wsRoot !== undefined;
@@ -46,6 +46,9 @@ export class QuickFileOpenService implements QuickOpenModel {
     private cancelIndicator = new CancellationTokenSource();
 
     public async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
+        if (!this.wsRoot) {
+            return;
+        }
         this.cancelIndicator.cancel();
         this.cancelIndicator = new CancellationTokenSource();
         const token = this.cancelIndicator.token;
@@ -69,7 +72,7 @@ export class QuickFileOpenService implements QuickOpenModel {
         const uri = new URI(uriString);
         const icon = this.fileIconProvider.getFileIconForURI(uri);
         const parent = uri.parent.toString();
-        const description = parent.substr(this.wsRoot.uri.length);
+        const description = parent.substr(this.wsRoot!.uri.length);
         return new FileQuickOpenItem(uri, icon, description, this.openerService);
     }
 

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -25,7 +25,7 @@ export class QuickFileOpenService implements QuickOpenModel {
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
         @inject(FileSearchService) protected readonly fileSearchService: FileSearchService
     ) {
-        workspaceService.tryRoot.then(root => this.wsRoot = root);
+        workspaceService.root.then(root => this.wsRoot = root);
     }
 
     private wsRoot: FileStat | undefined;

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -54,7 +54,10 @@ export class GitRepositoryProvider {
      *  - This method blocks, if the workspace root is not yet set.
      */
     async refresh(): Promise<void> {
-        const root = await this.workspaceService.root;
+        const root = await this.workspaceService.tryRoot;
+        if (!root) {
+            return;
+        }
         const repositories = await this.git.repositories(root.uri);
         this._allRepositories = repositories;
         // If no repository is selected or the selected one does not exist on the backend anymore, update the selected one.

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -54,7 +54,7 @@ export class GitRepositoryProvider {
      *  - This method blocks, if the workspace root is not yet set.
      */
     async refresh(): Promise<void> {
-        const root = await this.workspaceService.tryRoot;
+        const root = await this.workspaceService.root;
         if (!root) {
             return;
         }

--- a/packages/markers/src/browser/problem/problem-widget.ts
+++ b/packages/markers/src/browser/problem/problem-widget.ts
@@ -22,7 +22,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 @injectable()
 export class ProblemWidget extends TreeWidget {
 
-    protected workspacePath: string;
+    protected workspacePath: string | undefined;
 
     constructor(
         @inject(ProblemManager) protected readonly problemManager: ProblemManager,
@@ -40,8 +40,8 @@ export class ProblemWidget extends TreeWidget {
         this.title.closable = true;
         this.addClass('theia-marker-container');
 
-        this.workspaceService.tryRoot.then(workspaceFileStat => {
-            this.workspacePath = workspaceFileStat ? workspaceFileStat.uri : '';
+        this.workspaceService.root.then(workspaceFileStat => {
+            this.workspacePath = workspaceFileStat ? workspaceFileStat.uri : undefined;
             this.update();
         });
 

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -54,9 +54,11 @@ export class MonacoWorkspace extends BaseMonacoWorkspace implements lang.Workspa
         @inject(EditorManager) protected readonly editorManager: EditorManager
     ) {
         super(p2m, m2p);
-        workspaceService.root.then(rootStat => {
-            this._rootUri = rootStat.uri;
-            this.resolveReady();
+        workspaceService.tryRoot.then(rootStat => {
+            if (rootStat) {
+                this._rootUri = rootStat.uri;
+                this.resolveReady();
+            }
         });
         monaco.editor.onDidCreateModel(model => {
             this.textModelService.createModelReference(model.uri).then(reference => {

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -54,7 +54,7 @@ export class MonacoWorkspace extends BaseMonacoWorkspace implements lang.Workspa
         @inject(EditorManager) protected readonly editorManager: EditorManager
     ) {
         super(p2m, m2p);
-        workspaceService.tryRoot.then(rootStat => {
+        workspaceService.root.then(rootStat => {
             if (rootStat) {
                 this._rootUri = rootStat.uri;
                 this.resolveReady();

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -30,7 +30,7 @@ export class FileNavigatorContribution implements FrontendApplicationContributio
         this.fileNavigator.model.onSelectionChanged(selection =>
             this.selectionService.selection = selection
         );
-        this.workspaceService.tryRoot.then(resolvedRoot => {
+        this.workspaceService.root.then(resolvedRoot => {
             if (resolvedRoot) {
                 this.fileNavigator.model.root = DirNode.createRoot(resolvedRoot);
             } else {

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -184,7 +184,7 @@ export class TerminalWidget extends BaseWidget {
         this.registerResize();
 
         if (id === undefined) {
-            const root = await this.workspaceService.tryRoot;
+            const root = await this.workspaceService.root;
             const rootURI = root !== undefined ? root.uri : undefined;
             this.terminalId = await this.shellTerminalServer.create(
                 { rootURI, cols: this.cols, rows: this.rows });

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -241,7 +241,7 @@ export class FileSystemCommandHandler implements CommandHandler {
 
 export class WorkspaceRootAwareCommandHandler extends FileSystemCommandHandler {
 
-    protected rootUri: URI;
+    protected rootUri: URI | undefined;
 
     constructor(
         protected readonly workspaceService: WorkspaceService,
@@ -249,10 +249,13 @@ export class WorkspaceRootAwareCommandHandler extends FileSystemCommandHandler {
         protected readonly handler: UriCommandHandler
     ) {
         super(selectionService, handler);
-        workspaceService.root.then(root => {
-            this.rootUri = new URI(root.uri);
+        workspaceService.tryRoot.then(root => {
+            if (root) {
+                this.rootUri = new URI(root.uri);
+            }
         });
     }
+
     protected getUri(): URI | undefined {
         return UriSelection.getUri(this.selectionService.selection) || this.rootUri;
     }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -249,7 +249,7 @@ export class WorkspaceRootAwareCommandHandler extends FileSystemCommandHandler {
         protected readonly handler: UriCommandHandler
     ) {
         super(selectionService, handler);
-        workspaceService.tryRoot.then(root => {
+        workspaceService.root.then(root => {
             if (root) {
                 this.rootUri = new URI(root.uri);
             }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -45,7 +45,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
     }
 
     protected showFileDialog(): void {
-        this.workspaceService.tryRoot.then(async resolvedRoot => {
+        this.workspaceService.root.then(async resolvedRoot => {
             const root = resolvedRoot || await this.fileSystem.getCurrentUserHome();
             if (root) {
                 const rootUri = new URI(root.uri).parent;

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -7,7 +7,7 @@
 
 import { ContainerModule, interfaces } from 'inversify';
 import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
-import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { FileDialogFactory, createFileDialog, FileDialogProps } from '@theia/filesystem/lib/browser';
 import { WorkspaceServer, workspacePath } from '../common';
 import { WorkspaceFrontendContribution } from "./workspace-frontend-contribution";
@@ -20,6 +20,7 @@ import '../../src/browser/style/index.css';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bind(WorkspaceService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceService));
     bind(WorkspaceServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
         return provider.createProxy<WorkspaceServer>(workspacePath);

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -9,12 +9,15 @@ import { injectable, inject } from "inversify";
 import URI from "@theia/core/lib/common/uri";
 import { FileSystem, FileStat, FileSystemWatcher } from "@theia/filesystem/lib/common";
 import { WorkspaceServer } from "../common";
+import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 
 /**
  * The workspace service.
  */
 @injectable()
-export class WorkspaceService {
+export class WorkspaceService implements FrontendApplicationContribution {
+
+    private _root: FileStat | undefined;
 
     constructor(
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
@@ -22,7 +25,7 @@ export class WorkspaceService {
         @inject(WorkspaceServer) protected readonly server: WorkspaceServer
     ) {
         (async () => {
-            const root = await this.tryRoot;
+            const root = await this.root;
             if (root) {
                 const uri = new URI(root.uri);
                 this.updateTitle(uri);
@@ -36,15 +39,29 @@ export class WorkspaceService {
     }
 
     /**
-     * Unlike [root](WorkspaceService.root), this method gets resolved even if the workspace root URI is not yet set on the backend or if it
-     * is invalid. In such cases, it will resolve to `undefined`.
+     * on unload, we set our workspace root as the last recently used on the backend.
+     * @param app
      */
-    get tryRoot(): Promise<FileStat | undefined> {
+    onStop(app: FrontendApplication): void {
+        if (this._root) {
+            this.server.setRoot(this._root.uri);
+        }
+    }
+
+    /**
+     * returns the most recently used workspace root or undefined if no root is known.
+     */
+    get root(): Promise<FileStat | undefined> {
+        if (this._root) {
+            return Promise.resolve(this._root);
+        }
         return new Promise(async resolve => {
             const root = await this.server.getRoot();
             const validRoot = await this.isValidRoot(root);
-            // If the workspace root is either not set or invalid, we resolve the promise with `undefined`.
-            resolve(validRoot ? this.toFileStat(root!) : undefined);
+            if (validRoot) {
+                this._root = await this.toFileStat(root!);
+            }
+            resolve(this._root);
         });
     }
 
@@ -60,7 +77,7 @@ export class WorkspaceService {
         const valid = await this.isValidRoot(rootUri);
         if (valid) {
             // The same window has to be preserved too (instead of opening a new one), if the workspace root is not yet available and we are setting it for the first time.
-            const preserveWindow = !(await this.tryRoot);
+            const preserveWindow = !(await this.root);
             await this.server.setRoot(rootUri);
             this.openWindow(uri, Object.assign(options || {}, { preserveWindow }));
             return;

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -36,20 +36,6 @@ export class WorkspaceService {
     }
 
     /**
-     * A promise which will get resolved only and if only when the workspace root URI is set on the backend and it points to an existing directory.
-     */
-    get root(): Promise<FileStat> {
-        return new Promise(async resolve => {
-            const root = await this.server.getRoot();
-            const validRoot = await this.isValidRoot(root);
-            // If the workspace root is either not set or invalid, we never resolve the promise.
-            if (validRoot) {
-                resolve(this.toFileStat(root!));
-            }
-        });
-    }
-
-    /**
      * Unlike [root](WorkspaceService.root), this method gets resolved even if the workspace root URI is not yet set on the backend or if it
      * is invalid. In such cases, it will resolve to `undefined`.
      */

--- a/packages/workspace/src/browser/workspace-storage-service.ts
+++ b/packages/workspace/src/browser/workspace-storage-service.ts
@@ -23,7 +23,7 @@ export class WorkspaceStorageService implements StorageService {
 
     constructor( @inject(WorkspaceService) protected workspaceService: WorkspaceService,
         @inject(ILogger) protected logger: ILogger) {
-        this.initialized = this.workspaceService.tryRoot.then(stat => {
+        this.initialized = this.workspaceService.root.then(stat => {
             if (stat) {
                 this.prefix = stat.uri;
             } else {

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -7,6 +7,9 @@
 
 import * as path from 'path';
 import * as yargs from 'yargs';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+
 import { injectable, inject } from "inversify";
 import { FileUri } from '@theia/core/lib/node';
 import { CliContribution } from '@theia/core/lib/node/cli';
@@ -51,6 +54,14 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         @inject(WorkspaceCliContribution) protected readonly cliParams: WorkspaceCliContribution
     ) {
         this.root = this.getRootURIFromCli();
+        this.root.then(async root => {
+            if (!root) {
+                const data = await this.readFromUserHome();
+                if (data && data.recentRoots) {
+                    this.root = Promise.resolve(data.recentRoots[0]);
+                }
+            }
+        });
     }
 
     getRoot(): Promise<string | undefined> {
@@ -59,6 +70,9 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
 
     setRoot(uri: string): Promise<void> {
         this.root = Promise.resolve(uri);
+        this.writeToUserHome({
+            recentRoots: [uri]
+        });
         return Promise.resolve();
     }
 
@@ -67,4 +81,45 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         return arg !== undefined ? FileUri.create(arg).toString() : undefined;
     }
 
+    /**
+     * Writes the given uri as the most recently used workspace root to the user's home directory.
+     * @param uri most recently used uri
+     */
+    private async writeToUserHome(data: WorkspaceData): Promise<void> {
+        const file = this.getUserStoragePath();
+        if (!await fs.pathExists(file)) {
+            await fs.mkdirs(path.resolve(file, '..'));
+        }
+        await fs.writeJson(file, data);
+    }
+
+    /**
+     * Reads the most recently used workspace root from the user's home directory.
+     */
+    private async readFromUserHome(): Promise<WorkspaceData | undefined> {
+        const file = this.getUserStoragePath();
+        if (await fs.pathExists(file)) {
+            const config = await fs.readJson(file);
+            if (WorkspaceData.is(config)) {
+                return config;
+            }
+        }
+        return undefined;
+    }
+
+    protected getUserStoragePath(): string {
+        return path.resolve(os.homedir(), '.theia', 'recentworkspace.json');
+    }
+
+}
+
+interface WorkspaceData {
+    recentRoots: string[];
+}
+
+namespace WorkspaceData {
+    // tslint:disable-next-line:no-any
+    export function is(data: any): data is WorkspaceData {
+        return data.recentRoots !== undefined;
+    }
 }


### PR DESCRIPTION
With this PR, the recently used workspace root is updated when a frontend unloads, such that the next opened frontend app will use that again.
Also the most recently used workspace root is persisted on the backend's file system (user home), wuch that it can be used, in case no argument is provided on start.