### PR TITLE
 Make fields of Key readonly 

### DIFF
--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -139,7 +139,7 @@ export enum Modifier {
     M4 = "M4"
 }
 
-export declare type Key = { code: string, keyCode: number };
+export declare type Key = { readonly code: string, readonly keyCode: number };
 
 const CODE_TO_KEY: { [code: string]: Key } = {};
 const KEY_CODE_TO_KEY: { [keyCode: number]: Key } = {};


### PR DESCRIPTION
Some code could, by mistake, modifiy a global constant, like:

    const mykey = Key.KEY_A;
    mykey.keyCode++;

This would modify the global constant for everybody, potentially
breaking program functionality.  This example is a bit simple and
stupid, but in real code, it could be quite hard to find what code
changes it, if it happens.  The reference to the constant could be
passed around function calls before it is actually modified, and the
place where functionality breaks could be at a completely different
place.

Making the type immutable (making all fields readonly) should prevent
that.  If some code tries to modify it, it won't compile, forcing
callers to create a new instance.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>