### PR TITLE
fix jsdom clean-up

### DIFF
--- a/packages/core/src/browser/test/jsdom.ts
+++ b/packages/core/src/browser/test/jsdom.ts
@@ -7,26 +7,51 @@
 
 import { JSDOM } from 'jsdom';
 
-const dom = new JSDOM('<!doctype html><html><body></body></html>');
+/**
+ * ```typescript
+ * const disableJSDOM = enableJSDOM();
+ * // actions require DOM
+ * disableJSDOM();
+ * ```
+ */
+export function enableJSDOM(): () => void {
+    // tslint:disable:no-any
+    // tslint:disable:no-unused-expression
 
-(global as any)['document'] = dom.window.document;
-(global as any)['window'] = dom.window;
-(global as any)['navigator'] = { userAgent: 'node.js', platform: 'Mac' };
-(global as any)['HTMLElement'] = (global as any)['window'].HTMLElement;
-
-const toCleanup: string[] = [];
-Object.getOwnPropertyNames((dom.window as any)).forEach(property => {
-    if (typeof (global as any)[property] === 'undefined') {
-        (global as any)[property] = (dom.window as any)[property];
-        toCleanup.push(property);
+    // do nothing if running in browser
+    try {
+        global;
+    } catch (e) {
+        return () => { };
     }
-});
-
-(dom.window.document as any)['queryCommandSupported'] = function () { };
-
-export function cleanupJSDOM() {
-    for (const property of toCleanup) {
-        delete (global as any)[property];
+    // no need to enable twice
+    if (typeof (global as any)['_disableJSDOM'] === 'function') {
+        return (global as any)['_disableJSDOM'];
     }
-    delete (dom.window.document as any)['queryCommandSupported'];
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    (global as any)['document'] = dom.window.document;
+    (global as any)['window'] = dom.window;
+    (global as any)['navigator'] = { userAgent: 'node.js', platform: 'Mac' };
+
+    const toCleanup: string[] = [];
+    Object.getOwnPropertyNames((dom.window as any)).forEach(property => {
+        if (typeof (global as any)[property] === 'undefined') {
+            (global as any)[property] = (dom.window as any)[property];
+            toCleanup.push(property);
+        }
+    });
+    (dom.window.document as any)['queryCommandSupported'] = function () { };
+
+    const disableJSDOM = (global as any)['_disableJSDOM'] = () => {
+        let property: string | undefined;
+        while (property = toCleanup.pop()) {
+            delete (global as any)[property];
+        }
+        delete (dom.window.document as any)['queryCommandSupported'];
+        delete (global as any)['document'];
+        delete (global as any)['window'];
+        delete (global as any)['navigator'];
+        delete (global as any)['_disableJSDOM'];
+    };
+    return disableJSDOM;
 }

--- a/packages/core/src/common/keybinding.spec.ts
+++ b/packages/core/src/common/keybinding.spec.ts
@@ -4,7 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-import { cleanupJSDOM } from '../browser/test/jsdom';
+import { enableJSDOM } from '../browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
 
 import { Container, injectable, inject, ContainerModule } from 'inversify';
 import { bindContributionProvider } from './contribution-provider';
@@ -19,6 +21,8 @@ import { MockLogger } from './test/mock-logger';
 import * as os from './os';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
+
+disableJSDOM();
 
 /* tslint:disable:no-unused-expression */
 
@@ -63,11 +67,15 @@ before(async () => {
 
 });
 
-after(() => {
-    cleanupJSDOM();
-});
-
 describe('keybindings', () => {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
     beforeEach(() => {
         keybindingRegistry = testContainer.get<KeybindingRegistry>(KeybindingRegistry);
         keybindingRegistry.onStart();
@@ -236,6 +244,14 @@ describe('keybindings', () => {
 });
 
 describe("keys api", () => {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
     it("should parse a string to a KeyCode correctly", () => {
 
         const keycode = KeyCode.parse("ctrl+b");

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -4,7 +4,10 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-import { cleanupJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
 
 import { Container } from 'inversify';
 import * as chai from 'chai';
@@ -27,6 +30,8 @@ import { MockWorkspaceServer } from '@theia/workspace/lib/common/test/mock-works
 import { MockWindowService } from '@theia/core/lib/browser/window/test/mock-window-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import * as sinon from 'sinon';
+
+disableJSDOM();
 
 const expect = chai.expect;
 let testContainer: Container;
@@ -89,16 +94,14 @@ before(async () => {
     testContainer.bind(ILogger).to(MockLogger);
 });
 
-after(() => {
-    cleanupJSDOM();
-});
-
 describe('Preference Service', function () {
 
     before(() => {
+        disableJSDOM = enableJSDOM();
     });
 
     after(() => {
+        disableJSDOM();
     });
 
     beforeEach(() => {

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -5,12 +5,16 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { cleanupJSDOM } from '@theia/core/lib/browser/test/jsdom';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
 
 import * as chai from 'chai';
 import { expect } from 'chai';
 import URI from "@theia/core/lib/common/uri";
 import { MarkdownPreviewHandler } from './markdown-preview-handler';
+
+disableJSDOM();
 
 chai.use(require('chai-string'));
 
@@ -20,11 +24,15 @@ before(() => {
     previewHandler = new MarkdownPreviewHandler();
 });
 
-after(() => {
-    cleanupJSDOM();
-});
-
 describe("markdown-preview-handler", () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
 
     it("renders html with line information", async () => {
         const contentElement = await previewHandler.renderContent({ content: exampleMarkdown1, originUri: new URI('') });


### PR DESCRIPTION
this change let us use JSDOM more flexible in tests, as we can turn it on and off for import sections or per test, cf. https://github.com/theia-ide/theia/issues/1161#issuecomment-362388759.

it also resolves the issue reported by @kittaakos in https://github.com/theia-ide/theia/issues/1161#issuecomment-361685987, where the following test failed if executed in suite with JSDOM imported in another `spec.ts`:

```
import { expect } from 'chai';
import { setRootLogger } from './logger';
import { MockLogger } from './test/mock-logger';

describe('logger', () => {

    it('setting the root logger should not throw an error when the window is not defined', () => {
        expect(() => setRootLogger(new MockLogger())).to.not.throw('ReferenceError: window is not defined');
    });

});
```