### PR TITLE
Increase timeout in ripgrep-search-in-workspace-server.spec.ts

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -162,7 +162,9 @@ function compareSearchResults(expected: SearchInWorkspaceResult[], actual: Searc
     }
 }
 
-describe('ripgrep-search-in-workspace-server', () => {
+describe('ripgrep-search-in-workspace-server', function () {
+    this.timeout(10000);
+
     // Try some simple patterns with different case.
     it('returns 7 results when searching for "carrot"', function (done) {
         const pattern = 'carrot';


### PR DESCRIPTION
The build in Appveyor hit the 2000ms timeout for some tests in here, so
increase it.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>