### PR TITLE
Add dirty diff decorations to the editor 

### DIFF
--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -146,6 +146,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-disabled-color2: var(--md-blue-grey-200);
   --theia-disabled-color3: var(--md-blue-grey-50);
 
+  --theia-added-color0: rgba(0, 255, 0, 0.8);
+  --theia-removed-color0: rgba(230, 0, 0, 0.8);
+  --theia-modified-color0: rgba(0, 100, 150, 0.8);
+
   /* icons */
   --theia-icon-close: url(../icons/close-bright.svg);
   --theia-sprite-y-offset: 0px;

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -146,6 +146,10 @@ all of MD as it is not optimized for dense, information rich UIs.
   --theia-disabled-color2: var(--md-blue-grey-300);
   --theia-disabled-color3: var(--md-blue-grey-100);
 
+  --theia-added-color0: rgba(0, 255, 0, 0.8);
+  --theia-removed-color0: rgba(230, 0, 0, 0.8);
+  --theia-modified-color0: rgba(0, 100, 150, 0.8);
+
   /* icons */
   --theia-icon-close: url(../icons/close-dark.svg);
   --theia-sprite-y-offset: -20px;

--- a/packages/core/src/common/reference.spec.ts
+++ b/packages/core/src/common/reference.spec.ts
@@ -20,14 +20,17 @@ describe('reference', () => {
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), []);
 
         const reference = await references.acquire("a");
         assert.ok(references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), ["a"]);
 
         reference.dispose();
         assert.ok(!references.has("a"));
         assert.ok(expectation.disposed);
+        assert.deepEqual(references.keys(), []);
     });
 
     it('dispose 2 references', async () => {
@@ -39,19 +42,23 @@ describe('reference', () => {
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), []);
 
         const reference = await references.acquire("a");
         const reference2 = await references.acquire("a");
         assert.ok(references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), ["a"]);
 
         reference.dispose();
         assert.ok(references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), ["a"]);
 
         reference2.dispose();
         assert.ok(!references.has("a"));
         assert.ok(expectation.disposed);
+        assert.deepEqual(references.keys(), []);
     });
 
     it('dispose an object with 2 references', async () => {
@@ -63,15 +70,18 @@ describe('reference', () => {
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), []);
 
         await references.acquire("a");
         const reference = await references.acquire("a");
         assert.ok(references.has("a"));
         assert.ok(!expectation.disposed);
+        assert.deepEqual(references.keys(), ["a"]);
 
         reference.object.dispose();
         assert.ok(!references.has("a"));
         assert.ok(expectation.disposed);
+        assert.deepEqual(references.keys(), []);
     });
 
 });

