### PR TITLE
Improved handling of side panel sizes

### DIFF
--- a/examples/browser/test/bottom-panel/bottom-panel.ts
+++ b/examples/browser/test/bottom-panel/bottom-panel.ts
@@ -31,6 +31,8 @@ export class BottomPanel {
 
     waitForTerminal() {
         this.driver.waitForExist('.p-Widget div.terminal.xterm');
+        // Wait for animations to finish
+        this.driver.pause(200);
     }
 
     isProblemsViewVisible(): boolean {
@@ -39,10 +41,12 @@ export class BottomPanel {
 
     waitForProblemsView() {
         this.driver.waitForExist('.p-Widget div.theia-marker-container');
+        // Wait for animations to finish
+        this.driver.pause(200);
     }
 
     closeCurrentView() {
-        this.driver.click(`#theia-bottom-content-panel .p-TabBar-tab.theia-mod-current .p-TabBar-tabCloseIcon`);
+        this.driver.click('#theia-bottom-content-panel .p-TabBar-tab.theia-mod-current .p-TabBar-tabCloseIcon');
     }
 
 }

--- a/examples/browser/test/left-panel/left-panel.ts
+++ b/examples/browser/test/left-panel/left-panel.ts
@@ -17,12 +17,14 @@ export class LeftPanel {
 
     isTabActive(tabName: string): boolean {
         const tab = this.driver.element(`.p-TabBar.theia-app-left .p-TabBar-content`).element(`div\=${tabName}`);
-        /* Check if the parent li container has the p-mod-current class which makes it active*/
-        return (tab.$(`..`).getAttribute('class').split(' ').indexOf('p-mod-current') > -1);
+        /* Check if the parent li container has the p-mod-current class which makes it active */
+        return (tab.$(`..`).getAttribute('class').split(' ').indexOf('p-mod-current') !== -1);
     }
 
     openCloseTab(tabName: string) {
         this.driver.element(`.p-TabBar.theia-app-left .p-TabBar-content`).click(`div\=${tabName}`);
+        // Wait for animations to finish
+        this.driver.pause(200);
     }
 
     collapseTab(tabName: string) {
@@ -46,6 +48,6 @@ export class LeftPanel {
     }
 
     protected isPanelVisible(): boolean {
-        return (this.driver.element('#theia-left-side-panel').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1)
+        return (this.driver.element('#theia-left-side-panel').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1);
     }
 }

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -25,7 +25,7 @@ import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import {
     ApplicationShell, ApplicationShellOptions, DockPanelRenderer, TabBarRenderer,
-    TabBarRendererFactory, ShellLayoutRestorer, SidePanelHandler, SidePanelHandlerFactory
+    TabBarRendererFactory, ShellLayoutRestorer, SidePanelHandler, SidePanelHandlerFactory, SplitPositionHandler
 } from './shell';
 import { StatusBar, StatusBarImpl } from "./status-bar/status-bar";
 import { LabelParser } from './label-parser';
@@ -48,6 +48,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(ApplicationShell).toSelf().inSingletonScope();
     bind(SidePanelHandlerFactory).toAutoFactory(SidePanelHandler);
     bind(SidePanelHandler).toSelf();
+    bind(SplitPositionHandler).toSelf().inSingletonScope();
 
     bind(DockPanelRenderer).toSelf();
     bind(TabBarRendererFactory).toFactory(context => () => {

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -86,6 +86,7 @@ export class FrontendApplication {
      * - reveal the application shell if it was hidden by a startup indicator
      */
     async start(): Promise<void> {
+        this.shell.loading = true;
         await this.startContributions();
         const host = await this.getHost();
         this.attachShell(host);
@@ -94,6 +95,7 @@ export class FrontendApplication {
 
         window.addEventListener('resize', () => this.shell.update());
         document.addEventListener('keydown', event => this.keybindings.run(event), true);
+        this.shell.loading = false;
     }
 
     /**

--- a/packages/core/src/browser/shell/index.ts
+++ b/packages/core/src/browser/shell/index.ts
@@ -9,4 +9,5 @@ export * from './application-shell';
 export * from './shell-layout-restorer';
 export * from './view-contribution';
 export * from './side-panel-handler';
+export * from './split-panels';
 export * from './tab-bars';

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -393,30 +393,18 @@ export class SidePanelHandler {
      * container is a `SplitPanel`.
      */
     protected setPanelSize(size: number): Promise<void> {
-        const parent = this.container.parent;
-        if (parent instanceof SplitPanel && parent.isVisible && size >= 0) {
-            let index = parent.widgets.indexOf(this.container);
-            if (this.side === 'right') {
-                index--;
-            }
-
-            const parentWidth = parent.node.clientWidth;
-            let position: number = 0;
-            if (this.side === 'left') {
-                position = Math.max(Math.min(size, parentWidth), 0);
-            } else if (this.side === 'right') {
-                position = parentWidth - Math.max(Math.min(size, parentWidth), 0);
-            }
-
-            const options: SplitPositionOptions = {
-                referenceWidget: this.dockPanel,
-                duration: this.state.loading ? 0 : this.options.expandDuration
-            };
-            const promise = this.splitPositionHandler.moveSplitPos(parent, index, position, options);
-            this.state.pendingUpdate = this.state.pendingUpdate.then(() => promise);
-            return promise;
-        }
-        return Promise.resolve();
+        const options: SplitPositionOptions = {
+            side: this.side,
+            duration: this.state.loading ? 0 : this.options.expandDuration,
+            referenceWidget: this.dockPanel
+        };
+        const promise = this.splitPositionHandler.setSidePanelSize(this.container, size, options);
+        const result = new Promise<void>(resolve => {
+            // Resolve the resulting promise in any case, regardless of whether resizing was successful
+            promise.then(() => resolve(), () => resolve());
+        });
+        this.state.pendingUpdate = this.state.pendingUpdate.then(() => result);
+        return result;
     }
 
     /**

--- a/packages/core/src/browser/shell/split-panels.ts
+++ b/packages/core/src/browser/shell/split-panels.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from 'inversify';
+import { SplitPanel, SplitLayout, Widget } from '@phosphor/widgets';
+
+interface MoveEntry {
+    referenceWidget?: Widget;
+    layout: SplitLayout;
+    index: number;
+    position: number;
+    duration: number;
+    started: boolean;
+    ended: boolean;
+    startPos?: number;
+    startTime?: number
+    resolve(): void;
+}
+
+export interface SplitPositionOptions {
+    referenceWidget?: Widget;
+    duration?: number;
+    immediate?: boolean;
+}
+
+@injectable()
+export class SplitPositionHandler {
+
+    private readonly splitMoves: MoveEntry[] = [];
+    private currentMoveIndex: number = 0;
+
+    /**
+     * Move a handle of a split panel to the given position asynchronously. Unless the option `immediate`
+     * is set to `true`, this function makes sure that such movements are performed one after another in
+     * order to prevent the movements from overriding each other.
+     */
+    moveSplitPos(parent: SplitPanel, index: number, position: number, options: SplitPositionOptions = {}): Promise<void> {
+        return new Promise<void>(resolve => {
+            const move: MoveEntry = {
+                index, position, resolve,
+                referenceWidget: options.referenceWidget,
+                layout: parent.layout as SplitLayout,
+                duration: options.duration || 0,
+                started: false,
+                ended: false
+            };
+            if (options.immediate) {
+                this.endMove(move);
+            } else {
+                if (this.splitMoves.length === 0) {
+                    window.requestAnimationFrame(this.animationFrame.bind(this));
+                }
+                this.splitMoves.push(move);
+            }
+        });
+    }
+
+    protected animationFrame(time: number): void {
+        const move = this.splitMoves[this.currentMoveIndex];
+        if (move.ended || move.referenceWidget && move.referenceWidget.isHidden) {
+            this.splitMoves.splice(this.currentMoveIndex, 1);
+            move.resolve();
+        } else if (move.duration <= 0) {
+            this.endMove(move);
+        } else if (!move.started) {
+            move.startPos = this.getCurrentPosition(move);
+            move.startTime = time;
+            move.started = true;
+            if (move.startPos === undefined || move.startPos === move.position) {
+                this.endMove(move);
+            }
+        } else if (move.startTime !== undefined && move.startPos !== undefined) {
+            const elapsedTime = time - move.startTime;
+            if (elapsedTime >= move.duration) {
+                this.endMove(move);
+            } else {
+                const t = elapsedTime / move.duration;
+                const pos = move.startPos + (move.position - move.startPos) * t;
+                move.layout.moveHandle(move.index, pos);
+            }
+        }
+        if (!move.ended) {
+            if (this.currentMoveIndex < this.splitMoves.length - 1) {
+                this.currentMoveIndex++;
+            } else {
+                this.currentMoveIndex = 0;
+            }
+        }
+        if (this.splitMoves.length > 0) {
+            window.requestAnimationFrame(this.animationFrame.bind(this));
+        }
+    }
+
+    private getCurrentPosition(move: MoveEntry): number | undefined {
+        const layout = move.layout;
+        let pos: number | null;
+        if (layout.orientation === 'horizontal') {
+            pos = layout.handles[move.index].offsetLeft;
+        } else {
+            pos = layout.handles[move.index].offsetTop;
+        }
+        if (pos !== null) {
+            return pos;
+        } else {
+            return undefined;
+        }
+    }
+
+    private endMove(move: MoveEntry): void {
+        move.layout.moveHandle(move.index, move.position);
+        move.ended = true;
+    }
+
+}

--- a/packages/core/src/browser/style/dockpanel.css
+++ b/packages/core/src/browser/style/dockpanel.css
@@ -11,8 +11,8 @@
 
 .p-DockPanel-widget {
   background: var(--theia-layout-color3);
-  min-width: 150px;
-  min-height: 150px;
+  min-width: 100px;
+  min-height: 100px;
 }
 
 .p-DockPanel-handle[data-orientation='vertical'] {


### PR DESCRIPTION
Fixes #1241 and #1246.

 * Implemented animation for panel expansion.
 * Added state object to bettter track the side panel state.
 * Added options object to control the expansion behavior.

The initial size of all three panels can be controlled with the application shell options. The default value for the bottom panel is 0.382 times the shell height (excluding menu bar and status bar), which corresponds roughly to the [golden ratio](https://en.wikipedia.org/wiki/Golden_ratio). The default values for the left and right panel are half that size.