### PR TITLE
WIP Close widgets on resource disposal

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -14,6 +14,7 @@ export interface Saveable {
     readonly dirty: boolean;
     readonly onDirtyChanged: Event<void>;
     save(): MaybePromise<void>;
+    readonly onDispose: Event<void>;
 }
 
 export interface SaveableSource {
@@ -57,6 +58,7 @@ export namespace Saveable {
         if (saveable) {
             setDirty(widget, saveable.dirty);
             saveable.onDirtyChanged(() => setDirty(widget, saveable.dirty));
+            saveable.onDispose(() => widget.close());
 
             const close = widget.close.bind(widget);
             widget.close = async () => {

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -14,6 +14,7 @@ import { MaybePromise } from "./types";
 
 export interface Resource extends Disposable {
     readonly uri: URI;
+    readonly onDispose?: Event<void>;
     readContents(options?: { encoding?: string }): Promise<string>;
     saveContents?(content: string, options?: { encoding?: string }): Promise<void>;
     readonly onDidChangeContents?: Event<void>;

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -11,7 +11,7 @@ import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from "@theia/cor
 import { FileSystemNode } from './node-filesystem';
 import { FileSystemWatcher, FileSystem, FileSystemClient, fileSystemPath, bindFileSystemPreferences } from "../common";
 import { FileSystemWatcherServer, FileSystemWatcherClient, fileSystemWatcherPath } from '../common/filesystem-watcher-protocol';
-import { FileSystemWatcherServerClient } from './filesystem-watcher-client';
+import { FileSystemWatcherHostClient } from './filesystem-watcher-host-client';
 import { NsfwFileSystemWatcherServer } from './nsfw-watcher/nsfw-filesystem-watcher';
 
 export function bindFileSystem(bind: interfaces.Bind): void {
@@ -29,9 +29,9 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
             });
         });
     } else {
-        bind(FileSystemWatcherServerClient).toSelf();
+        bind(FileSystemWatcherHostClient).toSelf();
         bind(FileSystemWatcherServer).toDynamicValue(ctx =>
-            ctx.container.get(FileSystemWatcherServerClient)
+            ctx.container.get(FileSystemWatcherHostClient)
         );
     }
 }

