### PR TITLE
Add formatting settings to .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,12 @@
             "pattern": "**/*.spec.ts",
             "command": "yarn test:theia"
         }
-    ]
+    ],
+    "editor.insertSpaces": true,
+    "[typescript]": {
+        "editor.tabSize": 4
+    },
+    "[json]": {
+        "editor.tabSize": 2
+    }
 }


### PR DESCRIPTION
- Set the tabSize to be 4, so that it overrides the user setting, if set
  to something else.
- Set insertFinalNewline, so that vscode inserts an EOL at the end of
  files.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>