### PR TITLE
Keysequences

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -83,7 +83,7 @@ export class BrowserMainMenuFactory {
         /* Only consider the first keybinding. */
         if (bindings.length > 0) {
             const binding = bindings[0];
-            const keys = [this.acceleratorFor(binding)];
+            const keys = this.acceleratorFor(binding);
             commands.addKeyBinding({
                 command: command.id,
                 keys,
@@ -94,50 +94,58 @@ export class BrowserMainMenuFactory {
 
     /* Return a user visble representation of a keybinding.  */
     protected acceleratorFor(keybinding: Keybinding) {
-        const keyCode = KeyCode.parse(keybinding.keybinding);
-        let result = "";
-        let previous = false;
-        const separator = " ";
+        const keyCodesString = keybinding.keybinding.split(" ");
+        const result: string[] = [];
+        for (const keyCodeString of keyCodesString) {
+            let keyCodeResult = "";
+            const keyCode = KeyCode.parse(keyCodeString);
+            let previous = false;
+            const separator = " ";
 
-        if (keyCode.meta && isOSX) {
-            if (isOSX) {
-                result += "Cmd";
+            if (keyCode.meta && isOSX) {
+                if (isOSX) {
+                    keyCodeResult += "Cmd";
+                    previous = true;
+                }
+            }
+
+            if (keyCode.ctrl) {
+                if (previous) {
+                    keyCodeResult += separator;
+                }
+                keyCodeResult += "Ctrl";
                 previous = true;
             }
-        }
 
-        if (keyCode.ctrl) {
-            if (previous) {
-                result += separator;
+            if (keyCode.alt) {
+                if (previous) {
+                    keyCodeResult += separator;
+                }
+                keyCodeResult += "Alt";
+                previous = true;
             }
-            result += "Ctrl";
-            previous = true;
-        }
 
-        if (keyCode.alt) {
-            if (previous) {
-                result += separator;
+            if (keyCode.shift) {
+                if (previous) {
+                    keyCodeResult += separator;
+                }
+                keyCodeResult += "Shift";
+                previous = true;
             }
-            result += "Alt";
-            previous = true;
-        }
 
-        if (keyCode.shift) {
-            if (previous) {
-                result += separator;
+            if (keyCode.key) {
+
+                if (previous) {
+                    keyCodeResult += separator;
+                }
+                keyCodeResult += Key.getEasyKey(keyCode.key).easyString.toUpperCase();
             }
-            result += "Shift";
-            previous = true;
+            result.push(keyCodeResult);
         }
-
-        if (previous) {
-            result += separator;
-        }
-
-        result += Key.getEasyKey(keyCode.key).easyString.toUpperCase();
         return result;
     }
 }
+
 class DynamicMenuBarWidget extends MenuBarWidget {
 
     constructor() {

--- a/packages/core/src/common/keybinding.spec.ts
+++ b/packages/core/src/common/keybinding.spec.ts
@@ -186,13 +186,13 @@ describe('keybindings', () => {
 
         keybindingRegistry.setKeymap(KeybindingScope.WORKSPACE, keybindingsSpecific);
 
-        let bindings = keybindingRegistry.getKeybindingsForKeyCode(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }));
+        let bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] })]).full;
         expect(bindings).to.be.empty;
 
-        bindings = keybindingRegistry.getKeybindingsForKeyCode(KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [Modifier.M1] }));
+        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [Modifier.M1] })]).full;
         expect(bindings).to.be.empty;
 
-        bindings = keybindingRegistry.getKeybindingsForKeyCode(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] }));
+        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] })]).full;
         const keyCode = KeyCode.parse(bindings[0].keybinding);
         expect(keyCode.key).to.be.equal(validKeyCode.key);
     });
@@ -303,6 +303,35 @@ describe("keys api", () => {
 
         const parsedKeyCodes = KeySequence.parse("ctrlcmd+a c");
         expect(parsedKeyCodes).to.deep.equal(validKeyCodes);
+    });
+
+    it("it should compare keysequences properly", () => {
+        let a = KeySequence.parse("ctrlcmd+a");
+        let b = KeySequence.parse("ctrlcmd+a t");
+
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.PARTIAL);
+
+        a = KeySequence.parse("ctrlcmd+a t");
+        b = KeySequence.parse("ctrlcmd+a");
+
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.PARTIAL);
+
+        a = KeySequence.parse("ctrlcmd+a t c");
+        b = KeySequence.parse("ctrlcmd+a t");
+
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.PARTIAL);
+
+        a = KeySequence.parse("ctrlcmd+a t");
+        b = KeySequence.parse("ctrlcmd+a a");
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.NONE);
+
+        a = KeySequence.parse("ctrlcmd+a t");
+        b = KeySequence.parse("ctrlcmd+a t");
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.FULL);
+
+        a = KeySequence.parse("ctrlcmd+a t b");
+        b = KeySequence.parse("ctrlcmd+a t b");
+        expect(KeySequence.compare(a, b)).to.be.equal(KeySequence.CompareResult.FULL);
     });
 });
 

--- a/packages/core/src/common/keybinding.spec.ts
+++ b/packages/core/src/common/keybinding.spec.ts
@@ -13,7 +13,7 @@ import {
     KeybindingRegistry, KeybindingContext, KeybindingContextRegistry,
     Keybinding, KeybindingContribution, KeybindingScope
 } from './keybinding';