--- a/packages/core/src/common/reference.ts
+++ b/packages/core/src/common/reference.ts
@@ -15,6 +15,7 @@ export interface Reference<T> extends Disposable {
 export class ReferenceCollection<K, V extends Disposable> {
 
     protected readonly values = new Map<string, MaybePromise<V>>();
+    protected readonly keyMap = new Map<string, K>();
     protected readonly references = new Map<string, DisposableCollection>();
 
     constructor(protected readonly factory: (key: K) => MaybePromise<V>) { }
@@ -22,6 +23,10 @@ export class ReferenceCollection<K, V extends Disposable> {
     has(args: K): boolean {
         const key = this.toKey(args);
         return this.references.has(key);
+    }
+
+    keys(): K[] {
+        return [...this.keyMap.values()];
     }
 
     async acquire(args: K): Promise<Reference<V>> {
@@ -42,6 +47,7 @@ export class ReferenceCollection<K, V extends Disposable> {
             return existing;
         }
         const value = this.factory(args);
+        this.keyMap.set(key, args);
         this.values.set(key, value);
         return value;
     }
@@ -57,6 +63,7 @@ export class ReferenceCollection<K, V extends Disposable> {
         object.dispose = () => {
             disposeObject();
             this.values.delete(key);
+            this.keyMap.delete(key);
             this.references.delete(key);
             references!.dispose();
         };

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -10,7 +10,7 @@ import * as lsp from 'vscode-languageserver-types';
 import URI from "@theia/core/lib/common/uri";
 import { Event, Disposable } from '@theia/core/lib/common';
 import { Saveable } from '@theia/core/lib/browser';
-import { DecorationOptions } from './editor-decorations-service';
+import { DecorationOptions, DeltaDecoration } from './editor-decorations-service';
 
 export {
     Position, Range
@@ -59,6 +59,12 @@ export interface TextEditor extends Disposable, TextEditorSelection {
      * To remove decorations of a type, pass an empty options array.
      */
     setDecorations(params: SetDecorationParams): void;
+    /**
+     * Directly applies new decorations and removes old decorations.
+     *
+     * @returns identifiers of applied decorations, which can be removed in next call.
+     */
+    deltaDecorations(params: DeltaDecorationParams): string[];
 }
 
 export interface Dimension {
@@ -85,6 +91,12 @@ export interface SetDecorationParams {
     uri: string;
     type: string;
     options: DecorationOptions[];
+}
+
+export interface DeltaDecorationParams {
+    uri: string;
+    oldDecorations: string[];
+    newDecorations: DeltaDecoration[];
 }
 
 export namespace TextEditorSelection {

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -9,11 +9,13 @@
     "@theia/workspace": "^0.3.7",
     "@theia/navigator": "^0.3.7",
     "@types/fs-extra": "^4.0.2",
+    "@types/diff": "^3.2.2",
     "dugite-extra": "0.0.1-alpha.15",
     "find-git-repositories": "^0.1.0",
     "fs-extra": "^4.0.2",
     "ts-md5": "^1.2.2",
-    "octicons": "^7.1.0"
+    "octicons": "^7.1.0",
+    "diff": "^3.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/git/src/browser/dirty-diff/diff-computer.spec.ts
+++ b/packages/git/src/browser/dirty-diff/diff-computer.spec.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as chai from 'chai';
+import { expect } from 'chai';
+chai.use(require('chai-string'));
+
+import { DiffComputer, DirtyDiff } from './diff-computer';
+
+let diffComputer: DiffComputer;
+
+before(() => {
+    diffComputer = new DiffComputer();
+});
+
+// tslint:disable:no-unused-expression
+
+describe("dirty-diff-computer", () => {
+
+    it("remove single line", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "FIRST",
+                "SECOND TO-BE-REMOVED",
+                "THIRD"
+            ],
+            [
+                "FIRST",
+                "THIRD"
+            ],
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            added: [],
+            modified: [],
+            removed: [0],
+        });
+    });
+
+    [1, 2, 3, 20].forEach(lines => {
+        it(`remove ${formatLines(lines)} at the end`, () => {
+            const dirtyDiff = computeDirtyDiff(
+                sequenceOfN(2)
+                    .concat(sequenceOfN(lines, () => "TO-BE-REMOVED")),
+                sequenceOfN(2),
+            );
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [1],
+                added: [],
+            });
+        });
+    });
+
+    it("remove all lines", () => {
+        const dirtyDiff = computeDirtyDiff(
+            sequenceOfN(10, () => "TO-BE-REMOVED"),
+            [""]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            added: [],
+            modified: [],
+            removed: [0],
+        });
+    });
+
+    [1, 2, 3, 20].forEach(lines => {
+        it(`remove ${formatLines(lines)} at the beginning`, () => {
+            const dirtyDiff = computeDirtyDiff(
+                sequenceOfN(lines, () => "TO-BE-REMOVED")
+                    .concat(sequenceOfN(2)),
+                sequenceOfN(2),
+            );
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [0],
+                added: [],
+            });
+        });
+    });
+
+    [1, 2, 3, 20].forEach(lines => {
+        it(`add ${formatLines(lines)}`, () => {
+            const previous = sequenceOfN(3);
+            const modified = insertIntoArray(previous, 2, ...sequenceOfN(lines, () => "ADDED LINE"));
+            const dirtyDiff = computeDirtyDiff(previous, modified);
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [],
+                added: [{ start: 2, end: 2 + lines - 1 }],
+            });
+        });
+    });
+
+    [1, 2, 3, 20].forEach(lines => {
+        it(`add ${formatLines(lines)} at the beginning`, () => {
+            const dirtyDiff = computeDirtyDiff(
+                sequenceOfN(2),
+                sequenceOfN(lines, () => "ADDED LINE")
+                    .concat(sequenceOfN(2))
+            );
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [],
+                added: [{ start: 0, end: lines - 1 }],
+            });
+        });
+    });
+
+    it("add lines to empty file", () => {
+        const numberOfLines = 3;
+        const dirtyDiff = computeDirtyDiff(
+            [""],
+            sequenceOfN(numberOfLines, () => "ADDED LINE")
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            modified: [],
+            removed: [],
+            added: [{ start: 0, end: numberOfLines - 1 }],
+        });
+    });
+
+    it("add empty lines", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "1",
+                "2"
+            ],
+            [
+                "1",
+                "",
+                "",
+                "2"
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            modified: [],
+            removed: [],
+            added: [{ start: 1, end: 2 }],
+        });
+    });
+
+    it("add empty line after single line", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "1"
+            ],
+            [
+                "1",
+                ""
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            modified: [],
+            removed: [],
+            added: [{ start: 1, end: 1 }],
+        });
+    });
+
+    [1, 2, 3, 20].forEach(lines => {
+        it(`add ${formatLines(lines)} (empty) at the end`, () => {
+            const dirtyDiff = computeDirtyDiff(
+                sequenceOfN(2),
+                sequenceOfN(2)
+                    .concat(new Array(lines).map(() => ""))
+            );
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [],
+                added: [{ start: 2, end: 1 + lines }],
+            });
+        });
+    });
+
+    it("add empty and non-empty lines", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "FIRST",
+                "LAST"
+            ],
+            [
+                "FIRST",
+                "1. ADDED",
+                "2. ADDED",
+                "3. ADDED",
+                "4. ADDED",
+                "5. ADDED",
+                "LAST"
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            modified: [],
+            removed: [],
+            added: [{ start: 1, end: 5 }],
+        });
+    });
+
+    [1, 2, 3, 4, 5].forEach(lines => {
+        it(`add ${formatLines(lines)} after single line`, () => {
+            const dirtyDiff = computeDirtyDiff(
+                ["0"],
+                ["0"].concat(sequenceOfN(lines, () => "ADDED LINE"))
+            );
+            expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+                modified: [],
+                removed: [],
+                added: [{ start: 1, end: lines }],
+            });
+        });
+    });
+
+    it("modify single line", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "FIRST",
+                "TO-BE-MODIFIED",
+                "LAST"
+            ],
+            [
+                "FIRST",
+                "MODIFIED",
+                "LAST"
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            removed: [],
+            added: [],
+            modified: [{ start: 1, end: 1 }],
+        });
+    });
+
+    it("modify all lines", () => {
+        const numberOfLines = 10;
+        const dirtyDiff = computeDirtyDiff(
+            sequenceOfN(numberOfLines, () => "TO-BE-MODIFIED"),
+            sequenceOfN(numberOfLines, () => "MODIFIED")
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            removed: [],
+            added: [],
+            modified: [{ start: 0, end: numberOfLines - 1 }],
+        });
+    });
+
+    it("modify lines at the end", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "1",
+                "2",
+                "3",
+                "4"
+            ],
+            [
+                "1",
+                "2-changed",
+                "3-changed"
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            removed: [],
+            added: [],
+            modified: [{ start: 1, end: 2 }],
+        });
+    });
+
+    it("multiple diffs", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "TO-BE-CHANGED",
+                "1",
+                "2",
+                "3",
+                "TO-BE-REMOVED",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9"
+            ],
+            [
+                "CHANGED",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "ADDED",
+                ""
+            ]
+        );
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            removed: [3],
+            added: [{ start: 10, end: 11 }],
+            modified: [{ start: 0, end: 0 }],
+        });
+    });
+
+    it("multiple additions", () => {
+        const dirtyDiff = computeDirtyDiff(
+            [
+                "first line",
+                "",
+                "foo changed on master",
+                "bar changed on master",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "last line"
+            ],
+            [
+                "first line",
+                "",
+                "foo changed on master",
+                "bar changed on master",
+                "",
+                "NEW TEXT",
+                "",
+                "",
+                "",
+                "last line",
+                "",
+                ""
+            ]);
+        expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
+            removed: [11],
+            added: [{ start: 5, end: 5 }, { start: 9, end: 9 }],
+            modified: [],
+        });
+    });
+
+});
+
+function computeDirtyDiff(previous: string[], modified: string[]) {
+    return diffComputer.computeDirtyDiff(previous, modified);
+}
+
+function sequenceOfN(n: number, mapFn: (index: number) => string = i => i.toString()): string[] {
+    return Array.from(new Array(n).keys()).map((value, index) => mapFn(index));
+}
+
+function formatLines(n: number): string {
+    return n + ' line' + (n > 1 ? 's' : '');
+}
+
+function insertIntoArray(target: string[], start: number, ...items: string[]): string[] {
+    const copy = target.slice(0);
+    copy.splice(start, 0, ...items);
+    return copy;
+}

