### PR TITLE
First attach the application shell, then initialize the shell layout

### DIFF
--- a/dev-packages/application-package/src/generator/frontend-generator.ts
+++ b/dev-packages/application-package/src/generator/frontend-generator.ts
@@ -27,6 +27,7 @@ export class FrontendGenerator extends AbstractGenerator {
 </head>
 
 <body>
+  <div class="theia-preload"></div>
 </body>
 
 </html>`;

--- a/examples/browser/test/left-panel/left-panel.ui-spec.ts
+++ b/examples/browser/test/left-panel/left-panel.ui-spec.ts
@@ -19,8 +19,8 @@ before(() => {
     driver.url(url);
     leftPanel = new LeftPanel(driver);
     mainPage = new MainPage(driver);
-    /* Make sure that the application shell is loaded */
-    expect(mainPage.applicationShellExists()).to.be.true;
+    // Make sure that the application shell is loaded
+    mainPage.waitForStartup();
 });
 
 describe('theia left panel', () => {

--- a/examples/browser/test/main-page/main-page.ts
+++ b/examples/browser/test/main-page/main-page.ts
@@ -23,6 +23,10 @@ export class MainPage {
         return this.driver.waitForExist('#theia-app-shell');
     }
 
+    waitForStartup(): void {
+        this.driver.waitUntil(() => !this.driver.isExisting('.theia-preload'));
+    }
+
     mainContentPanelExists(): boolean {
         return this.driver.waitForExist('#theia-main-content-panel');
     }

--- a/examples/browser/test/main-page/main-page.ui-spec.ts
+++ b/examples/browser/test/main-page/main-page.ui-spec.ts
@@ -19,6 +19,8 @@ describe('theia main page', () => {
         driver = browser;
         driver.url(url);
         mainPage = new MainPage(driver);
+        // Make sure that the application shell is loaded
+        mainPage.waitForStartup();
     });
 
     it('should show the application shell', () => {

--- a/examples/browser/test/top-panel/top-panel.ui-spec.ts
+++ b/examples/browser/test/top-panel/top-panel.ui-spec.ts
@@ -22,8 +22,8 @@ before(() => {
     topPanel = new TopPanel(driver);
     bottomPanel = new BottomPanel(driver);
     mainPage = new MainPage(driver);
-    /* Make sure that the application shell is loaded */
-    expect(mainPage.applicationShellExists()).to.be.true;
+    // Make sure that the application shell is loaded
+    mainPage.waitForStartup();
 });
 
 describe('theia top panel (menubar)', () => {

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -67,20 +67,25 @@ export class ShellLayoutRestorer implements CommandContribution {
 
     async initializeLayout(app: FrontendApplication, contributions: FrontendApplicationContribution[]): Promise<void> {
         try {
+            // Try to restore the shell layout from the storage service
             const serializedLayoutData = await this.storageService.getData<string>(this.storageKey);
             if (serializedLayoutData !== undefined) {
                 const layoutData = await this.inflate(serializedLayoutData);
                 app.shell.setLayoutData(layoutData);
+                await app.shell.pendingUpdates;
                 return;
             }
         } catch (e) {
             this.logger.debug(e);
         }
+
+        // Fallback: Let the frontend application contributions initialize the layout
         for (const initializer of contributions) {
             if (initializer.initializeLayout) {
                 await initializer.initializeLayout(app);
             }
         }
+        await app.shell.pendingUpdates;
     }
 
     storeLayout(app: FrontendApplication): void {

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -11,11 +11,6 @@ body {
   overflow: hidden;
   font-family: var(--theia-ui-font-family);
   background: var(--theia-layout-color3);
-  background-image: var(--theia-preloader);
-  background-size: 60px 60px;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-position: center;
 }
 
 .theia-ApplicationShell {
@@ -25,6 +20,25 @@ body {
   right: 0;
   bottom: 0;
   background: var(--theia-layout-color3);
+}
+
+.theia-preload {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--theia-layout-color3);
+  background-image: var(--theia-preloader);
+  background-size: 60px 60px;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-position: center;
+  transition: opacity 0.8s;
+}
+
+.theia-preload.theia-hidden {
+  opacity: 0;
 }
 
 .theia-icon {


### PR DESCRIPTION
Fixes #1281 and eliminates the flickering reported in #1246 by waiting for all side panel updates before revealing the application shell. The animated gif shown during startup is faded out when the shell is ready, and then removed from the DOM.