### PR TITLE
Set content-type for keep-alive responses

### DIFF
--- a/packages/core/src/node/backend-connection-status.ts
+++ b/packages/core/src/node/backend-connection-status.ts
@@ -13,7 +13,10 @@ import { BackendApplicationContribution } from './backend-application';
 export class BackendConnectionStatusEndpoint implements BackendApplicationContribution {
 
     configure(app: express.Application): void {
-        app.get('/alive', (request, response) => response.send());
+        app.get('/alive', (request, response) => {
+            response.contentType('application/json');
+            return response.send();
+        });
     }
 
 }


### PR DESCRIPTION
When not specified Firefox parses it as XML, which throws an error in the browser console logs because the response is empty.

Setting the content-type to `plain/text` makes everything fails apparently, `application/json` worked so I kept it.