### PR TITLE
[styling] Aligned style of scrollbars

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -10,7 +10,7 @@ body {
   padding: 0;
   overflow: hidden;
   font-family: var(--theia-ui-font-family);
-  background: var(--theia-layout-color2);
+  background: var(--theia-layout-color3);
   background-image: var(--theia-preloader);
   background-size: 60px 60px;
   background-repeat: no-repeat;
@@ -24,7 +24,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background: var(--theia-layout-color2);
+  background: var(--theia-layout-color3);
 }
 
 .theia-icon {

--- a/packages/core/src/browser/style/scrollbars.css
+++ b/packages/core/src/browser/style/scrollbars.css
@@ -1,13 +1,13 @@
 ::-webkit-scrollbar {
-    height: 12px;
-    width: 12px;
-    background: var(--theia-layout-color1);
+    height: 9px;
+    width: 9px;
+    background: var(--theia-scrollbar-color);
 }
 
 ::-webkit-scrollbar-thumb {
-    background: var(--theia-ui-font-color2);
+    background: var(--theia-scrollbar-thumb-color);
 }
 
 ::-webkit-scrollbar-corner {
-    background: var(--theia-layout-color1);
+    background: transparent;
 }

--- a/packages/core/src/browser/style/variables-bright.css
+++ b/packages/core/src/browser/style/variables-bright.css
@@ -99,7 +99,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-layout-color0: white;
   --theia-layout-color1: white;
   --theia-layout-color2: var(--md-grey-200);
-  --theia-layout-color3: var(--md-grey-400); 
+  --theia-layout-color3: var(--md-grey-400);
+  --theia-layout-color4: var(--md-grey-600);
 
   /* Brand/accent */
 
@@ -145,4 +146,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-sprite-y-offset: 0px;
   --theia-icon-circle: url(../icons/circle-bright.svg);
   --theia-preloader: url(../icons/spinner.gif);
+
+  /* scrollbars */
+  --theia-scrollbar-thumb-color: var(--theia-layout-color4);
+  --theia-scrollbar-color: var(--theia-layout-color3);
 }

--- a/packages/core/src/browser/style/variables-dark.css
+++ b/packages/core/src/browser/style/variables-dark.css
@@ -100,6 +100,7 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-layout-color1: #333333;
   --theia-layout-color2: #2b2b2b;
   --theia-layout-color3: #1e1e1e;
+  --theia-layout-color4: #404040;
 
   /* Brand/accent */
 
@@ -145,4 +146,8 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-sprite-y-offset: -20px;
   --theia-icon-circle: url(../icons/circle-dark.svg);
   --theia-preloader: url(../icons/spinner.gif);
+
+  /* scrollbars */
+  --theia-scrollbar-thumb-color: var(--theia-layout-color4);
+  --theia-scrollbar-color: var(--theia-layout-color3);
 }

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -97,7 +97,17 @@ export class MonacoEditor implements TextEditor, IEditorReference {
     protected create(options?: IEditorConstructionOptions, override?: monaco.editor.IEditorOverrideServices): Disposable {
         return this.editor = monaco.editor.create(this.node, {
             ...options,
-            fixedOverflowWidgets: true
+            fixedOverflowWidgets: true,
+            minimap: {
+                enabled: false
+            },
+            scrollbar: {
+                useShadows: false,
+                verticalHasArrows: false,
+                horizontalHasArrows: false,
+                verticalScrollbarSize: 10,
+                horizontalScrollbarSize: 10
+            }
         }, override);
     }
 


### PR DESCRIPTION
I added alignment of scrollbars between monaco editors and the rest. Also, I made them a bit smaller and removed the editor's minimaps. I will bring in a preference for it in a separate PR.

This is what it looks like now:

<img width="1232" alt="screen shot 2017-11-18 at 07 44 12" src="https://user-images.githubusercontent.com/372735/32977773-59c4cb5e-cc34-11e7-96c5-59b9cb554c6d.png">