### PR TITLE
Schema compilation

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -115,8 +115,7 @@ export class MonacoEditorProvider {
     protected async createMonacoDiffEditor(uri: URI, override: IEditorOverrideServices, toDispose: DisposableCollection): Promise<MonacoDiffEditor> {
         const [original, modified] = DiffUris.decode(uri);
 
-        const originalModel = await this.getModel(original, toDispose);
-        const modifiedModel = await this.getModel(modified, toDispose);
+        const [originalModel, modifiedModel]  = await Promise.all([this.getModel(original, toDispose), this.getModel(modified, toDispose)]);
 
         const options = this.createMonacoDiffEditorOptions(originalModel, modifiedModel);
         const editor = new MonacoDiffEditor(


### PR DESCRIPTION
We previously recompiled the schema on every access to, which made opening editors super slow, as they ask for a lot of preferences. With this change, a schema is only compiled once.