### PR TITLE
cpp: Make function to check if current editor contains a cpp file

### DIFF
--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -28,6 +28,14 @@ export const FILE_OPEN_PATH = (path: string): Command => <Command>{
     id: `file:openPath`
 };
 
+export function editorContainsCppFiles(editorManager: EditorManager | undefined): boolean {
+    if (editorManager && editorManager.activeEditor) {
+        const uri = editorManager.activeEditor.editor.document.uri;
+        return HEADER_AND_SOURCE_FILE_EXTENSIONS.some(value => uri.endsWith("." + value));
+    }
+    return false;
+}
+
 @injectable()
 export class CppCommandContribution implements CommandContribution {
 
@@ -41,18 +49,9 @@ export class CppCommandContribution implements CommandContribution {
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(SWITCH_SOURCE_HEADER, {
-            isEnabled: () => {
-                if (this.editorService && !!this.editorService.activeEditor) {
-                    const uri = this.editorService.activeEditor.editor.document.uri;
-                    return HEADER_AND_SOURCE_FILE_EXTENSIONS.some(value => uri.endsWith("." + value));
-                }
-                return false;
-            },
-            execute: () => {
-                this.switchSourceHeader();
-            }
+            isEnabled: () => editorContainsCppFiles(this.editorService),
+            execute: () => this.switchSourceHeader()
         });
-
     }
 
     protected switchSourceHeader(): void {

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -10,7 +10,7 @@ import { EditorManager } from "@theia/editor/lib/browser";
 import {
     KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry
 } from "@theia/core/lib/common";
-import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
+import { editorContainsCppFiles } from "./cpp-commands";
 
 @injectable()
 export class CppKeybindingContext implements KeybindingContext {
@@ -18,14 +18,9 @@ export class CppKeybindingContext implements KeybindingContext {
 
     id = 'cpp.keybinding.context';
 
-    isEnabled(arg?: Keybinding) {
-        if (this.editorService && !!this.editorService.activeEditor) {
-            const uri = this.editorService.activeEditor.editor.document.uri;
-            return HEADER_AND_SOURCE_FILE_EXTENSIONS.some(value => uri.endsWith("." + value));
-        }
-        return false;
+    isEnabled(arg: Keybinding): boolean {
+        return editorContainsCppFiles(this.editorService);
     }
-
 }
 
 @injectable()


### PR DESCRIPTION
The same code to check if the active editor contains a cpp file is
duplicated, and we will likely to do the same check at other places in
the future.  Extract the code to a new function and use it.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>