### PR TITLE
Decorations API cleanup

### DIFF
--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -6,7 +6,7 @@
  */
 
 import { ContainerModule } from 'inversify';
-import { CommandContribution, MenuContribution, bindContributionProvider } from "@theia/core/lib/common";
+import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
 import {
     OpenHandler, WidgetFactory, FrontendApplicationContribution,
     KeybindingContribution, KeybindingContext, LabelProviderContribution
@@ -18,7 +18,7 @@ import { EditorCommandContribution } from './editor-command';
 import { EditorKeybindingContribution, EditorKeybindingContext } from "./editor-keybinding";
 import { bindEditorPreferences } from './editor-preferences';
 import { DiffUriLabelProviderContribution } from './diff-uris';
-import { EditorDecorationsService, EditorDecorationTypeProvider } from './editor-decorations-service';
+import { EditorDecorationsService } from './editor-decorations-service';
 import { EditorWidgetFactory } from './editor-widget-factory';
 
 export default new ContainerModule(bind => {
@@ -42,6 +42,5 @@ export default new ContainerModule(bind => {
 
     bind(LabelProviderContribution).to(DiffUriLabelProviderContribution).inSingletonScope();
 
-    bindContributionProvider(bind, EditorDecorationTypeProvider);
     bind(EditorDecorationsService).toSelf().inSingletonScope();
 });

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -10,7 +10,7 @@ import * as lsp from 'vscode-languageserver-types';
 import URI from "@theia/core/lib/common/uri";
 import { Event, Disposable } from '@theia/core/lib/common';
 import { Saveable } from '@theia/core/lib/browser';
-import { DecorationOptions, DeltaDecoration } from './editor-decorations-service';
+import { EditorDecoration } from './editor-decorations-service';
 
 export {
     Position, Range
@@ -54,13 +54,7 @@ export interface TextEditor extends Disposable, TextEditorSelection {
     setSize(size: Dimension): void;
 
     /**
-     * Applies decorations for given type and options.
-     * Previous decoration of the same type are not preserved.
-     * To remove decorations of a type, pass an empty options array.
-     */
-    setDecorations(params: SetDecorationParams): void;
-    /**
-     * Directly applies new decorations and removes old decorations.
+     * Applies given new decorations and removes old decorations identified by ids.
      *
      * @returns identifiers of applied decorations, which can be removed in next call.
      */
@@ -89,14 +83,14 @@ export interface RevealRangeOptions {
 
 export interface SetDecorationParams {
     uri: string;
-    type: string;
-    options: DecorationOptions[];
+    kind: string;
+    newDecorations: EditorDecoration[];
 }
 
 export interface DeltaDecorationParams {
     uri: string;
     oldDecorations: string[];
-    newDecorations: DeltaDecoration[];
+    newDecorations: EditorDecoration[];
 }
 
 export namespace TextEditorSelection {

--- a/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -7,8 +7,8 @@
 
 import { inject, injectable } from 'inversify';
 import {
-    EditorManager, EditorDecorationsService, Range, Position, DeltaDecoration,
-    ModelDecorationOptions, OverviewRulerLane
+    EditorManager, EditorDecorationsService, Range, Position, EditorDecoration,
+    EditorDecorationOptions, OverviewRulerLane
 } from '@theia/editor/lib/browser';
 import { DirtyDiffUpdate } from './dirty-diff-manager';
 import { LineRange } from './diff-computer';
@@ -19,7 +19,7 @@ export enum DirtyDiffDecorationType {
     ModifiedLine = 'dirty-diff-modified-line',
 }
 
-const AddedLineDecoration = <ModelDecorationOptions>{
+const AddedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-added-line',
     overviewRuler: {
         color: 'rgba(0, 255, 0, 0.8)',
@@ -27,7 +27,7 @@ const AddedLineDecoration = <ModelDecorationOptions>{
     }
 };
 
-const RemovedLineDecoration = <ModelDecorationOptions>{
+const RemovedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-removed-line',
     overviewRuler: {
         color: 'rgba(230, 0, 0, 0.8)',
@@ -35,7 +35,7 @@ const RemovedLineDecoration = <ModelDecorationOptions>{
     }
 };
 
-const ModifiedLineDecoration = <ModelDecorationOptions>{
+const ModifiedLineDecoration = <EditorDecorationOptions>{
     linesDecorationsClassName: 'dirty-diff-glyph dirty-diff-modified-line',
     overviewRuler: {
         color: 'rgba(0, 100, 150, 0.8)',
@@ -61,13 +61,13 @@ export class DirtyDiffDecorator {
 
     protected appliedDecorations = new Map<string, string[]>();
 
-    protected async setDecorations(uri: string, newDecorations: DeltaDecoration[]) {
+    protected async setDecorations(uri: string, newDecorations: EditorDecoration[]) {
         const oldDecorations = this.appliedDecorations.get(uri) || [];
         const decorationIds = await this.editorDecorationsService.deltaDecorations({ uri, oldDecorations, newDecorations });
         this.appliedDecorations.set(uri, decorationIds || []);
     }
 
-    protected toDeltaDecoration(from: LineRange | number, options: ModelDecorationOptions): DeltaDecoration {
+    protected toDeltaDecoration(from: LineRange | number, options: EditorDecorationOptions): EditorDecoration {
         const [start, end] = (typeof from === 'number') ? [from, from] : [from.start, from.end];
         const range = Range.create(Position.create(start, 0), Position.create(end, 0));
         return { range, options };

--- a/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
@@ -6,81 +6,23 @@
  */
 
 import { injectable, inject } from "inversify";
-import { EditorDecorationsService, OverviewRulerLane, Range, DecorationType, EditorDecorationTypeProvider, DecorationOptions } from "@theia/editor/lib/browser";
+import { EditorDecorationsService, OverviewRulerLane, Range, EditorDecoration, EditorDecorationOptions } from "@theia/editor/lib/browser";
 import { MergeConflictUpdateParams } from "./merge-conflicts-service";
 
-export enum MergeConflictsDecorationType {
-    CurrentMarker = 'merge-conflict-current-marker',
-    CurrentContent = 'merge-conflict-current-content',
-    BaseMarker = 'merge-conflict-base-marker',
-    BaseContent = 'merge-conflict-base-content',
-    IncomingMarker = 'merge-conflict-incoming-marker',
-    IncomingContent = 'merge-conflict-incoming-content',
-}
-
-const Type = MergeConflictsDecorationType;
-
 @injectable()
-export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
+export class MergeConflictsDecorations {
 
     constructor(
         @inject(EditorDecorationsService) protected readonly decorationsService: EditorDecorationsService,
     ) { }
 
-    get(): DecorationType[] {
-        return [
-            {
-                type: Type.CurrentMarker,
-                backgroundColor: 'rgba(0, 255, 0, 0.1)',
-                isWholeLine: true,
-            },
-            {
-                type: Type.CurrentContent,
-                backgroundColor: 'rgba(0, 255, 0, 0.3)',
-                isWholeLine: true,
-                overviewRuler: {
-                    position: OverviewRulerLane.Full,
-                    color: 'rgba(0, 255, 0, 0.3)',
-                }
-            },
-            {
-                type: Type.BaseMarker,
-                backgroundColor: 'rgba(125, 125, 125, 0.1)',
-                isWholeLine: true,
-            },
-            {
-                type: Type.BaseContent,
-                backgroundColor: 'rgba(125, 125, 125, 0.3)',
-                isWholeLine: true,
-                overviewRuler: {
-                    position: OverviewRulerLane.Full,
-                    color: 'rgba(125, 125, 125, 0.3)',
-                }
-            },
-            {
-                type: Type.IncomingMarker,
-                backgroundColor: 'rgba(0, 0, 255, 0.1)',
-                isWholeLine: true,
-            },
-            {
-                type: Type.IncomingContent,
-                backgroundColor: 'rgba(0, 0, 255, 0.3)',
-                isWholeLine: true,
-                overviewRuler: {
-                    position: OverviewRulerLane.Full,
-                    color: 'rgba(0, 0, 255, 0.3)',
-                }
-            }
-        ];
-    }
-
     onMergeConflictUpdate(params: MergeConflictUpdateParams): void {
         const uri = params.uri;
         const mergeConflicts = params.mergeConflicts;
-        this.setDecorations(uri, Type.CurrentMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.marker! })));
-        this.setDecorations(uri, Type.CurrentContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.current.content! })));
-        this.setDecorations(uri, Type.IncomingMarker, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.marker! })));
-        this.setDecorations(uri, Type.IncomingContent, mergeConflicts.map(mergeConflict => ({ range: mergeConflict.incoming.content! })));
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.CurrentMarker, mergeConflicts.map(c => c.current.marker!));
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.CurrentContent, mergeConflicts.map(c => c.current.content!));
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.IncomingMarker, mergeConflicts.map(c => c.incoming.marker!));
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.IncomingContent, mergeConflicts.map(c => c.incoming.content!));
 
         const baseMarkerRanges: Range[] = [];
         const baseContentRanges: Range[] = [];
@@ -92,12 +34,65 @@ export class MergeConflictsDecorations implements EditorDecorationTypeProvider {
                 baseContentRanges.push(b.content);
             }
         }));
-        this.setDecorations(uri, Type.BaseMarker, baseMarkerRanges.map(range => ({ range })));
-        this.setDecorations(uri, Type.BaseContent, baseContentRanges.map(range => ({ range })));
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.BaseMarker, baseMarkerRanges);
+        this.setDecorations(uri, MergeConflictsDecorations.Kind.BaseContent, baseContentRanges);
     }
 
