### PR TITLE
GH-1125: Re-enabled OS X build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ notifications:
     on_start: never
 jobs:
   fast_finish: true
+  allow_failures:
+    - os: osx
   include:
   - state: test
     os: linux
@@ -57,3 +59,8 @@ jobs:
       on:
         branch: master
       skip_cleanup: true
+  - stage: OSx test
+    os: osx
+    env: CXX=c++
+    before_script: skip
+    script: travis_retry yarn test:theia ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ branches:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: npm install --global --production windows-build-tools@1.3.2
+  - ps: npm install --global --production windows-build-tools
   - netsh advfirewall firewall add rule name="SeleniumIn" dir=in action=allow protocol=TCP localport=4444
   - netsh advfirewall firewall add rule name="SeleniumOut" dir=out action=allow protocol=TCP localport=4444
 


### PR DESCRIPTION
Also updated to the latest `windows-build-tools` version on the AppVeyor CI.

Closes #1125.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>