### PR TITLE
fixes gh-1290: include es6-promise polyfills

### DIFF
--- a/dev-packages/application-package/src/generator/frontend-generator.ts
+++ b/dev-packages/application-package/src/generator/frontend-generator.ts
@@ -35,12 +35,12 @@ export class FrontendGenerator extends AbstractGenerator {
 
     protected compileIndexHead(frontendModules: Map<string, string>): string {
         return `
-  <meta charset="UTF-8">
-  <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js" charset="utf-8"></script>`;
+  <meta charset="UTF-8">`;
     }
 
     protected compileIndexJs(frontendModules: Map<string, string>): string {
         return `// @ts-check
+${this.ifBrowser("require('es6-promise/auto');")}
 require('reflect-metadata');
 const { Container } = require('inversify');
 const { FrontendApplication } = require('@theia/core/lib/browser');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     "body-parser": "^1.17.2",
     "bunyan": "^1.8.10",
     "electron": "1.7.11",
+    "es6-promise": "^4.2.4",
     "express": "^4.15.3",
     "file-icons-js": "^1.0.3",
     "font-awesome": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,6 +2404,10 @@ es6-promise@^4.0.3, es6-promise@^4.0.5:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.1.tgz#3b98a6714ba1b9267428b2c00e6265b16dab0205"
 
+es6-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"


### PR DESCRIPTION
For Electron I removed it.

To verify:
 - [x] Windows browser
 - [x] Windows electron
 - [x] OS X browser
 - [x] OS X electron
 - [ ] Linux browser
 - [ ] Linux electron