### PR TITLE
[wip] GH-1081 Auto-dismiss notification.

### DIFF
--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -21,12 +21,17 @@ export interface Message {
     type: MessageType;
     text: string;
     actions?: string[];
+    options?: MessageOptions;
+}
+
+export interface MessageOptions {
+    timeout?: number;
 }
 
 @injectable()
 export class MessageClient {
 
-    constructor( @inject(ILogger) protected readonly logger: ILogger) { }
+    constructor(@inject(ILogger) protected readonly logger: ILogger) { }
 
     /**
      * Show a message of the given type and possible actions to the user.

--- a/packages/core/src/common/message-service.ts
+++ b/packages/core/src/common/message-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import { MessageClient, MessageType } from "./message-service-protocol";
+import { MessageClient, MessageType, MessageOptions } from "./message-service-protocol";
 
 @injectable()
 export class MessageService {
@@ -15,20 +15,50 @@ export class MessageService {
         @inject(MessageClient) protected readonly client: MessageClient
     ) { }
 
-    log(message: string, ...actions: string[]): Promise<string | undefined> {
-        return this.client.showMessage({ type: MessageType.Log, text: message, actions: actions || [] });
+    log(message: string, ...actions: string[]): Promise<string | undefined>;
+    log(message: string, options?: MessageOptions): Promise<string | undefined>;
+    log(message: string, options?: MessageOptions, ...actions: string[]): Promise<string | undefined>;
+    log(message: string, ...args: any[]): Promise<string | undefined> {
+        return this.processArgs(MessageType.Log, message, args);
     }
 
-    info(message: string, ...actions: string[]): Promise<string | undefined> {
-        return this.client.showMessage({ type: MessageType.Info, text: message, actions: actions || [] });
+    info(message: string, ...actions: string[]): Promise<string | undefined>;
+    info(message: string, options?: MessageOptions): Promise<string | undefined>;
+    info(message: string, options?: MessageOptions, ...actions: string[]): Promise<string | undefined>;
+    info(message: string, ...args: any[]): Promise<string | undefined> {
+        return this.processArgs(MessageType.Info, message, args);
     }
 
-    warn(message: string, ...actions: string[]): Promise<string | undefined> {
-        return this.client.showMessage({ type: MessageType.Warning, text: message, actions: actions || [] });
+    warn(message: string, ...actions: string[]): Promise<string | undefined>;
+    warn(message: string, options?: MessageOptions): Promise<string | undefined>;
+    warn(message: string, options?: MessageOptions, ...actions: string[]): Promise<string | undefined>;
+    warn(message: string, ...args: any[]): Promise<string | undefined> {
+        return this.processArgs(MessageType.Warning, message, args);
     }
 
-    error(message: string, ...actions: string[]): Promise<string | undefined> {
-        return this.client.showMessage({ type: MessageType.Error, text: message, actions: actions || [] });
+    error(message: string, ...actions: string[]): Promise<string | undefined>;
+    error(message: string, options?: MessageOptions): Promise<string | undefined>;
+    error(message: string, options?: MessageOptions, ...actions: string[]): Promise<string | undefined>;
+    error(message: string, ...args: any[]): Promise<string | undefined> {
+        return this.processArgs(MessageType.Error, message, args);
+    }
+
+    private processArgs(messageType: MessageType, messageText: string, args: any[]): Promise<string | undefined> {
+        let timeoutvalue: number | undefined;
+        let actionsValue: string[] | undefined;
+        if (args && args instanceof Object && args.length > 0) {
+            const options = <MessageOptions>args[0];
+            if (!!options.timeout) {
+                timeoutvalue = options.timeout;
+                if (args[1]) {
+                    actionsValue = args.slice(1);
+                }
+            } else {
+                actionsValue = args;
+            }
+            return this.client.showMessage({ type: messageType, options: { timeout: timeoutvalue }, text: messageText, actions: actionsValue });
+        }
+        return this.client.showMessage({ type: messageType, text: messageText });
     }
 
 }

--- a/packages/messages/src/browser/messages-frontend-module.ts
+++ b/packages/messages/src/browser/messages-frontend-module.ts
@@ -12,8 +12,10 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { NotificationsMessageClient } from './notifications-message-client';
 
 import '../../src/browser/style/index.css';
+import { bindNotificationPreferences } from './notification-preferences';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
+    bindNotificationPreferences(bind);
     bind(NotificationsMessageClient).toSelf().inSingletonScope();
     rebind(MessageClient).toDynamicValue(context => {
         const notificationsClient = context.container.get(NotificationsMessageClient);

--- a/packages/messages/src/browser/notification-preferences.ts
+++ b/packages/messages/src/browser/notification-preferences.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces } from "inversify";
+import {
+    createPreferenceProxy,
+    PreferenceProxy,
+    PreferenceService,
+    PreferenceContribution,
+    PreferenceSchema
+} from '@theia/core/lib/browser/preferences';
+
+export const NotificationConfigSchema: PreferenceSchema = {
+    "type": "object",
+    "properties": {
+        "notification.timeout": {
+            "type": "number",
+            "description": "The time before auto-dismiss the notification.",
+            "default": 5000 // time express in millisec. 0 means : Do not remove
+        }
+    }
+};
+
+export interface NotificationConfiguration {
+    'notification.timeout': number
+}
+
+export const NotificationPreferences = Symbol('NotificationPreferences');
+export type NotificationPreferences = PreferenceProxy<NotificationConfiguration>;
+
+export function createNotificationPreferences(preferences: PreferenceService): NotificationPreferences {
+    return createPreferenceProxy(preferences, NotificationConfigSchema);
+}
+
+export function bindNotificationPreferences(bind: interfaces.Bind): void {
+    bind(NotificationPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createNotificationPreferences(preferences);
+    });
+
+    bind(PreferenceContribution).toConstantValue({ schema: NotificationConfigSchema });
+}

--- a/packages/messages/src/browser/notifications-message-client.ts
+++ b/packages/messages/src/browser/notifications-message-client.ts
@@ -5,18 +5,20 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import {
     MessageClient,
     MessageType,
     Message
 } from '@theia/core/lib/common';
 import { Notifications, NotificationAction } from './notifications';
+import { NotificationPreferences } from "./notification-preferences";
 
 @injectable()
 export class NotificationsMessageClient extends MessageClient {
 
     protected notifications: Notifications = new Notifications();
+    @inject(NotificationPreferences) protected preferences: NotificationPreferences;
 
     showMessage(message: Message): Promise<string | undefined> {
         return this.show(message);
@@ -35,6 +37,11 @@ export class NotificationsMessageClient extends MessageClient {
             label: action,
             fn: element => onCloseFn(action)
         });
+
+        const timeout = (message.actions)
+            ? undefined
+            : (message.options !== undefined ? message.options.timeout : this.preferences['notification.timeout']);
+
         actions.push(<NotificationAction>{
             label: 'Close',
             fn: element => onCloseFn(undefined)
@@ -42,7 +49,8 @@ export class NotificationsMessageClient extends MessageClient {
         this.notifications.show({
             icon,
             text,
-            actions
+            actions,
+            timeout
         });
     }
 

--- a/packages/messages/src/browser/notifications.ts
+++ b/packages/messages/src/browser/notifications.ts
@@ -20,6 +20,7 @@ export interface NotificationProperties {
     icon: string;
     text: string;
     actions?: NotificationAction[];
+    timeout: number | undefined;
 }
 
 export interface Notification {
@@ -65,12 +66,21 @@ export class Notifications {
         const handler = <Notification>{ element, properties };
         const buttons = element.appendChild(document.createElement('div'));
         buttons.classList.add(BUTTONS);
+
+        const closeTimer = (!!properties.timeout && properties.timeout > 0) ?
+            window.setTimeout(() => {
+                close();
+            }, properties.timeout) : undefined;
+
         if (!!properties.actions) {
             for (const action of properties.actions) {
                 const button = buttons.appendChild(document.createElement('button'));
                 button.innerText = action.label;
                 button.addEventListener('click', () => {
                     action.fn(handler);
+                    if (closeTimer) {
+                        window.clearTimeout(closeTimer);
+                    }
                     close();
                 });
             }


### PR DESCRIPTION
Follow-up on #1355 closed by mistake and unable to re-open it.
Add notifications preferences to allow auto-dismiss
Auto-Dismiss can be used/disabled for each notification since it is optional
When the user has more than one action available,
the auto-Dismiss timeout will not be applied

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>