### PR TITLE
 Fix default label provider long name

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -34,6 +34,7 @@ import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContri
 
 import '../../src/browser/style/index.css';
 import 'font-awesome/css/font-awesome.min.css';
+import "file-icons-js/css/style.css";
 import { ThemingCommandContribution, ThemeService } from './theming';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {

--- a/packages/core/src/browser/label-provider.spec.ts
+++ b/packages/core/src/browser/label-provider.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import { DefaultUriLabelProviderContribution } from './label-provider';
+import URI from '../common/uri';
+
+describe("DefaultUriLabelProviderContribution", function () {
+
+    it("should return a short name", function () {
+        const prov = new DefaultUriLabelProviderContribution();
+        const shortName = prov.getName(new URI('file:///tmp/hello/you.txt'));
+
+        expect(shortName).eq('you.txt');
+    });
+
+    it("should return a long name", function () {
+        const prov = new DefaultUriLabelProviderContribution();
+        const longName = prov.getLongName(new URI('file:///tmp/hello/you.txt'));
+
+        expect(longName).eq('/tmp/hello/you.txt');
+    });
+
+    it("should return icon class for something that seems to be a file", function () {
+        const prov = new DefaultUriLabelProviderContribution();
+        const icon = prov.getIcon(new URI('file:///tmp/hello/you.txt'));
+
+        expect(icon).eq('text-icon');
+    });
+
+    it("should return icon class for something that seems to be a directory", function () {
+        const prov = new DefaultUriLabelProviderContribution();
+        const icon = prov.getIcon(new URI('file:///tmp/hello'));
+
+        expect(icon).eq('fa fa-folder');
+    });
+});

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -11,8 +11,6 @@ import URI from "../common/uri";
 import { ContributionProvider } from '../common/contribution-provider';
 import { Prioritizeable, MaybePromise } from '../common/types';
 
-import "file-icons-js/css/style.css";
-
 export const LabelProviderContribution = Symbol('LabelProviderContribution');
 export interface LabelProviderContribution {
 
@@ -71,7 +69,7 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
     }
 
     getLongName(uri: URI): string {
-        return uri.parent.path.toString();
+        return uri.path.toString();
     }
 }
 

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -78,9 +78,11 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
      */
     getLongName(element: URI | FileStat): string {
         const uri = this.getUri(element);
-        if (!this.wsRoot) {
+        const uriStr = uri.toString();
+        if (!this.wsRoot || !uriStr.startsWith(this.wsRoot)) {
             return super.getLongName(uri);
         }
+
         const short = uri.toString().substr(this.wsRoot.length);
         if (short[0] === '/') {
             return short.substr(1);


### PR DESCRIPTION
It currently returns the parent (directory) name, but it should return
the element name.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>