### PR TITLE
Refs #378: Very simple adaptive tab size

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -5,7 +5,6 @@
 :root {
   /* These need to be root because tabs get attached to the body during dragging. */
   --theia-private-horizontal-tab-height: 24px;
-  --theia-private-horizontal-tab-width: 144px;
   --theia-private-horizontal-tab-active-top-border: 2px;
 }
 
@@ -38,7 +37,7 @@
 }
 
 .p-DockPanel-tabBar .p-TabBar-tab {
-  flex: 0 1 var(--theia-private-horizontal-tab-width);
+  flex: 0 1 auto;
   min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-border-width));
   min-width: 35px;
   margin-left: calc(-1*var(--theia-border-width));
@@ -168,7 +167,6 @@
   font-size: var(--theia-ui-font-size1);
   line-height: var(--theia-private-horizontal-tab-height);
   min-height: var(--theia-private-horizontal-tab-height);
-  min-width: var(--theia-private-horizontal-tab-width);
   padding: 0px 10px;
   transform: translateX(-40%) translateY(-58%);
 }


### PR DESCRIPTION
Currently, all tabs have the same width, regardless of their content.
This means that long filenames are cut short.  While far from ideal, I
managed to make the situation a little bit better by setting flex-basis
(the 3rd parameter of flex) to auto.  The flex attribute now has the
default value, so we could as well remove it, but I think it's good to
leave it here for clarity.

With this patch, if there is enough room, tabs will show the entire
filename.  When there isn't enough space for all tabs, they will start
shrinking.  Prior to this patch, tabs had a fixed size, until there was
no more space, where they also started shrinking.

This is not ideal, because if you open many files, the tabs will be so
small that you won't be able to read any filename.  I still think that
this patch is a small improvement, because it improves the case where
you have few files open, while not changing the case where you have
many.

The constant --theia-private-horizontal-tab-width is now unused, should
I remove it or leave it there for future use?

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>