### PR TITLE
[WIP] GH-1410 - Replacing reconnecting-websockets with wska to enable ping/pong

### DIFF
--- a/dev-packages/application-package/src/generator/webpack-generator.ts
+++ b/dev-packages/application-package/src/generator/webpack-generator.ts
@@ -44,14 +44,16 @@ module.exports = {
         filename: 'bundle.js',
         path: outputPath
     },
+    externals: {
+        'crypto': '${this.ifBrowser('window.crypto', 'crypto')}'
+    },
     target: '${this.ifBrowser('web', 'electron-renderer')}',
     node: {${this.ifElectron(`
         __dirname: false,
         __filename: false`, `
         fs: 'empty',
         child_process: 'empty',
-        net: 'empty',
-        crypto: 'empty'`)}
+        net: 'empty'`)}
     },
     module: {
         rules: [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "font-awesome": "^4.7.0",
     "inversify": "^4.2.0",
     "perfect-scrollbar": "^1.3.0",
-    "reconnecting-websocket": "^3.0.7",
+    "wska": "^1.0.1",
     "reflect-metadata": "^0.1.10",
     "vscode-languageserver-types": "^3.4.0",
     "vscode-uri": "^1.0.1",

--- a/packages/languages/src/browser/language-client-factory.ts
+++ b/packages/languages/src/browser/language-client-factory.ts
@@ -40,9 +40,7 @@ export class LanguageClientFactory {
                                 const connection = createConnection(messageConnection, errorHandler, closeHandler);
                                 resolve(connection);
                             }
-                        },
-                            { reconnecting: false }
-                        );
+                        });
                     })
             }
         });

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -261,7 +261,7 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
 
     protected createWebSocket(pid: string): WebSocket {
         const url = this.endpoint.getWebSocketUrl().resolve(pid);
-        return this.webSocketConnectionProvider.createWebSocket(url.toString(), { reconnecting: false });
+        return this.webSocketConnectionProvider.createWebSocket(url.toString());
     }
 
     protected onActivateRequest(msg: Message): void {


### PR DESCRIPTION
My attempt to try and get websockets to both reconnect when disconnected and work in proxies : #1410 

Installed wska 1.01 and removed reconnecting-websocket. Moved crypto to excludes in webpack-generator and cleaned up left over options for reconnecting-websocket in languages and terminal.  Tried to have it use window.crypto if it is a browser.

It builds but does not load in the browser.  Shows the following error:

```
Error: TypeError: crypto.randomBytes is not a function
    at createWebSocket (index.js:45)
    at new WebSocketKeepAlive (index.js:37)
    at WebSocketConnectionProvider.createWebSocket (connection.ts:72)
    at WebSocketConnectionProvider.listen (connection.ts:42)
    at WebSocketConnectionProvider.createProxy (connection.ts:30)
    at Binding.dynamicValue (logger-frontend-module.ts:27)
    at resolver.js:63
    at invokeFactory (resolver.js:10)
    at resolver.js:63
    at Array.map (<anonymous>)
```


Signed-off-by: Zate Berg <zate75@gmail.com>