### PR TITLE
Introduce the Variable Resolver Extension

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -31,6 +31,7 @@
     "@theia/terminal": "^0.3.7",
     "@theia/typescript": "^0.3.7",
     "@theia/userstorage": "^0.3.7",
+    "@theia/variable-resolver": "^0.3.7",
     "@theia/workspace": "^0.3.7"
   },
   "scripts": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -34,6 +34,7 @@
     "@theia/terminal": "^0.3.7",
     "@theia/typescript": "^0.3.7",
     "@theia/userstorage": "^0.3.7",
+    "@theia/variable-resolver": "^0.3.7",
     "@theia/workspace": "^0.3.7"
   },
   "scripts": {

--- a/packages/variable-resolver/README.md
+++ b/packages/variable-resolver/README.md
@@ -1,0 +1,81 @@
+# Theia - Variable Resolver Extension
+
+The extension provides variable substitution mechanism inside of strings using `${variableName}` syntax.
+
+## Variable Contribution Point
+Extension provides a hook that allows any extensions to contribute its own variables.
+Here's the example of contributing two variables:
+- `${file}` - returns the name of the file opened in the current editor
+- `${lineNumber}` - returns the current line number in the current file
+
+```typescript
+@injectable()
+export class EditorVariableContribution implements VariableContribution {
+
+    constructor(
+        @inject(EditorManager) protected readonly editorManager: EditorManager
+    ) { }
+
+    registerVariables(variables: VariableRegistry): void {
+        variables.registerVariable({
+            name: 'file',
+            description: 'The name of the file opened in the current editor',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (currentEditor) {
+                    return currentEditor.uri.displayName;
+                }
+                return undefined;
+            }
+        });
+        variables.registerVariable({
+            name: 'lineNumber',
+            description: 'The current line number in the current file',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (currentEditor) {
+                    return `${currentEditor.cursor.line + 1}`;
+                }
+                return undefined;
+            }
+        });
+    }
+
+    protected getCurrentEditor(): TextEditor | undefined {
+        const currentEditor = this.editorManager.currentEditor;
+        if (currentEditor) {
+            return currentEditor.editor;
+        }
+        return undefined;
+    }
+}
+```
+
+Note that a Variable is resolved to `MaybePromise<string | undefined>` which means that it can be resolved synchronously or within a Promise.
+
+## Using the Variable Resolver Service
+
+There's the example of how one can use Variable Resolver Service in its own plugin:
+```typescript
+@injectable()
+export class MyService {
+
+    constructor(
+        @inject(VariableResolverService) protected readonly variableResolver: VariableResolverService
+    ) { }
+
+    async resolve(): Promise<void> {
+        const text = 'cursor is in file ${file} on line ${lineNumber}';
+        const resolved = await this.variableResolver.resolve(text);
+        console.log(resolved);
+    }
+}
+```
+
+If `package.json` file is currently opened and cursor is on line 5 then the following output will be logged to the console:
+```
+cursor is in file package.json on line 5
+```
+
+## License
+[Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/variable-resolver/compile.tsconfig.json
+++ b/packages/variable-resolver/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/variable-resolver/package.json
+++ b/packages/variable-resolver/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@theia/variable-resolver",
+  "version": "0.3.7",
+  "description": "Theia - Variable Resolver Extension",
+  "dependencies": {
+    "@theia/core": "^0.3.7"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/variable-resolver-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "contributors": [
+    {
+      "name": "Artem Zatsarynnyi",
+      "email": "azatsary@redhat.com"
+    }
+  ],
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test",
+    "docs": "theiaext docs"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.2.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/variable-resolver/src/browser/index.ts
+++ b/packages/variable-resolver/src/browser/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export * from './variable';
+export * from './variable-quick-open-service';
+export * from './variable-resolver-service';

--- a/packages/variable-resolver/src/browser/variable-quick-open-service.ts
+++ b/packages/variable-resolver/src/browser/variable-quick-open-service.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { inject, injectable } from 'inversify';
+import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/';
+import { VariableRegistry } from './variable';
+
+@injectable()
+export class VariableQuickOpenService implements QuickOpenModel {
+
+    protected items: QuickOpenItem[];
+
+    constructor(
+        @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
+        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService
+    ) { }
+
+    open(): void {
+        this.items = this.variableRegistry.getVariables().map(
+            v => new VariableQuickOpenItem(v.name, v.description)
+        );
+
+        this.quickOpenService.open(this, {
+            placeholder: 'Registered variables',
+            fuzzyMatchLabel: true,
+            fuzzyMatchDescription: true,
+            fuzzySort: true
+        });
+    }
+
+    onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+        acceptor(this.items);
+    }
+}
+
+export class VariableQuickOpenItem extends QuickOpenItem {
+
+    constructor(
+        protected readonly name: string,
+        protected readonly description?: string
+    ) {
+        super();
+    }
+
+    getLabel(): string {
+        return '${' + this.name + '}';
+    }
+
+    getDetail(): string {
+        return this.description || '';
+    }
+
+    run(mode: QuickOpenMode): boolean {
+        return false;
+    }
+}

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import * as chai from 'chai';
+import { Container, ContainerModule } from 'inversify';
+import { QuickOpenService } from '@theia/core/lib/browser';
+import { ILogger, bindContributionProvider } from '@theia/core/lib/common';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { VariableContribution, VariableRegistry } from './variable';
+import { VariableQuickOpenService } from './variable-quick-open-service';
+import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
+
+disableJSDOM();
+
+const expect = chai.expect;
+
+before(() => {
+    chai.config.showDiff = true;
+    chai.config.includeStack = true;
+});
+
+describe('variable-resolver-frontend-contribution', () => {
+
+    let testContainer: Container;
+    let variableRegistry: VariableRegistry;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+
+        testContainer = new Container();
+        const module = new ContainerModule((bind, unbind, isBound, rebind) => {
+            bindContributionProvider(bind, VariableContribution);
+            bind(VariableContribution).toConstantValue(new TestVariableContribution());
+
+            bind(ILogger).to(MockLogger);
+            bind(VariableRegistry).toSelf().inSingletonScope();
+
+            bind(QuickOpenService).toSelf();
+            bind(VariableQuickOpenService).toSelf();
+
+            bind(VariableResolverFrontendContribution).toSelf();
+        });
+        testContainer.load(module);
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    beforeEach(() => {
+        variableRegistry = testContainer.get<VariableRegistry>(VariableRegistry);
+
+        const variableRegistrar = testContainer.get(VariableResolverFrontendContribution);
+        variableRegistrar.onStart();
+    });
+
+    it('should register all variables from the contribution points', () => {
+        const variables = variableRegistry.getVariables();
+        expect(variables.length).to.be.equal(2);
+        expect(variables[0].name).to.be.equal('file');
+        expect(variables[1].name).to.be.equal('lineNumber');
+    });
+});
+
+export class TestVariableContribution implements VariableContribution {
+
+    registerVariables(variables: VariableRegistry): void {
+        variables.registerVariable({
+            name: 'file',
+            description: 'Resolves to file name opened in the current editor',
+            resolve: () => Promise.resolve('package.json')
+        });
+        variables.registerVariable({
+            name: 'lineNumber',
+            description: 'Resolves to current line number',
+            resolve: () => Promise.resolve('5')
+        });
+    }
+}

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, named } from 'inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { Command, CommandContribution, CommandRegistry, ContributionProvider } from '@theia/core/lib/common';
+import { VariableContribution, VariableRegistry } from './variable';
+import { VariableQuickOpenService } from './variable-quick-open-service';
+
+export const LIST_VARIABLES: Command = {
+    id: 'variable.list',
+    label: 'Variable: List All'
+};
+
+@injectable()
+export class VariableResolverFrontendContribution implements FrontendApplicationContribution, CommandContribution {
+
+    constructor(
+        @inject(ContributionProvider) @named(VariableContribution)
+        protected readonly contributionProvider: ContributionProvider<VariableContribution>,
+        @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
+        @inject(VariableQuickOpenService) protected readonly variableQuickOpenService: VariableQuickOpenService
+    ) { }
+
+    onStart(): void {
+        this.contributionProvider.getContributions().forEach(contrib =>
+            contrib.registerVariables(this.variableRegistry)
+        );
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(LIST_VARIABLES, {
+            isEnabled: () => true,
+            execute: () => this.variableQuickOpenService.open()
+        });
+    }
+}

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from 'inversify';
+import { bindContributionProvider, CommandContribution } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { VariableRegistry, VariableContribution } from './variable';
+import { VariableQuickOpenService } from './variable-quick-open-service';
+import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
+import { VariableResolverService } from './variable-resolver-service';
+
+export default new ContainerModule(bind => {
+    bind(VariableRegistry).toSelf().inSingletonScope();
+    bind(VariableResolverService).toSelf().inSingletonScope();
+    bindContributionProvider(bind, VariableContribution);
+
+    bind(VariableResolverFrontendContribution).toSelf().inSingletonScope();
+    for (const identifier of [FrontendApplicationContribution, CommandContribution]) {
+        bind(identifier).toService(VariableResolverFrontendContribution);
+    }
+
+    bind(VariableQuickOpenService).toSelf().inSingletonScope();
+});

--- a/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as chai from 'chai';
+import { Container, ContainerModule } from 'inversify';
+import { ILogger } from '@theia/core/lib/common';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { Variable, VariableRegistry } from './variable';
+import { VariableResolverService } from './variable-resolver-service';
+
+const expect = chai.expect;
+
+before(() => {
+    chai.config.showDiff = true;
+    chai.config.includeStack = true;
+});
+
+describe('variable-resolver-service', () => {
+
+    let testContainer: Container;
+
+    before(() => {
+        testContainer = new Container();
+        const module = new ContainerModule((bind, unbind, isBound, rebind) => {
+            bind(ILogger).to(MockLogger);
+            bind(VariableRegistry).toSelf().inSingletonScope();
+            bind(VariableResolverService).toSelf();
+        });
+        testContainer.load(module);
+    });
+
+    let variableRegistry: VariableRegistry;
+    let variableResolverService: VariableResolverService;
+
+    beforeEach(() => {
+        variableRegistry = testContainer.get(VariableRegistry);
+        variableResolverService = testContainer.get(VariableResolverService);
+
+        const variables: Variable[] = [
+            {
+                name: 'file',
+                description: 'current file',
+                resolve: () => Promise.resolve('package.json')
+            },
+            {
+                name: 'lineNumber',
+                description: 'current line number',
+                resolve: () => Promise.resolve('6')
+            }
+        ];
+        variables.forEach(v => variableRegistry.registerVariable(v));
+    });
+
+    it('should resolve known variables', async () => {
+        const resolved = await variableResolverService.resolve('file: ${file}; line: ${lineNumber}');
+        expect(resolved).is.equal('file: package.json; line: 6');
+    });
+
+    it('shouldn\'t resolve unknown variables', async () => {
+        const resolved = await variableResolverService.resolve('workspace: ${workspaceRoot}; file: ${file}; line: ${lineNumber}');
+        expect(resolved).is.equal('workspace: ${workspaceRoot}; file: package.json; line: 6');
+    });
+});

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { Variable, VariableRegistry } from './variable';
+
+/**
+ * The variable resolver service should be used to resolve variables in strings.
+ */
+@injectable()
+export class VariableResolverService {
+
+    protected static VAR_REGEXP = /\$\{(.*?)\}/g;
+
+    constructor(
+        @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry
+    ) { }
+
+    /**
+	 * Resolve variables in the given string.
+	 * @returns promise resolved to the provided string with already resolved variables.
+     * Never reject.
+	 */
+    async resolve(text: string): Promise<string> {
+        const variablesToValues = await this.resolveVariables(this.searchVariables(text));
+        const resolvedText = text.replace(VariableResolverService.VAR_REGEXP, (match: string, varName: string) => {
+            const value = variablesToValues.get(varName);
+            return value ? value : match;
+        });
+        return resolvedText;
+    }
+
+    /**
+     * Finds all variables in the given string.
+     */
+    protected searchVariables(text: string): Variable[] {
+        const variables: Variable[] = [];
+        let match;
+        while ((match = VariableResolverService.VAR_REGEXP.exec(text)) !== null) {
+            const variableName = match[1];
+            const variable = this.variableRegistry.getVariable(variableName);
+            if (variable) {
+                variables.push(variable);
+            }
+        }
+        return variables;
+    }
+
+    /**
+     * Resolve the given variables.
+     * @returns promise resolved to the map of the variable name to its value.
+     * Never reject.
+     */
+    protected async resolveVariables(variables: Variable[]): Promise<Map<string, string>> {
+        const resolvedVariables: Map<string, string> = new Map();
+        const promises: Promise<any>[] = [];
+        variables.forEach(variable => {
+            const promise = Promise.resolve(variable.resolve()).then(value => {
+                if (value) {
+                    resolvedVariables.set(variable.name, value);
+                }
+            });
+            promises.push(promise);
+        });
+        await Promise.all(promises);
+        return resolvedVariables;
+    }
+}

--- a/packages/variable-resolver/src/browser/variable.spec.ts
+++ b/packages/variable-resolver/src/browser/variable.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as chai from 'chai';
+import { Container, ContainerModule } from 'inversify';
+import { ILogger, Disposable } from '@theia/core/lib/common';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { Variable, VariableRegistry } from './variable';
+
+const expect = chai.expect;
+let variableRegistry: VariableRegistry;
+
+before(() => {
+    chai.config.showDiff = true;
+    chai.config.includeStack = true;
+});
+
+describe('variable api', () => {
+    let testContainer: Container;
+
+    before(() => {
+        testContainer = new Container();
+        const module = new ContainerModule((bind, unbind, isBound, rebind) => {
+            bind(ILogger).to(MockLogger);
+            bind(VariableRegistry).toSelf();
+        });
+        testContainer.load(module);
+    });
+
+    beforeEach(() => {
+        variableRegistry = testContainer.get<VariableRegistry>(VariableRegistry);
+    });
+
+    it('should register and return variable', () => {
+        registerTestVariable();
+
+        const variable = variableRegistry.getVariable(TEST_VARIABLE.name);
+        expect(variable).is.not.undefined;
+        if (variable) {
+            expect(variable.name).is.equal(TEST_VARIABLE.name);
+        }
+    });
+
+    it('should not register a variable for already existed name', () => {
+        const variables: Variable[] = [
+            {
+                name: 'workspaceRoot',
+                description: 'workspace root URI',
+                resolve: () => Promise.resolve('')
+            },
+            {
+                name: 'workspaceRoot',
+                description: 'workspace root URI 2',
+                resolve: () => Promise.resolve('')
+            }
+        ];
+        variables.forEach(v => variableRegistry.registerVariable(v));
+
+        const registeredVariables = variableRegistry.getVariables();
+        expect(registeredVariables.length).to.be.equal(1);
+        expect(registeredVariables[0].name).to.be.equal('workspaceRoot');
+        expect(registeredVariables[0].description).to.be.equal('workspace root URI');
+    });
+
+    it('should dispose variable', () => {
+        const disposable = registerTestVariable();
+        disposable.dispose();
+
+        const variable = variableRegistry.getVariable(TEST_VARIABLE.name);
+        expect(variable).is.undefined;
+    });
+
+    it('should unregister variables on dispose', () => {
+        registerTestVariable();
+
+        let variables = variableRegistry.getVariables();
+        expect(variables.length).to.be.equal(1);
+
+        variableRegistry.dispose();
+
+        variables = variableRegistry.getVariables();
+        expect(variables.length).to.be.equal(0);
+    });
+});
+
+const TEST_VARIABLE: Variable = {
+    name: 'workspaceRoot',
+    resolve: () => Promise.resolve('')
+};
+
+function registerTestVariable(): Disposable {
+    return variableRegistry.registerVariable(TEST_VARIABLE);
+}

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { ILogger, Disposable, DisposableCollection, MaybePromise } from '@theia/core';
+
+/**
+ * Variable can be used inside of strings using ${variableName} syntax.
+ */
+export interface Variable {
+
+    /**
+     * A unique name of this variable.
+     */
+    readonly name: string;
+
+    /**
+     * A human-readable description of this variable.
+     */
+    readonly description?: string;
+
+    /**
+     * Resolve to a string value of this variable or
+     * `undefined` if variable cannot be resolved.
+     * Never reject.
+     */
+    resolve(): MaybePromise<string | undefined>;
+}
+
+export const VariableContribution = Symbol("VariableContribution");
+/**
+ * The variable contribution should be implemented to register custom variables.
+ */
+export interface VariableContribution {
+    registerVariables(variables: VariableRegistry): void;
+}
+
+/**
+ * The variable registry manages variables.
+ */
+@injectable()
+export class VariableRegistry implements Disposable {
+
+    protected readonly variables: Map<string, Variable> = new Map();
+    protected readonly toDispose = new DisposableCollection();
+
+    constructor(
+        @inject(ILogger) protected readonly logger: ILogger
+    ) { }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    /**
+     * Register the given variable.
+     * Do nothing if a variable is already registered for the given variable name.
+     */
+    registerVariable(variable: Variable): Disposable {
+        if (this.variables.has(variable.name)) {
+            this.logger.warn(`A variables with name ${variable.name} is already registered.`);
+            return Disposable.NULL;
+        }
+        this.variables.set(variable.name, variable);
+        const disposable = {
+            dispose: () => this.variables.delete(variable.name)
+        };
+        this.toDispose.push(disposable);
+        return disposable;
+    }
+
+    /**
+     * Return all registered variables.
+     */
+    getVariables(): Variable[] {
+        return [...this.variables.values()];
+    }
+
+    /**
+     * Get a variable for the given name or `undefined` if none.
+     */
+    getVariable(name: string): Variable | undefined {
+        return this.variables.get(name);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -81,6 +81,9 @@
       ],
       "@theia/callhierarchy/lib/*": [
         "packages/callhierarchy/src/*"
+      ],
+      "@theia/variable-resolver/lib/*": [
+        "packages/variable-resolver/src/*"
       ]
     }
   },


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