--- a/packages/filesystem/src/node/filesystem-watcher-host-client.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-host-client.ts
@@ -14,7 +14,7 @@ import { FileSystemWatcherServer, WatchOptions, FileSystemWatcherClient, Reconne
 export const NSFW_WATCHER = 'nsfw-watcher';
 
 @injectable()
-export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
+export class FileSystemWatcherHostClient implements FileSystemWatcherServer {
 
     protected readonly proxyFactory = new JsonRpcProxyFactory<FileSystemWatcherServer>();
     protected readonly remote = new ReconnectingFileSystemWatcherServer(this.proxyFactory.createProxy());

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -166,14 +166,14 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
         this.changes.push({ uri, type });
 
         this.toDisposeOnFileChange.dispose();
-        const timer = setTimeout(() => this.fireDidFilesChanged(), this.fireDidFilesChangedTimeout);
+        const timer = setTimeout(() => this.fireDidFilesChanged(watcherId), this.fireDidFilesChangedTimeout);
         this.toDisposeOnFileChange.push(Disposable.create(() => clearTimeout(timer)));
     }
 
-    protected fireDidFilesChanged(): void {
+    protected fireDidFilesChanged(watcher: number): void {
         const changes = this.changes;
         this.changes = [];
-        const event = { changes };
+        const event = { watcher, changes };
         if (this.client) {
             this.client.onDidFilesChanged(event);
         }

--- a/packages/preferences/src/common/compound-preference-server.spec.ts
+++ b/packages/preferences/src/common/compound-preference-server.spec.ts
@@ -20,7 +20,7 @@ const preferencePath = '.theia/prefs.json';
 
 let compoundPrefServer: CompoundPreferenceServer;
 let preferenceFileUri: any;
-let helper = new JsonPrefHelper();
+const helper = new JsonPrefHelper();
 
 before(() => {
     chai.should();
@@ -46,7 +46,7 @@ describe('compound-preference-server', () => {
     it('register a client', async () => {
 
         // Register a simple client
-        let promise: Promise<boolean> = new Promise<boolean>((done) => {
+        const promise: Promise<boolean> = new Promise<boolean>((done) => {
             compoundPrefServer.setClient({
                 onDidChangePreference(event) {
                     for (const change of event.changes) {
@@ -66,17 +66,16 @@ describe('compound-preference-server', () => {
         // Modify the content.
         fs.writeFileSync(FileUri.fsPath(preferenceFileUri), fileContent);
 
-        let { content } = await helper.getFS().resolveContent(FileUri.fsPath(preferenceFileUri));
+        const { content } = await helper.getFS().resolveContent(FileUri.fsPath(preferenceFileUri));
         expect(content).to.be.equal(fileContent);
 
-        helper.getWatcher().fireEvents(
-            {
-                changes: [{
-                    uri: preferenceFileUri.toString(),
-                    type: 0
-                }]
-            }
-        );
+        helper.getWatcher().fireEvents({
+            changes: [{
+                uri: preferenceFileUri.toString(),
+                type: 0
+            }],
+            watcher: 2
+        });
 
         return promise;
 

--- a/packages/preferences/src/node/json-preference-server.spec.ts
+++ b/packages/preferences/src/node/json-preference-server.spec.ts
@@ -18,7 +18,7 @@ const expect = chai.expect;
 const preferencePath = '.theia/prefs.json';
 let preferenceFileUri: URI;
 let prefServer: JsonPreferenceServer;
-let helper = new JsonPrefHelper();
+const helper = new JsonPrefHelper();
 const track = temp.track();
 
 before(() => {
@@ -46,7 +46,7 @@ describe('json-preference-server', () => {
         it('Register a client and change the value', async () => {
 
             // Register a simple client
-            let promise: Promise<boolean> = new Promise<boolean>(async (done) => {
+            const promise: Promise<boolean> = new Promise<boolean>(async (done) => {
                 prefServer.setClient({
                     onDidChangePreference(event) {
                         for (const change of event.changes) {
@@ -62,17 +62,16 @@ describe('json-preference-server', () => {
             // Modify the content.
             fs.writeFileSync(FileUri.fsPath(preferenceFileUri), fileContent);
 
-            let { content } = await helper.getFS().resolveContent(FileUri.fsPath(preferenceFileUri));
+            const { content } = await helper.getFS().resolveContent(FileUri.fsPath(preferenceFileUri));
             expect(content).to.be.equal(fileContent);
 
-            helper.getWatcher().fireEvents(
-                {
-                    changes: [{
-                        uri: preferenceFileUri.toString(),
-                        type: 0
-                    }]
-                }
-            );
+            helper.getWatcher().fireEvents({
+                changes: [{
+                    uri: preferenceFileUri.toString(),
+                    type: 0
+                }],
+                watcher: 2
+            });
 
             return promise;
 

--- a/packages/userstorage/src/browser/user-storage-service.ts
+++ b/packages/userstorage/src/browser/user-storage-service.ts
@@ -14,9 +14,16 @@ export interface UserStorageService extends Disposable {
 
     saveContents(uri: URI, content: string): Promise<void>;
 
-    onUserStorageChanged: Event<UserStorageChangeEvent>;
+    onChanged: Event<UserStorageChange[]>;
 }
 
-export interface UserStorageChangeEvent {
-    uris: URI[];
+export interface UserStorageChange {
+    uri: URI;
+    type: UserStorageChangeType
+}
+
+export enum UserStorageChangeType {
+    UPDATED = 0,
+    ADDED = 1,
+    DELETED = 2
 }


### PR DESCRIPTION
- This PR fixes https://github.com/theia-ide/theia/issues/560 by disposing a file resource on a file deletion.
- Widgets depending on resources get closed if underlying resources get disposed regardless whether they are dirty, e.g. editors for file resources. Copied this behaviour from VS code and IntelliJ.
- https://github.com/theia-ide/theia/issues/717 should be fixed with it as well, reacting to other files changes was covered by the save-cycle implementation.
- This PR allows exclusive file watching with the callback. As discussed in https://github.com/theia-ide/theia/issues/942#issuecomment-349909873, it is a temporary minimal change since API is confusing. It will be better to have 2 APIs: one low level for exclusive watching and the second on the top for watching workspace changes.
- This PR also fixes bugs in the user storage service.