### PR TITLE
Don't try to call setContent on a directory while drag&drop file

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -190,7 +190,9 @@ export class FileTreeModel extends TreeModel implements LocationService {
         const content = base64.fromByteArray(new Uint8Array(fileContent));
         if (await this.fileSystem.exists(uri)) {
             const stat = await this.fileSystem.getFileStat(uri);
-            await this.fileSystem.setContent(stat, content, { encoding });
+            if (!stat.isDirectory) {
+                await this.fileSystem.setContent(stat, content, { encoding });
+            }
         } else {
             await this.fileSystem.createFile(uri, { content, encoding });
         }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

When I try to drag&drop an external file into the Files tree and there's a folder with the same name already exists I've got the following error on a browser's console:
![screenshot from 2018-01-26 17-18-58](https://user-images.githubusercontent.com/1636395/35446371-2ee517ee-02bd-11e8-8864-fb752e04d4c8.png)

This PR adds checking to prevent calling `setContent` on a directory.