### PR TITLE
[terminal] GH-514 source .profile on macOS

### DIFF
--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -9,7 +9,7 @@ import { injectable, inject, named } from 'inversify';
 import * as os from 'os';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { TerminalProcess, TerminalProcessOptions, ProcessManager, MultiRingBuffer } from '@theia/process/lib/node';
-import { isWindows } from "@theia/core/lib/common";
+import { isWindows, isOSX } from "@theia/core/lib/common";
 import URI from "@theia/core/lib/common/uri";
 import { FileUri } from "@theia/core/lib/node/file-uri";
 import { parseArgs } from '@theia/process/lib/node/utils';
@@ -76,6 +76,11 @@ export class ShellProcess extends TerminalProcess {
         if (args) {
             return parseArgs(args);
         }
-        return [];
+        if (isOSX) {
+            return ['-l'];
+        } else {
+            return [];
+        }
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/514
On macOS we need to use a login shell in order to source the `.profile` file (--login or -l flag)


Change-Id: I44e24addf03d30d242b5a00cb13717fe39303592
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
