### PR TITLE
Changed `Modifier` to `KeyModifier` and each enum member to its key

### DIFF
--- a/doc/Commands_Keybindings.md
+++ b/doc/Commands_Keybindings.md
@@ -95,9 +95,9 @@ With the `id`, the only other mandatory parameter is the `keycode`, which is bas
 
 **keys.ts**
 ```typescript
-export declare type Keystroke = { first: Key, modifiers?: Modifier[] };
+export declare type Keystroke = { first: Key, modifiers?: KeyModifier[] };
 ```
-Modifiers are platform independent, so `Modifier.M1` is Command on OS X and CTRL on Windows/Linux. Key string constants are defined in `keys.ts`
+Modifiers are platform independent, so `KeyModifier.CtrlCmd` is Command on OS X and CTRL on Windows/Linux. Key string constants are defined in `keys.ts`
 
 ### Binding the contribution to KeybindingContribution
 

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -15,7 +15,7 @@ import {
     KeybindingRegistry, KeybindingContext, KeybindingContextRegistry,
     Keybinding, KeybindingContribution, KeybindingScope
 } from './keybinding';
-import { KeyCode, Key, Modifier, KeySequence, EasyKey } from './keys';
+import { KeyCode, Key, KeyModifier, KeySequence, EasyKey } from './keys';
 import { CommandRegistry, CommandService, CommandContribution, Command } from '../common/command';
 import { LabelParser } from './label-parser';
 import { MockLogger } from '../common/test/mock-logger';
@@ -198,17 +198,17 @@ describe('keybindings', () => {
             keybinding: "ctrl+c"
         }];
 
-        const validKeyCode = KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] });
+        const validKeyCode = KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] });
 
         keybindingRegistry.setKeymap(KeybindingScope.WORKSPACE, keybindingsSpecific);
 
-        let bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] })]).full;
+        let bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.CtrlCmd] })]).full;
         expect(bindings).to.be.empty;
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [Modifier.M1] })]).full;
+        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_B, modifiers: [KeyModifier.CtrlCmd] })]).full;
         expect(bindings).to.be.empty;
 
-        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] })]).full;
+        bindings = keybindingRegistry.getKeybindingsForKeySequence([KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] })]).full;
         const keyCode = KeyCode.parse(bindings[0].keybinding);
         expect(keyCode.key).to.be.equal(validKeyCode.key);
     });
@@ -222,7 +222,7 @@ describe('keybindings', () => {
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindingsUser);
 
         const validKeyCodes = [];
-        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] }));
         validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_T }));
 
         const bindings = keybindingRegistry.getKeybindingsForKeySequence(KeySequence.parse("ctrlcmd+x"));
@@ -317,14 +317,14 @@ describe("keys api", () => {
 
     it("it should serialize a keycode properly with BACKQUOTE + M1", () => {
         stub = sinon.stub(os, 'isOSX').value(true);
-        let keyCode = KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] });
+        let keyCode = KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [KeyModifier.CtrlCmd] });
         let keyCodeString = keyCode.toString();
         expect(keyCodeString).to.be.equal("meta+`");
         let parsedKeyCode = KeyCode.parse(keyCodeString);
         expect(KeyCode.equals(parsedKeyCode, keyCode)).to.be.true;
 
         stub = sinon.stub(os, 'isOSX').value(false);
-        keyCode = KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [Modifier.M1] });
+        keyCode = KeyCode.createKeyCode({ first: Key.BACKQUOTE, modifiers: [KeyModifier.CtrlCmd] });
         keyCodeString = keyCode.toString();
         expect(keyCodeString).to.be.equal("ctrl+`");
         parsedKeyCode = KeyCode.parse(keyCodeString);
@@ -332,7 +332,7 @@ describe("keys api", () => {
     });
 
     it("it should serialize a keycode properly with a + M2 + M3", () => {
-        const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M2, Modifier.M3] });
+        const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Shift, KeyModifier.Alt] });
         const keyCodeString = keyCode.toString();
         expect(keyCodeString).to.be.equal("shift+alt+a");
         const parsedKeyCode = KeyCode.parse(keyCodeString);
@@ -344,11 +344,19 @@ describe("keys api", () => {
         const right = KeySequence.parse("alt+shift+a");
         expect(KeySequence.compare(left, right)).to.be.equal(KeySequence.CompareResult.FULL);
 
-        expect(KeySequence.compare([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M3, Modifier.M2] })], right)).to.be.equal(KeySequence.CompareResult.FULL);
-        expect(KeySequence.compare(left, [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M3, Modifier.M2] })])).to.be.equal(KeySequence.CompareResult.FULL);
+        expect(KeySequence.compare(
+            [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Alt, KeyModifier.Shift] })], right)).to.be.equal(
+                KeySequence.CompareResult.FULL);
+        expect(KeySequence.compare(
+            left, [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Alt, KeyModifier.Shift] })])).to.be.equal(
+                KeySequence.CompareResult.FULL);
 
-        expect(KeySequence.compare([KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M2, Modifier.M3] })], right)).to.be.equal(KeySequence.CompareResult.FULL);
-        expect(KeySequence.compare(left, [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M2, Modifier.M3] })])).to.be.equal(KeySequence.CompareResult.FULL);
+        expect(KeySequence.compare(
+            [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Shift, KeyModifier.Alt] })], right)).to.be.equal(
+                KeySequence.CompareResult.FULL);
+        expect(KeySequence.compare(
+            left, [KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.Shift, KeyModifier.Alt] })])).to.be.equal(
+                KeySequence.CompareResult.FULL);
     });
 
     it("it should parse ctrl key properly on both OS X and other platforms", () => {
@@ -365,7 +373,7 @@ describe("keys api", () => {
 
     it("it should serialize a keycode properly with a + M4", () => {
         stub = sinon.stub(os, 'isOSX').value(true);
-        const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M4] });
+        const keyCode = KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.MacCtrl] });
         const keyCodeString = keyCode.toString();
         expect(keyCodeString).to.be.equal("ctrl+a");
         const parsedKeyCode = KeyCode.parse(keyCodeString);
