### PR TITLE
Enable semicolon tslint rule

### DIFF
--- a/configs/strict.tslint.json
+++ b/configs/strict.tslint.json
@@ -37,11 +37,6 @@
         }
       ],
       "severity": "error"
-    },
-    "semicolon": [
-      true,
-      "always",
-      "ignore-interfaces"
-    ]
+    }
   }
 }

--- a/configs/tslint.json
+++ b/configs/tslint.json
@@ -28,6 +28,11 @@
       "check-whitespace"
     ],
     "radix": true,
+    "semicolon": [
+      true,
+      "always",
+      "ignore-interfaces"
+    ],
     "trailing-comma": [
       false
     ],

--- a/dev-packages/application-package/src/generator/frontend-generator.ts
+++ b/dev-packages/application-package/src/generator/frontend-generator.ts
@@ -36,7 +36,7 @@ export class FrontendGenerator extends AbstractGenerator {
     protected compileIndexHead(frontendModules: Map<string, string>): string {
         return `
   <meta charset="UTF-8">
-  <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js" charset="utf-8"></script>`
+  <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js" charset="utf-8"></script>`;
     }
 
     protected compileIndexJs(frontendModules: Map<string, string>): string {

--- a/dev-packages/application-package/src/rebuild.ts
+++ b/dev-packages/application-package/src/rebuild.ts
@@ -23,7 +23,7 @@ export function rebuild(target: 'electron' | 'browser', modules: string[]) {
             const src = path.join(nodeModulesPath, module);
             if (fs.existsSync(src)) {
                 const dest = path.join(browserModulesPath, module);
-                const packJson = fs.readJsonSync(path.join(src, 'package.json'))
+                const packJson = fs.readJsonSync(path.join(src, 'package.json'));
                 dependencies[module] = packJson.version;
                 fs.copySync(src, dest);
             }

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -98,7 +98,7 @@ yargs
         describe: 'webpack the ' + target + ' frontend',
         handler: async () => {
             try {
-                await manager.build(commandArgs('build'))
+                await manager.build(commandArgs('build'));
             } catch (err) {
                 console.error(err);
                 process.exit(1);

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -139,7 +139,7 @@ export class FrontendApplication {
                     }
                 }
             }
-        }
+        };
     }
 
 }

