### PR TITLE
update electron to 1.7.11

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -38,7 +38,7 @@
     "circular-dependency-plugin": "^2.0.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.1",
-    "electron": "1.7.6",
+    "electron": "1.7.11",
     "electron-rebuild": "^1.5.11",
     "file-loader": "^0.11.1",
     "font-awesome-webpack": "0.0.5-beta.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "@types/yargs": "^8.0.2",
     "body-parser": "^1.17.2",
     "bunyan": "^1.8.10",
-    "electron": "1.7.6",
+    "electron": "1.7.11",
     "express": "^4.15.3",
     "file-icons-js": "^1.0.3",
     "font-awesome": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,9 +2291,9 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.6.tgz#fb69ea31bd03df0eff247f26f0b538bd29b6ee72"
+electron@1.7.11:
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.11.tgz#993b6aa79e0e79a7cfcc369f4c813fbd9a0b08d9"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
There is apparently a security issue with the electron Election we are using. This changes the version to the new recommended one.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>