### PR TITLE
Use RawKeybindings to specify keybindings

### DIFF
--- a/doc/Commands_Keybindings.md
+++ b/doc/Commands_Keybindings.md
@@ -57,14 +57,14 @@ export class EditorKeybindingContribution implements KeybindingContribution {
     registerKeybindings(registry: KeybindingRegistry): void {
         [
             {
-                commandId: 'editor.close',
+                command: 'editor.close',
                 context: this.editorKeybindingContext,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_W, modifiers: [Modifier.M3] })
+                keybinding: "alt+w"
             },
             {
-                commandId: 'editor.close.all',
+                command: 'editor.close.all',
                 context: this.editorKeybindingContext,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_W, modifiers: [Modifier.M2, Modifier.M3] })
+                keybinding: "alt+shift+w"
             }
         ].forEach(binding => {
             registry.registerKeybinding(binding);

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -8,7 +8,6 @@
 import { injectable, inject } from "inversify";
 import { MAIN_MENU_BAR, MenuContribution, MenuModelRegistry } from '../common/menu';
 import { KeybindingContribution, KeybindingRegistry } from '../common/keybinding';
-import { KeyCode, Key, Modifier } from '../common/keys';
 import { CommandContribution, CommandRegistry, Command } from '../common/command';
 import { MessageService } from '../common/message-service';
 import { ApplicationShell } from './shell/application-shell';
@@ -312,74 +311,74 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
     registerKeybindings(registry: KeybindingRegistry): void {
         if (supportCut) {
             registry.registerKeybinding({
-                commandId: CommonCommands.CUT.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_X, modifiers: [Modifier.M1] })
+                command: CommonCommands.CUT.id,
+                keybinding: "ctrlcmd+x"
             });
         }
         if (supportCopy) {
             registry.registerKeybinding({
-                commandId: CommonCommands.COPY.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] })
+                command: CommonCommands.COPY.id,
+                keybinding: "ctrlcmd+c"
             });
         }
         if (supportPaste) {
             registry.registerKeybinding({
-                commandId: CommonCommands.PASTE.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_V, modifiers: [Modifier.M1] })
+                command: CommonCommands.PASTE.id,
+                keybinding: "ctrlcmd+v"
             });
         }
         registry.registerKeybindings(
             {
-                commandId: CommonCommands.UNDO.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_Z, modifiers: [Modifier.M1] })
+                command: CommonCommands.UNDO.id,
+                keybinding: "ctrlcmd+z"
             },
             {
-                commandId: CommonCommands.REDO.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_Z, modifiers: [Modifier.M2, Modifier.M1] })
+                command: CommonCommands.REDO.id,
+                keybinding: "ctrlcmd+shift+z"
             },
             {
-                commandId: CommonCommands.FIND.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_F, modifiers: [Modifier.M1] })
+                command: CommonCommands.FIND.id,
+                keybinding: "ctrlcmd+f"
             },
             {
-                commandId: CommonCommands.REPLACE.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_F, modifiers: [Modifier.M3, Modifier.M1] })
+                command: CommonCommands.REPLACE.id,
+                keybinding: "ctrlcmd+alt+f"
             },
             {
-                commandId: CommonCommands.NEXT_TAB.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.TAB, modifiers: [Modifier.M1] })
+                command: CommonCommands.NEXT_TAB.id,
+                keybinding: "ctrlcmd+tab"
             },
             {
-                commandId: CommonCommands.PREVIOUS_TAB.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.TAB, modifiers: [Modifier.M1, Modifier.M2] })
+                command: CommonCommands.PREVIOUS_TAB.id,
+                keybinding: "ctrlcmd+shift+tab"
             },
             {
-                commandId: CommonCommands.CLOSE_TAB.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_W, modifiers: [Modifier.M3] })
+                command: CommonCommands.CLOSE_TAB.id,
+                keybinding: "alt+w"
             },
             {
-                commandId: CommonCommands.CLOSE_OTHER_TABS.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_T, modifiers: [Modifier.M3, Modifier.M1] })
+                command: CommonCommands.CLOSE_OTHER_TABS.id,
+                keybinding: "ctrlcmd+alt+t"
             },
             {
-                commandId: CommonCommands.CLOSE_ALL_TABS.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_W, modifiers: [Modifier.M2, Modifier.M3] })
+                command: CommonCommands.CLOSE_ALL_TABS.id,
+                keybinding: "alt+shift+w"
             },
             {
-                commandId: CommonCommands.COLLAPSE_PANEL.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M3] })
+                command: CommonCommands.COLLAPSE_PANEL.id,
+                keybinding: "alt+c"
             },
             {
-                commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M2, Modifier.M3] })
+                command: CommonCommands.COLLAPSE_ALL_PANELS.id,
+                keybinding: "alt+shift+c",
             },
             {
-                commandId: CommonCommands.SAVE.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_S, modifiers: [Modifier.M1] })
+                command: CommonCommands.SAVE.id,
+                keybinding: "ctrlcmd+s"
             },
             {
-                commandId: CommonCommands.SAVE_ALL.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_S, modifiers: [Modifier.M3, Modifier.M1] })
+                command: CommonCommands.SAVE_ALL.id,
+                keybinding: "ctrlcmd+alt+s"
             }
         );
     }

