### PR TITLE
Enables dirty diffs for `file` URIs only.

### DIFF
--- a/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
@@ -51,6 +51,9 @@ export class DirtyDiffManager {
     protected async handleEditorCreated(editorWidget: EditorWidget): Promise<void> {
         const editor = editorWidget.editor;
         const uri = editor.document.uri;
+        if (new URI(uri).scheme !== 'file') {
+            return;
+        }
         const reference = await this.models.acquire(uri);
         editorWidget.disposed.connect(() => reference.dispose());
         const model = reference.object;


### PR DESCRIPTION
Editors opened with URIs other then `file:` should not be handled in dirty diff manager. In the example from #1475 the editor is opened with a `gitrev` URI from diffing a tree with another git branch.

Closes #1475.

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>