### PR TITLE
Theia-1385: Сlarify comment for ITreeNode visible property

### DIFF
--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -67,8 +67,8 @@ export interface ITreeNode {
      */
     readonly description?: string;
     /**
-     * Test whether this node is visible.
-     * If undefined then visible.
+     * Test whether this node should be rendered.
+     * If undefined then node will be rendered.
      */
     readonly visible?: boolean;
     /**


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### Changes
Сlarifies comment for `ITreeNode.visible` property to not to get confused with actual UI visibility of nodes.

### Resolves
https://github.com/theia-ide/theia/issues/1385