--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject } from 'inversify';
 import { QuickCommandService } from './quick-command-service';
-import { Command, CommandRegistry, CommandContribution, Key, Modifier, KeyCode, KeybindingRegistry, KeybindingContribution } from '../../common';
+import { Command, CommandRegistry, CommandContribution, KeybindingRegistry, KeybindingContribution } from '../../common';
 
 export const quickCommand: Command = {
     id: 'quickCommand',
@@ -28,12 +28,12 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
-            commandId: quickCommand.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.F1 })
+            command: quickCommand.id,
+            keybinding: "f1"
         });
         keybindings.registerKeybinding({
-            commandId: quickCommand.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_P, modifiers: [Modifier.M1, Modifier.M2] })
+            command: quickCommand.id,
+            keybinding: "ctrlcmd+shift+p"
         });
     }
 

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -9,7 +9,7 @@ import { injectable, inject } from "inversify";
 import {
     MenuModelRegistry, Command, CommandContribution,
     MenuContribution, KeybindingContribution, KeybindingRegistry,
-    KeyCode, CommandRegistry
+    CommandRegistry
 } from '../../common';
 import { WidgetManager } from '../widget-manager';
 import { Widget } from '@phosphor/widgets';
@@ -27,7 +27,7 @@ export interface ViewContributionOptions {
     widgetName: string;
     defaultWidgetOptions: ApplicationShell.WidgetOptions;
     toggleCommandId?: string;
-    toggleKeybinding?: KeyCode;
+    toggleKeybinding?: string;
 }
 
 /**
@@ -103,8 +103,8 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
     registerKeybindings(keybindings: KeybindingRegistry): void {
         if (this.toggleCommand && this.options.toggleKeybinding) {
             keybindings.registerKeybinding({
-                commandId: this.toggleCommand.id,
-                keyCode: this.options.toggleKeybinding
+                command: this.toggleCommand.id,
+                keybinding: this.options.toggleKeybinding
             });
         }
     }

--- a/packages/core/src/common/keybinding.spec.ts
+++ b/packages/core/src/common/keybinding.spec.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 /* tslint:disable:no-unused-expression */
-import { Container, injectable, ContainerModule } from 'inversify';
+import { Container, injectable, inject, ContainerModule } from 'inversify';
 import { bindContributionProvider } from './contribution-provider';
 import { ILogger } from './logger';
 import { KeybindingRegistry, KeybindingContext, KeybindingContextRegistry, Keybinding, KeybindingContribution, KeybindingScope, RawKeybinding } from './keybinding';
