### PR TITLE
Clarify error when language server fails to initialize

### DIFF
--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -6,6 +6,7 @@
  */
 
 import { injectable, inject } from "inversify";
+import { MessageService } from '@theia/core';
 import { Disposable } from "@theia/core/lib/common";
 import { FrontendApplication } from '@theia/core/lib/browser';
 import {
@@ -32,6 +33,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
 
     protected resolveReady: (languageClient: ILanguageClient) => void;
     protected ready: Promise<ILanguageClient>;
+    @inject(MessageService) protected readonly messageService: MessageService;
 
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
@@ -87,7 +89,11 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         const fileEvents = this.createFileEvents();
         return {
             documentSelector: this.documentSelector,
-            synchronize: { fileEvents }
+            synchronize: { fileEvents },
+            initializationFailedHandler: () => {
+                this.messageService.error("Failed to start language server '" + this.name + "'.");
+                return false;
+            }
         };
     }
 


### PR DESCRIPTION
When a language server fails to launch, an error message "Connection got
disposed" is shown to the user. This could be confusing because it could mean
that the connection to the backend was lost. This commit changes the message to
"Failed to start language server $NAME".

Further improvements would be to display full instructions to install the server
by adding actions to the notification and also possibly an action to never show
the message again. This could be addressed in separate commits.

Fixes #982

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>