### PR TITLE
Rename registerKeyBinding to registerKeybinding

### DIFF
--- a/doc/Commands_Keybindings.md
+++ b/doc/Commands_Keybindings.md
@@ -53,7 +53,7 @@ export class EditorKeybindingContribution implements KeybindingContribution {
         @inject(EditorKeybindingContext) protected readonly editorKeybindingContext: EditorKeybindingContext
     ) { }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
+    registerKeybindings(registry: KeybindingRegistry): void {
         [
             {
                 commandId: 'editor.close',
@@ -66,7 +66,7 @@ export class EditorKeybindingContribution implements KeybindingContribution {
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_W, modifiers: [Modifier.M2, Modifier.M3] })
             }
         ].forEach(binding => {
-            registry.registerKeyBinding(binding);
+            registry.registerKeybinding(binding);
         });
     }
 }

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -247,21 +247,21 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         });
     }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
+    registerKeybindings(registry: KeybindingRegistry): void {
         if (supportCut) {
-            registry.registerKeyBinding({
+            registry.registerKeybinding({
                 commandId: CommonCommands.CUT.id,
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_X, modifiers: [Modifier.M1] })
             });
         }
         if (supportCopy) {
-            registry.registerKeyBinding({
+            registry.registerKeybinding({
                 commandId: CommonCommands.COPY.id,
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] })
             });
         }
         if (supportPaste) {
-            registry.registerKeyBinding({
+            registry.registerKeybinding({
                 commandId: CommonCommands.PASTE.id,
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_V, modifiers: [Modifier.M1] })
             });

--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -26,12 +26,12 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
         });
     }
 