PR closes #1561

This PR introduces the `variable-resolver` extension which provides support of variable substitution mechanism inside strings. Extension adds:
- a contribution point to provide a hook that allows any extensions to contribute its own variables e.g.:
```typescript
export class EditorVariableContribution implements VariableContribution {
    registerVariables(variables: VariableRegistry): void {
        variables.registerVariable({
            name: 'lineNumber',
            description: 'The current line number in the current file',
            resolve: () => {
                const currentEditor = ...
                return Promise.resolve(`${currentEditor.cursor.line + 1}`);
            }
        });
    }
}
```
- `VariableResolverService` allows to resolve all known variables in a string e.g.:
```typescript
const resolved = await service.resolve('file: ${file}; line: ${lineNumber}');
expect(resolved).is.equal('file: package.json; line: 6');
```
- `VariableQuickOpenService` allows to get list of all registered variables e.g.:

![screenshot from 2018-03-26 17-20-30](https://user-images.githubusercontent.com/1636395/37914365-c03f22e4-311f-11e8-980a-7bbb02389b9f.png)

Note, this PR doesn't contribute any variables. I'm going to provide a couple of separate PRs a bit later to add support for variables in `tasks.json` and add the [VSCode's predefined variables](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables) to add a little bit more compatibility with VSCode Tasks.