--- a/packages/git/src/browser/dirty-diff/diff-computer.ts
+++ b/packages/git/src/browser/dirty-diff/diff-computer.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as jsdiff from 'diff';
+
+export class DiffComputer {
+
+    computeDiff(previous: string[], current: string[]): DiffResult[] {
+        const diffResult = jsdiff.diffArrays(previous, current);
+        return diffResult;
+    }
+
+    computeDirtyDiff(previous: string[], current: string[]): DirtyDiff {
+        const added: LineRange[] = [];
+        const removed: number[] = [];
+        const modified: LineRange[] = [];
+        const changes = this.computeDiff(previous, current);
+        let lastLine = -1;
+        for (let i = 0; i < changes.length; i++) {
+            const change = changes[i];
+            const next = changes[i + 1];
+            if (change.added) {
+                // case: addition
+                const start = lastLine + 1;
+                const end = lastLine + change.count!;
+                added.push(<LineRange>{ start, end });
+                lastLine = end;
+            } else if (change.removed && next && next.added) {
+                const isFirstChange = i === 0;
+                const isLastChange = i === changes.length - 2;
+                const isNextEmptyLine = next.value.length === 1 && next.value[0].length === 0;
+                const isPrevEmptyLine = change.value.length === 1 && change.value[0].length === 0;
+
+                if (isFirstChange && isNextEmptyLine) {
+                    // special case: removing at the beginning
+                    removed.push(0);
+                } else if (isFirstChange && isPrevEmptyLine) {
+                    // special case: adding at the beginning
+                    const start = 0;
+                    const end = next.count! - 1;
+                    added.push(<LineRange>{ start, end });
+                    lastLine = end;
+                } else if (isLastChange && isNextEmptyLine) {
+                    removed.push(lastLine + 1 /* = empty line */);
+                } else {
+                    // default case is a modification
+                    const start = lastLine + 1;
+                    const end = lastLine + next.count!;
+                    modified.push(<LineRange>{ start, end });
+                    lastLine = end;
+                }
+                i++; // consume next eagerly
+            } else if (change.removed && !(next && next.added)) {
+                removed.push(Math.max(0, lastLine));
+            } else {
+                lastLine += change.count!;
+            }
+        }
+        return <DirtyDiff>{ added, removed, modified };
+    }
+
+}
+
+export interface DiffResult extends jsdiff.IArrayDiffResult { }
+
+export interface DirtyDiff {
+    /**
+     * Lines added by comparision to previous revision.
+     */
+    readonly added: LineRange[];
+    /**
+     * Lines, after which lines were removed by comparison to previous revision.
+     */
+    readonly removed: number[];
+    /**
+     * Lines modified by comparison to previous revision.
+     */
+    readonly modified: LineRange[];
+}
+
+export interface LineRange {
+    start: number;
+    end: number;
+}

