### PR TITLE
[core] added the reference abstraction

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -7,6 +7,7 @@
 
 export * from './types';
 export * from './disposable';
+export * from './reference';
 export * from './event';
 export * from './cancellation';
 export * from './command';

--- a/packages/core/src/common/reference.spec.ts
+++ b/packages/core/src/common/reference.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from "assert";
+import { ReferenceCollection } from './reference';
+import { Disposable } from "./disposable";
+
+describe('reference', () => {
+
+    it('dispose a single reference', async () => {
+        const expectation: { disposed: boolean } = { disposed: false };
+        const references = new ReferenceCollection<string, Disposable>(key => ({
+            key, dispose: () => {
+                expectation.disposed = true;
+            }
+        }));
+        assert.ok(!references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        const reference = await references.acquire("a");
+        assert.ok(references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        reference.dispose();
+        assert.ok(!references.has("a"));
+        assert.ok(expectation.disposed);
+    });
+
+    it('dispose 2 references', async () => {
+        const expectation: { disposed: boolean } = { disposed: false };
+        const references = new ReferenceCollection<string, Disposable>(key => ({
+            key, dispose: () => {
+                expectation.disposed = true;
+            }
+        }));
+        assert.ok(!references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        const reference = await references.acquire("a");
+        const reference2 = await references.acquire("a");
+        assert.ok(references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        reference.dispose();
+        assert.ok(references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        reference2.dispose();
+        assert.ok(!references.has("a"));
+        assert.ok(expectation.disposed);
+    });
+
+    it('dispose an object with 2 references', async () => {
+        const expectation: { disposed: boolean } = { disposed: false };
+        const references = new ReferenceCollection<string, Disposable>(key => ({
+            key, dispose: () => {
+                expectation.disposed = true;
+            }
+        }));
+        assert.ok(!references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        await references.acquire("a");
+        const reference = await references.acquire("a");
+        assert.ok(references.has("a"));
+        assert.ok(!expectation.disposed);
+
+        reference.object.dispose();
+        assert.ok(!references.has("a"));
+        assert.ok(expectation.disposed);
+    });
+
+});

--- a/packages/core/src/common/reference.ts
+++ b/packages/core/src/common/reference.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { Disposable, DisposableCollection } from "./disposable";
+import { MaybePromise } from "./types";
+
+export interface Reference<T> extends Disposable {
+    readonly object: T
+}
+
+export class ReferenceCollection<K, V extends Disposable> {
+
+    protected readonly values = new Map<string, MaybePromise<V>>();
+    protected readonly references = new Map<string, DisposableCollection>();
+
+    constructor(protected readonly factory: (key: K) => MaybePromise<V>) { }
+
+    has(args: K): boolean {
+        const key = this.toKey(args);
+        return this.references.has(key);
+    }
+
+    async acquire(args: K): Promise<Reference<V>> {
+        const key = this.toKey(args);
+        const object = await this.getOrCreateValue(key, args);
+        const references = this.references.get(key) || this.createReferences(key, object);
+        const reference: Reference<V> = {
+            object,
+            dispose: () => { }
+        };
+        references.push(reference);
+        return reference;
+    }
+
+    protected async getOrCreateValue(key: string, args: K): Promise<V> {
+        const existing = this.values.get(key);
+        if (existing) {
+            return existing;
+        }
+        const value = this.factory(args);
+        this.values.set(key, value);
+        return value;
+    }
+
+    protected toKey(args: K): string {
+        return JSON.stringify(args);
+    }
+
+    protected createReferences(key: string, object: V): DisposableCollection {
+        const references = new DisposableCollection();
+        references.onDispose(() => object.dispose());
+        const disposeObject = object.dispose.bind(object);
+        object.dispose = () => {
+            disposeObject();
+            this.values.delete(key);
+            this.references.delete(key);
+            references!.dispose();
+        };
+        this.references.set(key, references);
+        return references;
+    }
+
+}

--- a/packages/git/src/node/dugite-git-watcher.ts
+++ b/packages/git/src/node/dugite-git-watcher.ts
@@ -33,7 +33,8 @@ export class DugiteGitWatcherServer implements GitWatcherServer {
     }
 
     async watchGitChanges(repository: Repository): Promise<number> {
-        const watcher = this.manager.getWatcher(repository);
+        const reference = await this.manager.getWatcher(repository);
+        const watcher = reference.object;
 
         const repositoryUri = repository.localUri;
         let subscriptions = this.subscriptions.get(repositoryUri);
@@ -51,10 +52,10 @@ export class DugiteGitWatcherServer implements GitWatcherServer {
             this.subscriptions.set(repositoryUri, subscriptions);
         }
 
-        const disposable = watcher.watch();
-        subscriptions.push(disposable);
+        watcher.watch();
+        subscriptions.push(reference);
         const watcherId = this.watcherSequence++;
-        this.watchers.set(watcherId, disposable);
+        this.watchers.set(watcherId, reference);
         return watcherId;
     }
 

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,66 +8,31 @@
 import { inject, injectable } from 'inversify';
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient';
 import URI from "@theia/core/lib/common/uri";
-import { DisposableCollection, Disposable, ResourceProvider } from "@theia/core/lib/common";
+import { ResourceProvider, ReferenceCollection } from "@theia/core/lib/common";
 import { EditorPreferences, EditorPreferenceChange } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from "./monaco-editor-model";
 
 @injectable()
 export class MonacoTextModelService implements monaco.editor.ITextModelService {
 
-    protected readonly models = new Map<string, monaco.Promise<MonacoEditorModel>>();
-    protected readonly references = new Map<monaco.editor.ITextEditorModel, DisposableCollection>();
+    protected readonly models = new ReferenceCollection<string, MonacoEditorModel>(
+        uri => this.loadModel(new URI(uri))
+    );
 
-    constructor(
-        @inject(ResourceProvider) protected readonly resourceProvider: ResourceProvider,
-        @inject(EditorPreferences) protected readonly editorPreferences: EditorPreferences,
-        @inject(MonacoToProtocolConverter) protected readonly m2p: MonacoToProtocolConverter,
-        @inject(ProtocolToMonacoConverter) protected readonly p2m: ProtocolToMonacoConverter
-    ) { }
+    @inject(ResourceProvider)
+    protected readonly resourceProvider: ResourceProvider;
+
+    @inject(EditorPreferences)
+    protected readonly editorPreferences: EditorPreferences;
+
+    @inject(MonacoToProtocolConverter)
+    protected readonly m2p: MonacoToProtocolConverter;
+
+    @inject(ProtocolToMonacoConverter)
+    protected readonly p2m: ProtocolToMonacoConverter;
 
     createModelReference(raw: monaco.Uri | URI): monaco.Promise<monaco.editor.IReference<MonacoEditorModel>> {
-        const uri = raw instanceof URI ? raw : new URI(raw.toString());
-        return this.getOrCreateModel(uri).then(model =>
-            this.newReference(model)
-        );
-    }
-
-    protected newReference(model: MonacoEditorModel): monaco.editor.IReference<MonacoEditorModel> {
-        let references = this.references.get(model);
-        if (references === undefined) {
-            references = new DisposableCollection();
-            references.onDispose(() => model.dispose());
-            model.onDispose(() => {
-                this.references.delete(model);
-                references!.dispose();
-            });
-            this.references.set(model, references);
-        }
-
-        let removeReference: Disposable;
-        const reference: monaco.editor.IReference<MonacoEditorModel> = {
-            object: model,
-            dispose: () =>
-                removeReference.dispose()
-        };
-        removeReference = references.push(reference);
-        return reference;
-    }
-
-    protected getOrCreateModel(uri: URI): monaco.Promise<MonacoEditorModel> {
-        const key = uri.toString();
-        const model = this.models.get(key);
-        if (model) {
-            return model;
-        }
-        const newModel = this.createModel(uri);
-        this.models.set(key, newModel);
-        newModel.then(m => m.onDispose(() => this.models.delete(key)));
-        return newModel;
-    }
-
-    protected createModel(uri: URI): monaco.Promise<MonacoEditorModel> {
-        return monaco.Promise.wrap(this.loadModel(uri));
+        return monaco.Promise.wrap(this.models.acquire(raw.toString()));
     }
 
     protected async loadModel(uri: URI): Promise<MonacoEditorModel> {
@@ -85,8 +50,8 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
     protected readonly modelOptions: {
         [name: string]: (keyof monaco.editor.ITextModelUpdateOptions | undefined)
     } = {
-        'editor.tabSize': 'tabSize'
-    };
+            'editor.tabSize': 'tabSize'
+        };
 
     protected updateModel(model: MonacoEditorModel, change: EditorPreferenceChange): void {
         if (change.preferenceName === "editor.autoSave") {


### PR DESCRIPTION
This PR generalizes the reference abstraction that allows managing a lifecycle of objects which existence depends on referencing clients. Two clients were simplified with it: the Monaco model provider and the git watcher manager. It is a groundwork to implement watching of the same workspace once. Other possible clients are the resource provider to manage a single resource per a URI, the widget manager could be simplified.