### PR TITLE
Improve git perf

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -10,7 +10,8 @@
     "@theia/workspace": "^0.2.1",
     "abs": "^1.3.8",
     "dugite-extra": "0.0.1-alpha.15",
-    "findit2": "^2.2.3"
+    "findit2": "^2.2.3",
+    "ignore": "^3.3.7"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/git/src/common/git-preferences.ts
+++ b/packages/git/src/common/git-preferences.ts
@@ -10,27 +10,14 @@ import { createPreferenceProxy, PreferenceProxy, PreferenceService } from '@thei
 import { PreferenceSchema } from '@theia/preferences-api/lib/common/';
 
 export interface GitConfiguration {
-
-    /**
-     * The time-interval (in milliseconds) to poll for the status changes in the local working directory.
-     */
-    'git.pollInterval': number
-
 }
 
 const DefaultGitConfiguration: GitConfiguration = {
-    'git.pollInterval': 1000
 };
 
 export const GitPreferenceSchema: PreferenceSchema = {
     'type': 'object',
-    'properties': {
-        'git.pollInterval': {
-            'type': 'number',
-            'minimum': 100,
-            'description': 'The time-interval (in milliseconds) to poll for the status changes in the local working directory.'
-        }
-    }
+    'properties': {}
 };
 
 export const GitPreferences = Symbol('GitPreferences');

--- a/packages/git/src/node/git-backend-module.ts
+++ b/packages/git/src/node/git-backend-module.ts
@@ -6,21 +6,21 @@
  */
 
 import { Git, GitPath } from '../common/git';
-import { GitWatcher, GitWatcherPath, GitWatcherClient, GitWatcherServer } from '../common/git-watcher';
+import { GitWatcherPath, GitWatcherClient, GitWatcherServer } from '../common/git-watcher';
 import { DugiteGit } from './dugite-git';
 import { DugiteGitWatcherServer } from './dugite-git-watcher';