@@ -218,7 +218,7 @@ describe("keys api", () => {
         const keycodeCommand = KeyCode.parse("cmd+b");
         expect(keycodeCommand).is.undefined;
 
-        const keycodeCtrlOrCommand = KeyCode.parse("ControlOrCommand+b");
+        const keycodeCtrlOrCommand = KeyCode.parse("ctrlcmd+b");
         expect(keycodeCtrlOrCommand).is.not.undefined;
         if (keycodeCtrlOrCommand) {
             expect(keycodeCtrlOrCommand.meta).to.be.false;
@@ -252,7 +252,7 @@ describe("keys api", () => {
             expect(keycodeCommand.key).is.equal(Key.KEY_B);
         }
 
-        const keycodeCtrlOrCommand = KeyCode.parse("ControlOrCommand+b");
+        const keycodeCtrlOrCommand = KeyCode.parse("ctrlcmd+b");
         expect(keycodeCtrlOrCommand).is.not.undefined;
         if (keycodeCtrlOrCommand) {
             expect(keycodeCtrlOrCommand.meta).to.be.true;
@@ -274,56 +274,51 @@ const TEST_COMMAND2: Command = {
 @injectable()
 export class TestContribution implements CommandContribution, KeybindingContribution {
 
-    constructor(
-    ) { }
+    constructor( @inject(KeybindingContextRegistry) protected readonly contextRegistry: KeybindingContextRegistry) {
+    }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(TEST_COMMAND);
         commands.registerCommand(TEST_COMMAND2);
     }
 
-    registerKeybindings(keybindings: KeybindingRegistry): void {
-        const keycode1 = KeyCode.parse('ctrl+a');
-        const keycode2 = KeyCode.parse('ctrl+f1');
-        const keycode3 = KeyCode.parse('ctrl+f2');
-        if (keycode1 && keycode2 && keycode3) {
-            [
-                {
-                    commandId: TEST_COMMAND.id,
-                    context: {
-                        id: 'testContext',
-                        isEnabled(arg?: Keybinding): boolean {
-                            return true;
-                        }
-                    },
-                    keyCode: keycode1
-                },
-                {
-                    commandId: TEST_COMMAND2.id,
-                    context: {
-                        id: 'testContext',
-                        isEnabled(arg?: Keybinding): boolean {
-                            return true;
-                        }
-                    },
-                    keyCode: keycode2
-                },
-                {
-                    commandId: TEST_COMMAND2.id,
-                    context: {
-                        id: 'testContext',
-                        isEnabled(arg?: Keybinding): boolean {
-                            return true;
-                        }
-                    },
-                    keyCode: keycode3
-                },
-            ].forEach(binding => {
-                keybindings.registerKeybinding(binding);
-            });
-        }
-
+    registerContexts() {
+        this.contextRegistry.registerContext(
+            {
+                id: 'testContext',
+                isEnabled(arg?: Keybinding): boolean {
+                    return true;
+                }
+            },
+            {
+                id: 'testContext',
+                isEnabled(arg?: Keybinding): boolean {
+                    return true;
+                }
+            },
+        );
     }
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        [{
+            command: TEST_COMMAND.id,
+            context: 'testContext',
+            keybinding: 'ctrl+a'
+        },
+        {
+            command: TEST_COMMAND2.id,
+            context: 'testContext',
+            keybinding: 'ctrl+f1'
+        },
+        {
+            command: TEST_COMMAND2.id,
+            context: 'testContext',
+            keybinding: 'ctrl+f2'
+        },
+        ].forEach(binding => {
+            keybindings.registerKeybinding(binding);
+        });
+    }
+
 }
 
 @injectable()

--- a/packages/core/src/common/keybinding.spec.ts
+++ b/packages/core/src/common/keybinding.spec.ts
@@ -187,44 +187,33 @@ describe('keybindings', () => {
 
 describe("keys api", () => {
     it("should parse a string to a KeyCode correctly", () => {
+
         let keycode = KeyCode.parse("ctrl+b");
-        expect(keycode).is.not.undefined;
-        if (keycode) {
-            expect(keycode.ctrl).to.be.true;
-            expect(keycode.key).is.equal(Key.KEY_B);
-        }
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.KEY_B);
+
         // Invalid keystroke string
-        keycode = KeyCode.parse("ctl+b");
-        expect(keycode).is.undefined;
+        expect(() => KeyCode.parse("ctl+b")).to.throw("Unrecognized key in ctl+b");
+
     });
 
     it("should parse a string containing special modifiers to a KeyCode correctly", () => {
         const stub = sinon.stub(os, 'isOSX').value(false);
 
         const keycode = KeyCode.parse("ctrl+b");
-        expect(keycode).is.not.undefined;
-        if (keycode) {
-            expect(keycode.ctrl).to.be.true;
-            expect(keycode.key).is.equal(Key.KEY_B);
-        }
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.KEY_B);
 
         const keycodeOption = KeyCode.parse("option+b");
-        expect(keycodeOption).is.not.undefined;
-        if (keycodeOption) {
-            expect(keycodeOption.alt).to.be.true;
-            expect(keycodeOption.key).is.equal(Key.KEY_B);
-        }
+        expect(keycodeOption.alt).to.be.true;
+        expect(keycodeOption.key).is.equal(Key.KEY_B);
 
-        const keycodeCommand = KeyCode.parse("cmd+b");
-        expect(keycodeCommand).is.undefined;
+        expect(() => KeyCode.parse("cmd+b")).to.throw("Can't parse keybinding cmd+b meta is for OSX only");
 
         const keycodeCtrlOrCommand = KeyCode.parse("ctrlcmd+b");
-        expect(keycodeCtrlOrCommand).is.not.undefined;
-        if (keycodeCtrlOrCommand) {
-            expect(keycodeCtrlOrCommand.meta).to.be.false;
-            expect(keycodeCtrlOrCommand.ctrl).to.be.true;
-            expect(keycodeCtrlOrCommand.key).is.equal(Key.KEY_B);
-        }
+        expect(keycodeCtrlOrCommand.meta).to.be.false;
+        expect(keycodeCtrlOrCommand.ctrl).to.be.true;
+        expect(keycodeCtrlOrCommand.key).is.equal(Key.KEY_B);
 
         stub.restore();
     });
@@ -232,33 +221,22 @@ describe("keys api", () => {
     it("should parse a string containing special modifiers to a KeyCode correctly (macOS)", () => {
         stub = sinon.stub(os, 'isOSX').value(true);
         const keycode = KeyCode.parse("ctrl+b");
-        expect(keycode).is.not.undefined;
-        if (keycode) {
-            expect(keycode.ctrl).to.be.true;
-            expect(keycode.key).is.equal(Key.KEY_B);
-        }
+        expect(keycode.ctrl).to.be.true;
+        expect(keycode.key).is.equal(Key.KEY_B);
 
         const keycodeOption = KeyCode.parse("option+b");
-        expect(keycodeOption).is.not.undefined;
-        if (keycodeOption) {
-            expect(keycodeOption.alt).to.be.true;
-            expect(keycodeOption.key).is.equal(Key.KEY_B);
-        }
+        expect(keycodeOption.alt).to.be.true;
+        expect(keycodeOption.key).is.equal(Key.KEY_B);
 
         const keycodeCommand = KeyCode.parse("cmd+b");
-        expect(keycodeCommand).is.not.undefined;
-        if (keycodeCommand) {
-            expect(keycodeCommand.meta).to.be.true;
-            expect(keycodeCommand.key).is.equal(Key.KEY_B);
-        }
+        expect(keycodeCommand.meta).to.be.true;
+        expect(keycodeCommand.key).is.equal(Key.KEY_B);
 
         const keycodeCtrlOrCommand = KeyCode.parse("ctrlcmd+b");
-        expect(keycodeCtrlOrCommand).is.not.undefined;
-        if (keycodeCtrlOrCommand) {
-            expect(keycodeCtrlOrCommand.meta).to.be.true;
-            expect(keycodeCtrlOrCommand.ctrl).to.be.false;
-            expect(keycodeCtrlOrCommand.key).is.equal(Key.KEY_B);
-        }
+        expect(keycodeCtrlOrCommand.meta).to.be.true;
+        expect(keycodeCtrlOrCommand.ctrl).to.be.false;
+        expect(keycodeCtrlOrCommand.key).is.equal(Key.KEY_B);
+
         stub.restore();
     });
 });

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -322,6 +322,7 @@ export namespace EasyKey {
 
     export const COMMA: EasyKey = { keyCode: 188, easyString: ',' };
     export const PERIOD: EasyKey = { keyCode: 190, easyString: '.' };
+    export const SLASH: EasyKey = { keyCode: 191, easyString: '/' };
     export const SEMICOLON: EasyKey = { keyCode: 186, easyString: ';' };
     export const QUOTE: EasyKey = { keyCode: 222, easyString: '\'' };
     export const BRACKET_LEFT: EasyKey = { keyCode: 219, easyString: '[' };
@@ -330,6 +331,8 @@ export namespace EasyKey {
     export const BACKSLASH: EasyKey = { keyCode: 220, easyString: '\\' };
     export const MINUS: EasyKey = { keyCode: 189, easyString: '-' };
     export const EQUAL: EasyKey = { keyCode: 187, easyString: '=' };
+    export const INTL_RO: EasyKey = { keyCode: 193, easyString: 'intlro' };
+    export const INTL_YEN: EasyKey = { keyCode: 255, easyString: 'intlyen' };
 }
 
 export namespace Key {

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -79,8 +79,8 @@ export class KeyCode {
                 } else {
                     return undefined;
                 }
-                /* ControlOrCommand for keybindings that work on both macOS and other platforms */
-            } else if (keyString === SpecialCases.CTRL_OR_COMMAND) {
+                /* ctrlcmd for M1 keybindings that work on both macOS and other platforms */
+            } else if (keyString === SpecialCases.CTRLCMD) {
                 sequence.push(`${Modifier.M1}`);
             } else if (Key.isKey(key)) {
                 if (Key.isModifier(key.code)) {
@@ -227,12 +227,11 @@ const SPECIAL_ALIASES: { [index: string]: string } = {
     'ins': 'insert',
     'del': 'delete',
     'control': 'ctrl',
-    'CommandOrControl': 'ControlOrCommand',
 };
 
 export namespace SpecialCases {
     export const META = 'meta';
-    export const CTRL_OR_COMMAND = 'ControlOrCommand';
+    export const CTRLCMD = 'ctrlcmd';
 }
 
 export namespace EasyKey {

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -475,6 +475,6 @@ export namespace Key {
 
     Object.keys(EasyKey).map(prop => Reflect.get(EasyKey, prop)).forEach(easykey => {
         EASY_TO_KEY[easykey.easyString] = KEY_CODE_TO_KEY[easykey.keyCode];
-        KEY_CODE_TO_EASY[easykey.code] = easykey;
+        KEY_CODE_TO_EASY[easykey.keyCode] = easykey;
     });
 })();

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -57,13 +57,13 @@ export class KeyCode {
      * Parses a string and returns a KeyCode object.
      * @param keybinding String representation of a keybinding
      */
-    public static parse(keybinding: string): KeyCode | undefined {
+    public static parse(keybinding: string): KeyCode {
         const sequence: string[] = [];
 
         const keys = keybinding.split('+');
         /* If duplicates i.e ctrl+ctrl+a or alt+alt+b or b+alt+b it is invalid */
         if (keys.length !== new Set(keys).size) {
-            return undefined;
+            throw new Error(`Can't parse keybinding ${keybinding} Duplicate modifiers`);
         }
 
         for (let keyString of keys) {
@@ -77,7 +77,7 @@ export class KeyCode {
                 if (isOSX) {
                     sequence.push(`${Modifier.M1}`);
                 } else {
-                    return undefined;
+                    throw new Error(`Can't parse keybinding ${keybinding} meta is for OSX only`);
                 }
                 /* ctrlcmd for M1 keybindings that work on both macOS and other platforms */
             } else if (keyString === SpecialCases.CTRLCMD) {
@@ -100,7 +100,7 @@ export class KeyCode {
                     sequence.unshift(key.code);
                 }
             } else {
-                return undefined;
+                throw new Error(`Unrecognized key in ${keybinding}`);
             }
         }
         return new KeyCode(sequence.join('+'));

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -9,7 +9,7 @@ import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
 import {
     Command, CommandContribution, CommandRegistry,
-    KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier,
+    KeybindingContribution, KeybindingRegistry,
     MenuModelRegistry, MenuContribution
 } from '../../common';
 import { FrontendApplication, FrontendApplicationContribution, CommonMenus } from '../../browser';
@@ -124,26 +124,26 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
 
     registerKeybindings(registry: KeybindingRegistry): void {
         registry.registerKeybinding({
-            commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_I, modifiers: [Modifier.M1, Modifier.M2] })
+            command: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
+            keybinding: "ctrlcmd+shift+i"
         });
 
         registry.registerKeybinding({
-            commandId: ElectronCommands.RELOAD.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_R, modifiers: [Modifier.M1] })
+            command: ElectronCommands.RELOAD.id,
+            keybinding: "ctrlcmd+r"
         });
 
         registry.registerKeybinding({
-            commandId: ElectronCommands.ZOOM_IN.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.EQUAL, modifiers: [Modifier.M1] })
+            command: ElectronCommands.ZOOM_IN.id,
+            keybinding: "ctrlcmd+="
         });
         registry.registerKeybinding({
-            commandId: ElectronCommands.ZOOM_OUT.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.MINUS, modifiers: [Modifier.M1] })
+            command: ElectronCommands.ZOOM_OUT.id,
+            keybinding: "ctrlcmd+-"
         });
         registry.registerKeybinding({
-            commandId: ElectronCommands.RESET_ZOOM.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.DIGIT0, modifiers: [Modifier.M1] })
+            command: ElectronCommands.RESET_ZOOM.id,
+            keybinding: "ctrlcmd+0"
         });
     }
 

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -8,7 +8,7 @@
 import { injectable, inject } from "inversify";
 import { EditorManager } from "@theia/editor/lib/browser";
 import {
-    KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier
+    KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry
 } from "@theia/core/lib/common";
 
 @injectable()
@@ -34,9 +34,9 @@ export class CppKeybindingContribution implements KeybindingContribution {
     registerKeybindings(registry: KeybindingRegistry): void {
         [
             {
-                commandId: 'switch_source_header',
-                contextId: this.cppKeybindingContext.id,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M3] })
+                command: 'switch_source_header',
+                context: this.cppKeybindingContext.id,
+                keybinding: "alt+o"
             }
         ].forEach(binding => {
             registry.registerKeybinding(binding);

--- a/packages/extension-manager/src/browser/extension-contribution.ts
+++ b/packages/extension-manager/src/browser/extension-contribution.ts
@@ -9,7 +9,6 @@ import { injectable, inject } from "inversify";
 import { MessageService } from "@theia/core";
 import { FrontendApplication } from '@theia/core/lib/browser';
 import { ExtensionManager } from '../common';
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common/keys';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { ExtensionWidget } from './extension-widget';
 
@@ -30,9 +29,7 @@ export class ExtensionContribution extends AbstractViewContribution<ExtensionWid
                 rank: 300
             },
             toggleCommandId: 'extensionsView:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_X, modifiers: [Modifier.M2, Modifier.M1]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+x'
         });
     }
 

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject } from 'inversify';
 import { QuickFileOpenService } from './quick-file-open';
