### PR TITLE
Improve debug output in RawProcess constructor

### DIFF
--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -50,9 +50,9 @@ export class RawProcess extends Process {
         @inject(ILogger) logger: ILogger) {
         super(processManager, logger, ProcessType.Raw, options);
 
-        this.logger.debug(`Starting raw process : ${options.command},`
-            + ` with args : ${options.args}, `
-            + ` options ${JSON.stringify(options.options)}`);
+        this.logger.debug(`Starting raw process: ${options.command},`
+            + ` with args: ${options.args ? options.args.join(' ') : ''}, `
+            + ` with options: ${JSON.stringify(options.options)}`);
 
         /* spawn can throw exceptions, for example if the file is not
            executable, it throws an error with EACCES.  Here, we try to


### PR DESCRIPTION
In the current debug output the arguments end up separated with commas.
It would be more useful to separate them with spaces, so it's possible
to copy paste if needed, to run the process by hand for example.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>