### PR TITLE
Removing `chai-as-promised` uses

### DIFF
--- a/examples/electron/test/basic-example.espec.ts
+++ b/examples/electron/test/basic-example.espec.ts
@@ -6,7 +6,6 @@
  */
 
 import * as chai from "chai";
-import * as chaiAsPromised from "chai-as-promised";
 import * as path from 'path';
 import * as electron from 'electron';
 
@@ -15,13 +14,6 @@ const expect = chai.expect;
 const mainWindow: Electron.BrowserWindow = new electron.BrowserWindow({ width: 1024, height: 728 });
 
 const { app } = require('electron');
-
-before(() => {
-    chai.config.showDiff = true;
-    chai.config.includeStack = true;
-    chai.should();
-    chai.use(chaiAsPromised);
-});
 
 describe('basic-example-spec', () => {
     describe('01 #start example app', () => {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/temp": "^0.8.29",
     "@types/webdriverio": "^4.7.0",
     "chai": "^4.1.0",
-    "chai-as-promised": "^7.1.1",
     "chai-string": "^1.4.0",
     "concurrently": "^3.5.0",
     "electron-mocha": "^3.5.0",

--- a/packages/core/src/browser/endpoint.spec.ts
+++ b/packages/core/src/browser/endpoint.spec.ts
@@ -12,11 +12,6 @@ const expect = chai.expect;
 
 describe("Endpoint", () => {
 
-    before(() => {
-        chai.config.showDiff = true;
-        chai.config.includeStack = true;
-    });
-
     describe("01 #getWebSocketUrl", () => {
 
         it("Should correctly join root pathname", () => {

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -26,8 +26,6 @@ disableJSDOM();
 /* tslint:disable:no-unused-expression */
 
 const expect = chai.expect;
-chai.config.showDiff = true;
-chai.config.includeStack = true;
 
 let keybindingRegistry: KeybindingRegistry;
 let commandRegistry: CommandRegistry;

--- a/packages/core/src/common/menu.spec.ts
+++ b/packages/core/src/common/menu.spec.ts
@@ -7,21 +7,9 @@
 
 import { CommandContribution, CommandRegistry } from './command';
 import { CompositeMenuNode, MenuContribution, MenuModelRegistry } from './menu';
-import "mocha";
 import * as chai from "chai";
-import * as chaiAsPromised from "chai-as-promised";
 
 const expect = chai.expect;
-
-before(() => {
-    chai.config.showDiff = true;
-    chai.config.includeStack = true;
-    chai.should();
-    chai.use(chaiAsPromised);
-});
-
-beforeEach(() => {
-});
 
 describe('menu-model-registry', () => {
 

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -5,22 +5,13 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import "mocha";
 import * as chai from "chai";
-import * as chaiAsPromised from "chai-as-promised";
 import { ConsoleLogger } from '../../node/messaging/logger';
 import { JsonRpcProxyFactory } from './proxy-factory';
 import { createMessageConnection } from "vscode-jsonrpc/lib/main";
 import * as stream from "stream";
 
 const expect = chai.expect;
-
-before(() => {
-    chai.config.showDiff = true;
-    chai.config.includeStack = true;
-    chai.should();
-    chai.use(chaiAsPromised);
-});
 
 class NoTransform extends stream.Transform {
 
@@ -53,10 +44,8 @@ class TestClient {
     }
 }
 
-beforeEach(() => {
-});
-
 describe('Proxy-Factory', () => {
+
     it('Should correctly send notifications and requests.', done => {
         const it = getSetup();
         it.clientProxy.notifyThat("hello");

--- a/packages/core/src/common/selection-service.spec.ts
+++ b/packages/core/src/common/selection-service.spec.ts
@@ -6,29 +6,17 @@
  */
 
 import { SelectionService } from './selection-service';
-import "mocha";
 import * as chai from "chai";
-import * as chaiAsPromised from "chai-as-promised";
 
 const expect = chai.expect;
-
-before(() => {
-    chai.config.showDiff = true;
-    chai.config.includeStack = true;
-    chai.should();
-    chai.use(chaiAsPromised);
-});
-
-beforeEach(() => {
-});
 
 describe('selection-service', () => {
 
     describe('01 #addListener and dispose', () => {
         it('Should be rejected when path argument is undefined.', () => {
-            let service = createSelectionService();
-            let events: any[] = [];
-            let disposable = service.onSelectionChanged(
+            const service = createSelectionService();
+            const events: any[] = [];
+            const disposable = service.onSelectionChanged(
                 e => events.push(e)
             );
             service.selection = "foo";

--- a/packages/core/src/common/test/expect.ts
+++ b/packages/core/src/common/test/expect.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+
+// tslint:disable-next-line:no-any
+export async function expectThrowsAsync(actual: Promise<any>, expected?: string | RegExp, message?: string): Promise<void>;
+// tslint:disable-next-line:no-any
+export async function expectThrowsAsync(actual: Promise<any>, constructor: Error | Function, expected?: string | RegExp, message?: string): Promise<void>;
+// tslint:disable-next-line:no-any
+export async function expectThrowsAsync(promise: Promise<any>, ...args: any[]): Promise<void> {
+    let synchronous = () => { };
+    try {
+        await promise;
+    } catch (e) {
+        synchronous = () => { throw e; };
+    } finally {
+        expect(synchronous).throw(...args);
+    }
+}

--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -10,15 +10,6 @@ import URI from "./uri";
 
 const expect = chai.expect;
 
-before(() => {
-    chai.config.showDiff = true;
-    chai.config.includeStack = true;
-    chai.should();
-});
-
-beforeEach(() => {
-});
-
 describe("uri", () => {
 
     describe("#getParent", () => {
@@ -131,7 +122,7 @@ describe("uri", () => {
 
     describe("#Uri.with...()", () => {
         it("produce proper URIs", () => {
-            let uri = new URI().withScheme('file').withPath('/foo/bar.txt').withQuery("x=12").withFragment("baz");
+            const uri = new URI().withScheme('file').withPath('/foo/bar.txt').withQuery("x=12").withFragment("baz");
             expect(uri.toString(true)).equals("file:///foo/bar.txt?x=12#baz");
 
             expect(uri.withoutScheme().toString(true)).equals("/foo/bar.txt?x=12#baz");

--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -5,7 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import 'mocha';
 import * as chai from 'chai';
 import * as path from 'path';
 import { FileSearchServiceImpl } from './file-search-service-impl';

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -9,11 +9,11 @@ import * as os from 'os';
 import * as temp from 'temp';
 import * as chai from 'chai';
 import * as fs from 'fs-extra';
-import * as chaiAsPromised from 'chai-as-promised';
 import URI from "@theia/core/lib/common/uri";
 import { FileUri } from "@theia/core/lib/node";
 import { FileSystem } from "../common/filesystem";
 import { FileSystemNode } from "./node-filesystem";
+import { expectThrowsAsync } from '@theia/core/lib/common/test/expect';
 
 // tslint:disable:no-unused-expression
 
@@ -27,13 +27,6 @@ describe("NodeFileSystem", function () {
 
     this.timeout(10000);
 
-    before(() => {
-        chai.config.showDiff = true;
-        chai.config.includeStack = true;
-        chai.should();
-        chai.use(chaiAsPromised);
-    });
-
     beforeEach(() => {
         root = FileUri.create(fs.realpathSync(temp.mkdirSync('node-fs-root')));
         fileSystem = createFileSystem();
@@ -45,25 +38,24 @@ describe("NodeFileSystem", function () {
 
     describe("01 #getFileStat", () => {
 
-        it("Should be rejected if not file exists under the given URI.", () => {
+        it("Should be rejected if not file exists under the given URI.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.getFileStat(uri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.getFileStat(uri.toString()), Error);
         });
 
-        it("Should return a proper result for a file.", () => {
+        it("Should return a proper result for a file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo");
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
 
-            return fileSystem.getFileStat(uri.toString()).then(stat => {
-                expect(stat.isDirectory).to.be.false;
-                expect(stat.uri).to.eq(uri.toString());
-            });
+            const stat = await fileSystem.getFileStat(uri.toString());
+            expect(stat.isDirectory).to.be.false;
+            expect(stat.uri).to.eq(uri.toString());
         });
 
-        it("Should return a proper result for a directory.", () => {
+        it("Should return a proper result for a directory.", async () => {
             const uri_1 = root.resolve("foo.txt");
             const uri_2 = root.resolve("bar.txt");
             fs.writeFileSync(FileUri.fsPath(uri_1), "foo");
@@ -71,76 +63,85 @@ describe("NodeFileSystem", function () {
             expect(fs.statSync(FileUri.fsPath(uri_1)).isFile()).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri_2)).isFile()).to.be.true;
 
-            return fileSystem.getFileStat(root.toString()).then(stat => {
-                expect(stat.children!.length).to.equal(2);
-            });
+            const stat = await fileSystem.getFileStat(root.toString());
+            expect(stat.children!.length).to.equal(2);
         });
 
     });
 
     describe("02 #resolveContent", () => {
 
-        it("Should be rejected with an error when trying to resolve the content of a non-existing file.", () => {
+        it("Should be rejected with an error when trying to resolve the content of a non-existing file.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.resolveContent(uri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.resolveContent(uri.toString()), Error);
         });
 
-        it("Should be rejected with an error when trying to resolve the content of a directory.", () => {
+        it("Should be rejected with an error when trying to resolve the content of a directory.", async () => {
             const uri = root.resolve("foo");
             fs.mkdirSync(FileUri.fsPath(uri));
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
 
-            return fileSystem.resolveContent(uri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.resolveContent(uri.toString()), Error);
         });
 
-        it("Should be rejected with an error if the desired encoding cannot be handled.", () => {
+        it("Should be rejected with an error if the desired encoding cannot be handled.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
             expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
 
-            return fileSystem.resolveContent(uri.toString(), { encoding: "unknownEncoding" }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.resolveContent(uri.toString(), { encoding: "unknownEncoding" }), Error);
         });
 
-        it("Should be return with the content for an existing file.", () => {
+        it("Should be return with the content for an existing file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
+            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" }))
+                .to.be.equal("foo");
 
-            return fileSystem.resolveContent(uri.toString()).should.eventually.have.property("content").that.is.equal("foo");
+            const content = await fileSystem.resolveContent(uri.toString());
+            expect(content).to.have.property("content")
+                .that.is.equal("foo");
         });
 
-        it("Should be return with the stat object for an existing file.", () => {
+        it("Should be return with the stat object for an existing file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
+            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" }))
+                .to.be.equal("foo");
 
-            const content = fileSystem.resolveContent(uri.toString());
-            return Promise.all([
-                content.should.eventually.be.fulfilled,
-                content.should.eventually.have.be.an("object"),
-                content.should.eventually.have.property("stat"),
-                content.should.eventually.have.property("stat").that.has.property("uri").that.is.equal(uri.toString()),
-                content.should.eventually.have.property("stat").that.has.property("size").that.is.greaterThan(1),
-                content.should.eventually.have.property("stat").that.has.property("lastModification").that.is.greaterThan(1),
-                content.should.eventually.have.property("stat").that.has.property("isDirectory").that.is.false,
-                content.should.eventually.have.property("stat").that.not.have.property("children"),
-            ]);
+            const content = await fileSystem.resolveContent(uri.toString());
+            expect(content).to.be.an("object");
+            expect(content).to.have.property("stat");
+            expect(content).to.have.property("stat")
+                .that.has.property("uri")
+                .that.is.equal(uri.toString());
+            expect(content).to.have.property("stat")
+                .that.has.property("size")
+                .that.is.greaterThan(1);
+            expect(content).to.have.property("stat")
+                .that.has.property("lastModification")
+                .that.is.greaterThan(1);
+            expect(content).to.have.property("stat")
+                .that.has.property("isDirectory")
+                .that.is.false;
+            expect(content).to.have.property("stat")
+                .that.not.have.property("children");
         });
 
     });
 
     describe("03 #setContent", () => {
 
-        it("Should be rejected with an error when trying to set the content of a non-existing file.", () => {
+        it("Should be rejected with an error when trying to set the content of a non-existing file.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
@@ -149,76 +150,78 @@ describe("NodeFileSystem", function () {
                 lastModification: new Date().getTime(),
                 isDirectory: false
             };
-            return fileSystem.setContent(stat, "foo").should.eventually.be.rejectedWith(Error);
+
+            await expectThrowsAsync(fileSystem.setContent(stat, "foo"), Error);
         });
 
-        it("Should be rejected with an error when trying to set the content of a directory.", () => {
+        it("Should be rejected with an error when trying to set the content of a directory.", async () => {
             const uri = root.resolve("foo");
             fs.mkdirSync(FileUri.fsPath(uri));
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
 
-            return fileSystem.getFileStat(uri.toString()).then(stat => {
-                fileSystem.setContent(stat, "foo").should.be.eventually.be.rejectedWith(Error);
-            });
+            const stat = await fileSystem.getFileStat(uri.toString());
+
+            await expectThrowsAsync(fileSystem.setContent(stat, "foo"), Error);
         });
 
-        it("Should be rejected with an error when trying to set the content of a file which is out-of-sync.", () => {
+        it("Should be rejected with an error when trying to set the content of a file which is out-of-sync.", async () => {
+            const uri = root.resolve("foo.txt");
+            fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
+            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
+            expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
+            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" }))
+                .to.be.equal("foo");
+
+            const stat = await fileSystem.getFileStat(uri.toString());
+            // Make sure current file stat is out-of-sync.
+            // Here the content is modified in the way that file sizes will differ.
+            fs.writeFileSync(FileUri.fsPath(uri), "longer", { encoding: "utf8" });
+            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" }))
+                .to.be.equal("longer");
+
+            await expectThrowsAsync(fileSystem.setContent(stat, "baz"), Error);
+        });
+
+        it("Should be rejected with an error when trying to set the content when the desired encoding cannot be handled.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
             expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
 
-            return fileSystem.getFileStat(uri.toString()).then(stat => {
-                // Make sure current file stat is out-of-sync.
-                // Here the content is modified in the way that file sizes will differ.
-                fs.writeFileSync(FileUri.fsPath(uri), "longer", { encoding: "utf8" });
-                expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("longer");
+            const stat = await fileSystem.getFileStat(uri.toString());
 
-                fileSystem.setContent(stat, "baz").should.be.eventually.be.rejectedWith(Error);
-            });
+            await expectThrowsAsync(fileSystem.setContent(stat, "baz", { encoding: "unknownEncoding" }), Error);
         });
 
-        it("Should be rejected with an error when trying to set the content when the desired encoding cannot be handled.", () => {
+        it("Should return with a stat representing the latest state of the successfully modified file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
             expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
 
-            return fileSystem.getFileStat(uri.toString()).then(stat => {
-                fileSystem.setContent(stat, "baz", { encoding: "unknownEncoding" }).should.be.eventually.be.rejectedWith(Error);
-            });
-        });
+            const currentStat = await fileSystem.getFileStat(uri.toString());
+            await fileSystem.setContent(currentStat, "baz");
 
-        it("Should return with a stat representing the latest state of the successfully modified file.", () => {
-            const uri = root.resolve("foo.txt");
-            fs.writeFileSync(FileUri.fsPath(uri), "foo", { encoding: "utf8" });
-            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
-            expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("foo");
-
-            return fileSystem.getFileStat(uri.toString()).then(currentStat =>
-                fileSystem.setContent(currentStat, "baz")
-            ).then(newStat => {
-                expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" })).to.be.equal("baz");
-            });
+            expect(fs.readFileSync(FileUri.fsPath(uri), { encoding: "utf8" }))
+                .to.be.equal("baz");
         });
 
     });
 
     describe("04 #move", () => {
 
-        it("Should be rejected with an error if no file exists under the source location.", () => {
+        it("Should be rejected with an error if no file exists under the source location.", async () => {
             const sourceUri = root.resolve("foo.txt");
             const targetUri = root.resolve("bar.txt");
             expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString()), Error);
         });
 
-        it("Should be rejected with an error if target exists and overwrite is not set to \'true\'.", () => {
+        it("Should be rejected with an error if target exists and overwrite is not set to \'true\'.", async () => {
             const sourceUri = root.resolve("foo.txt");
             const targetUri = root.resolve("bar.txt");
             fs.writeFileSync(FileUri.fsPath(sourceUri), "foo");
@@ -226,10 +229,10 @@ describe("NodeFileSystem", function () {
             expect(fs.statSync(FileUri.fsPath(sourceUri)).isFile()).to.be.true;
             expect(fs.statSync(FileUri.fsPath(targetUri)).isFile()).to.be.true;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString()), Error);
         });
 
-        it("Moving a file to an empty directory. Should be rejected with an error because files cannot be moved to an existing directory locations.", () => {
+        it("Moving a file to an empty directory. Should be rejected with an error because files cannot be moved to an existing directory locations.", async () => {
             const sourceUri = root.resolve("foo.txt");
             const targetUri = root.resolve("bar");
             fs.writeFileSync(FileUri.fsPath(sourceUri), "foo");
@@ -239,10 +242,10 @@ describe("NodeFileSystem", function () {
             expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
             expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.be.empty;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
-        it("Moving a file to a non-empty directory. Should be rejected with and error because files cannot be moved to an existing directory locations.", () => {
+        it("Moving a file to a non-empty directory. Should be rejected with and error because files cannot be moved to an existing directory locations.", async () => {
             const sourceUri = root.resolve("foo.txt");
             const targetUri = root.resolve("bar");
             const targetFileUri_01 = targetUri.resolve("bar_01.txt");
@@ -258,10 +261,10 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(targetFileUri_02), "utf8")).to.be.equal("bar_02");
             expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.include("bar_01.txt").and.to.include("bar_02.txt");
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
-        it("Moving an empty directory to file. Should be rejected with an error because directories and cannot be moved to existing file locations.", () => {
+        it("Moving an empty directory to file. Should be rejected with an error because directories and cannot be moved to existing file locations.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar.txt");
             fs.mkdirSync(FileUri.fsPath(sourceUri));
@@ -271,10 +274,10 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(targetUri), "utf8")).to.be.equal("bar");
             expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.be.empty;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
-        it("Moving a non-empty directory to file. Should be rejected with an error because directories cannot be moved to existing file locations.", () => {
+        it("Moving a non-empty directory to file. Should be rejected with an error because directories cannot be moved to existing file locations.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar.txt");
             const sourceFileUri_01 = sourceUri.resolve("foo_01.txt");
@@ -288,25 +291,27 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(targetUri), "utf8")).to.be.equal("bar");
             expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.include("foo_01.txt").and.to.include("foo_02.txt");
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
-        it("Moving file to file. Should overwrite the target file content and delete the source file.", () => {
+        it("Moving file to file. Should overwrite the target file content and delete the source file.", async () => {
             const sourceUri = root.resolve("foo.txt");
             const targetUri = root.resolve("bar.txt");
             fs.writeFileSync(FileUri.fsPath(sourceUri), "foo");
             expect(fs.statSync(FileUri.fsPath(sourceUri)).isFile()).to.be.true;
             expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.false;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).then(stat => {
-                expect(stat).is.an("object").and.has.property("uri").that.equals(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
-                expect(fs.statSync(FileUri.fsPath(targetUri)).isFile()).to.be.true;
-                expect(fs.readFileSync(FileUri.fsPath(targetUri), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true });
+            expect(stat).is.an("object")
+                .and.has.property("uri")
+                .that.equals(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
+            expect(fs.statSync(FileUri.fsPath(targetUri)).isFile()).to.be.true;
+            expect(fs.readFileSync(FileUri.fsPath(targetUri), "utf8"))
+                .to.be.equal("foo");
         });
 
-        it("Moving an empty directory to an empty directory. Should remove the source directory.", () => {
+        it("Moving an empty directory to an empty directory. Should remove the source directory.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             fs.mkdirSync(FileUri.fsPath(sourceUri));
@@ -316,15 +321,16 @@ describe("NodeFileSystem", function () {
             expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.be.empty;
             expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.be.empty;
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).then(stat => {
-                expect(stat).is.an("object").and.has.property("uri").that.equals(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
-                expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
-                expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.be.empty;
-            });
+            const stat = await fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true });
+            expect(stat).is.an("object")
+                .and.has.property("uri")
+                .that.equals(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
+            expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
+            expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.be.empty;
         });
 
-        it("Moving an empty directory to a non-empty directory. Should be rejected because the target folder is not empty.", () => {
+        it("Moving an empty directory to a non-empty directory. Should be rejected because the target folder is not empty.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             const targetFileUri_01 = targetUri.resolve("bar_01.txt");
@@ -340,10 +346,10 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(targetFileUri_02), "utf8")).to.be.equal("bar_02");
             expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.include("bar_01.txt").and.to.include("bar_02.txt");
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
-        it("Moving a non-empty directory to an empty directory. Source folder and its content should be moved to the target location.", () => {
+        it("Moving a non-empty directory to an empty directory. Source folder and its content should be moved to the target location.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             const sourceFileUri_01 = sourceUri.resolve("foo_01.txt");
@@ -359,17 +365,16 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(sourceFileUri_01), "utf8")).to.be.equal("foo_01");
             expect(fs.readFileSync(FileUri.fsPath(sourceFileUri_02), "utf8")).to.be.equal("foo_02");
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).then(stat => {
-                expect(stat).is.an("object").and.has.property("uri").that.equals(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
-                expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
-                expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.include("foo_01.txt").and.to.include("foo_02.txt");
-                expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo_01");
-                expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_02.txt")), "utf8")).to.be.equal("foo_02");
-            });
+            const stat = await fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true });
+            expect(stat).is.an("object").and.has.property("uri").that.equals(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
+            expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
+            expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.include("foo_01.txt").and.to.include("foo_02.txt");
+            expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo_01");
+            expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_02.txt")), "utf8")).to.be.equal("foo_02");
         });
 
-        it("Moving a non-empty directory to a non-empty directory. Should be rejected because the target location is not empty.", () => {
+        it("Moving a non-empty directory to a non-empty directory. Should be rejected because the target location is not empty.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             const sourceFileUri_01 = sourceUri.resolve("foo_01.txt");
@@ -391,24 +396,24 @@ describe("NodeFileSystem", function () {
             expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.include("foo_01.txt").and.to.include("foo_02.txt");
             expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.include("bar_01.txt").and.to.include("bar_02.txt");
 
-            return fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.move(sourceUri.toString(), targetUri.toString(), { overwrite: true }), Error);
         });
 
     });
 
     describe("05 #copy", () => {
 
-        it("Copy a file from non existing location. Should be rejected with an error. Nothing to copy.", () => {
+        it("Copy a file from non existing location. Should be rejected with an error. Nothing to copy.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             fs.mkdirSync(FileUri.fsPath(targetUri));
             expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.false;
             expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.copy(sourceUri.toString(), targetUri.toString()), Error);
         });
 
-        it("Copy a file to existing location without overwrite enabled. Should be rejected with an error.", () => {
+        it("Copy a file to existing location without overwrite enabled. Should be rejected with an error.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             fs.mkdirSync(FileUri.fsPath(targetUri));
@@ -416,40 +421,40 @@ describe("NodeFileSystem", function () {
             expect(fs.statSync(FileUri.fsPath(sourceUri)).isDirectory()).to.be.true;
             expect(fs.statSync(FileUri.fsPath(targetUri)).isDirectory()).to.be.true;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.copy(sourceUri.toString(), targetUri.toString()), Error);
         });
 
-        it("Copy an empty directory to a non-existing location. Should return with the file stat representing the new file at the target location.", () => {
+        it("Copy an empty directory to a non-existing location. Should return with the file stat representing the new file at the target location.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             fs.mkdirSync(FileUri.fsPath(sourceUri));
             expect(fs.statSync(FileUri.fsPath(sourceUri)).isDirectory()).to.be.true;
             expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.false;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.is.equal(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
-                expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
-            });
+            const stat = await fileSystem.copy(sourceUri.toString(), targetUri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri")
+                .that.is.equal(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
+            expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
         });
 
-        it("Copy an empty directory to a non-existing, nested location. Should return with the file stat representing the new file at the target location.", () => {
+        it("Copy an empty directory to a non-existing, nested location. Should return with the file stat representing the new file at the target location.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("nested/path/to/bar");
             fs.mkdirSync(FileUri.fsPath(sourceUri));
             expect(fs.statSync(FileUri.fsPath(sourceUri)).isDirectory()).to.be.true;
             expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.false;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.is.equal(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
-                expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
-            });
+            const stat = await fileSystem.copy(sourceUri.toString(), targetUri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri")
+                .that.is.equal(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
+            expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
         });
 
-        it("Copy a directory with content to a non-existing location. Should return with the file stat representing the new file at the target location.", () => {
+        it("Copy a directory with content to a non-existing location. Should return with the file stat representing the new file at the target location.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("bar");
             const subSourceUri = sourceUri.resolve("foo_01.txt");
@@ -460,19 +465,18 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
             expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.false;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.is.equal(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
-                expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
-                expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.contain("foo_01.txt");
-                expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.contain("foo_01.txt");
-                expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
-                expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.copy(sourceUri.toString(), targetUri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri").that.is.equal(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
+            expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
+            expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.contain("foo_01.txt");
+            expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.contain("foo_01.txt");
+            expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
+            expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo");
         });
 
-        it("Copy a directory with content to a non-existing, nested location. Should return with the file stat representing the new file at the target location.", () => {
+        it("Copy a directory with content to a non-existing, nested location. Should return with the file stat representing the new file at the target location.", async () => {
             const sourceUri = root.resolve("foo");
             const targetUri = root.resolve("nested/path/to/bar");
             const subSourceUri = sourceUri.resolve("foo_01.txt");
@@ -483,190 +487,188 @@ describe("NodeFileSystem", function () {
             expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
             expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.false;
 
-            return fileSystem.copy(sourceUri.toString(), targetUri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.is.equal(targetUri.toString());
-                expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
-                expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
-                expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.contain("foo_01.txt");
-                expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.contain("foo_01.txt");
-                expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
-                expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.copy(sourceUri.toString(), targetUri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri")
+                .that.is.equal(targetUri.toString());
+            expect(fs.existsSync(FileUri.fsPath(sourceUri))).to.be.true;
+            expect(fs.existsSync(FileUri.fsPath(targetUri))).to.be.true;
+            expect(fs.readdirSync(FileUri.fsPath(sourceUri))).to.contain("foo_01.txt");
+            expect(fs.readdirSync(FileUri.fsPath(targetUri))).to.contain("foo_01.txt");
+            expect(fs.readFileSync(FileUri.fsPath(subSourceUri), "utf8")).to.be.equal("foo");
+            expect(fs.readFileSync(FileUri.fsPath(targetUri.resolve("foo_01.txt")), "utf8")).to.be.equal("foo");
         });
 
     });
 
     describe("07 #createFile", () => {
 
-        it("Should be rejected with an error if a file already exists with the given URI.", () => {
+        it("Should be rejected with an error if a file already exists with the given URI.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo");
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
 
-            return fileSystem.createFile(uri.toString()).should.be.eventually.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.createFile(uri.toString()), Error);
         });
 
-        it("Should be rejected with an error if the encoding is given but cannot be handled.", () => {
+        it("Should be rejected with an error if the encoding is given but cannot be handled.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFile(uri.toString(), { encoding: "unknownEncoding" }).should.be.eventually.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.createFile(uri.toString(), { encoding: "unknownEncoding" }), Error);
         });
 
-        it("Should create an empty file without any contents by default.", () => {
+        it("Should create an empty file without any contents by default.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFile(uri.toString()).then(stat => {
-                expect(stat).is.an("object");
-                expect(stat).has.property("uri").that.is.equal(uri.toString());
-                expect(stat).not.has.property("children");
-                expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.empty;
-            });
+            const stat = await fileSystem.createFile(uri.toString());
+            expect(stat).is.an("object");
+            expect(stat).has.property("uri").that.is.equal(uri.toString());
+            expect(stat).not.has.property("children");
+            expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.empty;
         });
 
-        it("Should create a file with the desired content.", () => {
+        it("Should create a file with the desired content.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFile(uri.toString(), { content: "foo" }).then(stat => {
-                expect(stat).is.an("object");
-                expect(stat).has.property("uri").that.is.equal(uri.toString());
-                expect(stat).not.has.property("children");
-                expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.createFile(uri.toString(), { content: "foo" });
+            expect(stat).is.an("object");
+            expect(stat).has.property("uri")
+                .that.is.equal(uri.toString());
+            expect(stat).not.has.property("children");
+            expect(fs.readFileSync(FileUri.fsPath(uri), "utf8"))
+                .to.be.equal("foo");
         });
 
-        it("Should create a file with the desired content into a non-existing, nested location.", () => {
+        it("Should create a file with the desired content into a non-existing, nested location.", async () => {
             const uri = root.resolve("foo/bar/baz.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFile(uri.toString(), { content: "foo" }).then(stat => {
-                expect(stat).is.an("object");
-                expect(stat).has.property("uri").that.is.equal(uri.toString());
-                expect(stat).not.has.property("children");
-                expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.createFile(uri.toString(), { content: "foo" });
+            expect(stat).is.an("object");
+            expect(stat).has.property("uri")
+                .that.is.equal(uri.toString());
+            expect(stat).not.has.property("children");
+            expect(fs.readFileSync(FileUri.fsPath(uri), "utf8"))
+                .to.be.equal("foo");
         });
 
-        it("Should create a file with the desired content and encoding.", () => {
+        it("Should create a file with the desired content and encoding.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFile(uri.toString(), { content: "foo", encoding: "utf8" }).then(stat => {
-                expect(stat).is.an("object");
-                expect(stat).has.property("uri").that.is.equal(uri.toString());
-                expect(stat).not.has.property("children");
-                expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.equal("foo");
-            });
+            const stat = await fileSystem.createFile(uri.toString(), { content: "foo", encoding: "utf8" });
+            expect(stat).is.an("object");
+            expect(stat).has.property("uri")
+                .that.is.equal(uri.toString());
+            expect(stat).not.has.property("children");
+            expect(fs.readFileSync(FileUri.fsPath(uri), "utf8"))
+                .to.be.equal("foo");
         });
 
     });
 
     describe("08 #createFolder", () => {
 
-        it("Should be rejected with an error if a directory already exist under the desired URI.", () => {
+        it("Should be rejected with an error if a directory already exist under the desired URI.", async () => {
             const uri = root.resolve("foo");
             fs.mkdirSync(FileUri.fsPath(uri));
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
 
-            return fileSystem.createFolder(uri.toString()).should.eventually.be.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.createFolder(uri.toString()), Error);
         });
 
-        it("Should create a directory and return with the stat object on successful directory creation.", () => {
+        it("Should create a directory and return with the stat object on successful directory creation.", async () => {
             const uri = root.resolve("foo");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFolder(uri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.equals(uri.toString());
-                expect(stat).to.have.property("children").that.is.empty;
-            });
+            const stat = await fileSystem.createFolder(uri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri")
+                .that.equals(uri.toString());
+            expect(stat).to.have.property("children")
+                .that.is.empty;
         });
 
-        it("Should create a directory and return with the stat object on successful directory creation.", () => {
+        it("Should create a directory and return with the stat object on successful directory creation.", async () => {
             const uri = root.resolve("foo/bar");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.createFolder(uri.toString()).then(stat => {
-                expect(stat).to.be.an("object");
-                expect(stat).to.have.property("uri").that.equals(uri.toString());
-                expect(stat).to.have.property("children").that.is.empty;
-            });
+            const stat = await fileSystem.createFolder(uri.toString());
+            expect(stat).to.be.an("object");
+            expect(stat).to.have.property("uri")
+                .that.equals(uri.toString());
+            expect(stat).to.have.property("children")
+                .that.is.empty;
         });
 
     });
 
     describe("09 #touch", () => {
 
-        it("Should create a new file if it does not exist yet.", () => {
+        it("Should create a new file if it does not exist yet.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.touchFile(uri.toString()).then(stat => {
-                expect(stat).is.an("object");
-                expect(stat).has.property("uri").that.equals(uri.toString());
-                expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-            });
+            const stat = await fileSystem.touchFile(uri.toString());
+            expect(stat).is.an("object");
+            expect(stat).has.property("uri")
+                .that.equals(uri.toString());
+            expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
         });
 
-        it("Should update the modification timestamp on an existing file.", done => {
+        it("Should update the modification timestamp on an existing file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo");
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
 
-            fileSystem.getFileStat(uri.toString()).then(initialStat => {
-                expect(initialStat).is.an("object");
-                expect(initialStat).has.property("uri").that.equals(uri.toString());
-                expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-                return initialStat;
-            }).then(initialStat => {
-                // https://nodejs.org/en/docs/guides/working-with-different-filesystems/#timestamp-resolution
-                sleep(1000).then(() => {
-                    fileSystem.touchFile(uri.toString()).then(updatedStat => {
-                        expect(updatedStat).is.an("object");
-                        expect(updatedStat).has.property("uri").that.equals(uri.toString());
-                        expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
-                        expect(updatedStat.lastModification).to.be.greaterThan(initialStat.lastModification);
-                        done();
-                    });
-                });
-            });
+            const initialStat = await fileSystem.getFileStat(uri.toString());
+            expect(initialStat).is.an("object");
+            expect(initialStat).has.property("uri").that.equals(uri.toString());
+            expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
+
+            // https://nodejs.org/en/docs/guides/working-with-different-filesystems/#timestamp-resolution
+            await sleep(1000);
+
+            const updatedStat = await fileSystem.touchFile(uri.toString());
+            expect(updatedStat).is.an("object");
+            expect(updatedStat).has.property("uri").that.equals(uri.toString());
+            expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
+            expect(updatedStat.lastModification).to.be.greaterThan(initialStat.lastModification);
         });
 
     });
 
     describe("#10 delete", () => {
 
-        it("Should be rejected when the file to delete does not exist.", () => {
+        it("Should be rejected when the file to delete does not exist.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.delete(uri.toString(), { moveToTrash: false }).should.be.eventually.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.delete(uri.toString(), { moveToTrash: false }), Error);
         });
 
-        it("Should delete the file.", () => {
+        it("Should delete the file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo");
             expect(fs.readFileSync(FileUri.fsPath(uri), "utf8")).to.be.equal("foo");
 
-            return fileSystem.delete(uri.toString(), { moveToTrash: false }).then(() => {
-                expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
-            });
+            await fileSystem.delete(uri.toString(), { moveToTrash: false });
+            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
         });
 
-        it("Should delete a directory without content.", () => {
+        it("Should delete a directory without content.", async () => {
             const uri = root.resolve("foo");
             fs.mkdirSync(FileUri.fsPath(uri));
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
 
-            return fileSystem.delete(uri.toString(), { moveToTrash: false }).then(() => {
-                expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
-            });
+            await fileSystem.delete(uri.toString(), { moveToTrash: false });
+            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
         });
 
-        it("Should delete a directory with all its content.", () => {
+        it("Should delete a directory with all its content.", async () => {
             const uri = root.resolve("foo");
             const subUri = uri.resolve("bar.txt");
             fs.mkdirSync(FileUri.fsPath(uri));
@@ -674,37 +676,37 @@ describe("NodeFileSystem", function () {
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
             expect(fs.readFileSync(FileUri.fsPath(subUri), "utf8")).to.be.equal("bar");
 
-            return fileSystem.delete(uri.toString(), { moveToTrash: false }).then(() => {
-                expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
-                expect(fs.existsSync(FileUri.fsPath(subUri))).to.be.false;
-            });
+            await fileSystem.delete(uri.toString(), { moveToTrash: false });
+            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
+            expect(fs.existsSync(FileUri.fsPath(subUri))).to.be.false;
         });
 
     });
 
     describe("#11 getEncoding", () => {
 
-        it("Should be rejected with an error if no file exists under the given URI.", () => {
+        it("Should be rejected with an error if no file exists under the given URI.", async () => {
             const uri = root.resolve("foo.txt");
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
-            return fileSystem.getEncoding(uri.toString()).should.be.eventually.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.getEncoding(uri.toString()), Error);
         });
 
-        it("Should be rejected with an error if the URI points to a directory instead of a file.", () => {
+        it("Should be rejected with an error if the URI points to a directory instead of a file.", async () => {
             const uri = root.resolve("foo");
             fs.mkdirSync(FileUri.fsPath(uri));
             expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
 
-            return fileSystem.getEncoding(uri.toString()).should.be.eventually.rejectedWith(Error);
+            await expectThrowsAsync(fileSystem.getEncoding(uri.toString()), Error);
         });
 
-        it("Should return with the encoding of the file.", () => {
+        it("Should return with the encoding of the file.", async () => {
             const uri = root.resolve("foo.txt");
             fs.writeFileSync(FileUri.fsPath(uri), "foo");
             expect(fs.statSync(FileUri.fsPath(uri)).isFile()).to.be.true;
 
-            return fileSystem.getEncoding(uri.toString()).should.be.eventually.be.equal("utf8");
+            const encoding = await fileSystem.getEncoding(uri.toString());
+            expect(encoding).to.be.equal("utf8");
         });
 
     });

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -26,12 +26,6 @@ describe("nsfw-filesystem-watcher", function () {
 
     this.timeout(10000);
 
-    before(() => {
-        chai.config.showDiff = true;
-        chai.config.includeStack = true;
-        chai.should();
-    });
-
     beforeEach(async () => {
         root = FileUri.create(fs.realpathSync(temp.mkdirSync('node-fs-root')));
         watcherServer = createNsfwFileSystemWatcherServer();

--- a/packages/process/src/node/multi-ring-buffer.spec.ts
+++ b/packages/process/src/node/multi-ring-buffer.spec.ts
@@ -6,11 +6,7 @@
  */
 
 import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import { MultiRingBuffer } from './multi-ring-buffer';
-
-chai.use(chaiAsPromised);
 
 const expect = chai.expect;
 
@@ -310,7 +306,7 @@ describe('MultiRingBuffer', function () {
         expect(ringBuffer.sizeForReader(reader)).to.be.equal(0);
     });
 
-    it('expect data from stream on enq', function () {
+    it('expect data from stream on enq', async function () {
         const size = 5;
         const ringBuffer = new MultiRingBuffer({ size });
         const buffer = "abc";
@@ -323,10 +319,11 @@ describe('MultiRingBuffer', function () {
             });
         });
         ringBuffer.enq(buffer);
-        return expect(p).to.be.eventually.fulfilled;
+
+        await p;
     });
 
-    it('expect data from stream when data is already enqed', function () {
+    it('expect data from stream when data is already enqed', async function () {
         const size = 5;
         const ringBuffer = new MultiRingBuffer({ size });
         const buffer = "abc";
@@ -340,7 +337,7 @@ describe('MultiRingBuffer', function () {
             });
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it('expect disposing of a stream to delete it from the ringbuffer', function () {
@@ -382,7 +379,7 @@ describe('MultiRingBuffer', function () {
         expect(readBuffer).to.equal("test");
     });
 
-    it('expect data from stream in hex when enq in uf8', function () {
+    it('expect data from stream in hex when enq in uf8', async function () {
         const size = 5;
         const ringBuffer = new MultiRingBuffer({ size });
         const buffer = "test";
@@ -396,7 +393,7 @@ describe('MultiRingBuffer', function () {
             });
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it('expect deq a string < ring buffer size with the internal encoding in hex ', function () {

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -5,8 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import * as process from 'process';
 import * as stream from 'stream';
 import { testContainer } from './inversify.spec-config';
@@ -17,8 +15,6 @@ import { isWindows } from '@theia/core';
 
 /* Allow to create temporary files, but delete them when we're done.  */
 const track = temp.track();
-
-chai.use(chaiAsPromised);
 
 /**
  * Globals
@@ -31,7 +27,7 @@ describe('RawProcess', function () {
     this.timeout(5000);
     const rawProcessFactory = testContainer.get<RawProcessFactory>(RawProcessFactory);
 
-    it('test error on non-existent path', function () {
+    it('test error on non-existent path', async function () {
         const p = new Promise((resolve, reject) => {
             const rawProcess = rawProcessFactory({ command: '/non-existent' });
             rawProcess.onError(error => {
@@ -41,10 +37,10 @@ describe('RawProcess', function () {
             });
         });
 
-        return expect(p).to.eventually.equal('ENOENT');
+        expect(await p).to.be.equal('ENOENT');
     });
 
-    it('test error on non-executable path', function () {
+    it('test error on non-executable path', async function () {
         /* Create a non-executable file.  */
         const f = track.openSync('non-executable');
         fs.writeSync(f.fd, 'echo bob');
@@ -73,10 +69,10 @@ describe('RawProcess', function () {
             expectedCode = 'UNKNOWN';
         }
 
-        return expect(p).to.eventually.equal(expectedCode);
+        expect(await p).to.equal(expectedCode);
     });
 
-    it('test exit', function () {
+    it('test exit', async function () {
         const args = ['--version'];
         const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
         const p = new Promise((resolve, reject) => {
@@ -93,10 +89,10 @@ describe('RawProcess', function () {
             });
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
-    it('test pipe stdout stream', function () {
+    it('test pipe stdout stream', async function () {
         const args = ['--version'];
         const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
 
@@ -114,10 +110,10 @@ describe('RawProcess', function () {
 
         rawProcess.output.pipe(outStream);
 
-        return expect(p).to.be.eventually.equal(process.version);
+        expect(await p).to.be.equal(process.version);
     });
 
-    it('test pipe stderr stream', function () {
+    it('test pipe stderr stream', async function () {
         const args = ['invalidarg'];
         const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
 
@@ -135,6 +131,6 @@ describe('RawProcess', function () {
 
         rawProcess.errorOutput.pipe(outStream);
 
-        return expect(p).to.be.eventually.have.string('Error');
+        expect(await p).to.have.string('Error');
     });
 });

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -5,15 +5,11 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import * as process from 'process';
 import * as stream from 'stream';
 import { testContainer } from './inversify.spec-config';
 import { TerminalProcessFactory } from './terminal-process';
 import { isWindows } from "@theia/core/lib/common";
-
-chai.use(chaiAsPromised);
 
 /**
  * Globals
@@ -26,7 +22,7 @@ describe('TerminalProcess', function () {
     this.timeout(5000);
     const terminalProcessFactory = testContainer.get<TerminalProcessFactory>(TerminalProcessFactory);
 
-    it('test error on non existent path', function () {
+    it('test error on non existent path', async function () {
 
         /* Strangely, Linux returns exited with code 1 when using a non existing path but Windows throws an error.
         This would need to be investigated more.  */
@@ -40,11 +36,11 @@ describe('TerminalProcess', function () {
                 });
             });
 
-            return expect(p).to.be.eventually.fulfilled;
+            await p;
         }
     });
 
-    it('test exit', function () {
+    it('test exit', async function () {
         const args = ['--version'];
         const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
         const p = new Promise((resolve, reject) => {
@@ -60,10 +56,10 @@ describe('TerminalProcess', function () {
             });
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
-    it('test pipe stream', function () {
+    it('test pipe stream', async function () {
         const args = ['--version'];
         const terminalProcess = terminalProcessFactory({ command: process.execPath, 'args': args });
 
@@ -84,6 +80,6 @@ describe('TerminalProcess', function () {
         terminalProcess.createOutputStream().pipe(outStream);
 
         /* Avoid using equal since terminal characters can be inserted at the end.  */
-        return expect(p).to.eventually.have.string(process.version);
+        expect(await p).to.have.string(process.version);
     });
 });

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -5,9 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test-resources/inversify.spec-config';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
 import { TaskExitedEvent, TaskInfo, TaskServer, TaskOptions, ProcessType } from '../common/task-protocol';
@@ -19,14 +16,11 @@ import { isWindows } from '@theia/core/lib/common/os';
 import URI from "@theia/core/lib/common/uri";
 import { FileUri } from "@theia/core/lib/node";
 import { terminalsPath } from '@theia/terminal/lib/common/terminal-protocol';
-
-chai.use(chaiAsPromised);
+import { expectThrowsAsync } from '@theia/core/lib/common/test/expect';
 
 /**
  * Globals
  */
-
-const expect = chai.expect;
 
 // test scripts that we bundle with tasks
 const commandShortRunning = './task';
@@ -92,7 +86,8 @@ describe('Task server / back-end', function () {
                 reject(error);
             });
         });
-        return expect(p).to.be.eventually.fulfilled;
+
+        await p;
     });
 
     it("task using raw process - task server success response shall not contain a terminal id", async function () {
@@ -115,7 +110,7 @@ describe('Task server / back-end', function () {
             });
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task is executed successfully using terminal process", async function () {
@@ -124,7 +119,7 @@ describe('Task server / back-end', function () {
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task is executed successfully using raw process", async function () {
@@ -133,7 +128,7 @@ describe('Task server / back-end', function () {
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task can successfully execute command found in system path using a terminal process", async function () {
@@ -144,7 +139,7 @@ describe('Task server / back-end', function () {
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task can successfully execute command found in system path using a raw process", async function () {
@@ -153,7 +148,7 @@ describe('Task server / back-end', function () {
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task using terminal process can be killed", async function () {
@@ -168,9 +163,10 @@ describe('Task server / back-end', function () {
                 }
             });
         });
+
         await taskServer.kill(taskInfo.taskId);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task using raw process can be killed", async function () {
@@ -185,19 +181,20 @@ describe('Task server / back-end', function () {
                 }
             });
         });
+
         await taskServer.kill(taskInfo.taskId);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("task using terminal process can handle command that does not exist", async function () {
         const p = taskServer.run(createTaskOptions2('terminal', bogusCommand, []), wsRoot);
-        return expect(p).to.be.eventually.rejectedWith(`Command not found: ${bogusCommand}`);
+        await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
     });
 
     it("task using raw process can handle command that does not exist", async function () {
         const p = taskServer.run(createTaskOptions2('raw', bogusCommand, []), wsRoot);
-        return expect(p).to.be.eventually.rejectedWith(`Command not found: ${bogusCommand}`);
+        await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
     });
 
     it("getTasks(ctx) returns tasks according to created context", async function () {
@@ -241,7 +238,7 @@ describe('Task server / back-end', function () {
         await taskServer.kill(task5.taskId);
         await taskServer.kill(task6.taskId);
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
     it("creating and killing a bunch of tasks works as expected", async function () {
@@ -278,7 +275,7 @@ describe('Task server / back-end', function () {
             }
         });
 
-        return expect(p).to.be.eventually.fulfilled;
+        await p;
     });
 
 });
@@ -345,5 +342,6 @@ function checkSuccessfullProcessExit(taskInfo: TaskInfo, taskWatcher: TaskWatche
             }
         });
     });
+
     return p;
 }

--- a/packages/terminal/src/node/shell-terminal-server.spec.ts
+++ b/packages/terminal/src/node/shell-terminal-server.spec.ts
@@ -5,12 +5,8 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { IShellTerminalServer } from '../common/shell-terminal-protocol';
-
-chai.use(chaiAsPromised);
 
 /**
  * Globals
@@ -23,8 +19,9 @@ describe('ShellServer', function () {
     this.timeout(5000);
     const shellTerminalServer = testContainer.get<IShellTerminalServer>(IShellTerminalServer);
 
-    it('test shell terminal create', function () {
+    it('test shell terminal create', async function () {
         const createResult = shellTerminalServer.create({});
-        return expect(createResult).to.be.eventually.greaterThan(-1);
+
+        expect(await createResult).to.be.greaterThan(-1);
     });
 });

--- a/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
@@ -5,9 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
 import { IShellTerminalServer } from '../common/shell-terminal-protocol';
@@ -15,14 +12,6 @@ import * as ws from 'ws';
 import * as http from 'http';
 import * as https from 'https';
 import { terminalsPath } from '../common/terminal-protocol';
-
-chai.use(chaiAsPromised);
-
-/**
- * Globals
- */
-
-const expect = chai.expect;
 
 describe('Terminal Backend Contribution', function () {
 
@@ -48,6 +37,7 @@ describe('Terminal Backend Contribution', function () {
                 reject(error);
             });
         });
-        return expect(p).to.be.eventually.fulfilled;
+
+        await p;
     });
 });

--- a/packages/terminal/src/node/terminal-server.spec.ts
+++ b/packages/terminal/src/node/terminal-server.spec.ts
@@ -4,16 +4,13 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
+
 import * as chai from 'chai';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import { testContainer } from './test/inversify.spec-config';
 import { TerminalWatcher } from '../common/terminal-watcher';
 import { ITerminalServer } from '../common/terminal-protocol';
 import { IBaseTerminalExitEvent } from '../common/base-terminal-protocol';
 import { isWindows } from "@theia/core/lib/common";
-
-chai.use(chaiAsPromised);
 
 /**
  * Globals
@@ -27,17 +24,17 @@ describe('TermninalServer', function () {
     const terminalServer = testContainer.get<ITerminalServer>(ITerminalServer);
     const terminalWatcher = testContainer.get<TerminalWatcher>(TerminalWatcher);
 
-    it('test terminal create', function () {
+    it('test terminal create', async function () {
         const args = ['--version'];
         const createResult = terminalServer.create({ command: process.execPath, 'args': args });
-        return expect(createResult).to.be.eventually.greaterThan(-1);
+        expect(await createResult).to.be.greaterThan(-1);
     });
 
-    it('test terminal create from non-existant path', function () {
+    it('test terminal create from non-existant path', async function () {
         terminalServer.setClient(terminalWatcher.getTerminalClient());
         const createResult = terminalServer.create({ command: '/non-existant' });
         if (isWindows) {
-            return expect(createResult).to.eventually.equal(-1);
+            expect(await createResult).to.be.equal(-1);
         } else {
             const errorPromise = new Promise<void>((resolve, reject) => {
                 createResult.then((termId: number) => {
@@ -53,10 +50,8 @@ describe('TermninalServer', function () {
                 });
             });
 
-            return Promise.all([
-                expect(createResult).to.be.eventually.greaterThan(-1),
-                expect(errorPromise).to.be.eventually.fulfilled],
-            );
+            expect(await createResult).to.be.greaterThan(-1);
+            await errorPromise;
         }
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,12 +1119,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai-as-promised@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
-  dependencies:
-    check-error "^1.0.2"
-
 chai-string@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.4.0.tgz#359140c051d36a4e4b1a5fc6b910152f438a8d49"
@@ -1204,7 +1198,7 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-check-error@^1.0.1, check-error@^1.0.2:
+check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 


### PR DESCRIPTION
This commit fixes issue #928.

Replaced most calls to `eventually` and `should` by async/await constructs.

Added `@theia/core/lib/common/test/test.js` module that exposes a `throwsAsync` function, that is just an utility to test for Promise rejections.