### PR TITLE
Have multiple FileSystemWatcherServerProxy, FileSystemWatcherServers

### DIFF
--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -22,8 +22,8 @@ export default new ContainerModule(bind => {
 
     bind(FileSystemWatcherServerProxy).toDynamicValue(ctx =>
         WebSocketConnectionProvider.createProxy(ctx.container, fileSystemWatcherPath)
-    ).inSingletonScope();
-    bind(FileSystemWatcherServer).to(ReconnectingFileSystemWatcherServer).inSingletonScope();
+    );
+    bind(FileSystemWatcherServer).to(ReconnectingFileSystemWatcherServer);
     bind(FileSystemWatcher).toSelf().inSingletonScope();
 
     bind(FileSystemListener).toSelf().inSingletonScope();


### PR DESCRIPTION
Before, FileSystemWatcherServerProxy and FileSystemWatcherServers were
binded as singletons. This worked as long as there was a single client.
In the Task extension, a second client was added, effectively overriding
the original client, causing file changes to go un-noticed by the
intended client. This patch makes these two classes be injected as
new instances, instead of singletons, each able to serve a distinct
client.

fixes #1006

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>