### PR TITLE
[tsc] disable lib checking

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "skipLibCheck": true,
         "declaration": true,
         "noImplicitAny": true,
         "noEmitOnError": false,


### PR DESCRIPTION
This PR disables repetitive checking of d.ts. files by tsc compiler for each extension.

In the long run, it is better to compile/watch all extensions at once to avoid recompilation for each extension. It should be possible when https://github.com/Microsoft/TypeScript/issues/3469 is resolved.