--- a/packages/core/src/browser/messaging/connection.ts
+++ b/packages/core/src/browser/messaging/connection.ts
@@ -50,9 +50,9 @@ export class WebSocketConnectionProvider {
 
         const logger = this.createLogger();
         webSocket.onerror = function (error: Event) {
-            logger.error('' + error)
+            logger.error('' + error);
             return;
-        }
+        };
         doListen({
             webSocket,
             onConnection: handler.onConnection.bind(handler),
@@ -68,8 +68,8 @@ export class WebSocketConnectionProvider {
      * Creates a websocket URL to the current location
      */
     createWebSocketUrl(path: string): string {
-        const endpoint = new Endpoint({ path })
-        return endpoint.getWebSocketUrl().toString()
+        const endpoint = new Endpoint({ path });
+        return endpoint.getWebSocketUrl().toString();
     }
 
     /**

--- a/packages/core/src/browser/opener-service.spec.ts
+++ b/packages/core/src/browser/opener-service.spec.ts
@@ -28,7 +28,7 @@ describe("opener-service", () => {
     it("getOpeners", () => {
         return openerService.getOpeners().then(openers => {
             assert.deepStrictEqual([openHandler], openers);
-        })
+        });
     });
 
 });

--- a/packages/core/src/browser/tree/tree-iterator.ts
+++ b/packages/core/src/browser/tree/tree-iterator.ts
@@ -17,7 +17,7 @@ export namespace ITreeNodeIterator {
     }
     export const DEFAULT_OPTIONS: IOptions = {
         pruneCollapsed: false
-    }
+    };
 }
 
 export abstract class AbstractTreeNodeIterator implements ITreeNodeIterator {
@@ -91,7 +91,7 @@ export class BackwardTreeNodeIterator extends AbstractTreeNodeIterator {
             return node;
         }
         const lastChild = ICompositeTreeNode.getLastChild(node);
-        return this.findLastChild(lastChild)
+        return this.findLastChild(lastChild);
     }
 
 }

--- a/packages/core/src/browser/tree/tree-selection.ts
+++ b/packages/core/src/browser/tree/tree-selection.ts
@@ -59,7 +59,7 @@ export namespace ISelectableTreeNode {
             if (isVisible(node.parent)) {
                 return node.parent;
             }
-            return getVisibleParent(node.parent)
+            return getVisibleParent(node.parent);
         }
     }
 }

--- a/packages/core/src/browser/tree/tree-widget.ts
+++ b/packages/core/src/browser/tree/tree-widget.ts
@@ -54,7 +54,7 @@ export const defaultTreeProps: TreeProps = {
         width: 16,
         height: 16
     }
-}
+};
 
 @injectable()
 export class TreeWidget extends VirtualWidget implements StatefulWidget {
@@ -151,7 +151,7 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
         return {
             paddingLeft: `${props.indentSize}px`,
             display: props.visible ? 'block' : 'none',
-        }
+        };
     }
 
     protected renderNodeCaption(node: ITreeNode, props: NodeProps): h.Child {
@@ -205,7 +205,7 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
 
     protected renderChild(child: ITreeNode, parent: ICompositeTreeNode, props: NodeProps): h.Child {
         const childProps = this.createChildProps(child, parent, props);
-        return this.renderNodes(child, childProps)
+        return this.renderNodes(child, childProps);
     }
 
     protected createChildProps(child: ITreeNode, parent: ICompositeTreeNode, props: NodeProps): NodeProps {

--- a/packages/core/src/common/contribution-provider.ts
+++ b/packages/core/src/common/contribution-provider.ts
@@ -7,7 +7,7 @@
 
 import { interfaces } from "inversify";
 
-export const ContributionProvider = Symbol("ContributionProvider")
+export const ContributionProvider = Symbol("ContributionProvider");
 
 export interface ContributionProvider<T extends object> {
     getContributions(): T[]
@@ -35,7 +35,7 @@ class ContainerBasedContributionProvider<T extends object> implements Contributi
                 this.services = [];
             }
         }
-        return this.services
+        return this.services;
     }
 }
 

--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -11,7 +11,7 @@ export const ILoggerServer = Symbol('ILoggerServer');
 
 export const loggerPath = '/services/logger';
 
-export const LoggerServerOptions = Symbol('LoggerServerOptions')
+export const LoggerServerOptions = Symbol('LoggerServerOptions');
 
 export interface ILoggerServer extends JsonRpcServer<ILoggerClient> {
     setLogLevel(id: number, logLevel: number): Promise<void>;

--- a/packages/core/src/common/logger-watcher.ts
+++ b/packages/core/src/common/logger-watcher.ts
@@ -13,12 +13,12 @@ import { ILoggerClient, ILogLevelChangedEvent } from './logger-protocol';
 export class LoggerWatcher {
 
     getLoggerClient(): ILoggerClient {
-        const emitter = this.onLogLevelChangedEmitter
+        const emitter = this.onLogLevelChangedEmitter;
         return {
             onLogLevelChanged(event: ILogLevelChangedEvent) {
-                emitter.fire(event)
+                emitter.fire(event);
             }
-        }
+        };
     }
 
     private onLogLevelChangedEmitter = new Emitter<ILogLevelChangedEvent>();

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -84,7 +84,7 @@ export class MenuModelRegistry {
             return sub;
         }
         if (sub) {
-            throw Error(`'${menuId}' is not a menu group.`)
+            throw Error(`'${menuId}' is not a menu group.`);
         }
         const newSub = new CompositeMenuNode(menuId);
         current.addNode(newSub);
@@ -121,9 +121,9 @@ export class CompositeMenuNode implements MenuNode {
         this._children.push(node);
         this._children.sort((m1, m2) => {
             if (m1.sortString < m2.sortString) {
-                return -1
+                return -1;
             } else if (m1.sortString > m2.sortString) {
-                return 1
+                return 1;
             } else {
                 return 0;
             }
@@ -135,7 +135,7 @@ export class CompositeMenuNode implements MenuNode {
                     this._children.splice(idx, 1);
                 }
             }
-        }
+        };
     }
 
     get sortString() {
@@ -163,7 +163,7 @@ export class ActionMenuNode implements MenuNode {
         }
         const cmd = this.commands.getCommand(this.action.commandId);
         if (!cmd) {
-            throw new Error(`A command with id '${this.action.commandId}' does not exist.`)
+            throw new Error(`A command with id '${this.action.commandId}' does not exist.`);
         }
         return cmd.label || cmd.id;
     }

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -26,30 +26,30 @@ class NoTransform extends stream.Transform {
 
     public _transform(chunk: any, encoding: string, callback: Function): void {
         // console.log((chunk as Buffer).toString())
-        callback(undefined, chunk)
+        callback(undefined, chunk);
     }
 }
 
 class TestServer {
-    requests: string[] = []
+    requests: string[] = [];
     doStuff(arg: string): Promise<string> {
-        this.requests.push(arg)
-        return Promise.resolve(`done: ${arg}`)
+        this.requests.push(arg);
+        return Promise.resolve(`done: ${arg}`);
     }
 
     fails(arg: string, otherArg: string): Promise<string> {
-        throw new Error("fails failed")
+        throw new Error("fails failed");
     }
 
     fails2(arg: string, otherArg: string): Promise<string> {
-        return Promise.reject("fails2 failed")
+        return Promise.reject("fails2 failed");
     }
 }
 
 class TestClient {
-    notifications: string[] = []
+    notifications: string[] = [];
     notifyThat(arg: string): void {
-        this.notifications.push(arg)
+        this.notifications.push(arg);
     }
 }
 
@@ -58,61 +58,61 @@ beforeEach(() => {
 
 describe('Proxy-Factory', () => {
     it('Should correctly send notifications and requests.', done => {
-        let it = getSetup()
-        it.clientProxy.notifyThat("hello")
+        let it = getSetup();
+        it.clientProxy.notifyThat("hello");
         function check() {
             if (it.client.notifications.length === 0) {
-                console.log("waiting another 50 ms")
-                setTimeout(check, 50)
+                console.log("waiting another 50 ms");
+                setTimeout(check, 50);
             } else {
-                expect(it.client.notifications[0]).eq("hello")
+                expect(it.client.notifications[0]).eq("hello");
                 it.serverProxy.doStuff("foo").then(result => {
-                    expect(result).to.be.eq("done: foo")
-                    done()
-                })
+                    expect(result).to.be.eq("done: foo");
+                    done();
+                });
             }
         }
-        check()
+        check();
     });
     it('Rejected Promise should result in rejected Promise.', done => {
         let it = getSetup();
-        let handle = setTimeout(() => done("timeout"), 500)
+        let handle = setTimeout(() => done("timeout"), 500);
         it.serverProxy.fails('a', 'b').catch(err => {
-            expect(<Error>err.message).to.contain("fails failed")
-            clearTimeout(handle)
-            done()
-        })
-    })
+            expect(<Error>err.message).to.contain("fails failed");
+            clearTimeout(handle);
+            done();
+        });
+    });
     it('Remote Exceptions should result in rejected Promise.', done => {
         let it = getSetup();
-        let handle = setTimeout(() => done("timeout"), 500)
+        let handle = setTimeout(() => done("timeout"), 500);
         it.serverProxy.fails2('a', 'b').catch(err => {
-            expect(<Error>err.message).to.contain("fails2 failed")
-            clearTimeout(handle)
-            done()
-        })
-    })
+            expect(<Error>err.message).to.contain("fails2 failed");
+            clearTimeout(handle);
+            done();
+        });
+    });
 });
 
 function getSetup() {
-    let client = new TestClient()
-    let server = new TestServer()
+    let client = new TestClient();
+    let server = new TestServer();
 
-    let serverProxyFactory = new JsonRpcProxyFactory<TestServer>(client)
-    let client2server = new NoTransform()
-    let server2client = new NoTransform()
-    let serverConnection = createMessageConnection(server2client, client2server, new ConsoleLogger())
-    serverProxyFactory.listen(serverConnection)
-    let serverProxy = serverProxyFactory.createProxy()
+    let serverProxyFactory = new JsonRpcProxyFactory<TestServer>(client);
+    let client2server = new NoTransform();
+    let server2client = new NoTransform();
+    let serverConnection = createMessageConnection(server2client, client2server, new ConsoleLogger());
+    serverProxyFactory.listen(serverConnection);
+    let serverProxy = serverProxyFactory.createProxy();
 
-    let clientProxyFactory = new JsonRpcProxyFactory<TestClient>(server)
-    let clientConnection = createMessageConnection(client2server, server2client, new ConsoleLogger())
-    clientProxyFactory.listen(clientConnection)
-    let clientProxy = clientProxyFactory.createProxy()
+    let clientProxyFactory = new JsonRpcProxyFactory<TestClient>(server);
+    let clientConnection = createMessageConnection(client2server, server2client, new ConsoleLogger());
+    clientProxyFactory.listen(clientConnection);
+    let clientProxy = clientProxyFactory.createProxy();
     return {
         client,
         clientProxy,
         server,
         serverProxy
-    }
+    };
 }

--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -146,14 +146,14 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
     protected onRequest(method: string, ...args: any[]): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             try {
-                const promise = this.target[method](...args) as Promise<any>
+                const promise = this.target[method](...args) as Promise<any>;
                 promise
                     .catch(err => reject(err))
                     .then(result => resolve(result));
             } catch (err) {
                 reject(err);
             }
-        })
+        });
     }
 
     /**
@@ -204,7 +204,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
         if (p === 'setClient') {
             return (client: any) => {
                 this.target = client;
-            }
+            };
         }
         if (p === 'onDidOpenConnection') {
             return this.onDidOpenConnectionEmitter.event;

--- a/packages/core/src/common/path.spec.ts
+++ b/packages/core/src/common/path.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import * as assert from 'assert';
-import { Path } from "./path"
+import { Path } from "./path";
 
 describe("Path", () => {
 

--- a/packages/core/src/common/types.spec.ts
+++ b/packages/core/src/common/types.spec.ts
@@ -31,7 +31,7 @@ describe('types', () => {
                             value: -1
                         }
                     ], values)
-                )
+                );
         });
 
         it('prioritizeAll #02', () => {
@@ -54,7 +54,7 @@ describe('types', () => {
                             value: -1
                         }
                     ], values)
-                )
+                );
         });
     });
 });

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -17,7 +17,7 @@ export type MaybePromise<T> = T | Promise<T>;
 export type Prioritizeable<T> = {
     readonly priority: number,
     readonly value: T
-}
+};
 export namespace Prioritizeable {
     export type GetPriority<T> = (value: T) => MaybePromise<number>;
     export async function toPrioritizeable<T>(rawValue: MaybePromise<T>, getPriority: GetPriority<T>): Promise<Prioritizeable<T>>;

--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import * as chai from 'chai';
-import URI from "./uri"
+import URI from "./uri";
 
 const expect = chai.expect;
 
@@ -103,7 +103,7 @@ describe("uri", () => {
 
         it("Should not return the encoded path", () => {
             expect(new URI("file:///foo 3/bar 4/baz 4.txt").path.toString()).equals("/foo 3/bar 4/baz 4.txt");
-        })
+        });
     });
 
     describe("#withFragment", () => {
@@ -121,28 +121,28 @@ describe("uri", () => {
     describe("#toString()", () => {
         it("should produce the non encoded string", () => {
             function check(uri: string): void {
-                expect(new URI(uri).toString(true)).equals(uri)
+                expect(new URI(uri).toString(true)).equals(uri);
             }
-            check('file:///X?test=32')
-            check('file:///X?test=32#345')
-            check('file:///X test/ddd?test=32#345')
-        })
-    })
+            check('file:///X?test=32');
+            check('file:///X?test=32#345');
+            check('file:///X test/ddd?test=32#345');
+        });
+    });
 
     describe("#Uri.with...()", () => {
         it("produce proper URIs", () => {
-            let uri = new URI().withScheme('file').withPath('/foo/bar.txt').withQuery("x=12").withFragment("baz")
-            expect(uri.toString(true)).equals("file:///foo/bar.txt?x=12#baz")
+            let uri = new URI().withScheme('file').withPath('/foo/bar.txt').withQuery("x=12").withFragment("baz");
+            expect(uri.toString(true)).equals("file:///foo/bar.txt?x=12#baz");
 
-            expect(uri.withoutScheme().toString(true)).equals("/foo/bar.txt?x=12#baz")
+            expect(uri.withoutScheme().toString(true)).equals("/foo/bar.txt?x=12#baz");
 
-            expect(uri.withScheme("http").toString(true)).equals("http:/foo/bar.txt?x=12#baz")
+            expect(uri.withScheme("http").toString(true)).equals("http:/foo/bar.txt?x=12#baz");
 
-            expect(uri.withoutQuery().toString(true)).equals("file:///foo/bar.txt#baz")
+            expect(uri.withoutQuery().toString(true)).equals("file:///foo/bar.txt#baz");
 
-            expect(uri.withoutFragment().toString(true)).equals(uri.withFragment('').toString(true))
+            expect(uri.withoutFragment().toString(true)).equals(uri.withFragment('').toString(true));
 
-            expect(uri.withPath("hubba-bubba").toString(true)).equals("file://hubba-bubba?x=12#baz")
-        })
-    })
+            expect(uri.withPath("hubba-bubba").toString(true)).equals("file://hubba-bubba?x=12#baz");
+        });
+    });
 });

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -15,11 +15,11 @@ export default class URI {
 
     constructor(uri?: string | Uri) {
         if (uri === undefined) {
-            this.codeUri = Uri.from({})
+            this.codeUri = Uri.from({});
         } else if (uri instanceof Uri) {
-            this.codeUri = uri
+            this.codeUri = uri;
         } else {
-            this.codeUri = Uri.parse(uri)
+            this.codeUri = Uri.parse(uri);
         }
     }
 
@@ -66,7 +66,7 @@ export default class URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
             scheme
-        })
+        });
         return new URI(newCodeUri);
     }
 
@@ -74,7 +74,7 @@ export default class URI {
      * return this URI without a scheme
      */
     withoutScheme(): URI {
-        return this.withScheme('')
+        return this.withScheme('');
     }
 
     /**
@@ -84,7 +84,7 @@ export default class URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
             authority
-        })
+        });
         return new URI(newCodeUri);
     }
 
@@ -92,7 +92,7 @@ export default class URI {
      * return this URI without a authority
      */
     withoutAuthority(): URI {
-        return this.withAuthority('')
+        return this.withAuthority('');
     }
 
     /**
@@ -102,7 +102,7 @@ export default class URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
             path: path.toString()
-        })
+        });
         return new URI(newCodeUri);
     }
 
@@ -110,7 +110,7 @@ export default class URI {
      * return this URI without a path
      */
     withoutPath(): URI {
-        return this.withPath('')
+        return this.withPath('');
     }
 
     /**
@@ -120,7 +120,7 @@ export default class URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
             query
-        })
+        });
         return new URI(newCodeUri);
     }
 
@@ -128,7 +128,7 @@ export default class URI {
      * return this URI without a query
      */
     withoutQuery(): URI {
-        return this.withQuery('')
+        return this.withQuery('');
     }
 
     /**
@@ -138,7 +138,7 @@ export default class URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
             fragment
-        })
+        });
         return new URI(newCodeUri);
     }
 
@@ -146,15 +146,15 @@ export default class URI {
      * return this URI without a fragment
      */
     withoutFragment(): URI {
-        return this.withFragment('')
+        return this.withFragment('');
     }
 
     get scheme(): string {
-        return this.codeUri.scheme
+        return this.codeUri.scheme;
     }
 
     get authority(): string {
-        return this.codeUri.authority
+        return this.codeUri.authority;
     }
 
     get path(): Path {
@@ -165,11 +165,11 @@ export default class URI {
     }
 
     get query(): string {
-        return this.codeUri.query
+        return this.codeUri.query;
     }
 
     get fragment(): string {
-        return this.codeUri.fragment
+        return this.codeUri.fragment;
     }
 
     toString(skipEncoding?: boolean) {

--- a/packages/core/src/node/cluster/worker-reader.ts
+++ b/packages/core/src/node/cluster/worker-reader.ts
@@ -26,7 +26,7 @@ export class WorkerMessageReader extends AbstractStreamMessageReader {
                 this.fireError(error);
             }
             this.fireClose();
-        })
+        });
         this.worker.on('error', e =>
             this.fireError(e)
         );

--- a/packages/core/src/node/debug.ts
+++ b/packages/core/src/node/debug.ts
@@ -13,7 +13,7 @@ function isInDebugMode(): boolean {
     if (process && process.execArgv) {
         return process.execArgv.some(arg =>
             /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg)
-        )
+        );
     }
     return false;
 }

