### PR TITLE
Scroll beyond last line in preview

### DIFF
--- a/packages/preview/src/browser/style/preview-widget.css
+++ b/packages/preview/src/browser/style/preview-widget.css
@@ -10,6 +10,10 @@
     overflow-x: hidden;
 }
 
+.theia-preview-widget .scrollBeyondLastLine {
+	margin-bottom: calc(100vh - 22px);
+}
+
 .theia-preview-widget:focus {
     outline: 0;
     box-shadow: none;


### PR DESCRIPTION
This change adds evaluation of editor's preferences `editor.scrollBeyondLastLine` to extend scrolling in the preview widget. 

![2018-03-07 08 28 49](https://user-images.githubusercontent.com/914497/37079148-de539456-21e1-11e8-9583-b09b9a3dc59d.gif)



Closes #1254