### PR TITLE
[shell] Ensure that we have a rendering loop before initializing the layout, so the basic measurements of the shell have been computed. (fixes #1426)

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -89,6 +89,7 @@ export class FrontendApplication {
         await this.startContributions();
         const host = await this.getHost();
         this.attachShell(host);
+        await new Promise(resolve => requestAnimationFrame(() => resolve()));
         await this.layoutRestorer.initializeLayout(this, this.contributions.getContributions());
         await this.revealShell(host);
 


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>