### PR TITLE
Fixes #1209 : Update to latest TypeScript 2.7 version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
     },
     "[json]": {
         "editor.tabSize": 2
-    }
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ts-node": "^3.2.0",
     "tslint": "^5.7.0",
     "typedoc": "^0.8",
-    "typescript": "^2.6.1",
+    "typescript": "^2.7.1",
     "uuid": "^3.1.0",
     "wdio-mocha-framework": "^0.5.9",
     "wdio-phantomjs-service": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7796,9 +7796,9 @@ typescript@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
-typescript@^2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Update TypeScript version to 2.7.1 version which is the latest available at https://www.npmjs.com/package/typescript

Based on #1209, settings.json can specify the typescript sdk to use for the workspace but user is still requiring to perform the switch. (or to use user setting instead of workspace setting)
more info at https://github.com/Microsoft/vscode/issues/19451
https://code.visualstudio.com/docs/languages/typescript#_using-newer-typescript-versions

Change-Id: Idbfd8fe1327a8efebdd8d16eeacac82cfb7aaee4
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>