### PR TITLE
Fix window reload for Safari

### DIFF
--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -60,7 +60,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                 execute: () => {
                     this.shouldStoreLayout = false;
                     this.storageService.setData(this.storageKey, undefined)
-                        .then(() => window.location.reload());
+                        .then(() => window.location.reload(true));
                 }
             });
     }

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -24,7 +24,10 @@ export interface WindowService {
 export class DefaultWindowService implements WindowService {
 
     openNewWindow(url: string): void {
-        window.open(url);
+        const newWindow = window.open(url);
+        if (newWindow === null) {
+            throw new Error('Cannot open a new window for URL: ' + url);
+        }
     }
 
 }

--- a/packages/extension-manager/src/browser/extension-contribution.ts
+++ b/packages/extension-manager/src/browser/extension-contribution.ts
@@ -44,7 +44,7 @@ export class ExtensionContribution extends AbstractViewContribution<ExtensionWid
         this.extensionManager.onDidStopInstallation(({ reverting, failed }) => {
             if (!failed) {
                 const reloadMessage = !reverting ? 'Reload to complete the installation.' : 'Reload to revert the installation.';
-                this.messageService.info(reloadMessage).then(() => window.location.reload());
+                this.messageService.info(reloadMessage).then(() => window.location.reload(true));
             }
         });
     }


### PR DESCRIPTION
Fixes #981 (partly).

I added the `true` parameter to `window.location.reload()` as proposed by @kittaakos. But then I found another reason why Safari refuses to load the new workspace root: `window.open(url)` is blocked and returns `null`.

I handled this case by falling back to reloading the current window. That works, but afterwards the workspace root is still the same as before. I assume that is another bug that occurs on Safari?