--- a/packages/core/src/node/file-uri.spec.ts
+++ b/packages/core/src/node/file-uri.spec.ts
@@ -55,4 +55,4 @@ describe("file-uri", () => {
         expect(uri.toString(true)).to.be.equal('file:///c:/');
     });
 
-})
+});

--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -13,7 +13,7 @@ import { createServerWebSocketConnection } from "./connection";
 
 export const messagingBackendModule = new ContainerModule(bind => {
     bind<BackendApplicationContribution>(BackendApplicationContribution).to(MessagingContribution);
-    bindContributionProvider(bind, ConnectionHandler)
+    bindContributionProvider(bind, ConnectionHandler);
 });
 
 @injectable()
@@ -31,7 +31,7 @@ export class MessagingContribution implements BackendApplicationContribution {
                     path
                 }, connection => handler.onConnection(connection));
             } catch (error) {
-                console.error(error)
+                console.error(error);
             }
         }
     }

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { EditorManager } from "@theia/editor/lib/browser"
+import { EditorManager } from "@theia/editor/lib/browser";
 import {
     KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier
 } from "@theia/core/lib/common";

--- a/packages/cpp/src/common/cpp-preferences.ts
+++ b/packages/cpp/src/common/cpp-preferences.ts
@@ -30,7 +30,7 @@ export const CppConfigSchema: PreferenceSchema = {
             "description": "Literal command to start Clangd with. Can contain any relative or absolute path to clangd executable."
         }
     }
