### PR TITLE
Make process exit logging debug instead of info

### DIFF
--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -51,7 +51,7 @@ export class RawProcess extends Process {
         @inject(RawProcessOptions) options: RawProcessOptions,
         @inject(ProcessManager) processManager: ProcessManager,
         @inject(ILogger) logger: ILogger) {
-        super(processManager, logger, ProcessType.Raw);
+        super(processManager, logger, ProcessType.Raw, options.command, options.args);
 
         this.logger.debug(`Starting raw process : ${options.command},`
             + ` with args : ${options.args}, `

--- a/packages/process/src/node/terminal-process.ts
+++ b/packages/process/src/node/terminal-process.ts
@@ -35,7 +35,7 @@ export class TerminalProcess extends Process {
         @inject(ProcessManager) processManager: ProcessManager,
         @inject(MultiRingBuffer) protected readonly ringBuffer: MultiRingBuffer,
         @inject(ILogger) logger: ILogger) {
-        super(processManager, logger, ProcessType.Terminal);
+        super(processManager, logger, ProcessType.Terminal, options.command, options.args);
 
         this.logger.debug(`Starting terminal process: ${options.command},`
             + ` with args : ${options.args}, `


### PR DESCRIPTION
The quick search in workspace PR showed that having process exits logged
with the info log level was a bit too verbose.  This patch scales it
down to debug.

It has been suggested to log zero exit code as at the debug log level,
and non-zero exit codes as error.  However, a non-zero exit code does
not necessarily mean an error.  For example, with ripgrep, a search that
yields no result returns a non-zero exit code.  Logging this as an error
would be too alarmist, because nothing actually went wrong.  I think it
should be up to the calling code to log this as an error, if they know
that the non-zero exit code represents an error.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>