### PR TITLE
GH-1189: Set back `window-build-tools` version to `1.3.2`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ branches:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: npm install --global --production windows-build-tools
+  - ps: npm install --global --production windows-build-tools@1.3.2
   - netsh advfirewall firewall add rule name="SeleniumIn" dir=in action=allow protocol=TCP localport=4444
   - netsh advfirewall firewall add rule name="SeleniumOut" dir=out action=allow protocol=TCP localport=4444
 


### PR DESCRIPTION
Closes #1189.