### PR TITLE
Enable search in workspace only when there is a workspace root

### DIFF
--- a/packages/search-in-workspace/src/browser/quick-search-in-workspace.ts
+++ b/packages/search-in-workspace/src/browser/quick-search-in-workspace.ts
@@ -31,6 +31,10 @@ export class QuickSearchInWorkspace implements QuickOpenModel {
         @inject(ILogger) protected readonly logger: ILogger,
     ) { }
 
+    isEnabled(): boolean {
+        return this.searchInWorkspaceService.isEnabled();
+    }
+
     onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
         // If we have a search pending, it's not relevant anymore, cancel it.
         this.cancelCurrentSeach();
@@ -177,7 +181,8 @@ export class SearchInWorkspaceContributions implements CommandContribution, Menu
 
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(OpenQuickSearchInWorkspaceCommand, {
-            execute: what => this.quickSeachInWorkspace.open()
+            execute: what => this.quickSeachInWorkspace.open(),
+            isEnabled: () => this.quickSeachInWorkspace.isEnabled(),
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -65,6 +65,10 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
         client.setService(this);
     }
 
+    isEnabled(): boolean {
+        return this.workspaceService.opened;
+    }
+
     onResult(searchId: number, result: SearchInWorkspaceResult): void {
         const callbacks = this.pendingSearches.get(searchId);
 


### PR DESCRIPTION
When there is no workspace open, it's still possible to open and type in
the quick search in workspace widget.  Doing so prints an error in the
console:

Uncaught (in promise) Error: Search failed: no workspace root.
    at SearchInWorkspaceService.<anonymous> (search-in-workspace-service.ts:98)
    at step (search-in-workspace-service.ts:6)
    at Object.next (search-in-workspace-service.ts:6)
    at fulfilled (search-in-workspace-service.ts:6)
    at <anonymous>

This patch makes the command handler conditionally enabled based on
whether there is a workspace root or not.  Therefore, without a
workspace open, the menu entry will be greyed out.

Fixes #1306

Signed-off-by: Simon Marchi <simon.marchi@polymtl.ca>