### PR TITLE
quick-open: Don't omit entries without textual match

### DIFF
--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -19,6 +19,11 @@ export namespace QuickOpenOptions {
         readonly fuzzyMatchDescription: boolean;
         readonly fuzzySort: boolean;
 
+        /**
+         * Whether to display the items that don't have any highlight.
+         */
+        readonly showItemsWithoutHighlight: boolean;
+
         selectIndex(lookfor: string): number;
 
         onClose(canceled: boolean): void;
@@ -31,6 +36,8 @@ export namespace QuickOpenOptions {
         fuzzyMatchDetail: false,
         fuzzyMatchDescription: false,
         fuzzySort: false,
+
+        showItemsWithoutHighlight: false,
 
         onClose: () => { /* no-op*/ },
 

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -37,7 +37,8 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
     execute() {
         this.quickOpenService.open(this, {
             placeholder: 'Type to search for symbols.',
-            fuzzyMatchLabel: true
+            fuzzyMatchLabel: true,
+            showItemsWithoutHighlight: true,
         });
     }
 

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -160,7 +160,8 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
         const labelHighlights = this.options.fuzzyMatchLabel ? this.matchesFuzzy(lookFor, item.getLabel()) : item.getLabelHighlights();
         const descriptionHighlights = this.options.fuzzyMatchDescription ? this.matchesFuzzy(lookFor, item.getDescription()) : item.getDescriptionHighlights();
         const detailHighlights = this.options.fuzzyMatchDetail ? this.matchesFuzzy(lookFor, item.getDetail()) : item.getDetailHighlights();
-        if (lookFor && !labelHighlights && !descriptionHighlights && !detailHighlights) {
+        if ((lookFor && !labelHighlights && !descriptionHighlights && !detailHighlights)
+            && !this.options.showItemsWithoutHighlight) {
             return undefined;
         }
         const entry = item instanceof QuickOpenGroupItem ? new QuickOpenEntryGroup(item) : new QuickOpenEntry(item);


### PR DESCRIPTION
We are currently working on the workspace symbol support in clangd.
When the user types "ns1::func1", the workspace-symbol module wants to
generate an entry that looks like that.

  func1 | ns1:: - foo.c

Where "func1" is the label and "ns1:: - foo.c" the description part the
the quick open item.  Then, when the quick-open module processes it, it
tries to fuzzy match what the user typed literally ("ns1::func1") in the
label or description (depending on the options).  When there's no match,
it just drops the entry.  So in this case, the entry shown above won't
be shown, even though it's a valid match.

I think it's ok to have an option to fuzzy match to automatically add
the highlights, but I don't think we should drop the entry if there's no
literal match.  We should trust the data provider to provide us with
valid entries.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>