### PR TITLE
GH-1136: Added Git ahead-behind to the status bar.

### DIFF
--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -180,7 +180,7 @@ export class GitQuickOpenService {
             const items = repositories.map(repository => {
                 const uri = new URI(repository.localUri);
                 const execute = () => this.repositoryProvider.selectedRepository = repository;
-                const toLabel = () => uri.path.name;
+                const toLabel = () => uri.path.base;
                 const toDescription = () => FileUri.fsPath(uri);
                 return new GitQuickOpenItem<Repository>(repository, execute, toLabel, toDescription);
             });


### PR DESCRIPTION
Also fixed repository name. Previously, `name` was called on the repository path instead of `base`. So repositories with name like `a.b.c` was truncated to `a.b` incorrectly.

Closes #1136.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>