### PR TITLE
[cpp] Make "switch source/header" command work for other file extensions

### DIFF
--- a/packages/cpp/src/browser/cpp-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-client-contribution.ts
@@ -7,7 +7,7 @@
 
 import { injectable } from "inversify";
 import { BaseLanguageClientContribution } from '@theia/languages/lib/browser';
-import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME } from '../common';
+import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 @injectable()
 export class CppClientContribution extends BaseLanguageClientContribution {
@@ -16,14 +16,12 @@ export class CppClientContribution extends BaseLanguageClientContribution {
     readonly name = CPP_LANGUAGE_NAME;
 
     protected get documentSelector() {
-        return [
-            'h', 'hxx', 'hh', 'hpp', 'inc', 'c', 'cxx', 'C', 'c++', 'cc', 'cc', 'cpp'
-        ];
+        return HEADER_AND_SOURCE_FILE_EXTENSIONS;
     }
 
     protected get globPatterns() {
         return [
-            '**/*.h', '**/*.hxx', '**/*.hh', '**/*.hpp', '**/*.inc', '**/*.c', '**/*.cxx', '**/*.C', '**/*.c++', '**/*.cc', '**/*.cc', '**/*.cpp'
+            '**/*.{' + HEADER_AND_SOURCE_FILE_EXTENSIONS.join() + '}'
         ];
     }
 

--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -14,6 +14,7 @@ import { CppClientContribution } from "./cpp-client-contribution";
 import { SwitchSourceHeaderRequest } from "./cpp-protocol";
 import { TextDocumentIdentifier } from "@theia/languages/lib/common";
 import { EditorManager } from "@theia/editor/lib/browser";
+import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 /**
  * Switch between source/header file
@@ -40,8 +41,13 @@ export class CppCommandContribution implements CommandContribution {
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(SWITCH_SOURCE_HEADER, {
-            isEnabled: () => (this.editorService && !!this.editorService.activeEditor &&
-                (this.editorService.activeEditor.editor.document.uri.endsWith(".cpp") || this.editorService.activeEditor.editor.document.uri.endsWith(".h"))),
+            isEnabled: () => {
+                if (this.editorService && !!this.editorService.activeEditor) {
+                    const uri = this.editorService.activeEditor.editor.document.uri;
+                    return HEADER_AND_SOURCE_FILE_EXTENSIONS.some(value => uri.endsWith("." + value));
+                }
+                return false;
+            },
             execute: () => {
                 this.switchSourceHeader();
             }

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -10,6 +10,7 @@ import { EditorManager } from "@theia/editor/lib/browser";
 import {
     KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier
 } from "@theia/core/lib/common";
+import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 @injectable()
 export class CppKeybindingContext implements KeybindingContext {
@@ -18,8 +19,11 @@ export class CppKeybindingContext implements KeybindingContext {
     id = 'cpp.keybinding.context';
 
     isEnabled(arg?: Keybinding) {
-        return this.editorService && !!this.editorService.activeEditor &&
-            (this.editorService.activeEditor.editor.document.uri.endsWith(".cpp") || this.editorService.activeEditor.editor.document.uri.endsWith(".h"));
+        if (this.editorService && !!this.editorService.activeEditor) {
+            const uri = this.editorService.activeEditor.editor.document.uri;
+            return HEADER_AND_SOURCE_FILE_EXTENSIONS.some(value => uri.endsWith("." + value));
+        }
+        return false;
     }
 
 }

--- a/packages/cpp/src/common/cpp-preferences.ts
+++ b/packages/cpp/src/common/cpp-preferences.ts
@@ -16,6 +16,11 @@ import {
 
 export const CLANGD_COMMAND_DEFAULT = 'clangd';
 
+// These should become preferences eventually and be forwarded to the server.
+export const HEADER_FILE_EXTENSIONS = ['h', 'hxx', 'hh', 'hpp', 'inc'];
+export const SOURCE_FILE_EXTENSIONS = ['c', 'cxx', 'C', 'c++', 'cc', 'cpp'];
+export const HEADER_AND_SOURCE_FILE_EXTENSIONS = SOURCE_FILE_EXTENSIONS.concat(HEADER_FILE_EXTENSIONS);
+
 export const CppConfigSchema: PreferenceSchema = {
     "type": "object",
     "properties": {


### PR DESCRIPTION
The command was originally made to work only with .cpp/.h files. This patch
extract some constants for file extensions and reuses them to enable
the command for more extensions.

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>