### PR TITLE
Merge Conflicts Code Lense 

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -15,6 +15,7 @@
     "@theia/keymaps": "^0.3.4",
     "@theia/languages": "^0.3.3",
     "@theia/markers": "^0.3.4",
+    "@theia/merge-conflicts": "^0.3.4",
     "@theia/messages": "^0.3.3",
     "@theia/metrics": "^0.3.3",
     "@theia/monaco": "^0.3.4",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -18,6 +18,7 @@
     "@theia/keymaps": "^0.3.4",
     "@theia/languages": "^0.3.3",
     "@theia/markers": "^0.3.4",
+    "@theia/merge-conflicts": "^0.3.4",
     "@theia/messages": "^0.3.3",
     "@theia/metrics": "^0.3.3",
     "@theia/monaco": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/chai-as-promised": "0.0.31",
+    "@types/chai-string": "^1.4.0",
     "@types/jsdom": "^11.0.4",
     "@types/mocha": "^2.2.41",
     "@types/sinon": "^2.3.5",
@@ -16,6 +17,7 @@
     "@types/webdriverio": "^4.7.0",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
+    "chai-string": "^1.4.0",
     "concurrently": "^3.5.0",
     "electron-mocha": "^3.5.0",
     "istanbul": "^0.4.5",

--- a/packages/editor/src/browser/editor-decorations-service.ts
+++ b/packages/editor/src/browser/editor-decorations-service.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, named } from "inversify";
+import { Range } from "./editor";
+import { EditorManager } from "./editor-manager";
+import { ContributionProvider } from "@theia/core";
+import { DiffUris } from "./diff-uris";
+
+export const EditorDecorationTypeProvider = Symbol('EditorDecorationTypeProvider');
+
+@injectable()
+export class EditorDecorationsService {
+
+    constructor(
+        @inject(EditorManager) protected readonly editorManager: EditorManager,
+        @inject(ContributionProvider) @named(EditorDecorationTypeProvider)
+        protected readonly decorationTypeProviderContributions: ContributionProvider<EditorDecorationTypeProvider>
+    ) { }
+
+    /**
+     * Applies decorations for given type and options in all visible editors, which opened a resource of the given uri.
+     * Previous decoration of the same type are not preserved.
+     * To remove decorations of a type, pass an empty options array.
+     */
+    setDecorations(uri: string, type: string, options: DecorationOptions[]): void {
+        this.editorManager.editors.forEach(editorWidget => {
+            if (!editorWidget.isVisible) {
+                return;
+            }
+            const editorUri = editorWidget.editor.uri;
+            if (editorUri.toString() === uri) {
+                editorWidget.editor.setDecorations({ type, uri, options });
+            } else if (DiffUris.isDiffUri(editorUri)) {
+                const [uriLeft, uriRight] = DiffUris.decode(editorUri);
+                if (uriLeft.toString() === uri || uriRight.toString() === uri) {
+                    editorWidget.editor.setDecorations({ type, uri, options });
+                }
+            }
+        });
+    }
+
+    protected _decorationTypes: DecorationType[] | undefined;
+    getDecorationTypes(): DecorationType[] {
+        if (!this._decorationTypes) {
+            this._decorationTypes = [];
+            const providers = this.decorationTypeProviderContributions.getContributions();
+            for (const provider of providers) {
+                this._decorationTypes.push(...provider.get());
+            }
+        }
+        return this._decorationTypes;
+    }
+}
+
+export interface EditorDecorationTypeProvider {
+    get(): DecorationType[];
+}
+
+export interface DecorationType {
+    type: string;
+
+    /**
+     * should the decoration be rendered for the whole line.
+     * default is `false`.
+     */
+    isWholeLine?: boolean;
+    /**
+     * CSS property `background-color`, to be applied to a decoration.
+     * use `rgba` values to play well with other decorations.
+     */
+    backgroundColor?: string;
+    /**
+     * CSS property `outline`.
+     */
+    outline?: string;
+    /**
+     * CSS property `border`, to be applied to the text within a decoration.
+     */
+    border?: string;
+    /**
+     * CSS property `color`.
+     */
+    color?: string;
+    /**
+     * CSS property `cursor`.
+     */
+    cursor?: string;
+    /**
+     * CSS property `font-style`.
+     */
+    fontStyle?: string;
+    /**
+     * CSS property `font-weight`.
+     */
+    fontWeight?: string;
+    /**
+     * CSS property `text-decoration`.
+     */
+    textDecoration?: string;
+    /**
+     * color of the decoration in the overview ruler.
+     * use `rgba` values to play well with other decorations.
+     */
+    overviewRulerColor?: string;
+    /**
+     * position in the overview ruler.
+     */
+    overviewRulerLane?: OverviewRulerLane;
+    /**
+     * behavior of decorations when typing/editing near their edges.
+     */
+    rangeBehavior?: TrackedRangeStickiness;
+    /**
+     * options of the attachment to be inserted before the decorated text.
+     */
+    before?: AttachmentDecorationOptions;
+    /**
+     * options of the attachment to be inserted after the decorated text.
+     */
+    after?: AttachmentDecorationOptions;
+}
+
+export interface AttachmentDecorationOptions {
+    /**
+     * text content of the attachment to be inserted.
+     */
+    contentText?: string;
+    /**
+     * CSS property `color`, to be applied to the attachment.
+     */
+    color?: string;
+    /**
+     * CSS property `background-color`, to be applied to the attachment.
+     */
+    backgroundColor?: string;
+    /**
+     * CSS property `border`, to be applied to the attachment.
+     */
+    border?: string;
+    /**
+     * CSS property `height`, to be applied to the attachment.
+     */
+    height?: string;
+    /**
+     * CSS property `width`, to be applied to the attachment.
+     */
+    width?: string;
+    /**
+     * CSS property `margin`.
+     */
+    margin?: string;
+    /**
+     * CSS property `font-style`.
+     */
+    fontStyle?: string;
+    /**
+     * CSS property `font-weight`.
+     */
+    fontWeight?: string;
+    /**
+     * CSS property `text-decoration`.
+     */
+    textDecoration?: string;
+}
+
+export interface DecorationOptions {
+    /**
+     * range to which this decoration instance is applied.
+     */
+    range: Range;
+    /**
+     * hover message for this decoration.
+     */
+    hoverMessage?: string;
+    /**
+     * render options to be applied to this decoration instance.
+     * if possible, `DecorationType` render options should be used.
+     */
+    renderOptions?: DecorationInstanceRenderOptions;
+}
+
+export interface DecorationInstanceRenderOptions {
+    /**
+     * options of the attachment to be inserted before the decorated text.
+     */
+    before?: AttachmentDecorationOptions;
+    /**
+     * options of the attachment to be inserted after the decorated text.
+     */
+    after?: AttachmentDecorationOptions;
+}
+
+export enum OverviewRulerLane {
+    Left = 1,
+    Center = 2,
+    Right = 4,
+    Full = 7
+}
+
+export enum TrackedRangeStickiness {
+    AlwaysGrowsWhenTypingAtEdges = 0,
+    NeverGrowsWhenTypingAtEdges = 1,
+    GrowsOnlyWhenTypingBefore = 2,
+    GrowsOnlyWhenTypingAfter = 3,
+}

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 import { ContainerModule } from 'inversify';
-import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
+import { CommandContribution, MenuContribution, bindContributionProvider } from "@theia/core/lib/common";
 import {
     OpenHandler, WidgetFactory, FrontendApplicationContribution,
     KeybindingContribution, KeybindingContext
@@ -19,6 +19,7 @@ import { EditorKeybindingContribution, EditorKeybindingContext } from "./editor-
 import { bindEditorPreferences } from './editor-preferences';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import { DiffUriLabelProviderContribution } from './diff-uris';
+import { EditorDecorationsService, EditorDecorationTypeProvider } from './editor-decorations-service';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -39,4 +40,7 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(EditorContribution));
 
     bind(LabelProviderContribution).to(DiffUriLabelProviderContribution).inSingletonScope();