-}
+};
 
 export interface CppConfiguration {
     'cpp.clangdCompileCommandsPath': string,
@@ -40,7 +40,7 @@ export interface CppConfiguration {
 export const defaultCppConfiguration: CppConfiguration = {
     'cpp.clangdCompileCommandsPath': "-compile-commands-dir=/home/ewilenr/theiaEclipse/eclipse/git/llvm/build",
     'cpp.clangdPath': "/home/ewilenr/theiaEclipse/eclipse/git/llvm/build/bin/compile_commands.json"
-}
+};
 
 export const CppPreferences = Symbol('CppPreferences');
 export type CppPreferences = PreferenceProxy<CppConfiguration>;

--- a/packages/cpp/src/common/index.ts
+++ b/packages/cpp/src/common/index.ts
@@ -7,4 +7,4 @@
 
 export const CPP_LANGUAGE_ID = 'cpp';
 export const CPP_LANGUAGE_NAME = 'C/C++';
-export * from './cpp-preferences'
+export * from './cpp-preferences';

--- a/packages/cpp/src/package.spec.ts
+++ b/packages/cpp/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("cpp package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -66,6 +66,6 @@ export interface TextEditorSelection {
 
 export namespace TextEditorSelection {
     export function is(e: any): e is TextEditorSelection {
-        return e && e["uri"] instanceof URI
+        return e && e["uri"] instanceof URI;
     }
 }

--- a/packages/editor/src/package.spec.ts
+++ b/packages/editor/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("editor package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/extension-manager/src/node/npms.ts
+++ b/packages/extension-manager/src/node/npms.ts
@@ -33,4 +33,4 @@ export function search(query: string, from?: number, size?: number): Promise<Nod
             }
         });
     });
-};
+}

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -21,7 +21,7 @@ export class FileTree extends Tree {
         if (FileStatNode.is(parent)) {
             return this.resolveFileStat(parent).then(fileStat =>
                 this.toNodes(fileStat, parent)
-            )
+            );
         }
         return super.resolveChildren(parent);
     }
