### PR TITLE
[icons] Don’t use file icons for folders, only consider the display name of a uri (fixes #925)

### DIFF
--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -63,7 +63,7 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
     }
 
     protected getFileIcon(uri: URI): string | undefined {
-        return fileIcons.getClass(uri.path.toString());
+        return fileIcons.getClass(uri.displayName);
     }
 
     getName(uri: URI): string {

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -49,6 +49,9 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
     }
 
     async getIcon(element: URI | FileStat): Promise<string> {
+        if (FileStat.is(element) && element.isDirectory) {
+            return 'fa fa-folder';
+        }
         const uri = this.getUri(element);
         const icon = super.getFileIcon(uri);
         if (!icon) {


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>