### PR TITLE
add options to reveal methods of `TextEditor`

### DIFF
--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -39,7 +39,7 @@ export interface TextEditor extends Disposable, TextEditorSelection {
     isFocused(): boolean;
     readonly onFocusChanged: Event<boolean>;
 
-    revealPosition(position: Position): void;
+    revealPosition(position: Position, options?: RevealPositionOptions): void;
     revealRange(range: Range, options?: RevealRangeOptions): void;
 
     /**
@@ -64,8 +64,13 @@ export interface TextEditorSelection {
     selection?: Range
 }
 
+export interface RevealPositionOptions {
+    vertical: 'auto' | 'center' | 'centerIfOutsideViewport';
+    horizontal?: boolean;
+}
+
 export interface RevealRangeOptions {
-    at: 'center' | 'top' | 'centerIfOutsideViewport';
+    at: 'auto' | 'center' | 'top' | 'centerIfOutsideViewport';
 }
 
 export namespace TextEditorSelection {

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -40,7 +40,7 @@ export interface TextEditor extends Disposable, TextEditorSelection {
     readonly onFocusChanged: Event<boolean>;
 
     revealPosition(position: Position): void;
-    revealRange(range: Range): void;
+    revealRange(range: Range, options?: RevealRangeOptions): void;
 
     /**
      * Rerender the editor.
@@ -62,6 +62,10 @@ export interface TextEditorSelection {
     uri: URI
     cursor?: Position
     selection?: Range
+}
+
+export interface RevealRangeOptions {
+    at: 'center' | 'top' | 'centerIfOutsideViewport';
 }
 
 export namespace TextEditorSelection {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -17,7 +17,8 @@ import {
     Range,
     TextEditorDocument,
     TextEditor,
-    RevealRangeOptions
+    RevealRangeOptions,
+    RevealPositionOptions
 } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from "./monaco-editor-model";
 
@@ -182,9 +183,19 @@ export class MonacoEditor implements TextEditor, IEditorReference {
         return this.onSelectionChangedEmitter.event;
     }
 
-    revealPosition(raw: Position): void {
+    revealPosition(raw: Position, options: RevealPositionOptions = { vertical: 'center', horizontal: true }): void {
         const position = this.p2m.asPosition(raw);
-        this.editor.revealPositionInCenter(position);
+        switch (options.vertical) {
+            case 'auto':
+                this.editor.revealPosition(position, false, options.horizontal);
+                break;
+            case 'center':
+                this.editor.revealPosition(position, true, options.horizontal);
+                break;
+            case 'centerIfOutsideViewport':
+                this.editor.revealPositionInCenterIfOutsideViewport(position);
+                break;
+        }
     }
 
     revealRange(raw: Range, options: RevealRangeOptions = { at: 'center' }): void {
@@ -199,7 +210,7 @@ export class MonacoEditor implements TextEditor, IEditorReference {
             case 'centerIfOutsideViewport':
                 this.editor.revealRangeInCenterIfOutsideViewport(range!);
                 break;
-            default:
+            case 'auto':
                 this.editor.revealRange(range!);
                 break;
         }

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -16,7 +16,8 @@ import {
     Position,
     Range,
     TextEditorDocument,
-    TextEditor
+    TextEditor,
+    RevealRangeOptions
 } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from "./monaco-editor-model";
 
@@ -186,9 +187,22 @@ export class MonacoEditor implements TextEditor, IEditorReference {
         this.editor.revealPositionInCenter(position);
     }
 
-    revealRange(raw: Range): void {
+    revealRange(raw: Range, options: RevealRangeOptions = { at: 'center' }): void {
         const range = this.p2m.asRange(raw);
-        this.editor.revealRangeInCenter(range!);
+        switch (options.at) {
+            case 'top':
+                this.editor.revealRangeAtTop(range!);
+                break;
+            case 'center':
+                this.editor.revealRangeInCenter(range!);
+                break;
+            case 'centerIfOutsideViewport':
+                this.editor.revealRangeInCenterIfOutsideViewport(range!);
+                break;
+            default:
+                this.editor.revealRange(range!);
+                break;
+        }
     }
 
     focus() {


### PR DESCRIPTION
This change makes it possible to reveal a line, or a range at the top of editor, which is a prerequisite for PR #1051.