-    registerKeyBindings(keybindings: KeybindingRegistry): void {
-        keybindings.registerKeyBinding({
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
             commandId: quickCommand.id,
             keyCode: KeyCode.createKeyCode({ first: Key.F1 })
         });
-        keybindings.registerKeyBinding({
+        keybindings.registerKeybinding({
             commandId: quickCommand.id,
             keyCode: KeyCode.createKeyCode({ first: Key.KEY_P, modifiers: [Modifier.M1, Modifier.M2] })
         });

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -28,7 +28,7 @@ export interface Keybinding {
 
 export const KeybindingContribution = Symbol("KeybindingContribution");
 export interface KeybindingContribution {
-    registerKeyBindings(keybindings: KeybindingRegistry): void;
+    registerKeybindings(keybindings: KeybindingRegistry): void;
 }
 
 export const KeybindingContext = Symbol("KeybindingContextExtension");
@@ -108,13 +108,13 @@ export class KeybindingRegistry {
 
     onStart(): void {
         for (const contribution of this.contributions.getContributions()) {
-            contribution.registerKeyBindings(this);
+            contribution.registerKeybindings(this);
         }
     }
 
     registerKeybindings(...bindings: Keybinding[]): void {
         for (const binding of bindings) {
-            this.registerKeyBinding(binding);
+            this.registerKeybinding(binding);
         }
     }
 
@@ -123,7 +123,7 @@ export class KeybindingRegistry {
      *
      * @param binding
      */
-    registerKeyBinding(binding: Keybinding) {
+    registerKeybinding(binding: Keybinding) {
         const existing = this.keybindings[binding.keyCode.keystroke];
         if (existing) {
             const collided = existing.filter(b => b.context === binding.context);

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -122,26 +122,26 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
         });
     }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
-        registry.registerKeyBinding({
+    registerKeybindings(registry: KeybindingRegistry): void {
+        registry.registerKeybinding({
             commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
             keyCode: KeyCode.createKeyCode({ first: Key.KEY_I, modifiers: [Modifier.M1, Modifier.M2] })
         });
 
-        registry.registerKeyBinding({
+        registry.registerKeybinding({
             commandId: ElectronCommands.RELOAD.id,
             keyCode: KeyCode.createKeyCode({ first: Key.KEY_R, modifiers: [Modifier.M1] })
         });
 
-        registry.registerKeyBinding({
+        registry.registerKeybinding({
             commandId: ElectronCommands.ZOOM_IN.id,
             keyCode: KeyCode.createKeyCode({ first: Key.EQUAL, modifiers: [Modifier.M1] })
         });
-        registry.registerKeyBinding({
+        registry.registerKeybinding({
             commandId: ElectronCommands.ZOOM_OUT.id,
             keyCode: KeyCode.createKeyCode({ first: Key.MINUS, modifiers: [Modifier.M1] })
         });
-        registry.registerKeyBinding({
+        registry.registerKeybinding({
             commandId: ElectronCommands.RESET_ZOOM.id,
             keyCode: KeyCode.createKeyCode({ first: Key.DIGIT0, modifiers: [Modifier.M1] })
         });

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -31,7 +31,7 @@ export class CppKeybindingContribution implements KeybindingContribution {
         @inject(CppKeybindingContext) protected readonly cppKeybindingContext: CppKeybindingContext
     ) { }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
+    registerKeybindings(registry: KeybindingRegistry): void {
         [
             {
                 commandId: 'switch_source_header',
@@ -39,7 +39,7 @@ export class CppKeybindingContribution implements KeybindingContribution {
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M3] })
             }
         ].forEach(binding => {
-            registry.registerKeyBinding(binding);
+            registry.registerKeybinding(binding);
         });
 
     }

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -29,7 +29,7 @@ export class EditorKeybindingContribution implements KeybindingContribution {
         @inject(EditorKeybindingContext) protected readonly editorKeybindingContext: EditorKeybindingContext
     ) { }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
+    registerKeybindings(registry: KeybindingRegistry): void {
     }
 
 }

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -26,8 +26,8 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
         });
     }
 
-    registerKeyBindings(keybindings: KeybindingRegistry): void {
-        keybindings.registerKeyBinding({
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
             commandId: quickFileOpen.id,
             keyCode: KeyCode.createKeyCode({ first: Key.KEY_P, modifiers: [Modifier.M1] })
         });

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -42,8 +42,8 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         commands.registerCommand(this.command, this);
     }
 
-    registerKeyBindings(keybindings: KeybindingRegistry): void {
-        keybindings.registerKeyBinding({
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
             commandId: this.command.id,
             keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M1] }),
             accelerator: ['Accel O']

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -55,8 +55,8 @@ export class ProblemContribution implements CommandContribution, MenuContributio
         });
     }
 
-    registerKeyBindings(keybindings: KeybindingRegistry): void {
-        keybindings.registerKeyBinding({
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
             commandId: ProblemCommands.OPEN.id,
             keyCode: KeyCode.createKeyCode({
                 first: Key.KEY_M, modifiers: [Modifier.M2, Modifier.M1]

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -30,14 +30,14 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
         @inject(MonacoCommandRegistry) protected readonly commands: MonacoCommandRegistry
     ) { }
 
-    registerKeyBindings(registry: KeybindingRegistry): void {
+    registerKeybindings(registry: KeybindingRegistry): void {
         for (const item of KeybindingsRegistry.getDefaultKeybindings()) {
             const commandId = this.commands.validate(item.command);
             if (commandId) {
                 const raw = item.keybinding;
                 if (raw.type === monaco.keybindings.KeybindingType.Simple) {
                     const keybinding = raw as monaco.keybindings.SimpleKeybinding;
-                    registry.registerKeyBinding({
+                    registry.registerKeybinding({
                         commandId,
                         keyCode: this.keyCode(keybinding),
                         accelerator: this.accelerator(keybinding)
@@ -51,7 +51,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
         // `Select All` is not an editor action just like everything else.
         const selectAllCommand = this.commands.validate(MonacoCommands.SELECTION_SELECT_ALL);
         if (selectAllCommand) {
-            registry.registerKeyBinding({
+            registry.registerKeybinding({
                 commandId: selectAllCommand,
                 keyCode: KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }),
                 accelerator: ['Accel A']

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -53,14 +53,14 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         });
     }
 
-    registerKeyBindings(keybindings: KeybindingRegistry): void {
+    registerKeybindings(keybindings: KeybindingRegistry): void {
         [
             {
                 commandId: TerminalCommands.NEW.id,
                 keyCode: KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] })
             },
         ].forEach(binding => {
-            keybindings.registerKeyBinding(binding);
+            keybindings.registerKeybinding(binding);
         });
     }
 


### PR DESCRIPTION
All other names use the case "Keybinding" and not "KeyBinding", so
change this function name to follow the convention.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>