@@ -43,7 +43,7 @@ export class FileTree extends Tree {
     }
 
     protected toNode(fileStat: FileStat, parent: ICompositeTreeNode): FileNode | DirNode {
-        const uri = new URI(fileStat.uri)
+        const uri = new URI(fileStat.uri);
         const id = fileStat.uri;
         const node = this.getNode(id);
         if (fileStat.isDirectory) {
@@ -57,7 +57,7 @@ export class FileTree extends Tree {
                 expanded: false,
                 selected: false,
                 children: []
-            }
+            };
         }
         if (FileNode.is(node)) {
             node.fileStat = fileStat;
@@ -67,7 +67,7 @@ export class FileTree extends Tree {
         return <FileNode>{
             id, uri, fileStat, name, parent,
             selected: false
-        }
+        };
     }
 
 }
@@ -105,7 +105,7 @@ export namespace DirNode {
     }
 
     export function createRoot(fileStat: FileStat): DirNode {
-        const uri = new URI(fileStat.uri)
+        const uri = new URI(fileStat.uri);
         const id = fileStat.uri;
         return {
             id, uri, fileStat,
@@ -115,6 +115,6 @@ export namespace DirNode {
             children: [],
             expanded: true,
             selected: false
-        }
+        };
     }
 }

--- a/packages/filesystem/src/common/filesystem-preferences.ts
+++ b/packages/filesystem/src/common/filesystem-preferences.ts
@@ -35,7 +35,7 @@ export const defaultFileSystemConfiguration: FileSystemConfiguration = {
         "**/.git/subtree-cache/**": true,
         "**/node_modules/**": true
     }
-}
+};
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');
 export type FileSystemPreferences = PreferenceProxy<FileSystemConfiguration>;

--- a/packages/filesystem/src/common/filesystem-selection.ts
+++ b/packages/filesystem/src/common/filesystem-selection.ts
@@ -13,7 +13,7 @@ export interface UriSelection {
 
 export namespace UriSelection {
     export function is(e: any): e is UriSelection {
-        return e && e["uri"] instanceof URI
+        return e && e["uri"] instanceof URI;
     }
     export function getUri(selection: any): URI | undefined {
         if (UriSelection.is(selection)) {

--- a/packages/filesystem/src/common/filesystem-watcher-protocol.ts
+++ b/packages/filesystem/src/common/filesystem-watcher-protocol.ts
@@ -52,7 +52,7 @@ export enum FileChangeType {
     DELETED = 2
 }
 
-export const FileSystemWatcherServerProxy = Symbol('FileSystemWatcherServerProxy')
+export const FileSystemWatcherServerProxy = Symbol('FileSystemWatcherServerProxy');
 export type FileSystemWatcherServerProxy = JsonRpcProxy<FileSystemWatcherServer>;
 
 @injectable()
@@ -89,7 +89,7 @@ export class ReconnectingFileSystemWatcherServer implements FileSystemWatcherSer
 
     protected doWatchFileChanges(watcher: number, uri: string, options?: WatchOptions): Promise<number> {
         return this.proxy.watchFileChanges(uri, options).then(remote => {
-            this.localToRemoteWatcher.set(watcher, remote)
+            this.localToRemoteWatcher.set(watcher, remote);
             return watcher;
         });
     }

--- a/packages/filesystem/src/common/filesystem-watcher.ts
+++ b/packages/filesystem/src/common/filesystem-watcher.ts
@@ -13,7 +13,7 @@ import { FileSystemPreferences } from "./filesystem-preferences";
 
 export {
     FileChangeType
-}
+};
 
 export interface FileChange {
     uri: URI;
@@ -100,7 +100,7 @@ export class FileSystemWatcher implements Disposable {
         return this.getIgnored().then(ignored => {
             return {
                 ignored
-            }
+            };
         });
     }
 

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -132,7 +132,7 @@ describe("NodeFileSystem", () => {
             expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
 
             return fileSystem.resolveContent(uri.toString(), { encoding: "unknownEncoding" }).should.eventually.be.rejectedWith(Error);
-        })
+        });
 
         it("Should be return with the content for an existing file.", () => {
             const uri = root.resolve("foo.txt");
@@ -640,7 +640,7 @@ describe("NodeFileSystem", () => {
                 expect(stat).is.an("object");
                 expect(stat).has.property("uri").that.equals(uri.toString());
                 expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-            })
+            });
         });
 
         it("Should update the modification timestamp on an existing file.", done => {

--- a/packages/go/src/browser/go-client-contribution.ts
+++ b/packages/go/src/browser/go-client-contribution.ts
@@ -20,7 +20,7 @@ export class GoClientContribution extends BaseLanguageClientContribution {
         @inject(Languages) protected readonly languages: Languages,
         @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
     ) {
-        super(workspace, languages, languageClientFactory)
+        super(workspace, languages, languageClientFactory);
     }
 
     protected get documentSelector() {

--- a/packages/go/src/package.spec.ts
+++ b/packages/go/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("go package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -26,7 +26,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         @inject(Window) protected readonly window: Window,
         @inject(CommandService) protected readonly commandService: CommandService
     ) {
-        super(workspace, languages, languageClientFactory)
+        super(workspace, languages, languageClientFactory);
     }
 
     protected get globPatterns() {

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -55,7 +55,7 @@ export class JavaContribution extends BaseLanguageServerContribution {
             '-jar', jarPath,
             '-configuration', configurationPath,
             '-data', workspacePath
-        )
+        );
 
         Promise.all([
             this.startSocketServer(), this.startSocketServer()

--- a/packages/java/src/package.spec.ts
+++ b/packages/java/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("java package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/languages/src/browser/language-client-factory.ts
+++ b/packages/languages/src/browser/language-client-factory.ts
@@ -26,7 +26,7 @@ export class LanguageClientFactory {
 
     get(contribution: LanguageContribution, clientOptions: LanguageClientOptions): ILanguageClient {
         const { workspace, languages, commands, window } = this;
-        const services = { workspace, languages, commands, window }
+        const services = { workspace, languages, commands, window };
         return new BaseLanguageClient({
             name: contribution.name,
             clientOptions,
@@ -42,7 +42,7 @@ export class LanguageClientFactory {
                             }
                         },
                             { reconnecting: false }
-                        )
+                        );
                     })
             }
         });

--- a/packages/languages/src/browser/languages-frontend-contribution.ts
+++ b/packages/languages/src/browser/languages-frontend-contribution.ts
@@ -22,7 +22,7 @@ export class LanguagesFrontendContribution implements FrontendApplicationContrib
         for (const contribution of this.contributions.getContributions()) {
             contribution.waitForActivation(app).then(() =>
                 contribution.activate(app)
-            )
+            );
         }
     }
 

