### PR TITLE
file-search: Search through .gitignored files

### DIFF
--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -33,7 +33,8 @@ export class FileSearchServiceImpl implements FileSearchService {
         };
         const args: string[] = [
             '--files',
-            '--sort-files'
+            '--sort-files',
+            '-u',
         ];
         const process = this.rawProcessFactory({
             command: rgPath,


### PR DESCRIPTION
Since there is no option or way right now to enable looking for files
that are .gitignored, it would make more sense to not use .gitignore
right now.  Otherwise, users just don't have a way to open their files
through ctrl-p.  I think for now it's better to have more results than
not being able to use the feature.