-import { Command, CommandRegistry, CommandContribution, Key, Modifier, KeyCode, KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/common';
+import { Command, CommandRegistry, CommandContribution, KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/common';
 
 export const quickFileOpen: Command = {
     id: 'file-search.openFile',
@@ -28,8 +28,8 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
-            commandId: quickFileOpen.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_P, modifiers: [Modifier.M1] })
+            command: quickFileOpen.id,
+            keybinding: "ctrlcmd+p"
         });
     }
 

--- a/packages/git/src/browser/git-frontend-contribution.ts
+++ b/packages/git/src/browser/git-frontend-contribution.ts
@@ -11,7 +11,6 @@ import { StatusBar, StatusBarAlignment } from "@theia/core/lib/browser/status-ba
 import { GitWatcher, GitStatusChangeEvent } from '../common/git-watcher';
 import { GIT_COMMANDS } from './git-command';
 import { DisposableCollection } from "@theia/core";
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common/keys';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { GitWidget } from './git-widget';
 
@@ -35,9 +34,7 @@ export class GitFrontendContribution extends AbstractViewContribution<GitWidget>
                 rank: 200
             },
             toggleCommandId: 'gitView:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_G, modifiers: [Modifier.CTRL, Modifier.SHIFT]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+g'
         });
     }
 