--- a/packages/languages/src/common/console-window.ts
+++ b/packages/languages/src/common/console-window.ts
@@ -42,8 +42,8 @@ export class ConsoleWindow implements Window {
             show(): void {
                 // no-op
             }
-        }
-        this.channels.set(name, channel)
+        };
+        this.channels.set(name, channel);
         return channel;
     }
 }

--- a/packages/languages/src/common/languageclient-services.ts
+++ b/packages/languages/src/common/languageclient-services.ts
@@ -54,4 +54,4 @@ export interface ILanguageClient extends base.BaseLanguageClient { }
 import LanguageClientOptions = base.BaseLanguageClientOptions;
 export {
     LanguageClientOptions
-}
+};

--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -21,7 +21,7 @@ import { LanguageContribution } from "../common";
 
 export {
     LanguageContribution, IConnection, Message
-}
+};
 
 export const LanguageServerContribution = Symbol('LanguageServerContribution');
 export interface LanguageServerContribution extends LanguageContribution {
@@ -72,12 +72,12 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
     }
 
     protected onDidFailSpawnProcess(error: Error): void {
-        console.error(error)
+        console.error(error);
     }
 
     protected logError(data: string | Buffer) {
         if (data) {
-            console.error(`${this.name}: ${data}`)
+            console.error(`${this.name}: ${data}`);
         }
     }
 
@@ -89,7 +89,7 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
 
     protected startSocketServer(): Promise<net.Server> {
         return new Promise(resolve => {
-            const server = net.createServer()
+            const server = net.createServer();
             server.addListener('listening', () =>
                 resolve(server)
             );

--- a/packages/languages/src/package.spec.ts
+++ b/packages/languages/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("languages package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/monaco/src/browser/monaco-context-menu.ts
+++ b/packages/monaco/src/browser/monaco-context-menu.ts
@@ -33,7 +33,7 @@ export class MonacoContextMenuService implements IContextMenuService {
                 });
 
                 for (const action of actions) {
-                    const commandId = 'quickfix_' + actions.indexOf(action)
+                    const commandId = 'quickfix_' + actions.indexOf(action);
                     commands.addCommand(commandId, {
                         label: action.label,
                         className: action.class,

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -59,7 +59,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
      */
     protected initialize(content: string): void {
         if (!this.toDispose.disposed) {
-            this.model = monaco.editor.createModel(content, undefined, monaco.Uri.parse(this.resource.uri.toString()))
+            this.model = monaco.editor.createModel(content, undefined, monaco.Uri.parse(this.resource.uri.toString()));
             this.toDispose.push(this.model);
             this.toDispose.push(this.model.onDidChangeContent(event => this.markAsDirty()));
             if (this.resource.onDidChangeContents) {

--- a/packages/monaco/src/browser/monaco-languages.ts
+++ b/packages/monaco/src/browser/monaco-languages.ts
@@ -37,7 +37,7 @@ export class MonacoLanguages extends BaseMonacoLanguages implements Languages {
         const uris: string[] = [];
         return {
             set: (uri, diagnostics) => {
-                monacoCollection.set(uri, diagnostics)
+                monacoCollection.set(uri, diagnostics);
                 this.problemManager.setMarkers(new URI(uri), owner, diagnostics);
                 uris.push(uri);
             },

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -23,7 +23,7 @@ export function loadVsRequire(context: any): Promise<any> {
                 resolve(amdRequire);
             });
             document.body.appendChild(vsLoader);
-        }
+        };
     });
 }
 
@@ -71,4 +71,4 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 });
         });
     });
