### PR TITLE
Keep terminal hidden during startup

### DIFF
--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -196,7 +196,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                         }
                     }
                     return widget;
-                }).catch(err => {
+                }, err => {
                     this.logger.warn(`Couldn't restore widget for ${desc.constructionOptions.factoryId}. Error: ${err} `);
                     return undefined;
                 });

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -35,6 +35,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 50000;
   background: var(--theia-layout-color3);
   background-image: var(--theia-preloader);
   background-size: 60px 60px;

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -148,6 +148,8 @@ export class TerminalFrontendContribution implements CommandContribution, MenuCo
         const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(TERMINAL_WIDGET_FACTORY_ID, <TerminalWidgetFactoryOptions>{
             created: new Date().toString()
         });
+        this.shell.addWidget(widget, { area: 'bottom' });
+        this.shell.activateWidget(widget.id);
         widget.start();
     }
 

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -7,7 +7,7 @@
 
 import { ContainerModule, Container } from 'inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { ApplicationShell, KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext } from '@theia/core/lib/browser';
+import { KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext } from '@theia/core/lib/browser';
 import { TerminalFrontendContribution } from './terminal-frontend-contribution';
 import { TerminalWidget, TerminalWidgetOptions, TERMINAL_WIDGET_FACTORY_ID } from './terminal-widget';
 import { ITerminalServer, terminalPath, terminalsPath } from '../common/terminal-protocol';
@@ -39,12 +39,7 @@ export default new ContainerModule(bind => {
                 destroyTermOnClose: true,
                 ...options
             });
-            const result = child.get(TerminalWidget);
-
-            const shell = ctx.container.get(ApplicationShell);
-            shell.addWidget(result, { area: 'bottom' });
-            shell.activateWidget(result.id);
-            return result;
+            return child.get(TerminalWidget);
         }
     }));
 


### PR DESCRIPTION
Fixes #1474. It seems to be a bad idea to attach and activate a widget inside the widget factory. When the layout is restored from the local storage, the factory is invoked, but in that case attaching the widget is the responsibility of the shell.