### PR TITLE
guarantee order of the start of contributions and the restore of layout

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -71,7 +71,7 @@ export class FrontendApplication {
      * - display the application shell
      */
     async start(): Promise<void> {
-        this.startContributions();
+        await this.startContributions();
         await this.layoutRestorer.initializeLayout(this, this.contributions.getContributions());
         this.ensureLoaded().then(() =>
             this.attachShell()


### PR DESCRIPTION
It can happen, that widgets are restored before contributions are started, e.g. if `onStart` of a contribution delays the process. It would be nice, to rely on a fixed order.