### PR TITLE
Ask before overwriting a file with Drag & Drop

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -118,8 +118,8 @@ export class FileTreeModel extends TreeModel implements LocationService {
         if (DirNode.is(target) && FileStatNode.is(source)) {
             const sourceUri = source.uri.toString();
             const targetUri = target.uri.resolve(source.name).toString();
-            const targetExists = await this.fileSystem.exists(targetUri);
-            if (!targetExists || await this.shouldOverwrite(source.name)) {
+            const fileExistsInTarget = await this.fileSystem.exists(targetUri);
+            if (!fileExistsInTarget || await this.shouldReplace(source.name)) {
                 await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
                 // to workaround https://github.com/Axosoft/nsfw/issues/42
                 this.refresh(target);
@@ -127,7 +127,7 @@ export class FileTreeModel extends TreeModel implements LocationService {
         }
     }
 
-    async shouldOverwrite(fileName: string): Promise<boolean> {
+    async shouldReplace(fileName: string): Promise<boolean> {
         const dialog = new ConfirmDialog({
             title: 'Replace file',
             msg: `File '${fileName}' already exists in the destination folder. Do you want to replace it?`,

--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject } from "inversify";
 import URI from '@theia/core/lib/common/uri';
-import { ICompositeTreeNode, TreeModel, TreeServices, ITreeNode } from "@theia/core/lib/browser";
+import { ICompositeTreeNode, TreeModel, TreeServices, ITreeNode, ConfirmDialog } from "@theia/core/lib/browser";
 import { FileSystem, } from "../../common";
 import { FileSystemWatcher, FileChangeType, FileChange } from '../filesystem-watcher';
 import { FileStatNode, DirNode, FileTree } from "./file-tree";
@@ -118,10 +118,22 @@ export class FileTreeModel extends TreeModel implements LocationService {
         if (DirNode.is(target) && FileStatNode.is(source)) {
             const sourceUri = source.uri.toString();
             const targetUri = target.uri.resolve(source.name).toString();
-            await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
-            // to workaround https://github.com/Axosoft/nsfw/issues/42
-            this.refresh(target);
+            if (await !this.fileSystem.exists(targetUri) || await this.shouldOverwrite(source.name)) {
+                await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
+                // to workaround https://github.com/Axosoft/nsfw/issues/42
+                this.refresh(target);
+            }
         }
+    }
+
+    async shouldOverwrite(fileName: string): Promise<boolean> {
+        const dialog = new ConfirmDialog({
+            title: 'Replace file',
+            msg: `File '${fileName}' already exists in the destination folder. Do you want to replace it?`,
+            ok: 'Yes',
+            cancel: 'No'
+        });
+        return dialog.open();
     }
 
     upload(node: DirNode, items: DataTransferItemList): void {

--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -118,7 +118,8 @@ export class FileTreeModel extends TreeModel implements LocationService {
         if (DirNode.is(target) && FileStatNode.is(source)) {
             const sourceUri = source.uri.toString();
             const targetUri = target.uri.resolve(source.name).toString();
-            if (await !this.fileSystem.exists(targetUri) || await this.shouldOverwrite(source.name)) {
+            const targetExists = await this.fileSystem.exists(targetUri);
+            if (!targetExists || await this.shouldOverwrite(source.name)) {
                 await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
                 // to workaround https://github.com/Axosoft/nsfw/issues/42
                 this.refresh(target);


### PR DESCRIPTION
This PR fixes #1016 
When dragging a file, that already exists in a destination folder a dialog asks the user, whether the existing file should be overwritten.

![confirm-replace](https://user-images.githubusercontent.com/1636395/35487196-90765aac-0481-11e8-8933-4179acfdb8c8.gif)
