### PR TITLE
GH-1185: ensure that only one save is performed at the time

### DIFF
--- a/packages/core/src/common/cancellation.ts
+++ b/packages/core/src/common/cancellation.ts
@@ -20,7 +20,7 @@ export interface CancellationToken {
     readonly onCancellationRequested: Event<void>;
 }
 
-const shortcutEvent: Event<void> = Object.freeze(function (callback: any, contex?: any): any {
+const shortcutEvent: Event<void> = Object.freeze(function (callback: any, context?: any): any {
     const handle = setTimeout(callback.bind(context), 0);
     return { dispose() { clearTimeout(handle); } };
 });


### PR DESCRIPTION
@lmcbout, @hexa00 please try this change whether it fixes https://github.com/theia-ide/theia/issues/1185

Follow-ups discussed on Gitter:
- improve `FileResource` that it does not reread a content if a file state has not been changed
- improve the performance of sending big messages over ws, look into using https://github.com/developit/greenlet