### PR TITLE
Fixes #1128: git widget: Show parent after base file name

### DIFF
--- a/packages/git/src/browser/git-widget.ts
+++ b/packages/git/src/browser/git-widget.ts
@@ -96,7 +96,7 @@ export class GitWidget extends VirtualWidget {
                 const [icon, label, description] = await Promise.all([
                     this.labelProvider.getIcon(uri),
                     this.labelProvider.getName(uri),
-                    repository ? this.getRepositoryRelativePath(repository, uri) : this.labelProvider.getLongName(uri)
+                    repository ? this.getRepositoryRelativePath(repository, uri.parent) : this.labelProvider.getLongName(uri.parent)
                 ]);
                 if (GitFileStatus[GitFileStatus.Conflicted.valueOf()] !== GitFileStatus[change.status]) {
                     if (change.staged) {


### PR DESCRIPTION
The git widget currently shows the full path, including the file name,
after the base file name.  It should only show the parent (the
containing directory).

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>