### PR TITLE
Refs #532:Add passthrough keybindings, make ctrl-c work in terminal

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -74,8 +74,11 @@ export class BrowserMainMenuFactory {
             isVisible: () => this.commandRegistry.isVisible(command.id)
         });
 
-        const binding = this.keybindingRegistry.getKeybindingForCommand(command.id, { active: false });
-        if (binding) {
+        const bindings = this.keybindingRegistry.getKeybindingsForCommand(command.id);
+
+        /* Only consider the first keybinding. */
+        if (bindings.length > 0) {
+            const binding = bindings[0];
             const keys = binding.accelerator || [];
             commands.addKeyBinding({
                 command: command.id,

--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -68,7 +68,8 @@ export class CommandQuickOpenItem extends QuickOpenItem {
     }
 
     getKeybinding(): Keybinding | undefined {
-        return this.keybindings.getKeybindingForCommand(this.command.id);
+        const bindings = this.keybindings.getKeybindingsForCommand(this.command.id);
+        return bindings ? bindings[0] : undefined;
     }
 
     run(mode: QuickOpenMode): boolean {

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -16,10 +16,12 @@ import {
     Command,
     CommandRegistry,
     MenuContribution,
-    MenuModelRegistry
+    MenuModelRegistry,
+    Keybinding,
+    KeybindingContextRegistry
 } from '@theia/core/lib/common';
 import { FrontendApplication, CommonMenus } from '@theia/core/lib/browser';
-import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from './terminal-widget';
+import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions, TerminalWidget } from './terminal-widget';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 
@@ -30,13 +32,16 @@ export namespace TerminalCommands {
     };
 }
 
+const TERMINAL_ACTIVE_CONTEXT = "terminalActive";
+
 @injectable()
 export class TerminalFrontendContribution implements CommandContribution, MenuContribution, KeybindingContribution {
 
     constructor(
         @inject(FrontendApplication) protected readonly app: FrontendApplication,
         @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
+        @inject(KeybindingContextRegistry) protected readonly keybindingContextRegistry: KeybindingContextRegistry,
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
@@ -53,15 +58,98 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         });
     }
 
+    /* Return true if a TerminalWidget widget is currently in focus.  */
+
+    isTerminalFocused(binding: Keybinding): boolean {
+        return this.app.shell.currentWidget instanceof TerminalWidget;
+    }
+
     registerKeybindings(keybindings: KeybindingRegistry): void {
-        [
-            {
-                commandId: TerminalCommands.NEW.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] })
-            },
-        ].forEach(binding => {
-            keybindings.registerKeybinding(binding);
+        this.keybindingContextRegistry.registerContext({
+            id: TERMINAL_ACTIVE_CONTEXT,
+            isEnabled: (binding: Keybinding) => this.isTerminalFocused(binding),
         });
+
+        keybindings.registerKeybindings({
+            commandId: TerminalCommands.NEW.id,
+            keyCode: KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] }),
+        });
+
+        /* Register passthrough keybindings for combinations recognized by
+           xterm.js and converted to control characters.
+
+             See: https://github.com/xtermjs/xterm.js/blob/v3/src/Terminal.ts#L1684 */
+
+        /* Register ctrl + k (the passed Key) as a passthrough command in the
+           context of the terminal.  */
+        const regCtrl = (k: Key) => {
+            keybindings.registerKeybindings({
+                commandId: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
+                keyCode: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.M1] }),
+                contextId: TERMINAL_ACTIVE_CONTEXT,
+            });
+        };
+
+        /* Register alt + k (the passed Key) as a passthrough command in the
+           context of the terminal.  */
+        const regAlt = (k: Key) => {
+            keybindings.registerKeybindings({
+                commandId: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
+                keyCode: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.M3] }),
+                contextId: TERMINAL_ACTIVE_CONTEXT,
+            });
+        };
+
+        /* ctrl-space (000 - NUL).  */
+        regCtrl(Key.SPACE);
+
+        /* ctrl-A (001/1/0x1) through ctrl-Z (032/26/0x1A).  */
+        for (let i = 0; i < 26; i++) {
+            regCtrl({
+                keyCode: Key.KEY_A.keyCode + i,
+                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i)
+            });
+        }
+
+        /* ctrl-[ or ctrl-3 (033/27/0x1B - ESC).  */
+        regCtrl(Key.BRACKET_LEFT);
+        regCtrl(Key.DIGIT3);
+
+        /* ctrl-\ or ctrl-4 (034/28/0x1C - FS).  */
+        regCtrl(Key.BACKSLASH);
+        regCtrl(Key.DIGIT4);
+
+        /* ctrl-] or ctrl-5 (035/29/0x1D - GS).  */
+        regCtrl(Key.BRACKET_RIGHT);
+        regCtrl(Key.DIGIT5);
+
+        /* ctrl-6 (036/30/0x1E - RS).  */
+        regCtrl(Key.DIGIT6);
+
+        /* ctrl-7 (037/31/0x1F - US).  */
+        regCtrl(Key.DIGIT7);
+
+        /* ctrl-8 (177/127/0x7F - DEL).  */
+        regCtrl(Key.DIGIT8);
+
+        /* alt-A (0x1B 0x62) through alt-Z (0x1B 0x7A).  */
+        for (let i = 0; i < 26; i++) {
+            regAlt({
+                keyCode: Key.KEY_A.keyCode + i,
+                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i)
+            });
+        }
+
+        /* alt-` (0x1B 0x60).  */
+        regAlt(Key.BACKQUOTE);
+
+        /* alt-0 (0x1B 0x30) through alt-9 (0x1B 0x39).  */
+        for (let i = 0; i < 10; i++) {
+            regAlt({
+                keyCode: Key.DIGIT0.keyCode + i,
+                code: 'Digit' + String.fromCharCode('0'.charCodeAt(0) + i)
+            });
+        }
     }
 
     protected async newTerminal(): Promise<void> {


### PR DESCRIPTION
Currently, typing ctrl-c in the terminal does not yield the expected
result, which is sending a SIGINT to the running process.  The problem
is that a Theia keybinding is registered for ctrl-c (to copy).  Theia
catches it and thinks you want to copy.

When the focus is on a terminal, we don't want Theia to handle the event
itself, but rather let the event propagate.  xterm.js' keyboard event
handler will catch it, and things will work as usual.  To that end,
this patch introduces the concept of passthrough keybindings.  When
the user invokes such a keybinding, Theia does nothing and lets the
event propagate.  To specify a passthrough keybinding, one needs to use
"passthrough" as the command id, which is treated in a special way by
the KeybindingRegistry.

However, we also need the concept of event priority, to make sure that
when we are in a terminal context, that keybinding will take precedence
over the global one.  As a simple approximation, I made the
KeybindingRegistry consider bindings that specify a context before those
that don't.

The terminal module registers passthrough commands for all the key
combination xterm.js recognizes right now:

  https://github.com/xtermjs/xterm.js/blob/v3/src/Terminal.ts#L1684

Some improvements should be made for Mac though.  To match xterm.js'
behavior, the alt-<key> combinations should only be registered on
non-Mac computers, but I don't know how to do that.  Also, I suppose
that on Mac, the ctrl-<key> bindings should be registered with the M4
modifier?  Finally, there's the cmd-A shortcut registered specifically
for Mac.  It would be nice if somebody that has access to a Mac could
improve that.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>