### PR TITLE
[core] Don't assume online status

### DIFF
--- a/packages/core/src/browser/connection-status-service.spec.ts
+++ b/packages/core/src/browser/connection-status-service.spec.ts
@@ -39,7 +39,7 @@ describe('connection-status', function () {
     });
 
     it('should go from online to offline if the connection is down', async () => {
-        expect(connectionStatusService.currentState.state).to.be.equal(ConnectionState.ONLINE);
+        expect(connectionStatusService.currentState.state).to.be.equal(ConnectionState.INITIAL);
         connectionStatusService.alive = false;
         await pause();
 

--- a/packages/core/src/browser/connection-status-service.ts
+++ b/packages/core/src/browser/connection-status-service.ts
@@ -55,8 +55,12 @@ export enum ConnectionState {
     /**
      * The connection is lost between the client and the endpoint.
      */
-    OFFLINE
+    OFFLINE,
 
+    /**
+     * Initially we don't know whether we are online or offline.
+     */
+    INITIAL
 }
 
 @injectable()
@@ -253,17 +257,13 @@ export class ConnectionStatusImpl implements ConnectionStatus {
 
     constructor(
         protected readonly props: { readonly threshold: number },
-        public readonly state: ConnectionState = ConnectionState.ONLINE,
+        public readonly state: ConnectionState = ConnectionState.INITIAL,
         protected readonly history: boolean[] = []) {
     }
 
     next(success: boolean): ConnectionStatusImpl {
         const newHistory = this.updateHistory(success);
-        // Initial optimism.
-        let online = true;
-        if (newHistory.length > this.props.threshold) {
-            online = newHistory.slice(-this.props.threshold).some(s => s);
-        }
+        const online = newHistory.slice(-this.props.threshold).some(s => s);
         // Ideally, we do not switch back to online if we see any `true` items but, let's say, after three consecutive `true`s.
         return new ConnectionStatusImpl(this.props, online ? ConnectionState.ONLINE : ConnectionState.OFFLINE, newHistory);
     }


### PR DESCRIPTION
The connection-status-service should initially not assume to be only, so it fires a status change event on start. This is important because if the application was closed with status-offline last time, the status is not updated on restart. (fixes #1386)

Signed-off-by: svenefftinge <sven.efftinge@typefox.io>