### PR TITLE
extension-manager test: Optimize the query to npm repository in order to collect less extensions

### DIFF
--- a/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
+++ b/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
@@ -172,19 +172,19 @@ describe("node-extension-server", function () {
         this.timeout(50000);
 
         return server.list({
-            query: "scope:theia"
+            query: "scope:theia file"
         }).then(extensions => {
-            const filtered = extensions.filter(e => ['@theia/core', '@theia/editor'].indexOf(e.name) !== -1);
+            const filtered = extensions.filter(e => ['@theia/filesystem', '@theia/file-search'].indexOf(e.name) !== -1);
 
             assertExtension({
-                name: '@theia/core',
+                name: '@theia/filesystem',
                 installed: true,
-                outdated: true,
-                dependent: undefined
+                outdated: false,
+                dependent: "@theia/extension-manager"
             }, filtered);
 
             assertExtension({
-                name: '@theia/editor',
+                name: '@theia/file-search',
                 installed: false,
                 outdated: false,
                 dependent: undefined


### PR DESCRIPTION
There are more and more theia extensions published on npm registry. Thus, asking for all `scope:theia`extensions and iterating over can be slow with "limited" internet connections

Following previous discussion on https://github.com/theia-ide/theia/pull/1222, by using a more fine-grained query, it's faster on slow network as we limit the number of iterations
On my side, `list with search` test runs from 38s with previous query to 3s with new query

Change-Id: I07dba70d5bc934c4af98422e747e6cdfde6f30dc
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>