--- a/packages/java/src/browser/java-commands.ts
+++ b/packages/java/src/browser/java-commands.ts
@@ -8,7 +8,7 @@
 import { inject, injectable } from "inversify";
 import {
     CommandContribution, CommandRegistry, Command, MenuContribution, MenuModelRegistry, KeybindingContext,
-    Keybinding, KeybindingContextRegistry, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier
+    Keybinding, KeybindingContextRegistry, KeybindingContribution, KeybindingRegistry
 } from '@theia/core/lib/common';
 import { EditorCommands, EditorManager, EDITOR_CONTEXT_MENU } from "@theia/editor/lib/browser";
 import { WorkspaceEdit, Workspace } from "@theia/languages/lib/common";
@@ -108,10 +108,10 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
     registerKeybindings(keybindings: KeybindingRegistry): void {
         this.keybindingContextRegistry.registerContext(this.editorContext);
         keybindings.registerKeybinding({
-            commandId: JAVA_ORGANIZE_IMPORTS.id,
-            contextId: CONTEXT_ID,
+            command: JAVA_ORGANIZE_IMPORTS.id,
+            context: CONTEXT_ID,
             accelerator: ['Accel Shift O'],
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M1, Modifier.M2] })
+            keybinding: 'ctrlcmd+shift+o'
         });
     }
 }

