### PR TITLE
set diff editor's `uri` property to diff uri

### DIFF
--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -26,6 +26,7 @@ export class MonacoDiffEditor extends MonacoEditor {
     protected _diffEditor: IStandaloneDiffEditor;
 
     constructor(
+        readonly uri: URI,
         readonly node: HTMLElement,
         readonly originalModel: MonacoEditorModel,
         readonly modifiedModel: MonacoEditorModel,
@@ -34,7 +35,7 @@ export class MonacoDiffEditor extends MonacoEditor {
         options?: MonacoDiffEditor.IOptions,
         override?: IEditorOverrideServices,
     ) {
-        super(new URI(''), modifiedModel, node, m2p, p2m, options, override);
+        super(uri, modifiedModel, node, m2p, p2m, options, override);
         this.documents.add(originalModel);
         const original = originalModel.textEditorModel;
         const modified = modifiedModel.textEditorModel;

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -116,7 +116,7 @@ export class MonacoEditorProvider {
         const modifiedModel = await this.getModel(modified, toDispose);
 
         const options = this.createMonacoDiffEditorOptions(originalModel, modifiedModel);
-        const editor = new MonacoDiffEditor(document.createElement('div'), originalModel, modifiedModel, this.m2p, this.p2m, options, override);
+        const editor = new MonacoDiffEditor(uri, document.createElement('div'), originalModel, modifiedModel, this.m2p, this.p2m, options, override);
         toDispose.push(this.editorPreferences.onPreferenceChanged(event => this.updateMonacoDiffEditorOptions(editor, event)));
         return editor;
     }


### PR DESCRIPTION
as of now the `TextEditor.uri` property is an empty uri. using the diff uri would allow us to recognize the `EditorWidget` as diff editor.