### PR TITLE
[cpp] Add error message and instructions when clangd is not installed

### DIFF
--- a/packages/cpp/src/browser/cpp-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-client-contribution.ts
@@ -5,8 +5,11 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { injectable } from "inversify";
-import { BaseLanguageClientContribution } from '@theia/languages/lib/browser';
+import { inject, injectable } from "inversify";
+import { BaseLanguageClientContribution, LanguageClientFactory, LanguageClientOptions } from '@theia/languages/lib/browser';
+import { Languages, Workspace } from "@theia/languages/lib/common";
+import { ILogger } from '@theia/core/lib/common/logger';
+import { MessageService } from '@theia/core/lib/common/message-service';
 import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 @injectable()
@@ -14,6 +17,16 @@ export class CppClientContribution extends BaseLanguageClientContribution {
 
     readonly id = CPP_LANGUAGE_ID;
     readonly name = CPP_LANGUAGE_NAME;
+
+    constructor(
+        @inject(Workspace) protected readonly workspace: Workspace,
+        @inject(Languages) protected readonly languages: Languages,
+        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
+        @inject(MessageService) protected readonly messageService: MessageService,
+        @inject(ILogger) protected readonly logger: ILogger
+    ) {
+        super(workspace, languages, languageClientFactory);
+    }
 
     protected get documentSelector() {
         return HEADER_AND_SOURCE_FILE_EXTENSIONS;
@@ -25,4 +38,21 @@ export class CppClientContribution extends BaseLanguageClientContribution {
         ];
     }
 
+    protected createOptions(): LanguageClientOptions {
+        const clientOptions = super.createOptions();
+        clientOptions.initializationFailedHandler = () => {
+            const READ_INSTRUCTIONS_ACTION = "Read Instructions";
+            const ERROR_MESSAGE = "Error starting C/C++ language server. " +
+                "Please make sure 'clangd' is installed on your system. " +
+                "You can refer to the clangd page for instructions.";
+            this.messageService.error(ERROR_MESSAGE, READ_INSTRUCTIONS_ACTION).then(selected => {
+                if (READ_INSTRUCTIONS_ACTION === selected) {
+                    window.open("https://clang.llvm.org/extra/clangd.html");
+                }
+            });
+            this.logger.error(ERROR_MESSAGE);
+            return false;
+        };
+        return clientOptions;
+    }
 }


### PR DESCRIPTION
The error message is only displayed in the console for now.
The Clangd page will contain more instructions on how to install once the patch
is approved there, see https://reviews.llvm.org/D41306

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>