### PR TITLE
GH-1582: Bumped up the `electron` version to `1.8.2-beta.5`.

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -34,7 +34,7 @@
     "circular-dependency-plugin": "^4.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
-    "electron": "1.7.11",
+    "electron": "1.8.2-beta.5",
     "electron-rebuild": "^1.5.11",
     "file-loader": "^1.1.11",
     "font-awesome-webpack": "0.0.5-beta.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "ajv": "^5.2.2",
     "body-parser": "^1.17.2",
     "bunyan": "^1.8.10",
-    "electron": "1.7.11",
+    "electron": "1.8.2-beta.5",
     "es6-promise": "^4.2.4",
     "express": "^4.15.3",
     "file-icons-js": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,9 +247,9 @@
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.2.tgz#83b8103fa9a2c2e83d78f701a9aa7c9539739aa5"
 
-"@types/node@^7.0.18":
-  version "7.0.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.51.tgz#1fb9bd2c7d28b1e8b1fe438f01494d0da8e451af"
+"@types/node@^8.0.24":
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.0.tgz#f5d649cc49af8ed6507d15dc6e9b43fe8b927540"
 
 "@types/perfect-scrollbar@^1.3.0":
   version "1.3.0"
@@ -3077,11 +3077,11 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@1.7.11:
-  version "1.7.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.11.tgz#993b6aa79e0e79a7cfcc369f4c813fbd9a0b08d9"
+electron@1.8.2-beta.5:
+  version "1.8.2-beta.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2-beta.5.tgz#8324c483ed8cb4b052b3e13e514ddc858707fdeb"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
Closes #1582.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

I have verified it on both OS X and Windows. It works.

@epatpol, @marcdumais-work, could you please one of you verify the electron example on Linux?