### PR TITLE
GH-1369: Removed the unnecessary dependency.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ branches:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: npm install --global --production windows-build-tools
   - netsh advfirewall firewall add rule name="SeleniumIn" dir=in action=allow protocol=TCP localport=4444
   - netsh advfirewall firewall add rule name="SeleniumOut" dir=out action=allow protocol=TCP localport=4444
 


### PR DESCRIPTION
Remove the `windows-build-tools` dependency, as it should not be necessary based on the default `Visual Studio 2015` image we use.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Closes #1369.