--- a/packages/git/src/browser/dirty-diff/dirty-diff-contribution.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-contribution.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { inject, injectable } from 'inversify';
+import { FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser";
+import { DirtyDiffManager } from './dirty-diff-manager';
+import { DirtyDiffDecorator } from './dirty-diff-decorator';
+
+@injectable()
+export class DirtyDiffContribution implements FrontendApplicationContribution {
+
+    constructor(
+        @inject(DirtyDiffManager) protected readonly dirtyDiffManager: DirtyDiffManager,
+        @inject(DirtyDiffDecorator) protected readonly dirtyDiffDecorator: DirtyDiffDecorator,
+    ) { }
+
+    onStart(app: FrontendApplication): void {
+        this.dirtyDiffManager.onDirtyDiffUpdate(update => this.dirtyDiffDecorator.applyDecorations(update));
+    }
+
+}

--- a/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { inject, injectable } from 'inversify';
+import {
+    EditorManager, EditorDecorationsService, Range, Position, DeltaDecoration,
+    ModelDecorationOptions, OverviewRulerLane
+} from '@theia/editor/lib/browser';
+import { DirtyDiffUpdate } from './dirty-diff-manager';
+import { LineRange } from './diff-computer';
+
+export enum DirtyDiffDecorationType {
+    AddedLine = 'dirty-diff-added-line',
+    RemovedLine = 'dirty-diff-removed-line',
+    ModifiedLine = 'dirty-diff-modified-line',
+}
+
+const AddedLineDecoration = <ModelDecorationOptions>{
+    linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-added-line',
+    overviewRuler: {
+        color: 'rgba(0, 255, 0, 0.8)',
+        position: OverviewRulerLane.Left,
+    }
+};
+
+const RemovedLineDecoration = <ModelDecorationOptions>{
+    linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-removed-line',
+    overviewRuler: {
+        color: 'rgba(230, 0, 0, 0.8)',
+        position: OverviewRulerLane.Left,
+    }
+};
+
+const ModifiedLineDecoration = <ModelDecorationOptions>{
+    linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-modified-line',
+    overviewRuler: {
+        color: 'rgba(0, 100, 150, 0.8)',
+        position: OverviewRulerLane.Left,
+    }
+};
+
+@injectable()
+export class DirtyDiffDecorator {
+
+    constructor(
+        @inject(EditorManager) protected readonly editorManager: EditorManager,
+        @inject(EditorDecorationsService) protected readonly editorDecorationsService: EditorDecorationsService,
+    ) { }
+
+    applyDecorations(update: DirtyDiffUpdate): void {
+        const modifications = update.modified.map(range => this.toDeltaDecoration(range, ModifiedLineDecoration));
+        const additions = update.added.map(range => this.toDeltaDecoration(range, AddedLineDecoration));
+        const removals = update.removed.map(line => this.toDeltaDecoration(line, RemovedLineDecoration));
+        const decorations = [...modifications, ...additions, ...removals];
+        this.setDecorations(update.uri, decorations);
+    }
+
+    protected appliedDecorations = new Map<string, string[]>();
+
+    protected async setDecorations(uri: string, newDecorations: DeltaDecoration[]) {
+        const oldDecorations = this.appliedDecorations.get(uri) || [];
+        const decorationIds = await this.editorDecorationsService.deltaDecorations({ uri, oldDecorations, newDecorations });
+        this.appliedDecorations.set(uri, decorationIds || []);
+    }
+
+    protected toDeltaDecoration(from: LineRange | number, options: ModelDecorationOptions): DeltaDecoration {
+        const [start, end] = (typeof from === 'number') ? [from, from] : [from.start, from.end];
+        const range = Range.create(Position.create(start, 0), Position.create(end, 0));
+        return { range, options };
+    }
+}

--- a/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
+import { Workspace } from '@theia/languages/lib/common';
+import URI from '@theia/core/lib/common/uri';
+import { DiffComputer, DirtyDiff } from './diff-computer';
+import { Emitter, Event, Disposable, ReferenceCollection } from '@theia/core';
+import { GitPreferences, GitConfiguration } from '../git-preferences';
+import { PreferenceChangeEvent } from '@theia/core/lib/browser';
+import { GitResourceResolver, GIT_RESOURCE_SCHEME } from '../git-resource';
+import { WorkingDirectoryStatus, GitFileStatus, GitFileChange, Repository } from '../../common';
+import { GitRepositoryTracker } from '../git-repository-tracker';
+
+@injectable()
+export class DirtyDiffManager {
+
+    protected readonly models = new ReferenceCollection<string, DirtyDiffModel>(
+        uri => this.createNewModel(uri)
+    );
+
+    protected readonly onDirtyDiffUpdateEmitter = new Emitter<DirtyDiffUpdate>();
+    readonly onDirtyDiffUpdate: Event<DirtyDiffUpdate> = this.onDirtyDiffUpdateEmitter.event;
+
+    @inject(GitRepositoryTracker) protected readonly repositoryTracker: GitRepositoryTracker;
+    @inject(GitResourceResolver) protected readonly gitResourceResolver: GitResourceResolver;
+
+    @inject(EditorManager) protected readonly editorManager: EditorManager;
+
+    @inject(Workspace) protected readonly workspace: Workspace;
+    @inject(GitPreferences) protected readonly preferences: GitPreferences;
+
+    @postConstruct()
+    protected async initialize() {
+        this.workspace.onDidChangeTextDocument(async params => await this.handleDocumentChanged(params.textDocument.uri));
+        this.preferences.onPreferenceChanged(async e => await this.handlePreferenceChange(e));
+        this.editorManager.onCreated(async e => await this.handleEditorCreated(e));
+        this.repositoryTracker.onGitEvent(async event => await this.handleGitStatusUpdate(event.source, event.status));
+        const gitStatus = this.repositoryTracker.selectedRepositoryStatus;
+        const repository = this.repositoryTracker.selectedRepository;
+        if (gitStatus && repository) {
+            await this.handleGitStatusUpdate(repository, gitStatus);
+        }
+    }
+
+    protected async handleEditorCreated(editorWidget: EditorWidget): Promise<void> {
+        const editor = editorWidget.editor;
+        const uri = editor.document.uri;
+        const reference = await this.models.acquire(uri);
+        editorWidget.disposed.connect(() => reference.dispose());
+        const model = reference.object;
+        const gitStatus = this.repositoryTracker.selectedRepositoryStatus;
+        const repository = this.repositoryTracker.selectedRepository;
+        if (gitStatus && repository) {
+            const changes = gitStatus.changes.filter(c => c.uri === uri);
+            await model.handleGitStatusUpdate(repository, changes);
+        }
+        model.handleDocumentChanged(editor.document.getText());
+    }
+
+    protected createNewModel(uri: string): DirtyDiffModel {
+        const model = new DirtyDiffModel(uri, async gitUri => await this.readGitResourceContents(gitUri));
+        model.onDirtyDiffUpdate(e => this.onDirtyDiffUpdateEmitter.fire(e));
+        model.enabled = this.isEnabled();
+        return model;
+    }
+
+    protected async readGitResourceContents(uri: URI): Promise<string> {
+        const gitResource = await this.gitResourceResolver.getResource(uri);
+        return gitResource.readContents();
+    }
+
+    protected async handleDocumentChanged(uri: string): Promise<void> {
+        const model = await this.getModel(uri);
+        if (model) {
+            const document = this.workspace.textDocuments.find(d => d.uri === uri);
+            if (document) {
+                model.handleDocumentChanged(document.getText());
+            }
+        }
+    }
+
+    protected async handleGitStatusUpdate(repository: Repository, status: WorkingDirectoryStatus): Promise<void> {
+        const uris = new Set(this.models.keys());
+        const relevantChanges = status.changes.filter(c => uris.has(c.uri));
+        const models = await this.allModels();
+        for (const model of models) {
+            const uri = model.uri;
+            const changes = relevantChanges.filter(c => c.uri === uri);
+            await model.handleGitStatusUpdate(repository, changes);
+        }
+    }
+
+    protected isEnabled(): boolean {
+        return this.preferences["git.editor.decorations.enabled"];
+    }
+
+    protected async handlePreferenceChange(event: PreferenceChangeEvent<GitConfiguration>): Promise<void> {
+        const { preferenceName, newValue } = event;
+        if (preferenceName === "git.editor.decorations.enabled") {
+            const enabled = !!newValue;
+            const models = await this.allModels();
+            for (const model of models) {
+                model.enabled = enabled;
+                model.update();
+            }
+        }
+    }
+
+    protected async allModels(): Promise<DirtyDiffModel[]> {
+        const models = [];
+        const uris = this.models.keys();
+        for (const uri of uris) {
+            const reference = await this.models.acquire(uri);
+            models.push(reference.object);
+            reference.dispose();
+        }
+        return models;
+    }
+
+    protected async getModel(uri: string): Promise<DirtyDiffModel | undefined> {
+        if (this.models.has(uri)) {
+            const reference = await this.models.acquire(uri);
+            const model = reference.object;
+            reference.dispose();
+            return model;
+        }
+        return undefined;
+    }
+
+}
+
+export interface DirtyDiffUpdate extends DirtyDiff {
+    readonly uri: string;
+}
+
+export class DirtyDiffModel implements Disposable {
+
+    enabled = true;
+
+    protected dirty = true;
+    protected staged: boolean;
+    protected previousContent: string[];
+    protected currentContent: string[];
+
+    protected readonly onDirtyDiffUpdateEmitter = new Emitter<DirtyDiffUpdate>();
+    readonly onDirtyDiffUpdate: Event<DirtyDiffUpdate> = this.onDirtyDiffUpdateEmitter.event;
+    protected readonly updateDelayer = new DirtyDiffModel.Throttler(200);
+
+    constructor(
+        readonly uri: string,
+        protected readonly readGitResource: DirtyDiffModel.GitResourceReader
+    ) { }
+
+    update(): void {
+        const enabled = this.enabled && this.dirty;
+        const previous = enabled ? this.previousContent : [];
+        const current = enabled ? this.currentContent : [];
+        if (!previous || !current) {
+            return;
+        }
+        const uri = this.uri;
+        this.updateDelayer.push(() => {
+            const dirtyDiff = enabled
+                ? DirtyDiffModel.computeDirtyDiff(previous, current)
+                : <DirtyDiff>{ added: [], removed: [], modified: [] };
+            const dirtyDiffUpdate = <DirtyDiffUpdate>{ uri, ...dirtyDiff };
+            this.onDirtyDiffUpdateEmitter.fire(dirtyDiffUpdate);
+        });
+    }
+
+    handleDocumentChanged(documentContent: string): void {
+        this.currentContent = DirtyDiffModel.splitLines(documentContent);
+        this.update();
+    }
+
+    async handleGitStatusUpdate(repository: Repository, relevantChanges: GitFileChange[]): Promise<void> {
+        const noRelevantChanges = relevantChanges.length === 0;
+        const isNewAndStaged = relevantChanges.some(c => c.status === GitFileStatus.New && !!c.staged);
+        const isNewAndUnstaged = relevantChanges.some(c => c.status === GitFileStatus.New && !c.staged);
+        const modifiedChange = relevantChanges.find(c => c.status === GitFileStatus.Modified);
+        const isModified = !!modifiedChange;
+        if (isModified || isNewAndStaged) {
+            this.dirty = true;
+            this.staged = isNewAndStaged || modifiedChange!.staged || false;
+            try {
+                this.previousContent = await this.getPreviousRevision();
+            } catch {
+                this.dirty = false;
+                this.previousContent = [];
+            }
+        }
+        if (isNewAndUnstaged && !isNewAndStaged) {
+            this.dirty = false;
+            this.previousContent = [];
+        }
+        if (noRelevantChanges && this.isInGitRepository(repository)) {
+            try {
+                this.previousContent = await this.getPreviousRevision();
+            } catch { }
+        }
+        this.update();
+    }
+
+    protected isInGitRepository(repository: Repository): boolean {
+        const modelUri = new URI(this.uri).withoutScheme().toString();
+        const repoUri = new URI(repository.localUri).withoutScheme().toString();
+        return modelUri.startsWith(repoUri);
+    }
+
+    protected async getPreviousRevision(): Promise<string[]> {
+        const query = this.staged ? "" : "HEAD";
+        const uri = new URI(this.uri).withScheme(GIT_RESOURCE_SCHEME).withQuery(query);
+        const contents = await this.readGitResource(uri);
+        return DirtyDiffModel.splitLines(contents);
+    }
+
+    dispose(): void {
+        this.onDirtyDiffUpdateEmitter.dispose();
+    }
+}
+
+export namespace DirtyDiffModel {
+
+    const diffComputer = new DiffComputer();
+
+    export function computeDirtyDiff(previous: string[], current: string[]): DirtyDiff {
+        return diffComputer.computeDirtyDiff(previous, current);
+    }
+
+    export function splitLines(text: string): string[] {
+        return text.split(/\r\n|\n/);
+    }
+
+    export interface GitResourceReader {
+        (uri: URI): Promise<string>;
+    }
+
+    export class Throttler {
+
+        protected lastTask: () => void;
+        protected timeout: number | undefined;
+
+        constructor(protected readonly delay: number) { }
+
+        push(task: () => void): void {
+            this.lastTask = task;
+            if (!this.timeout) {
+                this.timeout = window.setTimeout(() => {
+                    this.timeout = undefined;
+                    this.lastTask();
+                }, this.delay);
+            }
+        }
+
+    }
+
+}

--- a/packages/git/src/browser/dirty-diff/dirty-diff-module.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-module.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces } from 'inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { DirtyDiffContribution } from './dirty-diff-contribution';
+import { DirtyDiffManager } from './dirty-diff-manager';
+import { DirtyDiffDecorator } from './dirty-diff-decorator';
+
+import '../../../src/browser/style/dirty-diff.css';
+
+export function bindDirtyDiff(bind: interfaces.Bind) {
+    bind(DirtyDiffManager).toSelf().inSingletonScope();
+    bind(DirtyDiffContribution).toSelf().inSingletonScope();
+    bind(DirtyDiffDecorator).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(DirtyDiffContribution);
+}

