### PR TITLE
GH-1530: Fixed the selection/focus issue in the naviagtor.

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -50,14 +50,6 @@
     background: var(--theia-accent-color5);
 }
 
-.theia-Tree:focus .theia-TreeNode.theia-mod-focus {
-    background: var(--theia-accent-color3);
-}
-
-.theia-Tree:not(:focus) .theia-TreeNode.theia-mod-focus {
-    background: var(--theia-accent-color5);
-}
-
 .theia-TreeNodeSegment {
     flex-grow: 0;
     user-select: none;

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -416,7 +416,7 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
     }
 
     protected getUri(): URI | undefined {
-        return UriSelection.getUri(this.selectionService.selection) || this.rootUri;
+        return super.getUri() || this.rootUri;
     }
 
 }


### PR DESCRIPTION
 - I have removed the bugos 'focus' styling.
Focus is only relevant for scrolling and calculating ranges.

 - Fixed the URI discovery in the WS root aware command handler.
It was not adapted to the multi-selection, so it falled back to root.

Closes #1530.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>