### PR TITLE
Improved frontend documents handling

### DIFF
--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -6,17 +6,62 @@
  */
 
 import { injectable, inject, named } from "inversify";
+import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
 import URI from "../common/uri";
 import { ContributionProvider } from './contribution-provider';
 import { Event } from "./event";
 import { Disposable } from "./disposable";
 import { MaybePromise } from "./types";
+import { CancellationToken } from "./cancellation";
 
 export interface Resource extends Disposable {
     readonly uri: URI;
     readContents(options?: { encoding?: string }): Promise<string>;
     saveContents?(content: string, options?: { encoding?: string }): Promise<void>;
+    saveContentChanges?(changes: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<void>;
     readonly onDidChangeContents?: Event<void>;
+}
+export namespace Resource {
+    export interface SaveContext {
+        content: string
+        changes: TextDocumentContentChangeEvent[]
+        options?: { encoding?: string }
+    }
+    export async function save(resource: Resource, context: SaveContext, token: CancellationToken): Promise<void> {
+        if (context.changes.length === 0 || !resource.saveContents) {
+            return;
+        }
+        if (await trySaveContentChanges(resource, context)) {
+            return;
+        }
+        if (token.isCancellationRequested) {
+            return;
+        }
+        await resource.saveContents(context.content, context.options);
+    }
+    export async function trySaveContentChanges(resource: Resource, context: SaveContext): Promise<boolean> {
+        if (!resource.saveContentChanges || shouldSaveContent(context)) {
+            return false;
+        }
+        try {
+            await resource.saveContentChanges(context.changes, context.options);
+        } catch (e) {
+            console.error(e);
+            return false;
+        }
+        return true;
+    }
+    export function shouldSaveContent({ content, changes }: SaveContext): boolean {
+        let contentChangesLength = 0;
+        const contentLength = content.length;
+        for (const change of changes) {
+            contentChangesLength += JSON.stringify(change).length;
+            if (contentChangesLength > contentLength) {
+                return true;
+            }
+        }
+        return contentChangesLength > contentLength;
+    }
 }
 
 export const ResourceResolver = Symbol('ResourceResolver');

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -5,6 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { TextDocumentContentChangeEvent } from 'vscode-languageserver-types';
 import { JsonRpcServer } from '@theia/core/lib/common';
 
 export const fileSystemPath = '/services/filesystem';
@@ -36,6 +37,11 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
      * Updates the content replacing its previous value.
      */
     setContent(file: FileStat, content: string, options?: { encoding?: string }): Promise<FileStat>;
+
+    /**
+     * Updates the content replacing its previous value.
+     */
+    updateContent(file: FileStat, contentChanges: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<FileStat>;
 
     /**
      * Moves the file to a new path identified by the resource.

--- a/packages/filesystem/src/common/test/mock-filesystem.ts
+++ b/packages/filesystem/src/common/test/mock-filesystem.ts
@@ -36,6 +36,10 @@ export class MockFilesystem implements FileSystem {
         return Promise.resolve(mockFileStat);
     }
 
+    updateContent(): Promise<FileStat> {
+        return Promise.resolve(mockFileStat);
+    }
+
     move(sourceUri: string, targetUri: string, options?: { overwrite?: boolean }): Promise<FileStat> {
         return Promise.resolve(mockFileStat);
     }

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { TextDocumentSaveReason, Position } from "vscode-languageserver-types";
+import { TextDocumentSaveReason, Position, TextDocumentContentChangeEvent } from "vscode-languageserver-types";
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from "monaco-languageclient";
 import { TextEditorDocument } from "@theia/editor/lib/browser";
 import { DisposableCollection, Disposable, Emitter, Event, Resource, CancellationTokenSource, CancellationToken } from '@theia/core';
@@ -15,10 +15,15 @@ export {
     TextDocumentSaveReason
 };
 
-export interface WillSaveModelEvent {
-    readonly model: monaco.editor.IModel;
+export interface WillSaveMonacoModelEvent {
+    readonly model: MonacoEditorModel;
     readonly reason: TextDocumentSaveReason;
     waitUntil(thenable: Thenable<monaco.editor.IIdentifiedSingleEditOperation[]>): void;
+}
+
+export interface MonacoModelContentChangedEvent {
+    readonly model: MonacoEditorModel;
+    readonly contentChanges: TextDocumentContentChangeEvent[];
 }
 
 export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
@@ -32,8 +37,14 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     protected readonly toDispose = new DisposableCollection();
     protected readonly toDisposeOnAutoSave = new DisposableCollection();
 
+    protected readonly onDidChangeContentEmitter = new Emitter<MonacoModelContentChangedEvent>();
+    readonly onDidChangeContent = this.onDidChangeContentEmitter.event;
+
     protected readonly onDidSaveModelEmitter = new Emitter<monaco.editor.IModel>();
-    protected readonly onWillSaveModelEmitter = new Emitter<WillSaveModelEvent>();
+    readonly onDidSaveModel = this.onDidSaveModelEmitter.event;
+
+    protected readonly onWillSaveModelEmitter = new Emitter<WillSaveMonacoModelEvent>();
+    readonly onWillSaveModel = this.onWillSaveModelEmitter.event;
 
     constructor(
         protected readonly resource: Resource,
@@ -42,6 +53,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     ) {
         this.toDispose.push(resource);
         this.toDispose.push(this.toDisposeOnAutoSave);
+        this.toDispose.push(this.onDidChangeContentEmitter);
         this.toDispose.push(this.onDidSaveModelEmitter);
         this.toDispose.push(this.onWillSaveModelEmitter);
         this.toDispose.push(this.onDirtyChangedEmitter);
@@ -61,7 +73,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         if (!this.toDispose.disposed) {
             this.model = monaco.editor.createModel(content, undefined, monaco.Uri.parse(this.resource.uri.toString()));
             this.toDispose.push(this.model);
-            this.toDispose.push(this.model.onDidChangeContent(event => this.markAsDirty()));
+            this.toDispose.push(this.model.onDidChangeContent(event => this.fireDidChangeContent(event)));
             if (this.resource.onDidChangeContents) {
                 this.toDispose.push(this.resource.onDidChangeContents(() => this.sync()));
             }
@@ -127,14 +139,6 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this.model;
     }
 
-    get onWillSaveModel(): Event<WillSaveModelEvent> {
-        return this.onWillSaveModelEmitter.event;
-    }
-
-    get onDidSaveModel(): Event<monaco.editor.IModel> {
-        return this.onDidSaveModelEmitter.event;
-    }
-
     load(): monaco.Promise<MonacoEditorModel> {
         return monaco.Promise.wrap(this.resolveModel).then(() => this);
     }
@@ -180,23 +184,16 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
             return;
         }
 
-        this.applyEdits([this.p2m.asTextEdit({
-            range: this.m2p.asRange(this.model.getFullModelRange()),
-            newText
-        }) as monaco.editor.IIdentifiedSingleEditOperation]);
+        const range = this.m2p.asRange(this.model.getFullModelRange());
+        this.applyEdits([this.p2m.asTextEdit({ range, newText }) as monaco.editor.IIdentifiedSingleEditOperation], {
+            ignoreDirty: true,
+            ignoreContentChanges: true
+        });
     }
 
-    protected ignoreEdits = false;
-    protected applyEdits(operations: monaco.editor.IIdentifiedSingleEditOperation[]): monaco.editor.IIdentifiedSingleEditOperation[] {
-        this.ignoreEdits = true;
-        try {
-            return this.model.applyEdits(operations);
-        } finally {
-            this.ignoreEdits = false;
-        }
-    }
+    protected ignoreDirtyEdits = false;
     protected markAsDirty(): void {
-        if (this.ignoreEdits) {
+        if (this.ignoreDirtyEdits) {
             return;
         }
         this.cancelSync();
@@ -228,6 +225,58 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this.run(() => this.doSave(reason, token));
     }
 
+    protected ignoreContentChanges = false;
+    protected contentChanges: TextDocumentContentChangeEvent[] = [];
+    protected pushContentChanges(contentChanges: TextDocumentContentChangeEvent[]): void {
+        if (!this.ignoreContentChanges) {
+            this.contentChanges.push(...contentChanges);
+        }
+    }
+    protected popContentChanges(): TextDocumentContentChangeEvent[] {
+        const contentChanges = this.contentChanges;
+        if (contentChanges.length !== 0) {
+            this.contentChanges = [];
+        }
+        return contentChanges;
+    }
+
+    protected fireDidChangeContent(event: monaco.editor.IModelContentChangedEvent): void {
+        const changeContentEvent = this.asContentChangedEvent(event);
+        this.onDidChangeContentEmitter.fire(changeContentEvent);
+        this.pushContentChanges(changeContentEvent.contentChanges);
+        this.markAsDirty();
+    }
+    protected asContentChangedEvent(event: monaco.editor.IModelContentChangedEvent): MonacoModelContentChangedEvent {
+        const contentChanges = event.changes.map(change => this.asTextDocumentContentChangeEvent(change));
+        return { model: this, contentChanges };
+    }
+    protected asTextDocumentContentChangeEvent(change: monaco.editor.IModelContentChange): TextDocumentContentChangeEvent {
+        const range = this.m2p.asRange(change.range);
+        const rangeLength = change.rangeLength;
+        const text = change.text;
+        return { range, rangeLength, text };
+    }
+
+    protected applyEdits(
+        operations: monaco.editor.IIdentifiedSingleEditOperation[],
+        options?: Partial<MonacoEditorModel.ApplyEditsOptions>
+    ): monaco.editor.IIdentifiedSingleEditOperation[] {
+        const resolvedOptions: MonacoEditorModel.ApplyEditsOptions = {
+            ignoreDirty: false,
+            ignoreContentChanges: false,
+            ...options
+        };
+        const { ignoreDirtyEdits, ignoreContentChanges } = this;
+        this.ignoreDirtyEdits = resolvedOptions.ignoreDirty;
+        this.ignoreContentChanges = resolvedOptions.ignoreContentChanges;
+        try {
+            return this.model.applyEdits(operations);
+        } finally {
+            this.ignoreDirtyEdits = ignoreDirtyEdits;
+            this.ignoreContentChanges = ignoreContentChanges;
+        }
+    }
+
     protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken): Promise<void> {
         if (token.isCancellationRequested || !this.resource.saveContents || !this.dirty) {
             return;
@@ -238,8 +287,13 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
             return;
         }
 
+        const changes = this.popContentChanges();
+        if (changes.length === 0) {
+            return;
+        }
+
         const content = this.model.getValue();
-        await this.resource.saveContents(content);
+        await Resource.save(this.resource, { changes, content }, token);
         if (token.isCancellationRequested) {
             return;
         }
@@ -249,7 +303,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     }
 
     protected fireWillSaveModel(reason: TextDocumentSaveReason, token: CancellationToken): Promise<void> {
-        const model = this.model;
+        const model = this;
         return new Promise<void>(resolve => {
             this.onWillSaveModelEmitter.fire({
                 model, reason,
@@ -258,7 +312,9 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
                         if (token.isCancellationRequested) {
                             resolve();
                         }
-                        this.applyEdits(operations);
+                        this.applyEdits(operations, {
+                            ignoreDirty: true
+                        });
                         resolve();
                     })
             });
@@ -267,5 +323,11 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
 
     protected fireDidSaveModel(): void {
         this.onDidSaveModelEmitter.fire(this.model);
+    }
+}
+export namespace MonacoEditorModel {
+    export interface ApplyEditsOptions {
+        ignoreDirty: boolean
+        ignoreContentChanges: boolean
     }
 }


### PR DESCRIPTION
This PR:
- removes intermediate workspace documents and use Monaco models directly
- filter out fs events in the file resource based on modification timestamp

