### PR TITLE
issue #640 A long Git repository name truncates the toolbar item from the tab

### DIFF
--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -142,6 +142,7 @@
     border-color: var(--theia-border-color1);
     background: var(--theia-layout-color0);
     color: var(--theia-ui-font-color1);
+    width: 100%;
 }
 
 #theia-gitContainer #repositoryListContainer {


### PR DESCRIPTION
Git repository do not overlaps the git toolbar menu items

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>