+
+    bindContributionProvider(bind, EditorDecorationTypeProvider);
+    bind(EditorDecorationsService).toSelf().inSingletonScope();
 });

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,6 +10,7 @@ import * as lsp from 'vscode-languageserver-types';
 import URI from "@theia/core/lib/common/uri";
 import { Event, Disposable } from '@theia/core/lib/common';
 import { Saveable } from '@theia/core/lib/browser';
+import { DecorationOptions } from './editor-decorations-service';
 
 export {
     Position, Range
@@ -51,6 +52,13 @@ export interface TextEditor extends Disposable, TextEditorSelection {
      */
     resizeToFit(): void;
     setSize(size: Dimension): void;
+
+    /**
+     * Applies decorations for given type and options.
+     * Previous decoration of the same type are not preserved.
+     * To remove decorations of a type, pass an empty options array.
+     */
+    setDecorations(params: SetDecorationParams): void;
 }
 
 export interface Dimension {
@@ -71,6 +79,12 @@ export interface RevealPositionOptions {
 
 export interface RevealRangeOptions {
     at: 'auto' | 'center' | 'top' | 'centerIfOutsideViewport';
+}
+
+export interface SetDecorationParams {
+    uri: string;
+    type: string;
+    options: DecorationOptions[];
 }
 
 export namespace TextEditorSelection {

--- a/packages/editor/src/browser/index.ts
+++ b/packages/editor/src/browser/index.ts
@@ -13,3 +13,4 @@ export * from './editor-menu';
 export * from './editor-keybinding';
 export * from './editor-frontend-module';
 export * from './editor-preferences';
+export * from './editor-decorations-service';

--- a/packages/git/src/browser/git-widget.ts
+++ b/packages/git/src/browser/git-widget.ts
@@ -300,6 +300,8 @@ export class GitWidget extends GitBaseWidget {
                             changeUri.withScheme(GIT_RESOURCE_SCHEME),
                             changeUri,
                             changeUri.displayName + ' (Working tree)');
+                    } else if (this.mergeChanges.find(c => c.uri === change.uri)) {
+                        uri = changeUri;
                     } else {
                         uri = DiffUris.encode(
                             changeUri.withScheme(GIT_RESOURCE_SCHEME).withQuery('HEAD'),

--- a/packages/merge-conflicts/README.md
+++ b/packages/merge-conflicts/README.md
@@ -1,0 +1,8 @@
+# Theia - Merge Conflicts Extension
+
+Helps to resolve merge conflicts.
+
+See [here](https://github.com/theia-ide/theia).
+
+## License
+[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/merge-conflicts/compile.tsconfig.json
+++ b/packages/merge-conflicts/compile.tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "baseUrl": "."
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/merge-conflicts/package.json
+++ b/packages/merge-conflicts/package.json
@@ -1,26 +1,18 @@
 {
-  "name": "@theia/preview",
+  "name": "@theia/merge-conflicts",
   "version": "0.3.4",
-  "description": "Theia - Preview Extension",
+  "description": "Theia - Merge Conflicts Extension",
   "dependencies": {
     "@theia/core": "^0.3.3",
     "@theia/editor": "^0.3.4",
-    "@theia/languages": "^0.3.3",
-    "@types/highlight.js": "^9.12.2",
-    "@types/markdown-it": "^0.0.4",
-    "@types/markdown-it-anchor": "^4.0.1",
-    "@types/throttle-debounce": "^1.0.0",
-    "highlight.js": "^9.12.0",
-    "markdown-it": "^8.4.0",
-    "markdown-it-anchor": "^4.0.0",
-    "throttle-debounce": "^1.0.1"
+    "@theia/languages": "^0.3.3"
   },
   "publishConfig": {
     "access": "public"
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/preview-frontend-module"
+      "frontend": "lib/browser/merge-conflicts-frontend-module"
     }
   ],
   "keywords": [

--- a/packages/merge-conflicts/src/browser/merge-conflict-resolver.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict-resolver.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { Workspace, TextDocumentEdit, TextEdit, TextDocument, Range } from "@theia/languages/lib/browser";
+import { CommandHandler } from '@theia/core/lib/common';
+import { MergeConflictCommandArgument, MergeConflict } from './merge-conflict';
+
+@injectable()
+export class MergeConflictResolver {
+
+    constructor(
+        @inject(Workspace) protected readonly workspace: Workspace,
+    ) { }
+
+    readonly acceptCurrent: CommandHandler = {
+        execute: args => this.doAcceptCurrent(args)
+    };
+
+    readonly acceptIncoming: CommandHandler = {
+        execute: args => this.doAcceptIncoming(args)
+    };
+
+    readonly acceptBoth: CommandHandler = {
+        execute: args => this.doAcceptBoth(args)
+    };
+
+    protected doAcceptCurrent(argument: MergeConflictCommandArgument) {
+        this.doAccept(argument, (textOfRange, conflict) =>
+            textOfRange(conflict.current.content!));
+    }
+
+    protected doAcceptIncoming(argument: MergeConflictCommandArgument) {
+        this.doAccept(argument, (textOfRange, conflict) =>
+            textOfRange(conflict.incoming.content!));
+    }
+
+    protected doAcceptBoth(argument: MergeConflictCommandArgument) {
+        this.doAccept(argument, (textOfRange, conflict) => {
+            const currentText = textOfRange(conflict.current.content!);
+            const incomingText = textOfRange(conflict.incoming.content!);
+            return `${currentText}\n${incomingText}`;
+        });
+    }
+
+    protected doAccept(argument: MergeConflictCommandArgument, newTextFn: ((textOfRange: (range: Range) => string, conflict: MergeConflict) => string)) {
+        const { uri, conflict } = argument;
+        const document = this.workspace.textDocuments.find(d => d.uri === uri);
+        if (document) {
+            const newText = newTextFn(range => this.getTextRange(range, document), conflict);
+            this.workspace.applyEdit!({
+                documentChanges: [TextDocumentEdit.create(document, [TextEdit.replace(conflict.total!, newText)])]
+            });
+        }
+    }
+
+    protected getTextRange(range: Range, document: TextDocument): string {
+        const start = document.offsetAt(range.start);
+        const end = document.offsetAt(range.end);
+        const text = document.getText().substring(start, end);
+        return text;
+    }
+
+}

--- a/packages/merge-conflicts/src/browser/merge-conflict.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { Range } from "@theia/languages/lib/common";
+import { Command } from '@theia/core/lib/common';
+
+export interface MarkedRegion {
+    marker?: Range;
+    content?: Range;
+}
+
+export interface MergeConflict {
+    total?: Range;
+    current: MarkedRegion;
+    incoming: MarkedRegion;
+    bases: MarkedRegion[];
+}
+
+export interface MergeConflictCommandArgument {
+    uri: string;
+    conflict: MergeConflict;
+}
+
+export namespace MergeConflictsCommands {
+    export const AcceptCurrent: Command = {
+        id: 'merge-conflicts:accept.current',
+        label: 'Accept Current Change'
+    };
+    export const AcceptIncoming: Command = {
+        id: 'merge-conflicts:accept.incoming',
+        label: 'Accept Incoming Change'
+    };
+    export const AcceptBoth: Command = {
+        id: 'merge-conflicts:accept.both',
+        label: 'Accept Both Changes'
+    };
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { CodeLensProvider, CodeLensParams, CodeLens, CancellationToken } from '@theia/languages/lib/common';
+import { MergeConflict, MergeConflictsCommands as Commands, MergeConflictCommandArgument } from "./merge-conflict";
+import { MergeConflictsService } from "./merge-conflicts-service";
+
+@injectable()
+export class MergeConflictsCodeLensProvider implements CodeLensProvider {
+
+    constructor(
+        @inject(MergeConflictsService) protected readonly mergeConflictsService: MergeConflictsService,
+    ) { }
+
+    provideCodeLenses(params: CodeLensParams, token: CancellationToken): Promise<CodeLens[]> {
+        const uri = params.textDocument.uri;
+        const mergeConflicts: MergeConflict[] = this.mergeConflictsService.get(uri);
+        const result: CodeLens[] = [];
+        mergeConflicts.forEach(mergeConflict => result.push(...this.toCodeLense(uri, mergeConflict)));
+        return Promise.resolve(result);
+    }
+
+    protected toCodeLense(uri: string, conflict: MergeConflict): CodeLens[] {
+        const result: CodeLens[] = [];
+        for (const cmd of [Commands.AcceptCurrent, Commands.AcceptIncoming, Commands.AcceptBoth]) {
+            result.push({
+                command: {
+                    command: cmd.id,
+                    title: cmd.label || '',
+                    arguments: [<MergeConflictCommandArgument>{ uri, conflict }]
+                },
+                range: conflict.current.marker!
+            });
+        }
+        return result;
+    }
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { EditorDecorationsService, OverviewRulerLane, Range, DecorationType, EditorDecorationTypeProvider } from "@theia/editor/lib/browser";
+import { MergeConflictUpdateParams } from "./merge-conflicts-service";
+
+export enum MergeConflictsDecorationType {
+    CurrentMarker = 'merge-conflict-current-marker',
+    CurrentContent = 'merge-conflict-current-content',
+    BaseMarker = 'merge-conflict-base-marker',
+    BaseContent = 'merge-conflict-base-content',
+    IncomingMarker = 'merge-conflict-incoming-marker',
+    IncomingContent = 'merge-conflict-incoming-content',
+}
+
+const Type = MergeConflictsDecorationType;
+
+@injectable()
+export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
+
+    constructor(
+        @inject(EditorDecorationsService) protected readonly decorationsService: EditorDecorationsService,
+    ) { }
+
+    get(): DecorationType[] {
+        return [
+            {
+                type: Type.CurrentMarker,
+                backgroundColor: 'rgba(0, 255, 0, 0.1)',
+                isWholeLine: true,
+            },
+            {
+                type: Type.CurrentContent,
+                backgroundColor: 'rgba(0, 255, 0, 0.3)',
+                isWholeLine: true,
+                overviewRulerColor: 'rgba(0, 255, 0, 0.3)',
+                overviewRulerLane: OverviewRulerLane.Full
+            },
+            {
+                type: Type.BaseMarker,
+                backgroundColor: 'rgba(125, 125, 125, 0.1)',
+                isWholeLine: true,
+            },
+            {
+                type: Type.BaseContent,
+                backgroundColor: 'rgba(125, 125, 125, 0.3)',
+                isWholeLine: true,
+                overviewRulerColor: 'rgba(125, 125, 125, 0.3)',
+                overviewRulerLane: OverviewRulerLane.Full
+            },
+            {
+                type: Type.IncomingMarker,
+                backgroundColor: 'rgba(0, 0, 255, 0.1)',
+                isWholeLine: true,
+            },
+            {
+                type: Type.IncomingContent,
+                backgroundColor: 'rgba(0, 0, 255, 0.3)',
+                isWholeLine: true,
+                overviewRulerColor: 'rgba(0, 0, 255, 0.3)',
+                overviewRulerLane: OverviewRulerLane.Full
+            }
+        ];
+    }
+
+    onMergeConflictUpdate(params: MergeConflictUpdateParams): void {
+        const uri = params.uri;
+        const mergeConflicts = params.mergeConflicts;
+        this.decorationsService.setDecorations(uri, Type.CurrentMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.marker! })));
+        this.decorationsService.setDecorations(uri, Type.CurrentContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.content! })));
+        this.decorationsService.setDecorations(uri, Type.IncomingMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.marker! })));
+        this.decorationsService.setDecorations(uri, Type.IncomingContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.content! })));
+
+        const baseMarkerRanges: Range[] = [];
+        const baseContentRanges: Range[] = [];
+        mergeConflicts.forEach(c => c.bases.forEach(b => {
+            if (b.marker) {
+                baseMarkerRanges.push(b.marker);
+            }
+            if (b.content) {
+                baseContentRanges.push(b.content);
+            }
+        }));
+        this.decorationsService.setDecorations(uri, Type.BaseMarker, baseMarkerRanges.map(range => ({ range })));
+        this.decorationsService.setDecorations(uri, Type.BaseContent, baseContentRanges.map(range => ({ range })));
+    }
+
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-contribution.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-contribution.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { CommandContribution, CommandRegistry } from '@theia/core/lib/common';
+import { Languages, Workspace } from '@theia/languages/lib/common';
+import { MergeConflictsCodeLensProvider } from './merge-conflicts-code-lense-provider';
+import { MergeConflictResolver } from './merge-conflict-resolver';
+import { MergeConflictsCommands as Commands } from './merge-conflict';
+import { MergeConflictsService } from "./merge-conflicts-service";
+import { MergeConflictsDecorations } from "./merge-conflicts-decorations";
+
+@injectable()
+export class MergeConflictsFrontendContribution implements FrontendApplicationContribution, CommandContribution {
+
+    constructor(
+        @inject(Languages) protected readonly languages: Languages,
+        @inject(MergeConflictsCodeLensProvider) protected readonly mergeConflictsCodeLensProvider: MergeConflictsCodeLensProvider,
+        @inject(MergeConflictResolver) protected readonly mergeConflictResolver: MergeConflictResolver,
+        @inject(MergeConflictsDecorations) protected readonly mergeConflictsDecorations: MergeConflictsDecorations,
+        @inject(MergeConflictsService) protected readonly mergeConflictsService: MergeConflictsService,
+        @inject(Workspace) protected readonly workspace: Workspace,
+    ) { }
+
+    onStart(app: FrontendApplication): void {
+        if (this.languages.registerCodeLensProvider) {
+            this.languages.registerCodeLensProvider([{ pattern: '**/*' }], this.mergeConflictsCodeLensProvider);
+        }
+        this.workspace.onDidOpenTextDocument(document => {
+            window.setTimeout(() => {
+                this.updateEditorDecorations(document.uri);
+            }, 1);
+        });
+        this.workspace.onDidChangeTextDocument(params => this.updateEditorDecorations(params.textDocument.uri));
+        this.mergeConflictsService.onMergeConflictUpdate(params => this.mergeConflictsDecorations.onMergeConflictUpdate(params));
+    }
+
+    protected updateEditorDecorations(uri: string) {
+        this.mergeConflictsService.get(uri);
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(Commands.AcceptCurrent, this.mergeConflictResolver.acceptCurrent);
+        registry.registerCommand(Commands.AcceptIncoming, this.mergeConflictResolver.acceptIncoming);
+        registry.registerCommand(Commands.AcceptBoth, this.mergeConflictResolver.acceptBoth);
+    }
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from 'inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { CommandContribution } from '@theia/core/lib/common';
+import { MergeConflictsFrontendContribution } from './merge-conflicts-frontend-contribution';
+import { MergeConflictsCodeLensProvider } from './merge-conflicts-code-lense-provider';
+import { MergeConflictsParser } from './merge-conflicts-parser';
+import { MergeConflictResolver } from './merge-conflict-resolver';
+import { MergeConflictsService } from './merge-conflicts-service';
+import { MergeConflictsDecorations } from './merge-conflicts-decorations';
+import { EditorDecorationTypeProvider } from '@theia/editor/lib/browser';
+
+export default new ContainerModule(bind => {
+    bind(MergeConflictsParser).toSelf().inSingletonScope();
+    bind(MergeConflictResolver).toSelf().inSingletonScope();
+    bind(MergeConflictsCodeLensProvider).toSelf().inSingletonScope();
+    bind(MergeConflictsDecorations).toSelf().inSingletonScope();
+    bind(EditorDecorationTypeProvider).toDynamicValue(context => context.container.get(MergeConflictsDecorations));
+    bind(MergeConflictsFrontendContribution).toSelf().inSingletonScope();
+    bind(MergeConflictsService).toSelf().inSingletonScope();
+    [CommandContribution, FrontendApplicationContribution].forEach(serviceIdentifier =>
+        bind(serviceIdentifier).toDynamicValue(c => c.container.get(MergeConflictsFrontendContribution)).inSingletonScope()
+    );
+});

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+chai.use(require('chai-string'));
+
+import { MergeConflictsParser } from './merge-conflicts-parser';
+import { Range, Position } from '@theia/editor/lib/browser';
+
+let parser: MergeConflictsParser;
+
+before(() => {
+    parser = new MergeConflictsParser();
+});
+
+// tslint:disable:no-unused-expression
+
+describe("merge-conflict-parser", () => {
+
+    it("simple merge conflict", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+        expect(conflict.total).to.not.be.undefined;
+        expect(conflict.current.marker).to.not.be.undefined;
+        expect(conflict.current.content).to.not.be.undefined;
+        expect(conflict.incoming.marker).to.not.be.undefined;
+        expect(conflict.incoming.content).to.not.be.undefined;
+    });
+
+    it("content regions are correct", () => {
+        const content = `first line
+<<<<<<< HEAD
+foo changed on master
+bar changed on master
+||||||| base 1
+foo
+bar
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+last line`;
+        const conflicts = parser.parse(content);
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        const total = conflict.total!;
+        expect(total, 'total range').to.deep.equal({
+            start: { line: 1, character: 0 },
+            end: { line: 10, character: 14 }
+        });
+        expect(substring(content, total)).to.equal(`<<<<<<< HEAD
+foo changed on master
+bar changed on master
+||||||| base 1
+foo
+bar
+=======
+foo on branch
+bar on branch
+>>>>>>> branch`);
+
+        const currentContent = conflict.current.content!;
+        expect(currentContent).to.deep.equal({
+            start: { line: 2, character: 0 },
+            end: { line: 3, character: 21 }
+        });
+        expect(substring(content, currentContent)).to.equal(`foo changed on master
+bar changed on master`);
+
+        const baseContent = conflict.bases[0].content!;
+        expect(baseContent).to.deep.equal({
+            start: { line: 5, character: 0 },
+            end: { line: 6, character: 3 }
+        });
+        expect(substring(content, baseContent)).to.equal(`foo
+bar`);
+
+        const incomingContent = conflict.incoming.content!;
+        expect(incomingContent).to.deep.equal({
+            start: { line: 8, character: 0 },
+            end: { line: 9, character: 13 }
+        });
+        expect(substring(content, incomingContent)).to.equal(`foo on branch
+bar on branch`);
+    });
+
+    it("multiple merge conflicts", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+
+<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+
+<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch`
+        );
+        expect(conflicts).to.have.lengthOf(3);
+    });
+
+    it("merge conflict with bases", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+||||||| base 1
+common base 1
+||||||| base 2
+||||||| base 3
+common base 3
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        const bases = conflict.bases;
+        expect(bases).to.have.lengthOf(3);
+
+        const base1Content = bases[0].content;
+        expect(base1Content).to.not.be.undefined;
+        expect(base1Content).to.deep.equal({
+            start: { line: 4, character: 0 },
+            end: { line: 4, character: 13 }
+        });
+
+        const base2Content = bases[1].content;
+        expect(base2Content).to.be.undefined;
+
+        const base3Content = bases[2].content;
+        expect(base3Content).to.not.be.undefined;
+        expect(base3Content).to.deep.equal({
+            start: { line: 7, character: 0 },
+            end: { line: 7, character: 13 }
+        });
+    });
+
+    it("broken 1: second current marker in current content", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        const total = conflict.total;
+        expect(total).to.not.be.undefined;
+        expect(total).to.deep.equal({
+            start: { line: 1, character: 0 },
+            end: { line: 7, character: 14 }
+        });
+    });
+
+    it("broken 2: current marker in incoming content", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+<<<<<<< HEAD
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(0);
+    });
+
+    it("broken 3: second separator", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(0);
+    });
+
+    it("broken 4: second separator in incoming content", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+=======
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(0);
+    });
+
+    it("broken 5: incoming marker, no separator", () => {
+        const conflicts = parser.parse(
+            `<<<<<<< HEAD
+foo changed on master
+bar changed on master
+foo on branch
+bar on branch
+>>>>>>> branch
+
+<<<<<<< HEAD
+foo changed on master
+bar changed on master
+=======
+foo on branch
+bar on branch
+>>>>>>> branch
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        const total = conflict.total;
+        expect(total).to.not.be.undefined;
+        expect(total).to.deep.equal({
+            start: { line: 7, character: 0 },
+            end: { line: 13, character: 14 }
+        });
+    });
+
+});
+
+function substring(text: string, range: Range): string {
+    const lines = text.split(/\r?\n|\r/);
+    const lineOffsets = [0];
+    for (let i = 1; i < lines.length; i++) {
+        lineOffsets[i] = lineOffsets[i - 1] + lines[i - 1].length + 1;
+    }
+    const offsetAt = (position: Position) => lineOffsets[position.line] + position.character;
+    const startOffset = offsetAt(range.start);
+    const endOffset = offsetAt(range.end);
+    const result = text.substring(startOffset, endOffset);
+    return result;
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from "inversify";
+import { MergeConflict } from "./merge-conflict";
+import { Range } from "@theia/editor/lib/browser";
+
+@injectable()
+export class MergeConflictsParser {
+    private parser: MergeConflictsParser.StateMachine<MergeConflictsParser.Context>;
+
+    constructor() {
+        this.init();
+    }
+
+    parse(text: string): MergeConflict[] {
+        const context = new MergeConflictsParser.Context();
+        this.parser.reset(context);
+        const lines = text.split(/\r?\n|\r/);
+        for (let line = 0; line < lines.length; line++) {
+            this.parser.read({ line, text: lines[line] });
+        }
+        return context.all;
+    }
+
+    private init(): void {
+        const parser = this.parser = new MergeConflictsParser.StateMachine(new MergeConflictsParser.Context());
+        // states
+        const start = parser.addState('start');
+        const currentMarker = parser.addState('current-marker');
+        const currentContent = parser.addState('current-content');
+        const baseMarker = parser.addState('base-marker');
+        const baseContent = parser.addState('base-content');
+        const separator = parser.addState('separator');
+        const incomingContent = parser.addState('incoming-content');
+        const incomingMarker = parser.addState('incoming-marker');
+        const push = parser.addState('push');
+
+        // conditions / triggers
+        const startsWithLt = (input: MergeConflictsParser.Input) => input.text.startsWith('<<<<<<<');
+        const startsWithEq = (input: MergeConflictsParser.Input) => input.text.startsWith('=======');
+        const startsWithGt = (input: MergeConflictsParser.Input) => input.text.startsWith('>>>>>>>');
+        const startsWithPp = (input: MergeConflictsParser.Input) => input.text.startsWith('|||||||');
+        const any = () => true;
+
+        // transitions
+        start.to(currentMarker, startsWithLt);
+        start.to(start, any);
+        currentMarker.to(currentMarker, startsWithLt);
+        currentMarker.to(separator, startsWithEq);
+        currentMarker.to(currentContent, any);
+        currentContent.to(currentMarker, startsWithLt);
+        currentContent.to(separator, startsWithEq);
+        currentContent.to(baseMarker, startsWithPp);
+        currentContent.to(start, startsWithGt);
+        currentContent.to(currentContent, any);
+        baseMarker.to(currentMarker, startsWithLt);
+        baseMarker.to(baseMarker, startsWithPp);
+        baseMarker.to(separator, startsWithEq);
+        baseMarker.to(baseContent, any);
+        baseContent.to(currentMarker, startsWithLt);
+        baseContent.to(separator, startsWithEq);
+        baseContent.to(baseMarker, startsWithPp);
+        baseContent.to(baseContent, any);
+        separator.to(currentMarker, startsWithLt);
+        separator.to(start, startsWithEq);
+        separator.to(incomingContent, any);
+        incomingContent.to(start, startsWithEq);
+        incomingContent.to(currentMarker, startsWithLt);
+        incomingContent.to(incomingMarker, startsWithGt);
+        incomingContent.to(incomingContent, any);
+        incomingMarker.to(push);
+        push.to(start);
+
+        // actions
+        currentMarker.onEnter = (input, ctx) => {
+            ctx.new = new MergeConflictsParser.Context().new;
+            ctx.new.current.marker = this.lineToRange(input);
+        };
+        currentContent.onEnter = (input, ctx) => {
+            const current = ctx.new.current;
+            current.content = this.addLineToRange(input, current.content);
+        };
+        baseMarker.onEnter = (input, ctx) => {
+            ctx.new.bases.push({ marker: this.lineToRange(input) });
+        };
+        baseContent.onEnter = (input, ctx) => {
+            const base = ctx.new.bases.slice(-1)[0];
+            base.content = this.addLineToRange(input, base.content);
+        };
+        incomingContent.onEnter = (input, ctx) => {
+            const incoming = ctx.new.incoming;
+            incoming.content = this.addLineToRange(input, incoming.content);
+        };
+        incomingMarker.onEnter = (input, ctx) => {
+            const markerRange = this.lineToRange(input);
+            ctx.new.incoming.marker = markerRange;
+            ctx.new.total = {
+                start: ctx.new.current.marker!.start,
+                end: markerRange.end
+            };
+        };
+        push.onEnter = (input, ctx) => {
+            ctx.all.push(ctx.new);
+        };
+    }
+
+    private lineToRange(input: MergeConflictsParser.Input): Range {
+        return {
+            start: { line: input.line, character: 0 },
+            end: { line: input.line, character: input.text.length },
+        };
+    }
+
+    private addLineToRange(input: MergeConflictsParser.Input, range: Range | undefined): Range {
+        if (!range) {
+            return this.lineToRange(input);
+        }
+        range.end = { line: input.line, character: input.text.length };
+        return range;
+    }
+}
+
+export namespace MergeConflictsParser {
+    export class Context {
+        new: MergeConflict = {
+            current: {},
+            incoming: {},
+            bases: []
+        };
+        all: MergeConflict[] = [];
+    }
+
+    export interface Input {
+        line: number;
+        text: string;
+    }
+
+    export class StateMachine<C extends object> {
+        current: State<C>;
+        readonly states: State<C>[] = [];
+
+        constructor(protected context: C) { }
+
+        reset(context: C): void {
+            this.current = this.states[0];
+            this.context = context;
+        }
+
+        read(input: Input): void {
+            let next = this.current.findNext(input, this.context);
+            while (next) {
+                if (next.onEnter) {
+                    next.onEnter(input, this.context);
+                }
+                if (next.immediateNext) {
+                    this.current = next;
+                    next = next.immediateNext;
+                } else {
+                    break;
+                }
+            }
+            if (!next) {
+                throw new Error(`Missing transition from (${this.current.id}) for input: L.${input.line} > ${input.text}`);
+            }
+            this.current = next;
+        }
+
+        addState(id: string): State<C> {
+            const state = new State<C>(id);
+            this.states.push(state);
+            if (!this.current) {
+                this.current = state;
+            }
+            return state;
+        }
+    }
+
+    export class State<C> {
+        onEnter?: (input: Input, context: C) => void;
+        readonly conditionalNext: { to: State<C>, condition: (input: Input, context: C) => boolean }[] = [];
+        immediateNext: State<C> | undefined;
+
+        constructor(readonly id: string) { }
+
+        findNext(input: Input, context: C): State<C> | undefined {
+            const match = this.conditionalNext.find(transition => transition.condition(input, context));
+            return match ? match.to : undefined;
+        }
+
+        to(next: State<C>, condition?: (input: Input, context: C) => boolean): void {
+            if (condition) {
+                this.immediateNext = undefined;
+                this.conditionalNext.push({ to: next, condition });
+            } else {
+                this.immediateNext = next;
+            }
+        }
+    }
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-service.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-service.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from "inversify";
+import { Workspace } from "@theia/languages/lib/browser";
+import { MergeConflictsParser } from "./merge-conflicts-parser";
+import { MergeConflict } from "./merge-conflict";
+import { Emitter, Event } from '@theia/core/lib/common/event';
+
+@injectable()
+export class MergeConflictsService {
+
+    private onMergeConflictUpdateEmitter = new Emitter<MergeConflictUpdateParams>();
+
+    constructor(
+        @inject(Workspace) protected readonly workspace: Workspace,
+        @inject(MergeConflictsParser) protected readonly mergeConflictParser: MergeConflictsParser,
+    ) { }
+
+    get(uri: string): MergeConflict[] {
+        const mergeConflicts = this.getMergeConflicts(uri);
+        this.onMergeConflictUpdateEmitter.fire({ uri, mergeConflicts });
+        return mergeConflicts;
+    }
+
+    protected getMergeConflicts(uri: string): MergeConflict[] {
+        const document = this.workspace.textDocuments.find(d => d.uri === uri);
+        if (!document) {
+            return [];
+        }
+        const mergeConflicts: MergeConflict[] = this.mergeConflictParser.parse(document.getText());
+        return mergeConflicts;
+    }
+
+    get onMergeConflictUpdate(): Event<MergeConflictUpdateParams> {
+        return this.onMergeConflictUpdateEmitter.event;
+    }
+
+}
+
+export interface MergeConflictUpdateParams {
+    uri: string,
+    mergeConflicts: MergeConflict[]
+}

--- a/packages/merge-conflicts/src/package.spec.ts
+++ b/packages/merge-conflicts/src/package.spec.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe("merge conflicts package", () => {
+
+    it("support code coverage statistics", () => true);
+
+});

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,7 +8,7 @@
 // tslint:disable:no-any
 import { DisposableCollection } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
-import { EditorPreferenceChange, EditorPreferences } from '@theia/editor/lib/browser';
+import { EditorPreferenceChange, EditorPreferences, EditorDecorationsService } from '@theia/editor/lib/browser';
 import { DiffUris } from '@theia/editor/lib/browser/diff-uris';
 import { inject, injectable } from 'inversify';
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient';
@@ -46,7 +46,8 @@ export class MonacoEditorProvider {
         @inject(MonacoWorkspace) protected readonly workspace: MonacoWorkspace,
         @inject(MonacoCommandServiceFactory) protected readonly commandServiceFactory: MonacoCommandServiceFactory,
         @inject(EditorPreferences) protected readonly editorPreferences: EditorPreferences,
-        @inject(MonacoQuickOpenService) protected readonly quickOpenService: MonacoQuickOpenService
+        @inject(MonacoQuickOpenService) protected readonly quickOpenService: MonacoQuickOpenService,
+        @inject(EditorDecorationsService) protected readonly decorationsService: EditorDecorationsService,
     ) { }
 
     protected async getModel(uri: URI, toDispose: DisposableCollection): Promise<MonacoEditorModel> {
@@ -91,7 +92,7 @@ export class MonacoEditorProvider {
     protected async createMonacoEditor(uri: URI, override: IEditorOverrideServices, toDispose: DisposableCollection): Promise<MonacoEditor> {
         const model = await this.getModel(uri, toDispose);
         const options = this.createMonacoEditorOptions(model);
-        const editor = new MonacoEditor(uri, model, document.createElement('div'), this.m2p, this.p2m, options, override);
+        const editor = new MonacoEditor(uri, model, document.createElement('div'), this.m2p, this.p2m, this.decorationsService, options, override);
         toDispose.push(this.editorPreferences.onPreferenceChanged(event => this.updateMonacoEditorOptions(editor, event)));
         return editor;
     }
@@ -116,7 +117,7 @@ export class MonacoEditorProvider {
         const modifiedModel = await this.getModel(modified, toDispose);
 
         const options = this.createMonacoDiffEditorOptions(originalModel, modifiedModel);
-        const editor = new MonacoDiffEditor(uri, document.createElement('div'), originalModel, modifiedModel, this.m2p, this.p2m, options, override);
+        const editor = new MonacoDiffEditor(uri, document.createElement('div'), originalModel, modifiedModel, this.m2p, this.p2m, this.decorationsService, options, override);
         toDispose.push(this.editorPreferences.onPreferenceChanged(event => this.updateMonacoDiffEditorOptions(editor, event)));
         return editor;
     }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -8,12 +8,47 @@ declare module monaco.instantiation {
 declare module monaco.editor {
 
     export interface ICommonCodeEditor {
+        readonly _codeEditorService: monaco.services.ICodeEditorService;
         readonly _commandService: monaco.commands.ICommandService;
         readonly _instantiationService: monaco.instantiation.IInstantiationService;
         readonly _contributions: {
             'editor.controller.quickOpenController': monaco.quickOpen.QuickOpenController
         }
         readonly cursor: ICursor;
+        setDecorations(decorationTypeKey: string, decorationOptions: IDecorationOptions[]): void;
+    }
+
+    export interface IDecorationRenderOptions {
+        isWholeLine?: boolean;
+        backgroundColor?: string | ThemeColor;
+
+        outlineColor?: string | ThemeColor;
+        outlineStyle?: string;
+        outlineWidth?: string;
+
+        color?: string | ThemeColor;
+
+        overviewRulerColor?: string | ThemeColor;
+        overviewRulerLane?: OverviewRulerLane;
+
+        after?: IContentDecorationRenderOptions;
+    }
+
+    export interface IContentDecorationRenderOptions {
+        contentText?: string;
+        color?: string | ThemeColor;
+        backgroundColor?: string | ThemeColor;
+    }
+
+    export interface IDecorationOptions {
+        range: monaco.IRange;
+        hoverMessage?: IMarkdownString | IMarkdownString[];
+        renderOptions?: IContentDecorationRenderOptions;
+    }
+
+    export interface IMarkdownString {
+        value: string;
+        isTrusted?: boolean;
     }
 
     export interface ICursor {
@@ -295,6 +330,10 @@ declare module monaco.services {
     }
 
     export interface IStandaloneThemeService extends monaco.theme.IThemeService { }
+
+    export interface ICodeEditorService {
+        registerDecorationType(key: string, options: monaco.editor.IDecorationRenderOptions, parentTypeKey?: string): void;
+    }
 
     export module StaticServices {
         export const standaloneThemeService: LazyStaticService<IStandaloneThemeService>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,9 @@
       "@theia/messages/lib/*": [
         "packages/messages/src/*"
       ],
+      "@theia/merge-conflicts/lib/*": [
+        "packages/merge-conflicts/src/*"
+      ],
       "@theia/output/lib/*": [
         "packages/output/src/*"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,9 +121,9 @@
   dependencies:
     "@types/chai" "*"
 
-"@types/chai-string@^1.1.31":
-  version "1.1.31"
-  resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.1.31.tgz#a22f75d713f69da8c5cf34f8bc808a62cd249405"
+"@types/chai-string@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.4.0.tgz#c8b78deb9ae53e86c05a446c256138faeaff53c1"
   dependencies:
     "@types/chai" "*"
 


### PR DESCRIPTION
This change set adds code lenses and editor decorations for merge conflicts (#1180). 
- Merge conflicts are decorated in code editors as well as in diff editors.
- Commands of code lenses should help to accept changes.

Open task:
- [x] in git view we might better show the code editor when a file with conflicts is opened.
- [ ] merge conflict decorators should be optional, consider editor preference.

Editor Decorations: 
![2018-02-12 11 00 06](https://user-images.githubusercontent.com/914497/36091460-18f15950-0fe4-11e8-9447-7cdcd31cdcf7.gif)

Git Widget integration:
![2018-02-12 11 41 22](https://user-images.githubusercontent.com/914497/36093104-e5407a9a-0fe9-11e8-837a-8947ccb5b87a.gif)