--- a/packages/git/src/browser/git-decorator.ts
+++ b/packages/git/src/browser/git-decorator.ts
@@ -19,7 +19,7 @@ import { GitWatcher } from '../common/git-watcher';
 import { WorkingDirectoryStatus } from '../common/git-model';
 import { GitRepositoryProvider } from './git-repository-provider';
 import { GitFileChange, GitFileStatus } from '../common/git-model';
-import { GitDecorationsPreferences, GitDecorationsConfiguration } from './git-decorator-preferences';
+import { GitPreferences, GitConfiguration } from './git-preferences';
 
 @injectable()
 export class GitDecorator implements TreeDecorator {
@@ -36,7 +36,7 @@ export class GitDecorator implements TreeDecorator {
         @inject(Git) protected readonly git: Git,
         @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
         @inject(GitWatcher) protected readonly watcher: GitWatcher,
-        @inject(GitDecorationsPreferences) protected readonly preferences: GitDecorationsPreferences,
+        @inject(GitPreferences) protected readonly preferences: GitPreferences,
         @inject(ILogger) protected readonly logger: ILogger) {
         this.emitter = new Emitter();
         this.toDispose = new DisposableCollection();
@@ -155,7 +155,7 @@ export class GitDecorator implements TreeDecorator {
         }
     }
 
-    protected async handlePreferenceChange(event: PreferenceChangeEvent<GitDecorationsConfiguration>): Promise<void> {
+    protected async handlePreferenceChange(event: PreferenceChangeEvent<GitConfiguration>): Promise<void> {
         let refresh = false;
         const { preferenceName, newValue } = event;
         if (preferenceName === 'git.decorations.enabled') {

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -25,6 +25,7 @@ import { GitUriLabelProviderContribution } from './git-uri-label-contribution';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser/navigator-decorator-service';
 import { GitDecorator } from './git-decorator';
 import { bindGitDecorationsPreferences } from './git-decorator-preferences';
+import { GitRepositoryTracker } from './git-repository-tracker';
 
 import '../../src/browser/style/index.css';
 
@@ -32,6 +33,7 @@ export default new ContainerModule(bind => {
     bindGitDecorationsPreferences(bind);
     bindGitDiffModule(bind);
     bindGitHistoryModule(bind);
+    bind(GitRepositoryTracker).toSelf().inSingletonScope();
     bind(GitWatcherServerProxy).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, GitWatcherPath)).inSingletonScope();
     bind(GitWatcherServer).to(ReconnectingGitWatcherServer).inSingletonScope();
     bind(GitWatcher).toSelf().inSingletonScope();

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -24,15 +24,17 @@ import { LabelProviderContribution } from '@theia/core/lib/browser/label-provide
 import { GitUriLabelProviderContribution } from './git-uri-label-contribution';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser/navigator-decorator-service';
 import { GitDecorator } from './git-decorator';
-import { bindGitDecorationsPreferences } from './git-decorator-preferences';
+import { bindGitPreferences } from './git-preferences';
+import { bindDirtyDiff } from './dirty-diff/dirty-diff-module';
 import { GitRepositoryTracker } from './git-repository-tracker';
 
 import '../../src/browser/style/index.css';
 
 export default new ContainerModule(bind => {
-    bindGitDecorationsPreferences(bind);
+    bindGitPreferences(bind);
     bindGitDiffModule(bind);
     bindGitHistoryModule(bind);
+    bindDirtyDiff(bind);
     bind(GitRepositoryTracker).toSelf().inSingletonScope();
     bind(GitWatcherServerProxy).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, GitWatcherPath)).inSingletonScope();
     bind(GitWatcherServer).to(ReconnectingGitWatcherServer).inSingletonScope();

--- a/packages/git/src/browser/git-preferences.ts
+++ b/packages/git/src/browser/git-preferences.ts
@@ -8,7 +8,7 @@
 import { interfaces } from 'inversify';
 import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
 
-export const GitDecorationsConfigSchema: PreferenceSchema = {
+export const GitConfigSchema: PreferenceSchema = {
     'type': 'object',
     'properties': {
         'git.decorations.enabled': {
@@ -21,25 +21,31 @@ export const GitDecorationsConfigSchema: PreferenceSchema = {
             'description': 'Use color decoration in the navigator.',
             'default': false
         },
+        'git.editor.decorations.enabled': {
+            'type': 'boolean',
+            'description': 'Show git decorations in the editor.',
+            'default': true
+        }
     }
 };
 
-export interface GitDecorationsConfiguration {
+export interface GitConfiguration {
     'git.decorations.enabled': boolean,
-    'git.decorations.colors': boolean
+    'git.decorations.colors': boolean,
+    'git.editor.decorations.enabled': boolean,
 }
 
-export const GitDecorationsPreferences = Symbol('GitDecorationsPreferences');
-export type GitDecorationsPreferences = PreferenceProxy<GitDecorationsConfiguration>;
+export const GitPreferences = Symbol('GitPreferences');
+export type GitPreferences = PreferenceProxy<GitConfiguration>;
 
-export function createGitDecorationsPreferences(preferences: PreferenceService): GitDecorationsPreferences {
-    return createPreferenceProxy(preferences, GitDecorationsConfigSchema);
+export function createGitPreferences(preferences: PreferenceService): GitPreferences {
+    return createPreferenceProxy(preferences, GitConfigSchema);
 }
 
-export function bindGitDecorationsPreferences(bind: interfaces.Bind): void {
-    bind(GitDecorationsPreferences).toDynamicValue(ctx => {
+export function bindGitPreferences(bind: interfaces.Bind): void {
+    bind(GitPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createGitDecorationsPreferences(preferences);
+        return createGitPreferences(preferences);
     });
-    bind(PreferenceContribution).toConstantValue({ schema: GitDecorationsConfigSchema });
+    bind(PreferenceContribution).toConstantValue({ schema: GitConfigSchema });
 }

--- a/packages/git/src/browser/git-repository-tracker.ts
+++ b/packages/git/src/browser/git-repository-tracker.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, postConstruct } from "inversify";
+import { Git, Repository, WorkingDirectoryStatus } from '../common';
+import { Event, Emitter, DisposableCollection } from "@theia/core";
+import { GitRepositoryProvider } from './git-repository-provider';
+import { GitWatcher, GitStatusChangeEvent } from "../common/git-watcher";
+
+/**
+ * The repository tracker watches the selected repository for status changes. It provides a convenient way to listen on status updates.
+ */
+@injectable()
+export class GitRepositoryTracker {
+
+    protected toDispose = new DisposableCollection();
+    protected workingDirectoryStatus: WorkingDirectoryStatus | undefined;
+    protected readonly onGitEventEmitter = new Emitter<GitStatusChangeEvent>();
+
+    constructor(
+        @inject(Git) protected readonly git: Git,
+        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
+        @inject(GitWatcher) protected readonly gitWatcher: GitWatcher,
+    ) { }
+
+    @postConstruct()
+    protected async init() {
+        this.repositoryProvider.onDidChangeRepository(async repository => {
+            this.workingDirectoryStatus = undefined;
+            this.toDispose.dispose();
+            if (repository) {
+                this.toDispose.push(await this.gitWatcher.watchGitChanges(repository));
+                this.toDispose.push(this.gitWatcher.onGitEvent((event: GitStatusChangeEvent) => {
+                    this.workingDirectoryStatus = event.status;
+                    this.onGitEventEmitter.fire(event);
+                }));
+                this.workingDirectoryStatus = await this.git.status(repository);
+            }
+        });
+        if (this.repositoryProvider.allRepositories.length === 0) {
+            await this.repositoryProvider.refresh();
+        }
+        if (this.selectedRepository) {
+            this.workingDirectoryStatus = await this.git.status(this.selectedRepository);
+        }
+    }
+
+    /**
+     * Returns the selected repository, or `undefined` if no repositories are available.
+     */
+    get selectedRepository(): Repository | undefined {
+        return this.repositoryProvider.selectedRepository;
+    }
+
+    /**
+     * Returns all known repositories.
+     */
+    get allRepositories(): Repository[] {
+        return this.repositoryProvider.allRepositories;
+    }
+
+    /**
+     * Returns the last known status of the selected respository, or `undefined` if no repositories are available.
+     */
+    get selectedRepositoryStatus(): WorkingDirectoryStatus | undefined {
+        return this.workingDirectoryStatus;
+    }
+
+    /**
+     * Emits when the selected repository has changed.
+     */
+    get onDidChangeRepository(): Event<Repository | undefined> {
+        return this.repositoryProvider.onDidChangeRepository;
+    }
+
+    /**
+     * Emits when status has changed in the selected repository.
+     */
+    get onGitEvent(): Event<GitStatusChangeEvent> {
+        return this.onGitEventEmitter.event;
+    }
+
+}

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -4,8 +4,8 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
- 
- .theia-git {
+
+.theia-git {
     color: var(--theia-ui-font-color1);
 }
 

--- a/packages/git/src/browser/style/dirty-diff-decorator.css
+++ b/packages/git/src/browser/style/dirty-diff-decorator.css
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.dirty-diff-glyph {
+	margin-left: 5px;
+	cursor: pointer;
+}
+
+.dirty-diff-removed-line:after {
+	content: '';
+	position: absolute;
+	bottom: -4px;
+	box-sizing: border-box;
+	width: 4px;
+	height: 0;
+	z-index: 9;
+	border-top: 4px solid transparent;
+	border-bottom: 4px solid transparent;
+	transition: border-top-width 80ms linear, border-bottom-width 80ms linear, bottom 80ms linear;
+}
+
+.dirty-diff-glyph:before {
+	position: absolute;
+	content: '';
+	height: 100%;
+	width: 0;
+	left: -2px;
+	transition: width 80ms linear, left 80ms linear;
+}
+
+.dirty-diff-removed-line:before {
+	margin-left: 3px;
+	height: 0;
+	bottom: 0;
+	transition: height 80ms linear;
+}
+
+.margin-view-overlays > div:hover > .dirty-diff-glyph:before {
+	position: absolute;
+	content: '';
+	height: 100%;
+	width: 9px;
+	left: -6px;
+}
+
+.margin-view-overlays > div:hover > .dirty-diff-removed-line:after {
+	bottom: 0;
+	border-top-width: 0;
+	border-bottom-width: 0;
+}

--- a/packages/git/src/browser/style/dirty-diff.css
+++ b/packages/git/src/browser/style/dirty-diff.css
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@import 'dirty-diff-decorator.css';
+
+.dirty-diff-added-line {
+	border-left: 3px solid var(--theia-added-color0);
+}
+.dirty-diff-added-line:before {
+	background: var(--theia-added-color0);
+}
+
+.dirty-diff-removed-line:after {
+	border-left: 4px solid var(--theia-removed-color0);
+}
+.dirty-diff-removed-line:before {
+	background: var(--theia-removed-color0);
+}
+
+.dirty-diff-modified-line {
+	border-left: 3px solid var(--theia-modified-color0);
+}
+.dirty-diff-modified-line:before {
+	background: var(--theia-modified-color0);
+}

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
- 
+
 .theia-git .commitListContainer .commitList .commitListElement {
     margin: 3px 0;
 }

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/git/src/typings/diff/index.d.ts
+++ b/packages/git/src/typings/diff/index.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/// <reference types='diff'/>
+
+declare module "mod" {
+    module "diff" {
+        function diffArrays(a: string[], b: string[]): IDiffArraysResult[];
+
+        interface IArrayDiffResult {
+            value: string[];
+            count?: number;
+            added?: boolean;
+            removed?: boolean;
+        }
+    }
+}

--- a/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { EditorDecorationsService, OverviewRulerLane, Range, DecorationType, EditorDecorationTypeProvider } from "@theia/editor/lib/browser";
+import { EditorDecorationsService, OverviewRulerLane, Range, DecorationType, EditorDecorationTypeProvider, DecorationOptions } from "@theia/editor/lib/browser";
 import { MergeConflictUpdateParams } from "./merge-conflicts-service";
 
 export enum MergeConflictsDecorationType {
@@ -38,8 +38,10 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
                 type: Type.CurrentContent,
                 backgroundColor: 'rgba(0, 255, 0, 0.3)',
                 isWholeLine: true,
-                overviewRulerColor: 'rgba(0, 255, 0, 0.3)',
-                overviewRulerLane: OverviewRulerLane.Full
+                overviewRuler: {
+                    position: OverviewRulerLane.Full,
+                    color: 'rgba(0, 255, 0, 0.3)',
+                }
             },
             {
                 type: Type.BaseMarker,
@@ -50,8 +52,10 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
                 type: Type.BaseContent,
                 backgroundColor: 'rgba(125, 125, 125, 0.3)',
                 isWholeLine: true,
-                overviewRulerColor: 'rgba(125, 125, 125, 0.3)',
-                overviewRulerLane: OverviewRulerLane.Full
+                overviewRuler: {
+                    position: OverviewRulerLane.Full,
+                    color: 'rgba(125, 125, 125, 0.3)',
+                }
             },
             {
                 type: Type.IncomingMarker,
@@ -62,8 +66,10 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
                 type: Type.IncomingContent,
                 backgroundColor: 'rgba(0, 0, 255, 0.3)',
                 isWholeLine: true,
-                overviewRulerColor: 'rgba(0, 0, 255, 0.3)',
-                overviewRulerLane: OverviewRulerLane.Full
+                overviewRuler: {
+                    position: OverviewRulerLane.Full,
+                    color: 'rgba(0, 0, 255, 0.3)',
+                }
             }
         ];
     }
@@ -71,10 +77,10 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
     onMergeConflictUpdate(params: MergeConflictUpdateParams): void {
         const uri = params.uri;
         const mergeConflicts = params.mergeConflicts;
-        this.decorationsService.setDecorations(uri, Type.CurrentMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.marker! })));
-        this.decorationsService.setDecorations(uri, Type.CurrentContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.content! })));
-        this.decorationsService.setDecorations(uri, Type.IncomingMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.marker! })));
-        this.decorationsService.setDecorations(uri, Type.IncomingContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.content! })));
+        this.setDecorations(uri, Type.CurrentMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.marker! })));
+        this.setDecorations(uri, Type.CurrentContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.content! })));
+        this.setDecorations(uri, Type.IncomingMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.marker! })));
+        this.setDecorations(uri, Type.IncomingContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.content! })));
 
         const baseMarkerRanges: Range[] = [];
         const baseContentRanges: Range[] = [];
