### PR TITLE
GH-815: Bumped up the node-pty version.

### DIFF
--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -4,7 +4,7 @@
   "description": "Theia process support.",
   "dependencies": {
     "@theia/core": "^0.2.0",
-    "node-pty": "^0.7.0"
+    "node-pty": "^0.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4606,9 +4606,9 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-pty@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.0.tgz#993038692d3a2921811a152658fc7dc211323ac2"
+node-pty@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.2.tgz#b6cff79fd01f58b84947c034434c8cbeb157da43"
   dependencies:
     nan "^2.6.2"
 


### PR DESCRIPTION
The new version is intentionally 0.7.1 to be sync with VSCode.
Closes #815.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>