### PR TITLE
GH-1484: Fixed tree node name styling issue in problems view.

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.ts
+++ b/packages/markers/src/browser/problem/problem-widget.ts
@@ -110,10 +110,11 @@ export class ProblemWidget extends TreeWidget {
     }
 
     protected decorateMarkerFileNode(node: MarkerInfoNode): h.Child {
-        const filenameDiv = h.div({ className: (node.icon || '') + ' file-icon' }, node.name);
+        const iconDiv = h.div({ className: (node.icon || '') + ' file-icon' });
+        const fileNameDiv = h.div({}, node.name);
         const pathDiv = h.div({ className: 'path' }, node.description || '');
         const counterDiv = h.div({ className: 'counter' }, node.numberOfMarkers.toString());
-        return h.div({ className: 'markerFileNode' }, filenameDiv, pathDiv, counterDiv);
+        return h.div({ className: 'markerFileNode' }, iconDiv, fileNameDiv, pathDiv, counterDiv);
     }
 
 }


### PR DESCRIPTION
It happened when the tree node did not have a specific node icon.

Closes #1484.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>