-};
+}

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -119,8 +119,8 @@ export class MonacoWorkspace extends BaseMonacoWorkspace implements lang.Workspa
     }
 
     createFileSystemWatcher(globPattern: string, ignoreCreateEvents?: boolean, ignoreChangeEvents?: boolean, ignoreDeleteEvents?: boolean): lang.FileSystemWatcher {
-        const disposables = new DisposableCollection()
-        const onFileEventEmitter = new lang.Emitter<lang.FileEvent>()
+        const disposables = new DisposableCollection();
+        const onFileEventEmitter = new lang.Emitter<lang.FileEvent>();
         disposables.push(onFileEventEmitter);
         disposables.push(this.fileSystemWatcher.onFilesChanged(changes => {
             for (const change of changes) {
@@ -153,7 +153,7 @@ export class MonacoWorkspace extends BaseMonacoWorkspace implements lang.Workspa
                 // start a fresh operation
                 model.pushStackElement();
                 const range = edit.range;
-                const selections = [new monaco.Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn)]
+                const selections = [new monaco.Selection(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn)];
                 model.pushEditOperations(selections, [{
                     identifier: undefined!,
                     forceMoveMarkers: false,

--- a/packages/monaco/src/package.spec.ts
+++ b/packages/monaco/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("monaco package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/navigator/src/package.spec.ts
+++ b/packages/navigator/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("navigator package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/preferences-api/src/common/preference-proxy.ts
+++ b/packages/preferences-api/src/common/preference-proxy.ts
@@ -7,12 +7,12 @@
 
 import { Disposable, DisposableCollection, Event, Emitter } from '@theia/core/lib/common';
 import { PreferenceService, PreferenceChange } from "./preference-service";
-import { PreferenceSchema } from "./preference-contribution"
+import { PreferenceSchema } from "./preference-contribution";
 import * as Ajv from "ajv";
 
 export type Configuration = {
     [preferenceName: string]: any
-}
+};
 export interface PreferenceChangeEvent<T> {
     readonly preferenceName: keyof T
     readonly newValue?: T[keyof T]
@@ -71,7 +71,7 @@ export function createPreferenceProxy<T extends Configuration>(preferences: Pref
             }
             throw new Error('unexpected property: ' + p);
         }
-    })
+    });
 }
 
 export function validatePreference(schema: PreferenceSchema, preference: Object) {

--- a/packages/preferences-api/src/common/preference-service.spec.ts
+++ b/packages/preferences-api/src/common/preference-service.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { PreferenceService } from './preference-service';
-import { PreferenceServer, PreferenceClient, PreferenceChangedEvent, PreferenceChange } from './'
+import { PreferenceServer, PreferenceClient, PreferenceChangedEvent, PreferenceChange } from './';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 
@@ -19,7 +19,7 @@ const prefJson: { [key: string]: any } = {
     "testString": "string",
     "testBooleanTrue": true,
     "testNumber1": 1,
-}
+};
 
 class PreferenceServerStub implements PreferenceServer {
     has(preferenceName: string): Promise<boolean> {
@@ -81,7 +81,7 @@ class PreferenceServerStub implements PreferenceServer {
 
     fireEvents() {
         for (const field of Object.keys(prefJson)) {
-            const event = { preferenceName: field, newValue: prefJson[field] }
+            const event = { preferenceName: field, newValue: prefJson[field] };
             const changes: PreferenceChange[] = [];
             changes.push(event);
 
@@ -146,13 +146,13 @@ describe('preference-service  (simplified api)', () => {
         expect(valBoolean).to.be.false;
 
         // should return true value as a "true" string
-        valString = prefService.getString("testBooleanTrue")
+        valString = prefService.getString("testBooleanTrue");
         expect(valString).to.be.equal("true");
 
         // should return NaN for a NaN
         valNumber = prefService.getNumber("testString");
         expect(isNaN(valNumber!)).to.be.true;
-    })
+    });
 
     it('should return undefined when wrong value and no default value supplied', () => {
         // should return undefined for a non-existing boolean key
@@ -189,7 +189,7 @@ describe('preference-service  (simplified api)', () => {
                 { preferenceName: "test" },
                 { preferenceName: "test2", newValue: true },
                 { preferenceName: "test3", newValue: true, oldValue: false }]
-        }
+        };
 
         prefService.onPreferenceChanged((event) => {
             switch (event.preferenceName) {
@@ -209,7 +209,7 @@ describe('preference-service  (simplified api)', () => {
                     break;
                 }
             }
-        })
+        });
 
         prefStub.onDidChangePreference(prefChangedEvent);
     });

--- a/packages/preferences-api/src/common/preference-service.ts
+++ b/packages/preferences-api/src/common/preference-service.ts
@@ -11,7 +11,7 @@ import { PreferenceServer, PreferenceChangedEvent, PreferenceChange } from './pr
 
 export {
     PreferenceChange
-}
+};
 
 @injectable()
 export class PreferenceService implements Disposable {

--- a/packages/preferences-api/src/package.spec.ts
+++ b/packages/preferences-api/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("preferences-api package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/preferences/src/browser/index.ts
+++ b/packages/preferences/src/browser/index.ts
@@ -5,4 +5,4 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export * from './preference-frontend-module'
+export * from './preference-frontend-module';

--- a/packages/preferences/src/common/compound-preference-server.spec.ts
+++ b/packages/preferences/src/common/compound-preference-server.spec.ts
@@ -10,8 +10,8 @@ import * as chaiAsPromised from "chai-as-promised";
 import * as temp from 'temp';
 import * as fs from 'fs-extra';
 
-import { CompoundPreferenceServer } from '@theia/preferences-api'
-import { JsonPrefHelper } from '../node/test/preference-stubs'
+import { CompoundPreferenceServer } from '@theia/preferences-api';
+import { JsonPrefHelper } from '../node/test/preference-stubs';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 
 const expect = chai.expect;
@@ -40,7 +40,7 @@ before(() => {
 after(() => {
     compoundPrefServer.dispose();
     track.cleanupSync();
-})
+});
 
 describe('compound-preference-server', () => {
     it('register a client', async () => {
@@ -58,8 +58,8 @@ describe('compound-preference-server', () => {
                         }
                     }
                 }
-            })
-        })
+            });
+        });
 
         const fileContent = '{ "showLineNumbers": true }';
 
@@ -76,9 +76,9 @@ describe('compound-preference-server', () => {
                     type: 0
                 }]
             }
-        )
+        );
 
         return promise;
 
-    })
+    });
 });

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -6,7 +6,7 @@
  */
 import * as chai from 'chai';
 import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised'
+import * as chaiAsPromised from 'chai-as-promised';
 import * as process from 'process';
 import * as stream from 'stream';
 import { testContainer } from './inversify.spec-config';

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -6,7 +6,7 @@
  */
 import * as chai from 'chai';
 import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised'
+import * as chaiAsPromised from 'chai-as-promised';
 import * as process from 'process';
 import * as stream from 'stream';
 import { testContainer } from './inversify.spec-config';
@@ -77,7 +77,7 @@ describe('TerminalProcess', function () {
             /* node-pty is not sending 'end' on the stream as it quits
             only 'exit' is sent on the terminal process.  */
             terminalProcess.onExit(() => {
-                resolve(version.trim())
+                resolve(version.trim());
             });
         });
 