-import { ContainerModule } from 'inversify';
-import { bindGitPreferences } from '../common/git-preferences';
+import { ContainerModule, Container } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from "@theia/core/lib/common";
+import { GitRepositoryManager } from './git-repository-manager';
+import { GitRepositoryWatcherFactory, GitRepositoryWatcherOptions, GitRepositoryWatcher } from './git-repository-watcher';
 
 export default new ContainerModule(bind => {
-    bindGitPreferences(bind);
     bind(DugiteGit).toSelf().inSingletonScope();
     bind(Git).toDynamicValue(ctx => ctx.container.get(DugiteGit)).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(context => new JsonRpcConnectionHandler(GitPath, () => context.container.get(Git))).inSingletonScope();
+
     bind(DugiteGitWatcherServer).toSelf();
     bind(GitWatcherServer).toDynamicValue(context => context.container.get(DugiteGitWatcherServer));
-    bind(GitWatcher).toSelf();
     bind(ConnectionHandler).toDynamicValue(context =>
         new JsonRpcConnectionHandler<GitWatcherClient>(GitWatcherPath, client => {
             const server = context.container.get<GitWatcherServer>(GitWatcherServer);
@@ -29,4 +29,13 @@ export default new ContainerModule(bind => {
             return server;
         })
     ).inSingletonScope();
+
+    bind(GitRepositoryManager).toSelf().inSingletonScope();
+    bind(GitRepositoryWatcherFactory).toFactory(ctx => (options: GitRepositoryWatcherOptions) => {
+        const child = new Container({ defaultScope: 'Singleton' });
+        child.parent = ctx.container;
+        child.bind(GitRepositoryWatcher).toSelf();
+        child.bind(GitRepositoryWatcherOptions).toConstantValue(options);
+        return child.get(GitRepositoryWatcher);
+    });
 });

--- a/packages/git/src/node/git-repository-locator.ts
+++ b/packages/git/src/node/git-repository-locator.ts
@@ -4,32 +4,72 @@
 * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 */
+
+import { injectable } from 'inversify';
 import * as fs from 'fs';
-import * as Path from 'path';
+import * as paths from 'path';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { Repository } from '../common/model';
 
+const ignore: () => IgnoreFilter = require('ignore');
 const abs: (path: string) => string = require('abs');
-const finder: any = require('findit2');
+const finder = require('findit2');
 
-/**
- * Resolves to an array of repositories, recursively discovered from the given root `path`.
- *
- * @param path the FS path of the root to start the discovery.
- */
-export function locateRepositories(path: string): Promise<Repository[]> {
-    return new Promise<Repository[]>((resolve, reject) => {
-        const repositoryPaths = new Set();
-        const emitter = finder(abs(path));
-        emitter.on('directory', (dir: string, stat: fs.Stats, stop: () => void) => {
-            const base = Path.basename(dir);
-            if (base === '.git') {
-                const dirName = Path.dirname(dir);
-                repositoryPaths.add(dirName);
-                stop();
-            }
+export interface IgnoreFilter {
+    add(patterns: string | IgnoreFilter): void
+    ignores(pathname: string): boolean;
+}
+
+@injectable()
+export class GitRepositoryLocator {
+
+    /**
+     * Resolves to an array of repositories, recursively discovered from the given root `path`.
+     *
+     * @param path the FS path of the root to start the discovery.
+     */
+    locate(path: string): Promise<Repository[]> {
+        return new Promise<Repository[]>((resolve, reject) => {
+            const filters = new Map<string, IgnoreFilter>();
+            const repositoryPaths = new Set();
+            const emitter = finder(abs(path));
+            emitter.on('directory', (dir: string, stat: fs.Stats, stop: () => void) => {
+                const base = paths.basename(dir);
+                if (base === '.git') {
+                    const dirName = paths.dirname(dir);
+                    repositoryPaths.add(dirName);
+                    stop();
+                    return;
+                }
+                if (this.shouldStop(dir, filters)) {
+                    stop();
+                    return;
+                }
+                filters.set(dir, this.createFilter(dir, filters));
+            });
+            emitter.on('end', () => resolve([...repositoryPaths].map(p => <Repository>{ localUri: FileUri.create(p).toString() })));
+            emitter.on('error', (error: Error) => reject(error));
         });
-        emitter.on('end', () => resolve([...repositoryPaths].map(p => <Repository>{ localUri: FileUri.create(p).toString() })));
-        emitter.on('error', (error: Error) => reject(error));
-    });
+    }
+
+    protected createFilter(path: string, filters: Map<string, IgnoreFilter>): IgnoreFilter {
+        const ig = ignore();
+        if (!fs.existsSync(paths.join(path, '.git'))) {
+            const parent = filters.get(paths.dirname(path));
+            if (parent) {
+                ig.add(parent);
+            }
+        }
+        if (fs.existsSync(paths.join(path, '.gitignore'))) {
+            ig.add(fs.readFileSync(paths.join(path, '.gitignore')).toString());
+        }
+        return ig;
+    }
+
+    protected shouldStop(pathname: string, filters: Map<string, IgnoreFilter>): boolean {
+        const parent = paths.dirname(pathname);
+        const ig = filters.get(parent);
+        return ig ? ig.ignores(pathname) : false;
+    }
+
 }

--- a/packages/git/src/node/git-repository-manager.ts
+++ b/packages/git/src/node/git-repository-manager.ts
@@ -1,0 +1,32 @@
+/*
+* Copyright (C) 2017 TypeFox and others.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+import { injectable, inject } from "inversify";
+import { Git, Repository } from '../common';
+import { GitRepositoryWatcher, GitRepositoryWatcherFactory } from "./git-repository-watcher";
+
+@injectable()
+export class GitRepositoryManager {
+
+    @inject(Git)
+    protected readonly git: Git;
+
+    @inject(GitRepositoryWatcherFactory)
+    protected readonly watcherFactory: GitRepositoryWatcherFactory;
+    protected readonly watchers = new Map<string, GitRepositoryWatcher>();
+
+    getWatcher(repository: Repository): GitRepositoryWatcher {
+        const existing = this.watchers.get(repository.localUri);
+        if (existing) {
+            return existing;
+        }
+        const watcher = this.watcherFactory({ repository });
+        this.watchers.set(repository.localUri, watcher);
+        return watcher;
+    }
+
+}

--- a/packages/git/src/node/git-repository-watcher.ts
+++ b/packages/git/src/node/git-repository-watcher.ts
@@ -1,0 +1,97 @@
+/*
+* Copyright (C) 2017 TypeFox and others.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+import { injectable, inject } from "inversify";
+import { Disposable, Event, Emitter, ILogger } from "@theia/core";
+import { Git, Repository, WorkingDirectoryStatus } from '../common';
+import { GitStatusChangeEvent } from "../common/git-watcher";
+
+export const GitRepositoryWatcherFactory = Symbol('GitRepositoryWatcherFactory');
+export type GitRepositoryWatcherFactory = (options: GitRepositoryWatcherOptions) => GitRepositoryWatcher;
+
+@injectable()
+export class GitRepositoryWatcherOptions {
+    readonly repository: Repository;
+}
+
+@injectable()
+export class GitRepositoryWatcher {
+
+    protected readonly onStatusChangedEmitter = new Emitter<GitStatusChangeEvent>();
+    readonly onStatusChanged: Event<GitStatusChangeEvent> = this.onStatusChangedEmitter.event;
+
+    @inject(Git)
+    protected readonly git: Git;
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    @inject(GitRepositoryWatcherOptions)
+    protected readonly options: GitRepositoryWatcherOptions;
+
+    protected references = 0;
+    watch(): Disposable {
+        this.schedule(0, true);
+        if (this.references === 0) {
+            this.logger.info('Started watching the git repo:', this.options.repository.localUri);
+        }
+        this.references++;
+        return Disposable.create(() => {
+            this.references--;
+            if (this.references === 0) {
+                this.logger.info('Stopped watching the git repo:', this.options.repository.localUri);
+                this.clear();
+            }
+        });
+    }
+
+    protected initial: boolean = true;
+    protected watchTimer: NodeJS.Timer | undefined;
+    protected schedule(delay: number = 1000, initial: boolean = false): void {
+        if (initial) {
+            this.initial = true;
+        }
+        if (this.watchTimer) {
+            return;
+        }
+        this.watchTimer = setTimeout(async () => {
+            this.watchTimer = undefined;
+            const initial = this.initial;
+            this.initial = false;
+            if (await this.sync(initial)) {
+                this.schedule();
+            }
+        }, delay);
+    }
+    protected clear(): void {
+        if (this.watchTimer) {
+            clearTimeout(this.watchTimer);
+            this.watchTimer = undefined;
+        }
+    }
+
+    protected status: WorkingDirectoryStatus | undefined;
+    async sync(initial: boolean = false): Promise<boolean> {
+        try {
+            const source = this.options.repository;
+            const status = await this.git.status(source);
+            const oldStatus = this.status;
+            if (initial || !WorkingDirectoryStatus.equals(status, oldStatus)) {
+                this.status = status;
+                this.onStatusChangedEmitter.fire({ source, status, oldStatus });
+            }
+        } catch (error) {
+            // TODO: Is it going to work only with `en` local?
+            if (error.message !== 'Unable to find path to repository on disk.') {
+                return false;
+            }
+            // TODO: Do we really want to swallow errors?
+        }
+        return true;
+    }
+
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,10 @@ ignore-loader@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ignore-loader/-/ignore-loader-0.1.2.tgz#d81f240376d0ba4f0d778972c3ad25874117a463"
 
+ignore@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"


### PR DESCRIPTION
This PR:
- ensures that the same repo is watched once by all clients
- uses `setTimeout` instead of `setInterval` to ensure that there are no parallel `git-status` requests for the same watcher
- prunes search of git repos based on .gitignore: 20985.367ms -> 439.025ms for Theia repo in the docker image