### PR TITLE
Fixes #1002

### DIFF
--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -72,13 +72,25 @@ export class KeyCode {
             }
             const key = EASY_TO_KEY[keyString];
 
-            if (keyString === 'meta') {
+            /* meta only works on macOS */
+            if (keyString === SpecialCases.META) {
+                if (isOSX) {
+                    sequence.push(`${Modifier.M1}`);
+                } else {
+                    return undefined;
+                }
+                /* ControlOrCommand for keybindings that work on both macOS and other platforms */
+            } else if (keyString === SpecialCases.CTRL_OR_COMMAND) {
                 sequence.push(`${Modifier.M1}`);
-            }
-            if (Key.isKey(key)) {
+            } else if (Key.isKey(key)) {
                 if (Key.isModifier(key.code)) {
                     if (key.keyCode === EasyKey.CONTROL.keyCode) {
-                        sequence.push(`${Modifier.M1}`);
+                        // CTRL on MacOS X (M4)
+                        if (isOSX) {
+                            sequence.push(`${Modifier.M4}`);
+                        } else {
+                            sequence.push(`${Modifier.M1}`);
+                        }
                     } else if (key.keyCode === EasyKey.SHIFT.keyCode) {
                         sequence.push(`${Modifier.M2}`);
                     } else if (key.keyCode === EasyKey.ALT.keyCode) {
@@ -201,8 +213,15 @@ const SPECIAL_ALIASES: { [index: string]: string } = {
     'esc': 'escape',
     'mod': 'ctrl',
     'ins': 'insert',
-    'del': 'delete'
+    'del': 'delete',
+    'control': 'ctrl',
+    'CommandOrControl': 'ControlOrCommand',
 };
+
+export namespace SpecialCases {
+    export const META = 'meta';
+    export const CTRL_OR_COMMAND = 'ControlOrCommand';
+}
 
 export namespace EasyKey {
     export const ENTER: EasyKey = { keyCode: 13, easyString: 'enter' };

--- a/packages/keymaps/README.md
+++ b/packages/keymaps/README.md
@@ -20,7 +20,7 @@ Example of a valid `keymaps.json` file
 
 For most keys you can directly use the name of the key i.e `a`, `3`,  `/`, `-`.
 
-You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`), `cmd` (`meta`) as modifiers.
+You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`), `cmd` (`meta`) as modifiers. You can also `ControlOrCommand` or `CommandOrControl` as modifiers if you want the shortcut to fallback on `ctrl` coming from macOS. Note that if you defined a custom shortcut with `cmd`, `command` or `meta`, the same keymaps file won't work on a Windows/Linux machine as this key doesn't have an equivalent.
 
 You can also use the following strings for special keys: `backspace`, `tab`, `enter`, `return`, `capslock`, `esc`, `escape`, `space`, `pageup`, `pagedown`, `end`, `home`, `left`, `up`, `right`, `down`, `ins`, `del` and `plus`.
 


### PR DESCRIPTION
The test creates a KeyCode object by passing a sequence composed of
keycode numbers (platform agnostic) and Modifiers (theia enum). However,
the constructor then checks which platform it's currently running and
creates the appropriate KeyCode object (Modifier.M1 sets the ctrl
property to true on Linux/Windows but the meta property on OS X). This
adds an OSX check in the test to make sure it expects the correct value.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>