### PR TITLE
Remove jsdom-global from yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,10 +4171,6 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom-global@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/jsdom-global/-/jsdom-global-3.0.2.tgz#6bd299c13b0c4626b2da2c0393cd4385d606acb9"
-
 jsdom@^11.5.1:
   version "11.5.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"


### PR DESCRIPTION
This was removed in #1160 but the updated yarn.lock wasn't committed.
Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>