### PR TITLE
Change --logLevel to --log-level

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "program": "${workspaceRoot}/examples/electron/src-gen/frontend/electron-main.js",
             "protocol": "inspector",
             "args": [
-                "--loglevel=debug",
+                "--log-level=debug",
                 "--hostname=localhost",
                 "--no-cluster",
                 "--app-project-path=${workspaceRoot}/examples/electron",
@@ -42,7 +42,7 @@
             "name": "Launch Backend",
             "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
             "args": [
-                "--loglevel=debug",
+                "--log-level=debug",
                 "--port=3000",
                 "--no-cluster",
                 "--app-project-path=${workspaceRoot}/examples/browser",
@@ -68,7 +68,7 @@
             "name": "Launch Backend (eclipse.jdt.ls)",
             "program": "${workspaceRoot}/examples/browser/src-gen/backend/main.js",
             "args": [
-                "--loglevel=debug",
+                "--log-level=debug",
                 "--root-dir=${workspaceRoot}/../eclipse.jdt.ls/org.eclipse.jdt.ls.core",
                 "--port=3000",
                 "--no-cluster",

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -218,7 +218,7 @@ Let assume you have to work for instance in the `@theia/navigator` extension. Bu
     - All variations of `--inspect` flag are supported: https://nodejs.org/en/docs/inspector/#command-line-options.
   - Attach the debugger to the logged port.
 
-In order to look up `server-name` run the backend server with `--logLevel=debug` flag to enable logging of IPC servers instantiation.
+In order to look up `server-name` run the backend server with `--log-level=debug` flag to enable logging of IPC servers instantiation.
 You should be able to see message of `[${server-name}: ${server-PID}]: IPC started` format, like `[nsfw-watcher: 37557] IPC started`.
 
 ## Testing

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -40,7 +40,7 @@
     "build": "theia build --mode development",
     "watch": "yarn build --watch --mode development",
     "start": "theia start",
-    "start:debug": "yarn start --logLevel=debug",
+    "start:debug": "yarn start --log-level=debug",
     "test": "wdio",
     "coverage:compile": "yarn build --config coverage-webpack.config.js",
     "coverage:remap": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-final.json --exclude 'frontend/index.js' && rimraf coverage/coverage.json",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -43,7 +43,7 @@
     "build": "theia build --mode development",
     "watch": "yarn build --watch --mode development",
     "start": "theia start",
-    "start:debug": "yarn start --loglevel=debug",
+    "start:debug": "yarn start --log-level=debug",
     "test": "electron-mocha --timeout 60000 --require ts-node/register \"./test/**/*.espec.ts\"",
     "test:ui": "wdio wdio.conf.js"
   },

--- a/packages/core/src/node/bunyan-logger-server.ts
+++ b/packages/core/src/node/bunyan-logger-server.ts
@@ -18,7 +18,7 @@ export class LogLevelCliContribution implements CliContribution {
     logLevel: string;
 
     configure(conf: yargs.Argv): void {
-        conf.option('logLevel', {
+        conf.option('log-level', {
             description: 'Sets the log level',
             default: 'info',
             choices: ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
@@ -26,7 +26,7 @@ export class LogLevelCliContribution implements CliContribution {
     }
 
     setArguments(args: yargs.Arguments): void {
-        this.logLevel = args['logLevel'];
+        this.logLevel = args['log-level'];
     }
 }
 


### PR DESCRIPTION
--logLevel is the only switch using camelcase.  Other switches use kebab
case.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>