### PR TITLE
Allow console log

### DIFF
--- a/configs/strict.tslint.json
+++ b/configs/strict.tslint.json
@@ -22,7 +22,7 @@
     "interface-over-type-literal": true,
     "jsdoc-format": true,
     "no-any": true,
-    "no-console": true,
+    "no-console": false,
     "no-construct": true,
     "no-magic-numbers": false,
     "no-null-keyword": true,

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -5,7 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// tslint:disable:no-console
 import * as yargs from 'yargs';
 import { ApplicationPackageTarget, ApplicationPackageManager, rebuild } from '@theia/application-package';
 

--- a/packages/core/src/browser/logger-frontend-module.ts
+++ b/packages/core/src/browser/logger-frontend-module.ts
@@ -13,12 +13,11 @@ import { WebSocketConnectionProvider } from './messaging';
 import { FrontendApplicationContribution } from './frontend-application';
 
 export const loggerFrontendModule = new ContainerModule(bind => {
-    bind(FrontendApplicationContribution).toDynamicValue(ctx =>
-        ({
-            initialize() {
-                setRootLogger(ctx.container.get<ILogger>(ILogger));
-            }
-        }));
+    bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
+        initialize() {
+            setRootLogger(ctx.container.get<ILogger>(ILogger));
+        }
+    }));
 
     bind(ILogger).to(Logger).inSingletonScope();
     bind(LoggerWatcher).toSelf().inSingletonScope();

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -22,8 +22,22 @@ export enum LogLevel {
 It can be used outside of the inversify context.  */
 export let logger: ILogger;
 
-export function setRootLogger(alogger: ILogger) {
-    logger = alogger;
+type ConsoleLog = typeof console.log;
+export function setRootLogger(aLogger: ILogger) {
+    logger = aLogger;
+
+    const frontend = !!window && typeof (window as any).process === 'undefined';
+    const log = (logLevel: number, consoleLog: ConsoleLog, message?: any, ...optionalParams: any[]) => {
+        aLogger.log(logLevel, String(message), ...optionalParams);
+        if (frontend) {
+            consoleLog(message, ...optionalParams);
+        }
+    };
+
+    console.log = log.bind(undefined, LogLevel.INFO, console.log);
+    console.info = log.bind(undefined, LogLevel.INFO, console.info);
+    console.warn = log.bind(undefined, LogLevel.WARN, console.warn);
+    console.error = log.bind(undefined, LogLevel.ERROR, console.error);
 }
 
 export type Log = (message: string, ...params: any[]) => void;

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
 
 describe('Proxy-Factory', () => {
     it('Should correctly send notifications and requests.', done => {
-        let it = getSetup();
+        const it = getSetup();
         it.clientProxy.notifyThat("hello");
         function check() {
             if (it.client.notifications.length === 0) {
@@ -75,8 +75,8 @@ describe('Proxy-Factory', () => {
         check();
     });
     it('Rejected Promise should result in rejected Promise.', done => {
-        let it = getSetup();
-        let handle = setTimeout(() => done("timeout"), 500);
+        const it = getSetup();
+        const handle = setTimeout(() => done("timeout"), 500);
         it.serverProxy.fails('a', 'b').catch(err => {
             expect(<Error>err.message).to.contain("fails failed");
             clearTimeout(handle);
@@ -84,9 +84,9 @@ describe('Proxy-Factory', () => {
         });
     });
     it('Remote Exceptions should result in rejected Promise.', done => {
-        let it = getSetup();
-        let handle = setTimeout(() => done("timeout"), 500);
-        it.serverProxy.fails2('a', 'b').catch(err => {
+        const { serverProxy } = getSetup();
+        const handle = setTimeout(() => done("timeout"), 500);
+        serverProxy.fails2('a', 'b').catch(err => {
             expect(<Error>err.message).to.contain("fails2 failed");
             clearTimeout(handle);
             done();
@@ -95,20 +95,20 @@ describe('Proxy-Factory', () => {
 });
 
 function getSetup() {
-    let client = new TestClient();
-    let server = new TestServer();
+    const client = new TestClient();
+    const server = new TestServer();
 
-    let serverProxyFactory = new JsonRpcProxyFactory<TestServer>(client);
-    let client2server = new NoTransform();
-    let server2client = new NoTransform();
-    let serverConnection = createMessageConnection(server2client, client2server, new ConsoleLogger());
+    const serverProxyFactory = new JsonRpcProxyFactory<TestServer>(client);
+    const client2server = new NoTransform();
+    const server2client = new NoTransform();
+    const serverConnection = createMessageConnection(server2client, client2server, new ConsoleLogger());
     serverProxyFactory.listen(serverConnection);
-    let serverProxy = serverProxyFactory.createProxy();
+    const serverProxy = serverProxyFactory.createProxy();
 
-    let clientProxyFactory = new JsonRpcProxyFactory<TestClient>(server);
-    let clientConnection = createMessageConnection(client2server, server2client, new ConsoleLogger());
+    const clientProxyFactory = new JsonRpcProxyFactory<TestClient>(server);
+    const clientConnection = createMessageConnection(client2server, server2client, new ConsoleLogger());
     clientProxyFactory.listen(clientConnection);
-    let clientProxy = clientProxyFactory.createProxy();
+    const clientProxy = clientProxyFactory.createProxy();
     return {
         client,
         clientProxy,

--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { MessageConnection, ResponseError, ErrorCodes } from "vscode-jsonrpc";
+import { MessageConnection, ResponseError } from "vscode-jsonrpc";
 import { Event, Emitter } from "../event";
 import { Disposable } from "../disposable";
 import { ConnectionHandler } from './handler';
@@ -152,8 +152,8 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
             }
             const reason = e.message || '';
             const stack = e.stack || '';
-            throw new ResponseError(ErrorCodes.InternalError, `Request ${method} failed with error: ${reason}
-${stack}`);
+            console.error(`Request ${method} failed with error: ${reason}`, stack);
+            throw e;
         }
     }
 

--- a/packages/core/src/node/cluster.spec.ts
+++ b/packages/core/src/node/cluster.spec.ts
@@ -5,7 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// tslint:disable:no-console
 import * as path from 'path';
 import * as cluster from 'cluster';
 import { MasterProcess } from './cluster/master-process';

--- a/packages/core/src/node/cluster/main.ts
+++ b/packages/core/src/node/cluster/main.ts
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-// tslint:disable:no-console
+
 import * as cluster from 'cluster';
 import { checkParentAlive } from '../messaging/ipc-protocol';
 import { MasterProcess } from './master-process';

--- a/packages/core/src/node/cluster/master-process.ts
+++ b/packages/core/src/node/cluster/master-process.ts
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-// tslint:disable:no-console
+
 import { EventEmitter } from 'events';
 import { ServerWorker } from './server-worker';
 

--- a/packages/core/src/node/cluster/server-worker.ts
+++ b/packages/core/src/node/cluster/server-worker.ts
@@ -4,7 +4,6 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-// tslint:disable:no-console
 
 import * as cluster from 'cluster';
 import { createIpcEnv } from '../messaging/ipc-protocol';

--- a/packages/core/src/node/test/cluster-test-worker.ts
+++ b/packages/core/src/node/test/cluster-test-worker.ts
@@ -5,7 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// tslint:disable:no-console
 import 'reflect-metadata';
 import { clusterRemoteMasterProcessFactory, ServerProcess } from '../cluster';
 

--- a/packages/filesystem/src/node/nsfw-watcher/index.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/index.ts
@@ -11,7 +11,6 @@ import { FileSystemWatcherClient } from '../../common/filesystem-watcher-protoco
 import { NsfwFileSystemWatcherServer } from './nsfw-filesystem-watcher';
 import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
 
-// tslint:disable:no-console
 // tslint:disable:no-any
 
 const options: {


### PR DESCRIPTION
This PR:
- allows usages of console.log by binding it to ILogger to log messages from 3rd party libraries and not-inversify context. In the frontend, data is also logged to the original console log.
- logs json-rpc errors in the backend instead of sending a stack trace to the client to avoid changing the original error message