### PR TITLE
Increase timeout delay on node-extension-server test

### DIFF
--- a/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
+++ b/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
@@ -169,7 +169,7 @@ describe("node-extension-server", function () {
     });
 
     it("list with search", function () {
-        this.timeout(30000);
+        this.timeout(50000);
 
         return server.list({
             query: "scope:theia"


### PR DESCRIPTION
It avoids error on timeout as reported on issue https://github.com/theia-ide/theia/issues/1110
```
1) node-extension-server list with search:
ERR!      Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```
Change-Id: Ia7b81f45a39c181fa2a9c4508ef91e8f71c4a666
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>