--- a/packages/keymaps/README.md
+++ b/packages/keymaps/README.md
@@ -20,7 +20,9 @@ Example of a valid `keymaps.json` file
 
 For most keys you can directly use the name of the key i.e `a`, `3`,  `/`, `-`.
 
-You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`), `cmd` (`meta`) as modifiers. You can also `ControlOrCommand` or `CommandOrControl` as modifiers if you want the shortcut to fallback on `ctrl` coming from macOS. Note that if you defined a custom shortcut with `cmd`, `command` or `meta`, the same keymaps file won't work on a Windows/Linux machine as this key doesn't have an equivalent.
+To use `ctrl` on Linux/Windows and `cmd` on OSX, use `ctrlcmd`.
+
+You can use `shift`, `ctrl`, `alt`, `meta`, `option` (`alt`), `command` (`meta`), `cmd` (`meta`) as modifiers. Note that if you defined a custom shortcut with `cmd`, `command` or `meta`, the same keymaps file won't work on a Windows/Linux machine as this key doesn't have an equivalent.
 
 You can also use the following strings for special keys: `backspace`, `tab`, `enter`, `return`, `capslock`, `esc`, `escape`, `space`, `pageup`, `pagedown`, `end`, `home`, `left`, `up`, `right`, `down`, `ins`, `del` and `plus`.
 

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -8,7 +8,7 @@
 import { inject, injectable } from 'inversify';
 import { FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 import { Disposable, DisposableCollection, CommandRegistry, KeybindingRegistry, ILogger, ResourceProvider, Resource } from '@theia/core/lib/common';
-import { RawKeybinding, KeybindingScope } from '@theia/core/lib/common';
+import { Keybinding, KeybindingScope } from '@theia/core/lib/common';
 import { UserStorageUri } from '@theia/userstorage/lib/browser/';
 import URI from '@theia/core/lib/common/uri';
 import * as ajv from 'ajv';
@@ -98,18 +98,18 @@ export class KeymapsService implements Disposable, FrontendApplicationContributi
     }
 
     protected setKeymap(keybindings: any) {
-        const rawBindings: RawKeybinding[] = [];
+        const bindings: Keybinding[] = [];
 
         for (const keybinding of keybindings) {
-            rawBindings.push({
+            bindings.push({
                 command: keybinding.command,
                 keybinding: keybinding.keybinding,
                 context: keybinding.context
             });
         }
 
-        if (this.ajv.validate(keymapsSchema, rawBindings)) {
-            this.keyBindingRegistry.setKeymap(KeybindingScope.USER, rawBindings);
+        if (this.ajv.validate(keymapsSchema, bindings)) {
+            this.keyBindingRegistry.setKeymap(KeybindingScope.USER, bindings);
         }
     }
 }

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -11,7 +11,7 @@ import { QuickOpenService, QuickOpenModel, QuickOpenItem, OpenerService, QuickOp
 import { WorkspaceSymbolParams, SymbolInformation } from 'vscode-base-languageclient/lib/base';
 import { CancellationTokenSource, CommandRegistry, CommandHandler, Command, SelectionService } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
-import { CommandContribution, KeybindingContribution, KeybindingRegistry, KeyCode, Key, Modifier } from '@theia/core/lib/common';
+import { CommandContribution, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/common';
 import { Range } from 'vscode-languageserver-types';
 
 @injectable()
@@ -44,8 +44,8 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
-            commandId: this.command.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.KEY_O, modifiers: [Modifier.M1] }),
+            command: this.command.id,
+            keybinding: "ctrlcmd+o",
             accelerator: ['Accel O']
         });
     }

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -6,7 +6,6 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common';
 import { FrontendApplication } from '@theia/core/lib/browser';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
@@ -28,9 +27,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
                 area: 'bottom'
             },
             toggleCommandId: 'problemsView:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_M, modifiers: [Modifier.M2, Modifier.M1]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+m'
         });
     }
 
@@ -55,5 +52,4 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             command: this.toggleCommand ? this.toggleCommand.id : undefined
         });
     }
-
 }

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -52,8 +52,8 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
         const selectAllCommand = this.commands.validate(MonacoCommands.SELECTION_SELECT_ALL);
         if (selectAllCommand) {
             registry.registerKeybinding({
-                commandId: selectAllCommand,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }),
+                command: selectAllCommand,
+                keybinding: "ctrlcmd+a",
                 accelerator: ['Accel A']
             });
         }

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -32,14 +32,14 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
 
     registerKeybindings(registry: KeybindingRegistry): void {
         for (const item of KeybindingsRegistry.getDefaultKeybindings()) {
-            const commandId = this.commands.validate(item.command);
-            if (commandId) {
+            const command = this.commands.validate(item.command);
+            if (command) {
                 const raw = item.keybinding;
                 if (raw.type === monaco.keybindings.KeybindingType.Simple) {
                     const keybinding = raw as monaco.keybindings.SimpleKeybinding;
                     registry.registerKeybinding({
-                        commandId,
-                        keyCode: this.keyCode(keybinding),
+                        command,
+                        keybinding: this.keyCode(keybinding).toString(),
                         accelerator: this.accelerator(keybinding)
                     });
                 } else {

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -5,9 +5,10 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import { QuickOpenService, QuickOpenModel, QuickOpenOptions, QuickOpenItem, QuickOpenGroupItem, QuickOpenMode } from "@theia/core/lib/browser";
 import { KEY_CODE_MAP } from './monaco-keycode-map';
+import { KeyCode, ILogger } from '@theia/core';
 
 export interface MonacoQuickOpenControllerOpts extends monaco.quickOpen.IQuickOpenControllerOpts {
     readonly prefix?: string;
@@ -23,7 +24,7 @@ export class MonacoQuickOpenService extends QuickOpenService {
     protected opts: MonacoQuickOpenControllerOpts | undefined;
     protected previousActiveElement: Element | undefined;
 
-    constructor() {
+    constructor( @inject(ILogger) protected readonly logger: ILogger) {
         super();
         const overlayWidgets = document.createElement('div');
         overlayWidgets.classList.add('quick-open-overlay');
@@ -230,12 +231,20 @@ export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
         if (!keybinding) {
             return undefined;
         }
+
+        let keyCode: KeyCode;
+        try {
+            keyCode = KeyCode.parse(keybinding.keybinding);
+        } catch (error) {
+            return undefined;
+        }
+
         const simple = new monaco.keybindings.SimpleKeybinding(
-            keybinding.keyCode.ctrl,
-            keybinding.keyCode.shift,
-            keybinding.keyCode.alt,
-            keybinding.keyCode.meta,
-            KEY_CODE_MAP[keybinding.keyCode.key.keyCode]
+            keyCode.ctrl,
+            keyCode.shift,
+            keyCode.alt,
+            keyCode.meta,
+            KEY_CODE_MAP[keyCode.key.keyCode]
         );
         return new monaco.keybindings.USLayoutResolvedKeybinding(simple, monaco.platform.OS);
     }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -7,7 +7,6 @@
 
 import { injectable } from "inversify";
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common/keys';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 
 @injectable()
@@ -22,9 +21,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
                 rank: 100
             },
             toggleCommandId: 'fileNavigator:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_E, modifiers: [Modifier.M2, Modifier.M1]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+e'
         });
     }
 

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -6,7 +6,6 @@
  */
 
 import { injectable } from "inversify";
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common/keys';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { OutlineViewWidget } from './outline-view-widget';
 
@@ -24,10 +23,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
                 rank: 100
             },
             toggleCommandId: 'outlineView:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_O, modifiers: [Modifier.CTRL, Modifier.SHIFT]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+o'
         });
     }
-
 }

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -7,7 +7,6 @@
 
 import { injectable } from "inversify";
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { KeyCode, Key, Modifier } from '@theia/core/lib/common/keys';
 import { OUTPUT_WIDGET_KIND, OutputWidget } from "./output-widget";
 
 @injectable()
@@ -21,9 +20,7 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> {
                 area: 'bottom'
             },
             toggleCommandId: 'output:toggle',
-            toggleKeybinding: KeyCode.createKeyCode({
-                first: Key.KEY_U, modifiers: [Modifier.M2, Modifier.M1]
-            })
+            toggleKeybinding: 'ctrlcmd+shift+u'
         });
     }
 

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -85,9 +85,9 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
            context of the terminal.  */
         const regCtrl = (k: Key) => {
             keybindings.registerKeybindings({
-                commandId: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
-                keyCode: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.CTRL] }),
-                contextId: TERMINAL_ACTIVE_CONTEXT,
+                command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
+                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.CTRL] }).toString(),
+                context: TERMINAL_ACTIVE_CONTEXT,
             });
         };
 
@@ -95,9 +95,9 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
            context of the terminal.  */
         const regAlt = (k: Key) => {
             keybindings.registerKeybinding({
-                commandId: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
-                keyCode: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.M3] }),
-                contextId: TERMINAL_ACTIVE_CONTEXT,
+                command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
+                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.M3] }).toString(),
+                context: TERMINAL_ACTIVE_CONTEXT,
             });
         };
 
@@ -156,7 +156,7 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
             keybindings.registerKeybindings({
                 command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
                 keybinding: "ctrlcmd+a",
-                contextId: TERMINAL_ACTIVE_CONTEXT
+                context: TERMINAL_ACTIVE_CONTEXT
             });
         }
     }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -72,8 +72,8 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         });
 
         keybindings.registerKeybinding({
-            commandId: TerminalCommands.NEW.id,
-            keyCode: KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] }),
+            command: TerminalCommands.NEW.id,
+            keybinding: "ctrlcmd+`"
         });
 
         /* Register passthrough keybindings for combinations recognized by
@@ -154,9 +154,9 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         if (isOSX) {
             // selectAll on OSX
             keybindings.registerKeybindings({
-                commandId: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
-                keyCode: KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }),
-                contextId: TERMINAL_ACTIVE_CONTEXT,
+                command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
+                keybinding: "ctrlcmd+a",
+                contextId: TERMINAL_ACTIVE_CONTEXT
             });
         }
     }


### PR DESCRIPTION
This patch makes extensions use RawKeybindings instead of Keybindings to
specify keybindings.

For the moment the registerKeybinding(s) function is still compatible with
the old Keybinding inputs.  But this will be changed when all extensions
are changed and when serialization is done properly for keybindings.

Also this patch changes the "ControlOrCommand" string to specify the M1
motifier (cmd on OSX and ctrl on win/linux) to "ctrlcmd".

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>