### PR TITLE
[styling] Add padding to the terminal and the quick open widget (fixes #1064, fixes #1038)

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -36,3 +36,7 @@
     margin-bottom: 4px;
     margin-right: 0px;
 }
+
+.monaco-tree-row  {
+    padding-right: 11px;
+}

--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -8,15 +8,5 @@
 .terminal-container {
     width:100%;
     height:100%;
-}
-
-/* This one is created by xterm.js.  */
-.terminal-container .terminal {
-    /* We should be able to add back the padding once
-
-         https://github.com/xtermjs/xterm.js/pull/1123
-
-       is merged in xterm.js.  */
-    /* padding-top: calc(var(--theia-code-padding)*3) !important;
-    padding-left: calc(var(--theia-code-padding)*3) !important; */
+    padding: var(--theia-code-padding);
 }


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>