### PR TITLE
WIP incremental updating of document buffers

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -15,7 +15,6 @@
     "@theia/keymaps": "^0.3.7",
     "@theia/languages": "^0.3.7",
     "@theia/markers": "^0.3.7",
-    "@theia/merge-conflicts": "^0.3.7",
     "@theia/messages": "^0.3.7",
     "@theia/metrics": "^0.3.7",
     "@theia/monaco": "^0.3.7",

--- a/packages/core/src/browser/messaging/connection.ts
+++ b/packages/core/src/browser/messaging/connection.ts
@@ -21,6 +21,12 @@ export interface WebSocketOptions {
 @injectable()
 export class WebSocketConnectionProvider {
 
+    static bindProxy<T extends object>(bind: interfaces.Bind): WebSocketConnectionProvider.BindProxy<T> {
+        return (serviceIdentifier, path, target) => bind(serviceIdentifier).toDynamicValue(ctx =>
+            WebSocketConnectionProvider.createProxy<T>(ctx.container, path, target)
+        );
+    }
+
     static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T> {
         return container.get(WebSocketConnectionProvider).createProxy<T>(path, target);
     }
@@ -90,4 +96,7 @@ export class WebSocketConnectionProvider {
         return new WebSocket(url);
     }
 
+}
+export namespace WebSocketConnectionProvider {
+    export type BindProxy<T extends object> = (serviceIdentifier: interfaces.ServiceIdentifier<T>, path: string, target?: object) => interfaces.BindingInWhenOnSyntax<T>;
 }

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './types';
+export * from './promise-util';
 export * from './disposable';
 export * from './reference';
 export * from './event';

--- a/packages/core/src/common/reference.ts
+++ b/packages/core/src/common/reference.ts
@@ -12,13 +12,20 @@ export interface Reference<T> extends Disposable {
     readonly object: T
 }
 
-export class ReferenceCollection<K, V extends Disposable> {
+export class ReferenceCollection<K, V extends Disposable> implements Disposable {
 
     protected readonly values = new Map<string, MaybePromise<V>>();
     protected readonly keyMap = new Map<string, K>();
     protected readonly references = new Map<string, DisposableCollection>();
 
     constructor(protected readonly factory: (key: K) => MaybePromise<V>) { }
+
+    dispose(): void {
+        this.values.forEach(async promise => {
+            const value = await promise;
+            value.dispose();
+        });
+    }
 
     has(args: K): boolean {
         const key = this.toKey(args);

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -6,6 +6,7 @@
  */
 
 import { injectable, inject, named } from "inversify";
+import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
 import URI from "../common/uri";
 import { ContributionProvider } from './contribution-provider';
 import { Event } from "./event";
@@ -14,8 +15,9 @@ import { MaybePromise } from "./types";
 
 export interface Resource extends Disposable {
     readonly uri: URI;
-    readContents(options?: { encoding?: string }): Promise<string>;
-    saveContents?(content: string, options?: { encoding?: string }): Promise<void>;
+    readContents(): Promise<string>;
+    updateContents?(changes: TextDocumentContentChangeEvent[]): Promise<void>;
+    saveContents?(): Promise<void>
     readonly onDidChangeContents?: Event<void>;
 }
 

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -5,9 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export type Deferred<T> = {
-    [P in keyof T]: Promise<T[P]>
-};
 export type RecursivePartial<T> = {
     [P in keyof T]?: RecursivePartial<T[P]>;
 };

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -8,7 +8,7 @@
 import { ContainerModule } from 'inversify';
 import { ResourceResolver } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
-import { FileSystem, fileSystemPath, DocumentManager, documentManagerPath } from "../common";
+import { FileSystem, fileSystemPath, DocumentManager, documentManagerPath, DocumentManagerProxy, ReconnectingDocumentManager } from "../common";
 import {
     fileSystemWatcherPath, FileSystemWatcherServer,
     FileSystemWatcherServerProxy, ReconnectingFileSystemWatcherServer
@@ -34,7 +34,8 @@ export default new ContainerModule(bind => {
         return filesystem;
     });
 
-    bindProxy(DocumentManager, documentManagerPath);
+    bindProxy(DocumentManagerProxy, documentManagerPath);
+    bind(DocumentManager).to(ReconnectingDocumentManager);
     bind(FileResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(FileResourceResolver);
 });

--- a/packages/filesystem/src/common/document-manager.ts
+++ b/packages/filesystem/src/common/document-manager.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
+import { JsonRpcServer, Disposable } from "@theia/core";
+
+export const documentManagerPath = '/services/documents';
+
+export const DocumentManager = Symbol('DocumentManager');
+export interface DocumentManager extends JsonRpcServer<DocumentManagerClient> {
+    open(uri: string): Promise<void>;
+    read(uri: string): Promise<string>;
+    update(uri: string, changes: TextDocumentContentChangeEvent[]): Promise<void>;
+    save(uri: string): Promise<void>;
+    close(uri: string): Promise<void>;
+}
+
+export interface DocumentManagerClient {
+    onDidChange(uri: string): void
+}
+
+export class DispatchingDocumentManagerClient implements DocumentManagerClient {
+
+    protected readonly clients = new Map<string, DocumentManagerClient>();
+
+    onDidChange(uri: string): void {
+        const client = this.clients.get(uri);
+        if (client) {
+            client.onDidChange(uri);
+        }
+    }
+
+    set(uri: string, client: DocumentManagerClient): Disposable {
+        this.clients.set(uri, client);
+        return Disposable.create(() => this.clients.delete(uri));
+    }
+
+}

--- a/packages/filesystem/src/common/document-manager.ts
+++ b/packages/filesystem/src/common/document-manager.ts
@@ -5,8 +5,9 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { inject, injectable, postConstruct } from "inversify";
 import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
-import { JsonRpcServer, Disposable } from "@theia/core";
+import { JsonRpcServer, Disposable, DisposableCollection, JsonRpcProxy } from "@theia/core";
 
 export const documentManagerPath = '/services/documents';
 
@@ -21,6 +22,114 @@ export interface DocumentManager extends JsonRpcServer<DocumentManagerClient> {
 
 export interface DocumentManagerClient {
     onDidChange(uri: string): void
+}
+
+export const DocumentManagerProxy = Symbol('DocumentManagerProxy');
+export type DocumentManagerProxy = JsonRpcProxy<DocumentManager>;
+
+@injectable()
+export class ReconnectingDocumentManager implements DocumentManager {
+
+    @inject(DocumentManagerProxy)
+    protected readonly proxy: DocumentManagerProxy;
+
+    protected readonly opened = new Set<string>();
+
+    @postConstruct()
+    protected init(): void {
+        this.proxy.onDidOpenConnection(() => this.connected = true);
+        this.proxy.onDidCloseConnection(() => this.connected = false);
+    }
+
+    protected _connected = false;
+    protected readonly toDisposeOnConnect = new DisposableCollection();
+    protected get connected() {
+        return this._connected;
+    }
+    protected set connected(connected: boolean) {
+        this._connected = connected;
+        if (connected) {
+            this.toDisposeOnConnect.dispose();
+        }
+        if (!connected) {
+            this.toDisposeOnConnect.push(Disposable.create(() => this.reconnect()));
+        }
+    }
+
+    protected reconnect(): void {
+        for (const uri of this.opened) {
+            this.reopen(uri);
+        }
+    }
+    protected async reopen(uri: string): Promise<void> {
+        try {
+            await this.proxy.open(uri);
+            if (this.client) {
+                this.client.onDidChange(uri);
+            }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    dispose(): void {
+        this.proxy.dispose();
+    }
+
+    async open(uri: string): Promise<void> {
+        await this.proxy.open(uri);
+        this.opened.add(uri);
+    }
+
+    protected pendingUpdates = Promise.resolve();
+    update(uri: string, changes: TextDocumentContentChangeEvent[]): Promise<void> {
+        return this.pendingUpdates = this.pendingUpdates.then(() => this.doUpdate(uri, changes));
+    }
+    protected flush(uri: string): Promise<void> {
+        return this.update(uri, []);
+    }
+
+    protected readonly pendingChanges = new Map<string, TextDocumentContentChangeEvent[]>();
+    protected async doUpdate(uri: string, newChanges: TextDocumentContentChangeEvent[]): Promise<void> {
+        const pendingChanges = this.pendingChanges.get(uri) || [];
+        const changes = [...pendingChanges, ...newChanges];
+        if (changes.length === 0) {
+            return;
+        }
+        this.pendingChanges.set(uri, changes);
+        if (!this.connected) {
+            return;
+        }
+        try {
+            await this.proxy.update(uri, changes);
+            this.pendingChanges.set(uri, []);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    async read(uri: string): Promise<string> {
+        await this.flush(uri);
+        return this.proxy.read(uri);
+    }
+
+    async save(uri: string): Promise<void> {
+        await this.flush(uri);
+        return this.proxy.save(uri);
+    }
+
+    async close(uri: string): Promise<void> {
+        await this.flush(uri);
+        await this.proxy.close(uri);
+        this.opened.delete(uri);
+    }
+
+    protected client: DocumentManagerClient | undefined;
+    setClient(client: DocumentManagerClient | undefined): void {
+        this.client = client;
+        this.proxy.setClient(client);
+    }
+
 }
 
 export class DispatchingDocumentManagerClient implements DocumentManagerClient {

--- a/packages/filesystem/src/common/index.ts
+++ b/packages/filesystem/src/common/index.ts
@@ -7,3 +7,5 @@
 
 export * from './filesystem';
 export * from './filesystem-selection';
+// FIXME consider to move to own extension or to core
+export * from './document-manager';

--- a/packages/filesystem/src/node/document-manager-impl.spec.ts
+++ b/packages/filesystem/src/node/document-manager-impl.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from "assert";
+import { Container } from "inversify";
+import { Emitter } from "@theia/core";
+import { ReconnectingDocumentManager, DocumentManagerProxy, DocumentManager } from "../common";
+import { DocumentManagerImpl } from "./document-manager-impl";
+
+export interface MockDocumentManagerProxy extends DocumentManagerProxy {
+    readonly connected: boolean;
+    connect(): void;
+    disconnect(): void;
+}
+
+describe('ReconnectingDocumentManager', () => {
+
+    const fooUri = 'inmemory://Foo.txt';
+
+    let proxy: MockDocumentManagerProxy;
+    let manager: DocumentManager;
+    beforeEach(() => {
+        const container = new Container({ defaultScope: 'Singleton' });
+        container.bind(DocumentManagerImpl).toSelf();
+        container.bind<MockDocumentManagerProxy>(DocumentManagerProxy).toDynamicValue(() => {
+            const impl = container.get(DocumentManagerImpl);
+            const onDidOpenConnectionEmitter = new Emitter<void>();
+            const onDidCloseConnectionEmitter = new Emitter<void>();
+
+            let connected = false;
+            onDidOpenConnectionEmitter.event(() => connected = true);
+            onDidCloseConnectionEmitter.event(() => connected = false);
+            async function stub<T>(fn: () => Promise<T>): Promise<T> {
+                if (!connected) {
+                    throw new Error('disconnected');
+                }
+                return fn();
+            }
+            return {
+                connected,
+                connect: () => onDidOpenConnectionEmitter.fire(undefined),
+                disconnect: () => onDidCloseConnectionEmitter.fire(undefined),
+                onDidOpenConnection: onDidOpenConnectionEmitter.event,
+                onDidCloseConnection: onDidCloseConnectionEmitter.event,
+                dispose: () => {
+                    impl.dispose();
+                    onDidOpenConnectionEmitter.dispose();
+                    onDidCloseConnectionEmitter.dispose();
+                },
+                setClient: () => { },
+                open: uri => stub(() => impl.open(uri)),
+                read: uri => stub(() => impl.read(uri)),
+                update: (uri, changes) => stub(() => impl.update(uri, changes)),
+                save: uri => stub(() => impl.save(uri)),
+                close: uri => stub(() => impl.close(uri))
+            };
+        });
+        container.bind(ReconnectingDocumentManager).toSelf();
+        proxy = container.get(DocumentManagerProxy);
+        manager = container.get(ReconnectingDocumentManager);
+    });
+
+    afterEach(() => {
+        manager.dispose();
+    });
+
+    it('reopen on reconnect', async () => {
+        manager.setClient({
+            onDidChange: () => assert.fail('First connection should be skipped')
+        });
+        proxy.connect();
+        await manager.open(fooUri);
+        proxy.disconnect();
+
+        const reopenedUri = new Promise(resolve => manager.setClient({
+            onDidChange: uri => {
+                manager.setClient(undefined);
+                resolve(uri);
+            }
+        }));
+        proxy.connect();
+        assert.equal(fooUri, await reopenedUri);
+    });
+
+    it('update on reconnect', async () => {
+        proxy.connect();
+        await manager.open(fooUri);
+        proxy.disconnect();
+
+        manager.update(fooUri, [{ text: 'Hello World' }]);
+        manager.update(fooUri, [{ text: 'Hello Anton' }]);
+
+        proxy.connect();
+        assert.equal('Hello Anton', await manager.read(fooUri));
+    });
+
+    it('update on reconnect 2', async () => {
+        proxy.connect();
+        await manager.open(fooUri);
+        proxy.disconnect();
+
+        manager.update(fooUri, [{
+            text: `/// <reference path="moduleNameResolver.ts"/>
+/// <reference path="binder.ts"/>
+/// <reference path="symbolWalker.ts" />
+
+namespace ts2 {
+    let nextSymbolId = 1;
+    let nextNodeId = 1;
+    let nextNodeeId = 1;
+    let nextFlowId = 1;
+}` }]);
+        await manager.update(fooUri, [{
+            "text": `
+    let nextSymbolId = 1;
+    let nextNodeId = 1;
+    let nextNodeeId = 1;
+    let nextFlowId = 1;`,
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 23
+                },
+                "end": {
+                    "line": 8,
+                    "character": 23
+                }
+            },
+            "rangeLength": 0
+        }]);
+
+        proxy.connect();
+        manager.update(fooUri, [{
+            "text": "2",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 18
+                },
+                "end": {
+                    "line": 8,
+                    "character": 18
+                }
+            },
+            "rangeLength": 0
+        }]);
+        assert.equal(`/// <reference path="moduleNameResolver.ts"/>
+/// <reference path="binder.ts"/>
+/// <reference path="symbolWalker.ts" />
+
+namespace ts2 {
+    let nextSymbolId = 1;
+    let nextNodeId = 1;
+    let nextNodeeId = 1;
+    let nextFlowId2 = 1;
+    let nextSymbolId = 1;
+    let nextNodeId = 1;
+    let nextNodeeId = 1;
+    let nextFlowId = 1;
+}`, await manager.read(fooUri));
+    });
+
+});

--- a/packages/filesystem/src/node/document-manager-impl.ts
+++ b/packages/filesystem/src/node/document-manager-impl.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from "inversify";
+import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
+import { ReferenceCollection, Reference } from "@theia/core";
+import URI from "@theia/core/lib/common/uri";
+import { DocumentManager, DocumentManagerClient } from "../common";
+import { Document, FileDocument } from "./document";
+
+// FIXME: should we ensure that all requests processed in order? here?
+@injectable()
+export class DocumentManagerImpl implements DocumentManager {
+
+    protected readonly documents = new ReferenceCollection<string, Document>(
+        uri => this.create(uri)
+    );
+
+    dispose(): void {
+        this.documents.dispose();
+    }
+
+    protected client: DocumentManagerClient | undefined;
+    setClient(client: DocumentManagerClient | undefined): void {
+        this.client = client;
+    }
+
+    async open(uri: string): Promise<void> {
+        const { object } = await this.documents.acquire(uri);
+        object.onDidChange(() => {
+            if (this.client) {
+                this.client.onDidChange(uri);
+            }
+        });
+    }
+
+    async read(uri: string): Promise<string> {
+        const reference = await this.get(uri);
+        try {
+            return reference.object.content.getText();
+        } finally {
+            reference.dispose();
+        }
+    }
+
+    async update(uri: string, changes: TextDocumentContentChangeEvent[]): Promise<void> {
+        const reference = await this.get(uri);
+        try {
+            return reference.object.update(changes);
+        } finally {
+            reference.dispose();
+        }
+    }
+
+    async save(uri: string): Promise<void> {
+        const reference = await this.get(uri);
+        try {
+            return reference.object.save();
+        } finally {
+            reference.dispose();
+        }
+    }
+
+    async close(uri: string): Promise<void> {
+        const { object } = await this.get(uri);
+        object.dispose();
+    }
+
+    protected async get(uri: string): Promise<Reference<Document>> {
+        if (this.documents.has(uri)) {
+            return this.documents.acquire(uri);
+        }
+        throw new Error(`${uri} is not opened`);
+    }
+
+    protected async create(stringUri: string): Promise<Document> {
+        // FIXME support other documents?
+        const resource = new FileDocument(new URI(stringUri));
+        await resource.ready;
+        return resource;
+    }
+
+}

--- a/packages/filesystem/src/node/document-manager-impl.ts
+++ b/packages/filesystem/src/node/document-manager-impl.ts
@@ -10,9 +10,8 @@ import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
 import { ReferenceCollection, Reference } from "@theia/core";
 import URI from "@theia/core/lib/common/uri";
 import { DocumentManager, DocumentManagerClient } from "../common";
-import { Document, FileDocument } from "./document";
+import { Document, FileDocument, BaseDocument } from "./document";
 
-// FIXME: should we ensure that all requests processed in order? here?
 @injectable()
 export class DocumentManagerImpl implements DocumentManager {
 
@@ -78,10 +77,13 @@ export class DocumentManagerImpl implements DocumentManager {
     }
 
     protected async create(stringUri: string): Promise<Document> {
-        // FIXME support other documents?
-        const resource = new FileDocument(new URI(stringUri));
-        await resource.ready;
-        return resource;
+        const uri = new URI(stringUri);
+        // FIXME support other URIs?
+        const document = uri.scheme === 'file' ?
+            new FileDocument(new URI(stringUri)) :
+            new BaseDocument(uri);
+        await document.ready;
+        return document;
     }
 
 }

--- a/packages/filesystem/src/node/document.spec.ts
+++ b/packages/filesystem/src/node/document.spec.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as assert from 'assert';
+import { FileUri } from "@theia/core/lib/node";
+import { BaseDocument } from "./document";
+
+describe("BaseDocument", () => {
+
+    it('update 01', async () => {
+        const text = `Hello World
+Hello Anton`;
+        const document = new BaseDocument(FileUri.create('/foo.txt'));
+        await document.ready;
+        document.update([{ text }]);
+        assert.equal(text, document.content.getText());
+    });
+
+    it('update 02', async () => {
+        const document = new BaseDocument(FileUri.create('/foo.txt'));
+        await document.ready;
+        document.update([{ text: 'Hello World' }]);
+        assert.equal('Hello World', document.content.getText());
+        document.update([{
+            "text": "\n",
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 11
+                },
+                "end": {
+                    "line": 0,
+                    "character": 11
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "H",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 0
+                },
+                "end": {
+                    "line": 1,
+                    "character": 0
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "e",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 1
+                },
+                "end": {
+                    "line": 1,
+                    "character": 1
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "l",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 2
+                },
+                "end": {
+                    "line": 1,
+                    "character": 2
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "l",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 3
+                },
+                "end": {
+                    "line": 1,
+                    "character": 3
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "o",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 4
+                },
+                "end": {
+                    "line": 1,
+                    "character": 4
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": " ",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 5
+                },
+                "end": {
+                    "line": 1,
+                    "character": 5
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "A",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 6
+                },
+                "end": {
+                    "line": 1,
+                    "character": 6
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "n",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 7
+                },
+                "end": {
+                    "line": 1,
+                    "character": 7
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "t",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 8
+                },
+                "end": {
+                    "line": 1,
+                    "character": 8
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "o",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 9
+                },
+                "end": {
+                    "line": 1,
+                    "character": 9
+                }
+            },
+            "rangeLength": 0
+        },
+        {
+            "text": "n",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 10
+                },
+                "end": {
+                    "line": 1,
+                    "character": 10
+                }
+            },
+            "rangeLength": 0
+        }]);
+        assert.equal(`Hello World
+Hello Anton`, document.content.getText());
+    });
+
+});

--- a/packages/filesystem/src/node/document.ts
+++ b/packages/filesystem/src/node/document.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as fs from "fs-extra";
+import { TextDocument, TextDocumentContentChangeEvent } from "vscode-languageserver-types";
+import { Emitter, Event, Disposable, DisposableCollection, MaybePromise } from "@theia/core";
+import URI from "@theia/core/lib/common/uri";
+import { FileUri } from "@theia/core/lib/node";
+
+export interface Document extends Disposable {
+    readonly content: TextDocument;
+    readonly onDidChange: Event<void>;
+    update(changes: TextDocumentContentChangeEvent[]): MaybePromise<void>;
+    save(): MaybePromise<void>;
+}
+
+export class BaseDocument implements Document {
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    readonly ready: Promise<void>;
+    protected _document: TextDocument;
+
+    constructor(
+        readonly uri: URI,
+        readonly languageId: string = ''
+    ) {
+        this.toDispose.push(this.onDidChangeEmitter);
+        this.ready = this.init();
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    get content(): TextDocument {
+        return this._document;
+    }
+
+    protected async init(): Promise<void> {
+        const content = await this.read();
+        this._document = TextDocument.create(this.uri.toString(), this.languageId, 0, content);
+    }
+
+    protected async sync(): Promise<void> {
+        const content = await this.read();
+        if (this._document.getText() !== content) {
+            this.updateDocument(content);
+            this.onDidChangeEmitter.fire(undefined);
+        }
+    }
+
+    update(changes: TextDocumentContentChangeEvent[]): void {
+        const newContent = this.applyContenChanges(changes);
+        this.updateDocument(newContent);
+    }
+
+    protected applyContenChanges(changes: TextDocumentContentChangeEvent[]): string {
+        let d = this._document;
+        for (const change of changes) {
+            let content = change.text;
+            if (change.range) {
+                const start = d.offsetAt(change.range.start);
+                const end = d.offsetAt(change.range.end);
+                content = d.getText().substr(0, start) + change.text + d.getText().substr(end);
+            }
+            d = TextDocument.create(d.uri, d.languageId, d.version, content);
+        }
+        return d.getText();
+    }
+
+    protected updateDocument(content: string): void {
+        this._document = TextDocument.create(this._document.uri, this._document.languageId, this._document.version + 1, content);
+    }
+
+    save(): MaybePromise<void> {
+        // no-op
+    }
+
+    protected read(): MaybePromise<string> {
+        return this._document ? this._document.getText() : '';
+    }
+
+}
+
+export class FileDocument extends BaseDocument {
+
+    protected fsPath: string;
+
+    protected readonly options = {
+        encoding: 'utf8'
+    };
+
+    protected async init(): Promise<void> {
+        if (this.uri.scheme !== 'file') {
+            throw new Error('The given uri is not a file uri: ' + this.uri);
+        }
+        this.fsPath = FileUri.fsPath(this.uri);
+
+        // FIXME throw if a directory
+        // FIXME await when exists
+
+        const listener = this.sync.bind(this);
+        fs.watchFile(this.fsPath, listener);
+        this.toDispose.push(Disposable.create(() => fs.unwatchFile(this.fsPath, listener)));
+
+        await super.init();
+    }
+
+    protected async read(): Promise<string> {
+        try {
+            const result = await fs.readFile(this.fsPath, this.options);
+            return result.toString();
+        } catch {
+            return '';
+        }
+    }
+
+    async save(): Promise<void> {
+        await fs.writeFile(this.fsPath, this._document.getText(), this.options);
+    }
+}

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -20,7 +20,7 @@ import { GitQuickOpenService } from './git-quick-open-service';
 import { GitUriLabelProviderContribution } from './git-uri-label-contribution';
 import { GitDecorator } from './git-decorator';
 import { bindGitPreferences } from './git-preferences';
-import { bindDirtyDiff } from './dirty-diff/dirty-diff-module';
+// import { bindDirtyDiff } from './dirty-diff/dirty-diff-module';
 import { GitRepositoryTracker } from './git-repository-tracker';
 
 import '../../src/browser/style/index.css';
@@ -29,7 +29,7 @@ export default new ContainerModule(bind => {
     bindGitPreferences(bind);
     bindGitDiffModule(bind);
     bindGitHistoryModule(bind);
-    bindDirtyDiff(bind);
+    // bindDirtyDiff(bind);
     bind(GitRepositoryTracker).toSelf().inSingletonScope();
     bind(GitWatcherServerProxy).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, GitWatcherPath)).inSingletonScope();
     bind(GitWatcherServer).to(ReconnectingGitWatcherServer).inSingletonScope();

--- a/packages/java/src/browser/java-resource.ts
+++ b/packages/java/src/browser/java-resource.ts
@@ -22,7 +22,7 @@ export class JavaResource implements Resource {
     dispose(): void {
     }
 
-    readContents(options: { encoding?: string }): Promise<string> {
+    readContents(): Promise<string> {
         const uri = this.uri.toString();
         return this.clientContribution.languageClient.then(languageClient =>
             languageClient.sendRequest(ClassFileContentsRequest.type, { uri }).then(content =>

--- a/packages/userstorage/src/browser/user-storage-resource.ts
+++ b/packages/userstorage/src/browser/user-storage-resource.ts
@@ -6,6 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
+import { TextDocumentContentChangeEvent } from 'vscode-languageserver-types';
 import URI from '@theia/core/lib/common/uri';
 import { Resource, ResourceResolver, Emitter, Event, MaybePromise, DisposableCollection } from '@theia/core/lib/common';
 import { UserStorageService } from './user-storage-service';
@@ -38,8 +39,14 @@ export class UserStorageResource implements Resource {
         return this.service.readContents(this.uri);
     }
 
-    saveContents(content: string): Promise<void> {
-        return this.service.saveContents(this.uri, content);
+    protected content = '';
+    async updateContents(changes: TextDocumentContentChangeEvent[]): Promise<void> {
+        // FIXME: handle changes properly
+        this.content = changes[0]!.text;
+    }
+
+    saveContents(): Promise<void> {
+        return this.service.saveContents(this.uri, this.content);
     }
 
     get onDidChangeContents(): Event<void> {

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
@@ -210,7 +210,7 @@ describe('User Storage Resource (Filesystem implementation)', () => {
 
     it('Should save and read correctly to fs', async () => {
         const testContent = 'test content';
-        await userStorageResource.saveContents(testContent);
+        await userStorageResource.updateContents([{ text: testContent }]);
         const testFsUri = UserStorageServiceFilesystemImpl.toFilesystemURI(userStorageFolder, userStorageResource.uri);
 
         expect(files[testFsUri.toString()]).eq(testContent);

--- a/packages/userstorage/src/browser/user-storage-service.ts
+++ b/packages/userstorage/src/browser/user-storage-service.ts
@@ -11,9 +11,7 @@ export const UserStorageService = Symbol('UserStorageService');
 
 export interface UserStorageService extends Disposable {
     readContents(uri: URI): Promise<string>;
-
     saveContents(uri: URI, content: string): Promise<void>;
-
     onUserStorageChanged: Event<UserStorageChangeEvent>;
 }
 


### PR DESCRIPTION
This PR introduces the document manager on the backend which keeps document buffers per a page. The frontend fetches the content once and after that incrementally notify the backend about changes.

It is not finished yet:
- [x] reopen document buffers on reconnecting
- [ ] handle the case when a file does not exist or gets deleted
- [ ] ~consider sending a content diff to the frontend if a document is changed on the filesystem instead of fetching again the whole content~ - it happens quite rare
- [ ] hook up language servers to send increments to backend only once, not for each ls as now
- [ ] adapt the user storage service
- [ ] allow configuring encoding from the frontend

I've disabled dirty diffs and merge conflicts to get the clean measurement. I will enable them in the final version.

For trying out one can use https://github.com/Microsoft/TypeScript repo. It has files with 20K LOC and more.