### PR TITLE
issue #1038 Vertical scroll bar hide the last char of the key accelerator in the command menu list.

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -36,3 +36,7 @@
     margin-bottom: 4px;
     margin-right: 0px;
 }
+
+.monaco-tree-wrapper {
+    right: 10px;
+}


### PR DESCRIPTION
Open the task quick open (CTRL + SHFT+ P).
The scrollbar will not hide the last char of the key binding accelerator

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>