### PR TITLE
Repair Travis build deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
-    - oracle-java8-set-default
+    - oracle-java9-set-default
     - libsecret-1-dev
     chrome: stable
 before_script:


### PR DESCRIPTION
It seems the java 8 package we were using is no longer available.
The error suggests using java 9 instead.

Fixes #1224

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>