### PR TITLE
Fix issues with DiffNavigator

### DIFF
--- a/packages/editor/src/browser/diff-navigator.ts
+++ b/packages/editor/src/browser/diff-navigator.ts
@@ -6,9 +6,8 @@
  */
 
 import { TextEditor } from './editor';
-import { Disposable } from '@theia/core/lib/common';
 
-export interface DiffNavigator extends Disposable {
+export interface DiffNavigator {
     revealFirst: boolean;
     canNavigate(): boolean;
     hasNext(): boolean;

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -44,8 +44,8 @@ export class MonacoDiffEditor extends MonacoEditor {
         this.documents.add(originalModel);
         const original = originalModel.textEditorModel;
         const modified = modifiedModel.textEditorModel;
-        this._diffEditor.setModel({ original, modified });
         this._diffNavigator = diffNavigatorFactory.createdDiffNavigator(this._diffEditor, options);
+        this._diffEditor.setModel({ original, modified });
     }
 
     get diffEditor(): IStandaloneDiffEditor {

--- a/packages/monaco/src/browser/monaco-diff-nagivator-factory.ts
+++ b/packages/monaco/src/browser/monaco-diff-nagivator-factory.ts
@@ -28,7 +28,7 @@ export class MonacoDiffNavigatorFactory {
         const navigator = monaco.editor.createDiffNavigator(editor, options);
         const ensureInitialized = (fwd: boolean) => {
             if (navigator.nextIdx < -1) {
-                navigator._initIdx(fwd);
+                navigator.initIdx(fwd);
             }
         };
         return <DiffNavigator>{

--- a/packages/monaco/src/browser/monaco-diff-nagivator-factory.ts
+++ b/packages/monaco/src/browser/monaco-diff-nagivator-factory.ts
@@ -21,7 +21,6 @@ export class MonacoDiffNavigatorFactory {
         next: () => { },
         previous: () => { },
         revealFirst: false,
-        dispose: () => { },
     };
 
     createdDiffNavigator(editor: IStandaloneDiffEditor, options?: IDiffNavigatorOptions): DiffNavigator {
@@ -44,7 +43,6 @@ export class MonacoDiffNavigatorFactory {
             next: () => navigator.next(),
             previous: () => navigator.previous(),
             revealFirst: navigator.revealFirst,
-            dispose: () => navigator.dispose(),
         };
     }
 }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -10,7 +10,7 @@ declare module monaco.editor {
     export interface IDiffNavigator {
         readonly ranges: IDiffRange[];
         readonly nextIdx: number;
-        _initIdx(fwd: boolean): void;
+        initIdx(fwd: boolean): void;
     }
 
     export interface IDiffRange {


### PR DESCRIPTION
 * error in `IDiffNavigator` typing
 * diff navigator should be created *before* model is set, otherwise it leads to a non-navigable navigator up to next diff model update.

Closes #1346

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>