-import { KeyCode, Key, Modifier } from './keys';
+import { KeyCode, Key, Modifier, KeySequence } from './keys';
 import { CommandRegistry, CommandContribution, Command } from './command';
 import { MockLogger } from './test/mock-logger';
 import * as os from './os';
@@ -285,6 +285,24 @@ describe("keys api", () => {
         expect(keyCodeString).to.be.equal("ctrl+a");
         const parsedKeyCode = KeyCode.parse(keyCodeString);
         expect(KeyCode.equals(parsedKeyCode, keyCode)).to.be.true;
+    });
+
+    it("it should parse a multi keycode keybinding", () => {
+        const validKeyCodes = [];
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1, Modifier.M2] }));
+
+        const parsedKeyCodes = KeySequence.parse("ctrlcmd+a ctrlcmd+shift+c");
+        expect(parsedKeyCodes).to.deep.equal(validKeyCodes);
+    });
+
+    it("it should parse a multi keycode keybinding with no modifiers", () => {
+        const validKeyCodes = [];
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C }));
+
+        const parsedKeyCodes = KeySequence.parse("ctrlcmd+a c");
+        expect(parsedKeyCodes).to.deep.equal(validKeyCodes);
     });
 });
 

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -15,6 +15,35 @@ import { isOSX } from './os';
  */
 export declare type Keystroke = { first: Key, modifiers?: Modifier[] };
 
+export type KeySequence = KeyCode[];
+export namespace KeySequence {
+
+    export function equals(a: KeySequence, b: KeySequence) {
+        if (a.length !== b.length) {
+            return false;
+        }
+
+        for (let i = 0; i < a.length; i++) {
+            if (a[i].equals(b[i]) === false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    export function parse(keybinding: string): KeySequence {
+        const keyCodes = [];
+        const rawKeyCodes = keybinding.split(" ");
+        for (const rawKeyCode of rawKeyCodes) {
+            const keyCode = KeyCode.parse(rawKeyCode);
+            if (keyCode !== undefined) {
+                keyCodes.push(keyCode);
+            }
+        }
+        return keyCodes;
+    }
+}
+
 /**
  * Representation of a platform independent key code.
  */

--- a/packages/core/src/common/keys.ts
+++ b/packages/core/src/common/keys.ts
@@ -31,6 +31,44 @@ export namespace KeySequence {
         return true;
     }
 
+    export enum CompareResult {
+        NONE = 0,
+        PARTIAL,
+        FULL
+    }
+
+    /* Compares two KeySequences, returns:
+     * FULL if the KeySequences are the same.
+     * PARTIAL if the KeySequence is part of the other.
+     * NONE if the KeySequences are not the same at all.
+     */
+    export function compare(a: KeySequence, b: KeySequence): CompareResult {
+        let partial = false;
+        let first = a;
+        let second = b;
+
+        if (b.length < a.length) {
+            first = b;
+            second = a;
+        }
+
+        for (let i = 0; i < first.length; i++) {
+            if (first[i].equals(second[i]) === false) {
+                if (partial === true && first.length !== second.length) {
+                    return KeySequence.CompareResult.PARTIAL;
+                } else {
+                    return KeySequence.CompareResult.NONE;
+                }
+            } else {
+                partial = true;
+            }
+        }
+        if (first.length < second.length) {
+            return KeySequence.CompareResult.PARTIAL;
+        }
+        return KeySequence.CompareResult.FULL;
+    }
+
     export function parse(keybinding: string): KeySequence {
         const keyCodes = [];
         const rawKeyCodes = keybinding.split(" ");

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -86,8 +86,16 @@ export class ElectronMainMenuFactory {
 
     /* Return a user visble representation of a keybinding.  */
     protected acceleratorFor(keybinding: Keybinding) {
-        const keyCode = KeyCode.parse(keybinding.keybinding);
+        const keyCodesString = keybinding.keybinding.split(" ");
         let result = "";
+        /* FIXME see https://github.com/electron/electron/issues/11740
+           Key Sequences can't be represented properly in the electron menu. */
+        if (keyCodesString.length > 1) {
+            return result;
+        }
+
+        const keyCodeString = keyCodesString[0];
+        const keyCode = KeyCode.parse(keyCodeString);
         let previous = false;
         const separator = "+";
 
@@ -122,11 +130,14 @@ export class ElectronMainMenuFactory {
             previous = true;
         }
 
-        if (previous) {
-            result += separator;
+        if (keyCode.key) {
+            if (previous) {
+                result += separator;
+            }
+
+            result += Key.getEasyKey(keyCode.key).easyString;
         }
 
-        result += Key.getEasyKey(keyCode.key).easyString;
         return result;
     }
 


### PR DESCRIPTION
    Support keysequences
    
    This patch enables support for key sequences so that for example
    keybindings like this one are supported:
    
    "Ctrl-u t", meaning press Ctrl-u and then press t.
    
    Here's a few limitations at the moment however:
    
      - These keybindings can't be shown as part of an electron MenuItem see:
      https://github.com/electron/electron/issues/11740#issuecomment-360980460
    
      - Monaco only supports a sequence of 2 keybinding so "Ctrl-u t" will
        work but not "Ctrl-u t a"
    
        This means that for now in the QuickMenu if the sequence is more then
        2 keychords long we don't show it.
    
    Also note that at the moment the delay to enter a sequence is hardcoded to 1 sec
    between keystrokes.
    
    Fixes: #472

Note I will create issues about these limitations and see what can be done.