### PR TITLE
Fix undefined `require` for monaco

### DIFF
--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -19,7 +19,9 @@ export function loadVsRequire(context: any): Promise<any> {
             vsLoader.addEventListener('load', () => {
                 // Save Monaco's amd require and restore the original require
                 const amdRequire = context.require;
-                context.require = originalRequire;
+                if (originalRequire) {
+                    context.require = originalRequire;
+                }
                 resolve(amdRequire);
             });
             document.body.appendChild(vsLoader);


### PR DESCRIPTION
Closes #1343

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>