### PR TITLE
Update TypeScript to 2.7.2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ts-node": "^3.2.0",
     "tslint": "^5.7.0",
     "typedoc": "^0.8",
-    "typescript": "^2.7.1",
+    "typescript": "^2.7.2",
     "uuid": "^3.1.0",
     "wdio-mocha-framework": "^0.5.9",
     "wdio-phantomjs-service": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7811,9 +7811,9 @@ typescript@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
-typescript@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
With TypeScript 2.7.1 there was a problem
https://github.com/theia-ide/theia/issues/1239 fixed in https://github.com/Microsoft/TypeScript/issues/21478 

so upgrading to TypeScript 2.7.2

Change-Id: I1aa71c50873baa380cc03dc49d55475fe2f10a11
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>