@@ -374,8 +382,8 @@ describe("keys api", () => {
 
     it("it should parse a multi keycode keybinding", () => {
         const validKeyCodes = [];
-        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }));
-        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [Modifier.M1, Modifier.M2] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.CtrlCmd] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd, KeyModifier.Shift] }));
 
         const parsedKeyCodes = KeySequence.parse("ctrlcmd+a ctrlcmd+shift+c");
         expect(parsedKeyCodes).to.deep.equal(validKeyCodes);
@@ -383,7 +391,7 @@ describe("keys api", () => {
 
     it("it should parse a multi keycode keybinding with no modifiers", () => {
         const validKeyCodes = [];
-        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [Modifier.M1] }));
+        validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_A, modifiers: [KeyModifier.CtrlCmd] }));
         validKeyCodes.push(KeyCode.createKeyCode({ first: Key.KEY_C }));
 
         const parsedKeyCodes = KeySequence.parse("ctrlcmd+a c");
@@ -420,15 +428,15 @@ describe("keys api", () => {
 
     it("it should be a modifier only", () => {
 
-        const keyCode = KeyCode.createKeyCode({ modifiers: [Modifier.M1] });
-        expect(keyCode).to.be.deep.equal(KeyCode.createKeyCode({ modifiers: [Modifier.M1] }));
+        const keyCode = KeyCode.createKeyCode({ modifiers: [KeyModifier.CtrlCmd] });
+        expect(keyCode).to.be.deep.equal(KeyCode.createKeyCode({ modifiers: [KeyModifier.CtrlCmd] }));
         expect(keyCode.isModifierOnly()).to.be.true;
     });
 
     it("it should be multiple modifiers only", () => {
 
-        const keyCode = KeyCode.createKeyCode({ modifiers: [Modifier.M1, Modifier.M3] });
-        expect(keyCode).to.be.deep.equal(KeyCode.createKeyCode({ modifiers: [Modifier.M1, Modifier.M3] }));
+        const keyCode = KeyCode.createKeyCode({ modifiers: [KeyModifier.CtrlCmd, KeyModifier.Alt] });
+        expect(keyCode).to.be.deep.equal(KeyCode.createKeyCode({ modifiers: [KeyModifier.CtrlCmd, KeyModifier.Alt] }));
         expect(keyCode.isModifierOnly()).to.be.true;
     });
 });

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { KeybindingContribution, KeybindingRegistry, Key, KeyCode, Keystroke, Modifier } from '@theia/core/lib/browser';
+import { KeybindingContribution, KeybindingRegistry, Key, KeyCode, Keystroke, KeyModifier } from '@theia/core/lib/browser';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import { KEY_CODE_MAP } from './monaco-keycode-map';
@@ -62,16 +62,16 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             modifiers: []
         };
         if (keybinding.ctrlKey) {
-            sequence.modifiers!.push(Modifier.M1);
+            sequence.modifiers!.push(KeyModifier.CtrlCmd);
         }
         if (keybinding.shiftKey) {
-            sequence.modifiers!.push(Modifier.M2);
+            sequence.modifiers!.push(KeyModifier.Shift);
         }
         if (keybinding.altKey) {
-            sequence.modifiers!.push(Modifier.M3);
+            sequence.modifiers!.push(KeyModifier.Alt);
         }
         if (keybinding.metaKey) {
-            sequence.modifiers!.push(Modifier.M4);
+            sequence.modifiers!.push(KeyModifier.MacCtrl);
         }
         return KeyCode.createKeyCode(sequence);
     }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -16,7 +16,7 @@ import {
 } from '@theia/core/lib/common';
 import {
     CommonMenus, ApplicationShell, KeybindingContribution, KeyCode, Key,
-    Modifier, KeybindingRegistry, Keybinding, KeybindingContextRegistry,
+    KeyModifier, KeybindingRegistry, Keybinding, KeybindingContextRegistry,
 } from '@theia/core/lib/browser';
 import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions, TerminalWidget } from './terminal-widget';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
@@ -82,7 +82,7 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         const regCtrl = (k: Key) => {
             keybindings.registerKeybindings({
                 command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
-                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.CTRL] }).toString(),
+                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [KeyModifier.CTRL] }).toString(),
                 context: TERMINAL_ACTIVE_CONTEXT,
             });
         };
@@ -92,7 +92,7 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         const regAlt = (k: Key) => {
             keybindings.registerKeybinding({
                 command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
-                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [Modifier.M3] }).toString(),
+                keybinding: KeyCode.createKeyCode({ first: k, modifiers: [KeyModifier.Alt] }).toString(),
                 context: TERMINAL_ACTIVE_CONTEXT,
             });
         };


### PR DESCRIPTION
This is my attempt at fixing #458

Re-opened a new pull-request pointing to a specific branch, so that I can work on a per-feature basis (seems easier to create a PR on a specific branch rather than playing around in master alone...)

As I could not change the branch used for the PR I recreated this one, it felt cleaner.
(also now that I better know how it works I won't mess up too much the PR logs, sorry)

_(also seems like I could have used the `user/branch` notation, still learning)_