### PR TITLE
Add prefix to extension commands

### DIFF
--- a/examples/browser/test/top-panel/top-panel.ts
+++ b/examples/browser/test/top-panel/top-panel.ts
@@ -17,7 +17,7 @@ export class TopPanel {
 
     openNewTerminal() {
         this.clickMenuTab('File');
-        this.clickSubMenu('New Terminal');
+        this.clickSubMenu('Open New Terminal');
     }
 
     openProblemsView() {

--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -12,7 +12,7 @@ import { KeybindingRegistry, KeybindingContribution } from "../keybinding";
 
 export const quickCommand: Command = {
     id: 'quickCommand',
-    label: 'Quick Command'
+    label: 'Open Quick Command'
 };
 
 @injectable()

--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -21,7 +21,7 @@ import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
  */
 export const SWITCH_SOURCE_HEADER: Command = {
     id: 'switch_source_header',
-    label: 'Switch between source/header file'
+    label: 'C++: Switch between source/header file'
 };
 
 export const FILE_OPEN_PATH = (path: string): Command => <Command>{

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -18,7 +18,7 @@ export const quickFileOpen: Command = {
 @injectable()
 export class QuickFileOpenFrontendContribution implements CommandContribution, KeybindingContribution {
 
-    constructor( @inject(QuickFileOpenService) protected readonly quickFileOpenService: QuickFileOpenService) { }
+    constructor(@inject(QuickFileOpenService) protected readonly quickFileOpenService: QuickFileOpenService) { }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -22,7 +22,7 @@ import { Git } from "../../common";
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
         id: 'git-diff:open-file-diff',
-        label: 'Compare with ...'
+        label: 'Diff: Compare With ...'
     };
 }
 

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -23,19 +23,19 @@ const GIT_AHEAD_BEHIND = 'git-ahead-behind';
 export namespace GIT_COMMANDS {
     export const FETCH = {
         id: 'git.fetch',
-        label: 'Git: Fetch'
+        label: 'Git: Fetch...'
     };
     export const PULL = {
         id: 'git.pull',
-        label: 'Git: Pull'
+        label: 'Git: Pull...'
     };
     export const PUSH = {
         id: 'git.push',
-        label: 'Git: Push'
+        label: 'Git: Push...'
     };
     export const MERGE = {
         id: 'git.merge',
-        label: 'Git: Merge'
+        label: 'Git: Merge...'
     };
     export const CHECKOUT = {
         id: 'git.checkout',
@@ -43,7 +43,7 @@ export namespace GIT_COMMANDS {
     };
     export const CHANGE_REPOSITORY = {
         id: 'git.change.repository',
-        label: 'Git: Change Repository'
+        label: 'Git: Change Repository...'
     };
     export const OPEN_FILE = {
         id: 'git.open.file',

--- a/packages/merge-conflicts/src/browser/merge-conflict.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict.ts
@@ -28,14 +28,14 @@ export interface MergeConflictCommandArgument {
 export namespace MergeConflictsCommands {
     export const AcceptCurrent: Command = {
         id: 'merge-conflicts:accept.current',
-        label: 'Accept Current Change'
+        label: 'Merge Conflict: Accept Current Change'
     };
     export const AcceptIncoming: Command = {
         id: 'merge-conflicts:accept.incoming',
-        label: 'Accept Incoming Change'
+        label: 'Merge Conflict: Accept Incoming Change'
     };
     export const AcceptBoth: Command = {
         id: 'merge-conflicts:accept.both',
-        label: 'Accept Both Changes'
+        label: 'Merge Conflict: Accept Both Changes'
     };
 }

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -25,12 +25,12 @@ export namespace TaskCommands {
     // run task command
     export const TASK_RUN: Command = {
         id: 'task:run',
-        label: 'Run Task...'
+        label: 'Tasks: Run...'
     };
 
     export const TASK_ATTACH: Command = {
         id: 'task:attach',
-        label: 'Attach to Task ...'
+        label: 'Tasks: Attach...'
     };
 }
 
@@ -66,10 +66,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         menus.registerSubmenu(TaskCommands.TASK_MENU, TaskCommands.TASK_MENU_LABEL);
         menus.registerMenuAction(TaskCommands.RUN_GROUP, {
             commandId: TaskCommands.TASK_RUN.id,
+            label: TaskCommands.TASK_RUN.label ? TaskCommands.TASK_RUN.label.slice('Tasks: '.length) : TaskCommands.TASK_RUN.label,
             order: '0'
         });
+
         menus.registerMenuAction(TaskCommands.RUN_GROUP, {
             commandId: TaskCommands.TASK_ATTACH.id,
+            label: TaskCommands.TASK_ATTACH.label ? TaskCommands.TASK_ATTACH.label.slice('Tasks: '.length) : TaskCommands.TASK_ATTACH.label,
             order: '1'
         });
     }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -26,7 +26,7 @@ import { TerminalKeybindingContexts } from "./terminal-keybinding-contexts";
 export namespace TerminalCommands {
     export const NEW: Command = {
         id: 'terminal:new',
-        label: 'New Terminal'
+        label: 'Open New Terminal'
     };
 }
 


### PR DESCRIPTION
I still need to write the doc for this, I'll do it on the website repository after this is merged. As I wrote in the issue, I decided not to add prefixes to core/workspace/monaco commands as I think it would be too much, let me know what you think.