-    protected setDecorations(uri: string, type: string, options: DecorationOptions[]) {
-        this.decorationsService.setDecorations({ uri, type, options });
+    protected setDecorations(uri: string, kind: MergeConflictsDecorations.Kind, ranges: Range[]) {
+        const options = MergeConflictsDecorations.Options[kind];
+        const newDecorations = ranges.map(range => <EditorDecoration>{ range, options });
+        this.decorationsService.setDecorations({ uri, kind, newDecorations });
     }
 
+}
+
+export namespace MergeConflictsDecorations {
+
+    export enum Kind {
+        CurrentMarker = 'merge-conflict-current-marker',
+        CurrentContent = 'merge-conflict-current-content',
+        BaseMarker = 'merge-conflict-base-marker',
+        BaseContent = 'merge-conflict-base-content',
+        IncomingMarker = 'merge-conflict-incoming-marker',
+        IncomingContent = 'merge-conflict-incoming-content',
+    }
+
+    export const Options = {
+        [Kind.CurrentMarker]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.CurrentMarker.toString()
+        },
+        [Kind.CurrentContent]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.CurrentContent.toString(),
+            overviewRuler: {
+                position: OverviewRulerLane.Full,
+                color: 'rgba(0, 255, 0, 0.3)',
+            }
+        },
+        [Kind.BaseMarker]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.BaseMarker.toString()
+        },
+        [Kind.BaseContent]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.BaseContent.toString(),
+            overviewRuler: {
+                position: OverviewRulerLane.Full,
+                color: 'rgba(125, 125, 125, 0.3)',
+            }
+        },
+        [Kind.IncomingMarker]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.IncomingMarker.toString()
+        },
+        [Kind.IncomingContent]: <EditorDecorationOptions>{
+            isWholeLine: true,
+            className: Kind.IncomingContent.toString(),
+            overviewRuler: {
+                position: OverviewRulerLane.Full,
+                color: 'rgba(0, 0, 255, 0.3)',
+            }
+        },
+    };
 }

