### PR TITLE
[cpp] file/folder exclusion preference for clangd indexer

### DIFF
--- a/packages/cpp/src/browser/cpp-protocol.ts
+++ b/packages/cpp/src/browser/cpp-protocol.ts
@@ -16,4 +16,5 @@ export interface ActionableMessage {
 
 export namespace SwitchSourceHeaderRequest {
     export const type = new RequestType<TextDocumentIdentifier, string | undefined, void, void>("textDocument/switchSourceHeader");
+
 }

--- a/packages/cpp/src/common/cpp-preferences.ts
+++ b/packages/cpp/src/common/cpp-preferences.ts
@@ -32,6 +32,10 @@ export const CppConfigSchema: PreferenceSchema = {
         "cpp.clangdCommandArgs": {
             "type": "array",
             "description": "Arguments to the clangd command."
+        },
+        "cpp.indexingExclusions": {
+            "type": "array",
+            "description": "Files and folders that are ignored by the indexer."
         }
     }
 };
@@ -39,13 +43,15 @@ export const CppConfigSchema: PreferenceSchema = {
 export interface CppConfiguration {
     'cpp.clangdCompilationDatabaseDirectory': string,
     'cpp.clangdCommand': string,
-    'cpp.clangdCommandArgs': string[]
+    'cpp.clangdCommandArgs': string[],
+    'cpp.indexingExclusions': string[]
 }
 
 export const defaultCppConfiguration: CppConfiguration = {
     'cpp.clangdCompilationDatabaseDirectory': '',
     'cpp.clangdCommand': CLANGD_COMMAND_DEFAULT,
-    'cpp.clangdCommandArgs': []
+    'cpp.clangdCommandArgs': [],
+    'cpp.indexingExclusions': []
 };
 
 export const CppPreferences = Symbol('CppPreferences');

--- a/packages/cpp/src/node/cpp-contribution.ts
+++ b/packages/cpp/src/node/cpp-contribution.ts
@@ -29,6 +29,7 @@ export class CppContribution extends BaseLanguageServerContribution {
             if (message.method === InitializeRequest.type.method) {
                 const initializeParams = message.params as InitializeParams;
                 initializeParams.processId = process.pid;
+                initializeParams.initializationOptions = this.cppPreferences['cpp.indexingExclusions'];
             }
         }
         return message;


### PR DESCRIPTION
initializationOptions for clangd now take into account cpp.indexExclusions field in settings.json to ignore files and folders for indexing.