### PR TITLE
Compare KeyCodes using KeyCode.equals

### DIFF
--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -102,7 +102,8 @@ export function addKeyListener<K extends keyof HTMLElementEventMap>(element: HTM
     const toDispose = new DisposableCollection();
     const keyCode = KeyCode.createKeyCode({ first: keybinding });
     toDispose.push(addEventListener(element, 'keydown', e => {
-        if (KeyCode.createKeyCode(e) === keyCode) {
+        const kc = KeyCode.createKeyCode(e);
+        if (kc.equals(keyCode)) {
             action();
             e.stopPropagation();
             e.preventDefault();


### PR DESCRIPTION
A few keybindings don't work currently, at least on my Linux desktop.
An example is the new file dialog.  We would expect escape to close the
dialog, and enter to validate.

The problem is that the callback in widget.ts:addKeyListener uses === to
test equality of two KeyCodes.  However, this checks if the two objects
are the same instance, which is not necessarily the case.  Change it to
KeyCode.equals.

Fixes #1007

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>