--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
@@ -14,14 +14,14 @@ import { MergeConflictsParser } from './merge-conflicts-parser';
 import { MergeConflictResolver } from './merge-conflict-resolver';
 import { MergeConflictsService } from './merge-conflicts-service';
 import { MergeConflictsDecorations } from './merge-conflicts-decorations';
-import { EditorDecorationTypeProvider } from '@theia/editor/lib/browser';
+
+import '../../src/browser/style/index.css';
 
 export default new ContainerModule(bind => {
     bind(MergeConflictsParser).toSelf().inSingletonScope();
     bind(MergeConflictResolver).toSelf().inSingletonScope();
     bind(MergeConflictsCodeLensProvider).toSelf().inSingletonScope();
     bind(MergeConflictsDecorations).toSelf().inSingletonScope();
-    bind(EditorDecorationTypeProvider).toDynamicValue(context => context.container.get(MergeConflictsDecorations));
     bind(MergeConflictsFrontendContribution).toSelf().inSingletonScope();
     bind(MergeConflictsService).toSelf().inSingletonScope();
     [CommandContribution, FrontendApplicationContribution].forEach(serviceIdentifier =>

--- a/packages/merge-conflicts/src/browser/style/index.css
+++ b/packages/merge-conflicts/src/browser/style/index.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+.merge-conflict-current-marker {
+     background-color: rgba(0, 255, 0, 0.1);
+}
+
+.merge-conflict-current-content {
+     background-color: rgba(0, 255, 0, 0.3);
+}
+
+.merge-conflict-base-marker {
+    background-color: rgba(125, 125, 125, 0.1);
+}
+
+.merge-conflict-base-content {
+    background-color: rgba(125, 125, 125, 0.3);
+}
+
+.merge-conflict-incoming-marker {
+    background-color: rgba(0, 0, 255, 0.1);
+}
+
+.merge-conflict-incoming-content {
+    background-color: rgba(0, 0, 255, 0.3);
+}

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -8,7 +8,7 @@
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient';
 import URI from '@theia/core/lib/common/uri';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common';
-import { Dimension, EditorDecorationsService, SetDecorationParams, DiffNavigator, DeltaDecorationParams } from '@theia/editor/lib/browser';
+import { Dimension, EditorDecorationsService, DiffNavigator, DeltaDecorationParams } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from './monaco-editor-model';
 import { MonacoEditor } from './monaco-editor';
 import { MonacoDiffNavigatorFactory } from './monaco-diff-nagivator-factory';
@@ -92,17 +92,6 @@ export class MonacoDiffEditor extends MonacoEditor {
     isActionSupported(id: string): boolean {
         const action = this._diffEditor.getActions().find(a => a.id === id);
         return !!action && action.isSupported() && super.isActionSupported(id);
-    }
-
-    setDecorations(params: SetDecorationParams): void {
-        const type = params.type;
-        const uri = params.uri;
-        const decorationOptions = this.toDecorationOptions(params);
-        for (const editor of [this._diffEditor.getOriginalEditor(), this._diffEditor.getModifiedEditor()]) {
-            if (editor.getModel().uri.toString() === uri) {
-                editor.setDecorations(type, decorationOptions);
-            }
-        }
     }
 
     deltaDecorations(params: DeltaDecorationParams): string[] {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -20,14 +20,11 @@ import {
     RevealRangeOptions,
     RevealPositionOptions,
     EditorDecorationsService,
-    SetDecorationParams,
     DeltaDecorationParams,
 } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from "./monaco-editor-model";
 
 import IEditorConstructionOptions = monaco.editor.IEditorConstructionOptions;
-import IDecorationRenderOptions = monaco.editor.IDecorationRenderOptions;
-import IDecorationOptions = monaco.editor.IDecorationOptions;
 import IModelDeltaDecoration = monaco.editor.IModelDeltaDecoration;
 import IEditorOverrideServices = monaco.editor.IEditorOverrideServices;
 import IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
@@ -64,23 +61,6 @@ export class MonacoEditor implements TextEditor, IEditorReference {
         this.minHeight = options && options.minHeight !== undefined ? options.minHeight : -1;
         this.toDispose.push(this.create(options, override));
         this.addHandlers(this.editor);
-        this.registerDecorationTypes();
-    }
-
-    protected registerDecorationTypes(): void {
-        const decoarationTypes = this.decorationsService.getDecorationTypes();
-        const codeEditorService = this.editor._codeEditorService;
-        decoarationTypes.forEach(decorationType => {
-            const options = <IDecorationRenderOptions>{
-                ...decorationType,
-            };
-            const overviewRulerOptions = decorationType.overviewRuler;
-            if (overviewRulerOptions) {
-                options.overviewRulerColor = overviewRulerOptions.color;
-                options.overviewRulerLane = overviewRulerOptions.position;
-            }
-            codeEditorService.registerDecorationType(decorationType.type, options);
-        });
     }
 
     protected create(options?: IEditorConstructionOptions, override?: monaco.editor.IEditorOverrideServices): Disposable {
@@ -326,23 +306,6 @@ export class MonacoEditor implements TextEditor, IEditorReference {
 
     get instantiationService(): monaco.instantiation.IInstantiationService {
         return this.editor._instantiationService;
-    }
-
-    get codeEditorService(): monaco.services.ICodeEditorService {
-        return this.editor._codeEditorService;
-    }
-
-    setDecorations(params: SetDecorationParams): void {
-        const type = params.type;
-        const decorationOptions = this.toDecorationOptions(params);
-        this.editor.setDecorations(type, decorationOptions);
-    }
-
-    protected toDecorationOptions(params: SetDecorationParams): IDecorationOptions[] {
-        return params.options.map(decorationOptions => <IDecorationOptions>{
-            ...decorationOptions,
-            range: this.p2m.asRange(decorationOptions.range),
-        });
     }
 
     deltaDecorations(params: DeltaDecorationParams): string[] {

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -25,40 +25,6 @@ declare module monaco.editor {
             'editor.controller.quickOpenController': monaco.quickOpen.QuickOpenController
         }
         readonly cursor: ICursor;
-        setDecorations(decorationTypeKey: string, decorationOptions: IDecorationOptions[]): void;
-    }
-
-    export interface IDecorationRenderOptions {
-        isWholeLine?: boolean;
-        backgroundColor?: string | ThemeColor;
-
-        outlineColor?: string | ThemeColor;
-        outlineStyle?: string;
-        outlineWidth?: string;
-
-        color?: string | ThemeColor;
-
-        overviewRulerColor?: string | ThemeColor;
-        overviewRulerLane?: OverviewRulerLane;
-
-        after?: IContentDecorationRenderOptions;
-    }
-
-    export interface IContentDecorationRenderOptions {
-        contentText?: string;
-        color?: string | ThemeColor;
-        backgroundColor?: string | ThemeColor;
-    }
-
-    export interface IDecorationOptions {
-        range: monaco.IRange;
-        hoverMessage?: IMarkdownString | IMarkdownString[];
-        renderOptions?: IContentDecorationRenderOptions;
-    }
-
-    export interface IMarkdownString {
-        value: string;
-        isTrusted?: boolean;
     }
 
     export interface ICursor {
@@ -107,7 +73,6 @@ declare module monaco.editor {
 
     export interface IEditorService {
         openEditor(input: IResourceInput, sideBySide?: boolean): monaco.Promise<IEditorReference | undefined>;
-
     }
 
     export interface IReference<T> extends monaco.IDisposable {
@@ -340,10 +305,6 @@ declare module monaco.services {
     }
 
     export interface IStandaloneThemeService extends monaco.theme.IThemeService { }
-
-    export interface ICodeEditorService {
-        registerDecorationType(key: string, options: monaco.editor.IDecorationRenderOptions, parentTypeKey?: string): void;
-    }
 
     export module StaticServices {
         export const standaloneThemeService: LazyStaticService<IStandaloneThemeService>;


### PR DESCRIPTION
This PR reverts the exposure of monaco's decorations types introduced in #1180. In #1345 we added the more powerful _model decorations_ to the `EditorDecorationsService` in `@theia/editor`, which is also the underlying api for decoration types in monaco. The main advantages of this change are:

- less restriction, as decoration types do not support all kind of styles possible with the _model decorations_ 
- less usage of unexposed monaco internals