--- a/packages/python/src/package.spec.ts
+++ b/packages/python/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("python package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -27,7 +27,7 @@ export namespace TerminalCommands {
     export const NEW: Command = {
         id: 'terminal:new',
         label: 'New Terminal'
-    }
+    };
 }
 
 @injectable()

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { ContainerModule, Container } from 'inversify'
+import { ContainerModule, Container } from 'inversify';
 import { CommandContribution, MenuContribution, KeybindingContribution } from '@theia/core/lib/common';
 import { TerminalFrontendContribution } from './terminal-frontend-contribution';
 import { TerminalWidget, TerminalWidgetOptions, TERMINAL_WIDGET_FACTORY_ID } from './terminal-widget';

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -52,11 +52,11 @@ interface TerminalCSSProperties {
 @injectable()
 export class TerminalWidget extends BaseWidget {
 
-    private terminalId: number | undefined
-    private term: Xterm.Terminal
-    private cols: number = 80
-    private rows: number = 40
-    private endpoint: Endpoint
+    private terminalId: number | undefined;
+    private term: Xterm.Terminal;
+    private cols: number = 80;
+    private rows: number = 40;
+    private endpoint: Endpoint;
 
     constructor(
         @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
@@ -79,8 +79,8 @@ export class TerminalWidget extends BaseWidget {
             ));
         }
 
-        this.title.closable = true
-        this.addClass("terminal-container")
+        this.title.closable = true;
+        this.addClass("terminal-container");
 
         /* Read CSS properties from the page and apply them to the terminal.  */
         const cssProps = this.getCSSPropertiesFromPage();
@@ -155,7 +155,7 @@ export class TerminalWidget extends BaseWidget {
     }
 
     protected registerResize(): void {
-        const initialGeometry = (this.term as any).proposeGeometry()
+        const initialGeometry = (this.term as any).proposeGeometry();
         this.cols = initialGeometry.cols;
         this.rows = initialGeometry.rows;
 
@@ -209,23 +209,23 @@ export class TerminalWidget extends BaseWidget {
     }
 
     protected createWebSocket(pid: string): WebSocket {
-        const url = this.endpoint.getWebSocketUrl().resolve(pid)
-        return this.webSocketConnectionProvider.createWebSocket(url.toString(), { reconnecting: false })
+        const url = this.endpoint.getWebSocketUrl().resolve(pid);
+        return this.webSocketConnectionProvider.createWebSocket(url.toString(), { reconnecting: false });
     }
 
     protected onActivateRequest(msg: Message): void {
-        super.onActivateRequest(msg)
-        this.term.focus()
+        super.onActivateRequest(msg);
+        this.term.focus();
     }
 
-    private resizeTimer: any
+    private resizeTimer: any;
 
     protected onResize(msg: Widget.ResizeMessage): void {
         super.onResize(msg);
-        clearTimeout(this.resizeTimer)
+        clearTimeout(this.resizeTimer);
         this.resizeTimer = setTimeout(() => {
-            this.doResize()
-        }, 500)
+            this.doResize();
+        }, 500);
     }
 
     protected monitorTerminal(id: number) {
@@ -260,9 +260,9 @@ export class TerminalWidget extends BaseWidget {
     }
 
     private doResize() {
-        const geo = (this.term as any).proposeGeometry()
-        this.cols = geo.cols
-        this.rows = geo.rows - 1 // subtract one row for margin
-        this.term.resize(this.cols, this.rows)
+        const geo = (this.term as any).proposeGeometry();
+        this.cols = geo.cols;
+        this.rows = geo.rows - 1; // subtract one row for margin
+        this.term.resize(this.cols, this.rows);
     }
 }

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -7,7 +7,7 @@
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 
-export interface IBaseTerminalServerOptions { };
+export interface IBaseTerminalServerOptions { }
 
 export interface IBaseTerminalServer extends JsonRpcServer<IBaseTerminalClient> {
     create(IBaseTerminalServerOptions: object): Promise<number>;

--- a/packages/terminal/src/common/terminal-watcher.ts
+++ b/packages/terminal/src/common/terminal-watcher.ts
@@ -17,12 +17,12 @@ export class TerminalWatcher {
         const errorEmitter = this.onTerminalErrorEmitter;
         return {
             onTerminalExitChanged(event: IBaseTerminalExitEvent) {
-                exitEmitter.fire(event)
+                exitEmitter.fire(event);
             },
             onTerminalError(event: IBaseTerminalErrorEvent) {
                 errorEmitter.fire(event);
             }
-        }
+        };
     }
 
     private onTerminalExitEmitter = new Emitter<IBaseTerminalExitEvent>();

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -50,7 +50,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
         if (term && term instanceof TerminalProcess) {
             term.resize(cols, rows);
         } else {
-            console.error("Couldn't resize terminal " + id + ", because it doesn't exist.")
+            console.error("Couldn't resize terminal " + id + ", because it doesn't exist.");
         }
         return Promise.resolve();
     }

--- a/packages/terminal/src/node/shell-terminal-server.spec.ts
+++ b/packages/terminal/src/node/shell-terminal-server.spec.ts
@@ -6,7 +6,7 @@
  */
 import * as chai from 'chai';
 import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised'
+import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { IShellTerminalServer } from '../common/shell-terminal-protocol';
 

--- a/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
@@ -7,7 +7,7 @@
 
 import * as chai from 'chai';
 import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised'
+import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
 import { IShellTerminalServer } from '../common/shell-terminal-protocol';

--- a/packages/terminal/src/node/terminal-backend-contribution.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.ts
@@ -26,12 +26,12 @@ export class TerminalBackendContribution implements BackendApplicationContributi
         openSocket({
             server,
             matches: (request) => {
-                const uri = new URI(request.url!)
-                return uri.path.toString().startsWith('/services/terminals/')
+                const uri = new URI(request.url!);
+                return uri.path.toString().startsWith('/services/terminals/');
             }
         }, (ws, request) => {
-            const uri = new URI(request.url!)
-            const id = parseInt(uri.path.base, 10)
+            const uri = new URI(request.url!);
+            const id = parseInt(uri.path.base, 10);
             let term = this.processManager.get(id);
             if (!term) {
                 return;
@@ -43,7 +43,7 @@ export class TerminalBackendContribution implements BackendApplicationContributi
                 try {
                     ws.send(data.toString());
                 } catch (ex) {
-                    console.error(ex)
+                    console.error(ex);
                 }
             });
 
@@ -51,7 +51,7 @@ export class TerminalBackendContribution implements BackendApplicationContributi
 
             ws.on('message', (msg: any) => {
                 if (term instanceof TerminalProcess) {
-                    term.write(msg)
+                    term.write(msg);
                 }
             });
             ws.on('close', (msg: any) => {

--- a/packages/terminal/src/node/terminal-server.spec.ts
+++ b/packages/terminal/src/node/terminal-server.spec.ts
@@ -6,7 +6,7 @@
  */
 import * as chai from 'chai';
 import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised'
+import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { TerminalWatcher } from '../common/terminal-watcher';
 import { ITerminalServer } from '../common/terminal-protocol';

--- a/packages/terminal/src/package.spec.ts
+++ b/packages/terminal/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("terminal package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });

--- a/packages/workspace/src/package.spec.ts
+++ b/packages/workspace/src/package.spec.ts
@@ -17,5 +17,5 @@ describe("workspace package", () => {
 
     it("support code coverage statistics", () => {
         return true;
-    })
+    });
 });


### PR DESCRIPTION
We currently have inconsistent use of semicolon, fix it and enable the
linter rule.  Also, I don't see why we shouldn't enforce the use of
semicolons in interfaces, since it will just lead to more inconsistency,
so I removed that part of the rule.