### PR TITLE
GH-1232: Updated the `webpack` generator to handle UMD modules.

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -49,6 +49,7 @@
     "semver": "^5.4.1",
     "source-map-loader": "^0.2.1",
     "source-map-support": "^0.4.18",
+    "umd-compat-loader": "^2.1.1",
     "url-loader": "^0.5.8",
     "webpack": "^2.2.1",
     "write-json-file": "^2.2.0"

--- a/dev-packages/application-package/src/generator/webpack-generator.ts
+++ b/dev-packages/application-package/src/generator/webpack-generator.ts
@@ -91,9 +91,12 @@ module.exports = {
             {
                 test: /\\.woff(2)?(\\?v=[0-9]\\.[0-9]\\.[0-9])?$/,
                 loader: "url-loader?limit=10000&mimetype=application/font-woff"
+            },
+            {
+                test: /node_modules[\\\\|\/](vscode-languageserver-types|vscode-uri|jsonc-parser)/,
+                use: { loader: 'umd-compat-loader' }
             }
-        ],
-        noParse: /vscode-languageserver-types|vscode-uri|jsonc-parser/
+        ]
     },
     resolve: {
         extensions: ['.js']${this.ifMonaco(() => `,

--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -7,7 +7,7 @@
     "@theia/userstorage": "^0.3.4",
     "@theia/workspace": "^0.3.4",
     "ajv": "^5.2.2",
-    "jsonc-parser": "^1.0.0"
+    "jsonc-parser": "^1.0.1"
   },
   "devDependencies": {
     "@theia/ext-scripts": "0.2.0",

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -9,7 +9,7 @@
     "@theia/workspace": "^0.3.4",
     "@types/fs-extra": "^4.0.2",
     "fs-extra": "^4.0.2",
-    "jsonc-parser": "^1.0.0"
+    "jsonc-parser": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -8,7 +8,7 @@
     "@theia/process": "^0.3.3",
     "@theia/terminal": "^0.3.4",
     "@theia/workspace": "^0.3.4",
-    "jsonc-parser": "^1.0.0"
+    "jsonc-parser": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,14 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
+ast-types@^0.9.2:
+  version "0.9.14"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -2434,7 +2442,7 @@ esprima@2.7.x, esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.3:
+esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -4242,9 +4250,9 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonc-parser@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-1.0.0.tgz#ddcc864ae708e60a7a6dd36daea00172fa8d9272"
+jsonc-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-1.0.1.tgz#7f8f296414e6e7c4a33b9e4914fc8c47e4421675"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -4483,7 +4491,7 @@ loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@~0
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@^1.0.2, loader-utils@^1.0.3, loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
   dependencies:
@@ -6114,6 +6122,10 @@ pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
 
+private@~0.1.5:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -6373,6 +6385,15 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+recast@^0.11.17:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -7060,7 +7081,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -7823,6 +7844,14 @@ uid-number@^0.0.6:
 ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
+umd-compat-loader@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/umd-compat-loader/-/umd-compat-loader-2.1.1.tgz#1a44674f57deeb429f4d1533668453a3cf322422"
+  dependencies:
+    ast-types "^0.9.2"
+    loader-utils "^1.0.3"
+    recast "^0.11.17"
 
 unbzip2-stream@^1.0.9:
   version "1.2.5"


### PR DESCRIPTION
Currently, we explicitly handle the following packages:
 - `vscode-languageserver-types`,
 - `vscode-uri`, and
 - `jsonc-parser`.

Closes #1232.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>