### PR TITLE
GH-1391: Resolved tree flickering. Adjusted icon padding in the tabs.

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.ts
+++ b/packages/core/src/browser/tree/tree-widget.ts
@@ -166,6 +166,8 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
             className,
             style: {
                 paddingLeft: '4px',
+                paddingRight: '4px',
+                width: '0.5em'
             },
             onclick: event => {
                 this.handleClickEvent(node, event);

--- a/packages/filesystem/src/browser/style/file-icons.css
+++ b/packages/filesystem/src/browser/style/file-icons.css
@@ -19,5 +19,4 @@
     font-size: calc(var(--theia-content-font-size) * 0.8);
     text-align: center;
     margin-right: 4px;
-    margin-left: 4px; 
 }


### PR DESCRIPTION
I have added `width: '0.5em'` to have the same dimension when the node is collapsed/expanded.
To fix the icon in the tabs, I had to remove `margin-left: 4px; ` which I have added to the toggle padding (`paddingRight: '4px'`).

Closes #1391
Closes #1376

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Result:
![screencast 2018-02-27 13-22-39](https://user-images.githubusercontent.com/1405703/36728829-6a3679fa-1bc2-11e8-99df-479be2467922.gif)