@@ -86,8 +92,12 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
                 baseContentRanges.push(b.content);
             }
         }));
-        this.decorationsService.setDecorations(uri, Type.BaseMarker, baseMarkerRanges.map(range => ({ range })));
-        this.decorationsService.setDecorations(uri, Type.BaseContent, baseContentRanges.map(range => ({ range })));
+        this.setDecorations(uri, Type.BaseMarker, baseMarkerRanges.map(range => ({ range })));
+        this.setDecorations(uri, Type.BaseContent, baseContentRanges.map(range => ({ range })));
+    }
+
+    protected setDecorations(uri: string, type: string, options: DecorationOptions[]) {
+        this.decorationsService.setDecorations({ uri, type, options });
     }
 
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,10 @@
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.10.tgz#0eb222c7353adde8e0980bea04165d4d3b6afef3"
 
+"@types/diff@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.2.2.tgz#4d6f45537322a7a420d353a0939513c7e96d14a6"
+
 "@types/events@*":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
@@ -2150,7 +2154,7 @@ diff@3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.1.tgz#aa8567a6eed03c531fc89d3f711cd0e5259dec75"
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.1.0, diff@^3.2.0, diff@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 


### PR DESCRIPTION
This PR brings decorations for dirty diff to the editor. Added and modified lines are decorated with a colored border on the left side, and a red triangles mark positions of removed lines.

<img width="495" alt="screen shot 2018-02-22 at 11 14 46" src="https://user-images.githubusercontent.com/914497/36532689-b6349328-17c1-11e8-989c-9821ef3d9255.png">


Open tasks:
 - [x] update baseline for comparison on git repository changes affecting the resource
 - [x] throttle change events to improve performance with large files. 


Closes #1265.
