### PR TITLE
Remove accelerator from Keybinding structure

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -8,8 +8,12 @@
 import { injectable, inject } from "inversify";
 import { MenuBar as MenuBarWidget, Menu as MenuWidget, Widget } from "@phosphor/widgets";
 import { CommandRegistry as PhosphorCommandRegistry } from "@phosphor/commands";
-import { CommandRegistry, KeybindingRegistry, ActionMenuNode, CompositeMenuNode, MenuModelRegistry, MAIN_MENU_BAR, MenuPath } from "../../common";
+import {
+    CommandRegistry, KeybindingRegistry, ActionMenuNode, CompositeMenuNode,
+    MenuModelRegistry, MAIN_MENU_BAR, MenuPath, KeyCode, Key, Keybinding
+} from "../../common";
 import { FrontendApplicationContribution, FrontendApplication } from "../frontend-application";
+import { isOSX } from '../../common/os';
 
 @injectable()
 export class BrowserMainMenuFactory {
@@ -79,7 +83,7 @@ export class BrowserMainMenuFactory {
         /* Only consider the first keybinding. */
         if (bindings.length > 0) {
             const binding = bindings[0];
-            const keys = binding.accelerator || [];
+            const keys = [this.acceleratorFor(binding)];
             commands.addKeyBinding({
                 command: command.id,
                 keys,
@@ -88,6 +92,51 @@ export class BrowserMainMenuFactory {
         }
     }
 
+    /* Return a user visble representation of a keybinding.  */
+    protected acceleratorFor(keybinding: Keybinding) {
+        const keyCode = KeyCode.parse(keybinding.keybinding);
+        let result = "";
+        let previous = false;
+        const separator = " ";
+
+        if (keyCode.meta && isOSX) {
+            if (isOSX) {
+                result += "Cmd";
+                previous = true;
+            }
+        }
+
+        if (keyCode.ctrl) {
+            if (previous) {
+                result += separator;
+            }
+            result += "Ctrl";
+            previous = true;
+        }
+
+        if (keyCode.alt) {
+            if (previous) {
+                result += separator;
+            }
+            result += "Alt";
+            previous = true;
+        }
+
+        if (keyCode.shift) {
+            if (previous) {
+                result += separator;
+            }
+            result += "Shift";
+            previous = true;
+        }
+
+        if (previous) {
+            result += separator;
+        }
+
+        result += Key.getEasyKey(keyCode.key).easyString.toUpperCase();
+        return result;
+    }
 }
 class DynamicMenuBarWidget extends MenuBarWidget {
 

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject, named } from 'inversify';
 import { CommandRegistry } from './command';
-import { KeyCode, Accelerator } from './keys';
+import { KeyCode } from './keys';
 import { ContributionProvider } from './contribution-provider';
 import { ILogger } from "./logger";
 
@@ -31,8 +31,7 @@ export namespace Keybinding {
         const copy: Keybinding = {
             command: binding.command,
             keybinding: binding.keybinding,
-            context: binding.context,
-            accelerator: binding.accelerator
+            context: binding.context
         };
         return JSON.stringify(copy);
     }
@@ -49,11 +48,6 @@ export interface Keybinding {
      * keybinding context.
      */
     context?: string;
-
-    /**
-     * Sugar for showing the keybindings in the menus.
-     */
-    accelerator?: Accelerator;
 }
 
 export const KeybindingContribution = Symbol("KeybindingContribution");

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -7,14 +7,6 @@
 
 import { isOSX } from './os';
 
-export declare type Accelerator = string[];
-
-export const AcceleratorProvider = Symbol("AcceleratorProvider");
-
-export interface AcceleratorProvider {
-    getAccelerator(keyCode: KeyCode): Accelerator
-}
-
 /**
  * The key sequence for this binding. This key sequence should consist of one or more key strokes. Key strokes
  * consist of one or more keys held down at the same time. This should be zero or more modifier keys, and one other key.
@@ -400,6 +392,10 @@ export namespace Key {
         } else {
             return CODE_TO_KEY[arg];
         }
+    }
+
+    export function getEasyKey(key: Key) {
+        return KEY_CODE_TO_EASY[key.keyCode];
     }
 
     export function isModifier(arg: string | number) {

--- a/packages/java/src/browser/java-commands.ts
+++ b/packages/java/src/browser/java-commands.ts
@@ -110,7 +110,6 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
         keybindings.registerKeybinding({
             command: JAVA_ORGANIZE_IMPORTS.id,
             context: CONTEXT_ID,
-            accelerator: ['Accel Shift O'],
             keybinding: 'ctrlcmd+shift+o'
         });
     }

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -46,7 +46,6 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         keybindings.registerKeybinding({
             command: this.command.id,
             keybinding: "ctrlcmd+o",
-            accelerator: ['Accel O']
         });
     }
 

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -7,12 +7,11 @@
 
 import { injectable, inject } from 'inversify';
 import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/common/keybinding';
-import { Accelerator, Key, KeyCode, Keystroke, Modifier } from '@theia/core/lib/common/keys';
+import { Key, KeyCode, Keystroke, Modifier } from '@theia/core/lib/common/keys';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import { KEY_CODE_MAP } from './monaco-keycode-map';
 import KeybindingsRegistry = monaco.keybindings.KeybindingsRegistry;
-import KeyCodeUtils = monaco.keybindings.KeyCodeUtils;
 
 function monaco2BrowserKeyCode(keyCode: monaco.KeyCode): number {
     for (let i = 0; i < KEY_CODE_MAP.length; i++) {
@@ -40,7 +39,6 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                     registry.registerKeybinding({
                         command,
                         keybinding: this.keyCode(keybinding).toString(),
-                        accelerator: this.accelerator(keybinding)
                     });
                 } else {
                     // FIXME support chord keybindings properly, KeyCode does not allow it right now
@@ -54,7 +52,6 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             registry.registerKeybinding({
                 command: selectAllCommand,
                 keybinding: "ctrlcmd+a",
-                accelerator: ['Accel A']
             });
         }
     }
@@ -79,24 +76,4 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
         }
         return KeyCode.createKeyCode(sequence);
     }
-
-    protected accelerator(keybinding: monaco.keybindings.SimpleKeybinding): Accelerator {
-        const keyCode = keybinding.keyCode;
-        const keys: string[] = [];
-        if (keybinding.metaKey) {
-            keys.push('Accel');
-        }
-        if (keybinding.altKey) {
-            keys.push('Alt');
-        }
-        if (keybinding.ctrlKey) {
-            keys.push('Accel');
-        }
-        if (keybinding.shiftKey) {
-            keys.push('Shift');
-        }
-        keys.push(KeyCodeUtils.toString(keyCode & 255));
-        return [keys.join(' ')];
-    }
-
 }


### PR DESCRIPTION
Serialize the keybinding instead in a user friendly way for the browser
and electron.

Fixes: #1089,#490

Signed-off-by: Antoine Tremblay <antoine.tremblay@ericsson.com>