### PR TITLE
Refactoring of git widgets. Fixes #1381.

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.ts
+++ b/packages/git/src/browser/diff/git-diff-widget.ts
@@ -11,15 +11,16 @@ import { VirtualRenderer, open, OpenerService, StatefulWidget, SELECTED_CLASS } 
 import { GIT_RESOURCE_SCHEME } from '../git-resource';
 import URI from "@theia/core/lib/common/uri";
 import { GitFileChange, GitFileStatus, Git, WorkingDirectoryStatus } from '../../common';
-import { GitBaseWidget, GitFileChangeNode } from "../git-base-widget";
+import { GitNavigableListWidget } from "../git-navigable-list-widget";
 import { DiffNavigatorProvider, DiffNavigator } from "@theia/editor/lib/browser/diff-navigator";
 import { EditorManager } from "@theia/editor/lib/browser";
 import { GitWatcher } from "../../common/git-watcher";
 import { inject, injectable, postConstruct } from "inversify";
+import { GitFileChangeNode } from "../git-widget";
 
 export const GIT_DIFF = "git-diff";
 @injectable()
-export class GitDiffWidget extends GitBaseWidget<GitFileChangeNode> implements StatefulWidget {
+export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> implements StatefulWidget {
 
     protected fileChangeNodes: GitFileChangeNode[];
     protected options: Git.Options.Diff;
@@ -132,12 +133,12 @@ export class GitDiffWidget extends GitBaseWidget<GitFileChangeNode> implements S
         const leftButton = h.span({
             className: "fa fa-arrow-left",
             title: "Previous Change",
-            onclick: () => this.handleLeft()
+            onclick: () => this.navigateLeft()
         });
         const rightButton = h.span({
             className: "fa fa-arrow-right",
             title: "Next Change",
-            onclick: () => this.handleRight()
+            onclick: () => this.navigateRight()
         });
         const lrBtns = h.div({ className: 'lrBtns' }, leftButton, rightButton);
         const headerRow = h.div({ className: 'header-row space-between' }, header, lrBtns);
@@ -182,7 +183,7 @@ export class GitDiffWidget extends GitBaseWidget<GitFileChangeNode> implements S
         return h.div({ className: `gitItem noselect${change.selected ? ' ' + SELECTED_CLASS : ''}` }, ...elements);
     }
 
-    protected handleRight(): void {
+    protected navigateRight(): void {
         const selected = this.getSelected();
         if (selected && GitFileChangeNode.is(selected)) {
             const uri = this.getUriToOpen(selected);
@@ -205,7 +206,7 @@ export class GitDiffWidget extends GitBaseWidget<GitFileChangeNode> implements S
         }
     }
 
-    protected handleLeft(): void {
+    protected navigateLeft(): void {
         const selected = this.getSelected();
         if (GitFileChangeNode.is(selected)) {
             const uri = this.getUriToOpen(selected);
@@ -225,7 +226,7 @@ export class GitDiffWidget extends GitBaseWidget<GitFileChangeNode> implements S
         }
     }
 
-    protected handleEnter(): void {
+    protected handleListEnter(): void {
         this.openSelected();
     }
 

--- a/packages/git/src/browser/diff/git-diff-widget.ts
+++ b/packages/git/src/browser/diff/git-diff-widget.ts
@@ -226,6 +226,24 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         }
     }
 
+    protected selectNextNode() {
+        const idx = this.indexOfSelected;
+        if (idx >= 0 && idx < this.gitNodes.length - 1) {
+            this.selectNode(this.gitNodes[idx + 1]);
+        } else if (this.gitNodes.length > 0 && (idx === -1 || idx === this.gitNodes.length - 1)) {
+            this.selectNode(this.gitNodes[0]);
+        }
+    }
+
+    protected selectPreviousNode() {
+        const idx = this.indexOfSelected;
+        if (idx > 0) {
+            this.selectNode(this.gitNodes[idx - 1]);
+        } else if (idx === 0) {
+            this.selectNode(this.gitNodes[this.gitNodes.length - 1]);
+        }
+    }
+
     protected handleListEnter(): void {
         this.openSelected();
     }

--- a/packages/git/src/browser/history/git-commit-detail-widget.ts
+++ b/packages/git/src/browser/history/git-commit-detail-widget.ts
@@ -13,7 +13,7 @@ import { h } from "@phosphor/virtualdom";
 import URI from "@theia/core/lib/common/uri";
 import { injectable, inject } from "inversify";
 import { Widget } from "@phosphor/widgets";
-import { GitFileChangeNode } from "../git-base-widget";
+import { GitFileChangeNode } from "../git-widget";
 
 export const GIT_COMMIT_DETAIL = "git-commit-detail-widget";
 

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -5,6 +5,9 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import URI from "@theia/core/lib/common/uri";
+import { Path } from "@theia/core";
+
 export interface WorkingDirectoryStatus {
 
     /**
@@ -162,6 +165,13 @@ export namespace Repository {
             return repository.localUri === repository2.localUri;
         }
         return repository === repository2;
+    }
+    export function is(repository: Object | undefined): repository is Repository {
+        return !!repository && 'localUri' in repository;
+    }
+    export function relativePath(repository: Repository | string, uri: URI | string): Path {
+        const repositoryUri = new URI(Repository.is(repository) ? repository.localUri : repository);
+        return new Path(uri.toString().substr(repositoryUri.toString().length + 1));
     }
 }
 


### PR DESCRIPTION
To have a super class for all git widgets was superfluous and led to wrong behaviour in git-widget. 
See #1381.
So, now the git-widget does not inherit from git-base-widget anymore, and git-base-widget is actually now called git-navigable-list-widget. 