### PR TITLE
Fixes missing await calls that slipped through in #874.

### DIFF
--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -60,7 +60,7 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
     async readContents(uri: URI) {
         const folderUri = await this.userStorageFolder;
         const filesystemUri = UserStorageServiceFilesystemImpl.toFilesystemURI(folderUri, uri);
-        const exists = this.fileSystem.exists(filesystemUri.toString());
+        const exists = await this.fileSystem.exists(filesystemUri.toString());
 
         if (exists) {
             return this.fileSystem.resolveContent(filesystemUri.toString()).then(({ stat, content }) => content);
@@ -72,7 +72,7 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
     async saveContents(uri: URI, content: string) {
         const folderUri = await this.userStorageFolder;
         const filesystemUri = UserStorageServiceFilesystemImpl.toFilesystemURI(folderUri, uri);
-        const exists = this.fileSystem.exists(filesystemUri.toString());
+        const exists = await this.fileSystem.exists(filesystemUri.toString());
 
         if (exists) {
             this.fileSystem.getFileStat(filesystemUri.toString()).then(fileStat => {


### PR DESCRIPTION
Without these js `await` calls, the if is always true and thus the
filesystem tries to resolve a file, even though the promise for checking
if the file exists hasn't resolved yet.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>