### PR TITLE
Add support for variables in Tasks

### DIFF
--- a/packages/task/README.md
+++ b/packages/task/README.md
@@ -118,6 +118,13 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
 }
 ```
 
+### Variables
+The variables are supported in the following properties, using `${variableName}` syntax:
+- `cwd`
+- `processOptions.command`
+- `processOptions.args`
+- `windowsProcessOptions.command`
+- `windowsProcessOptions.args`
 
 See [here](https://github.com/theia-ide/theia) for other Theia documentation.
 

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -7,6 +7,7 @@
     "@theia/markers": "^0.3.8",
     "@theia/process": "^0.3.8",
     "@theia/terminal": "^0.3.8",
+    "@theia/variable-resolver": "^0.3.8",
     "@theia/workspace": "^0.3.8",
     "jsonc-parser": "^1.0.1"
   },

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -105,11 +105,7 @@ export class TaskConfigurations implements Disposable {
 
     /** returns the task configuration for a given label */
     getTask(taskLabel: string): TaskOptions | undefined {
-        if (this.tasksMap.has(taskLabel)) {
-            return this.tasksMap.get(taskLabel);
-        } else {
-            return undefined;
-        }
+        return this.tasksMap.get(taskLabel);
     }
 
     /** returns the string uri of where the config file would be, if it existed under a given root directory */

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -87,7 +87,7 @@ export class TaskServerImpl implements TaskServer {
         // When we create a process to execute a command, it's difficult to know if it failed
         // because the executable or script was not found, or if it was found, ran, and exited
         // unsuccessfully. So here we look to see if it seems we can find a file of that name
-        // that is likely to be the one we want, before attemting to execute it.
+        // that is likely to be the one we want, before attempting to execute it.
         const cmd = await this.findCommand(command, cwd);
         if (cmd) {
             try {
@@ -128,7 +128,7 @@ export class TaskServerImpl implements TaskServer {
                 return taskInfo;
 
             } catch (error) {
-                this.logger.error(`Error occured while creating task: ${error}`);
+                this.logger.error(`Error occurred while creating task: ${error}`);
                 return Promise.reject(new Error(error));
             }
         } else {
@@ -180,11 +180,11 @@ export class TaskServerImpl implements TaskServer {
     }
 
     /**
-     * uses heuristics to look-for a command. Will look into the system path, if the command
+     * Uses heuristics to look-for a command. Will look into the system path, if the command
      * is given without a path. Will resolve if a potential match is found, else reject. There
-     * is no garantee that a command we find will be the one executed, if multiple commands with
+     * is no guarantee that a command we find will be the one executed, if multiple commands with
      * the same name exist.
-     * @param command command name to look-for
+     * @param command command name to look for
      * @param cwd current working directory
      */
     protected async findCommand(command: string, cwd: string): Promise<string | undefined> {
@@ -222,7 +222,7 @@ export class TaskServerImpl implements TaskServer {
     }
 
     /**
-     * Checks for the existance of a file, at the provided path, and make sure that
+     * Checks for the existence of a file, at the provided path, and make sure that
      * it's readable and executable.
      */
     protected async executableFileExists(filePath: string): Promise<boolean> {

--- a/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
@@ -55,12 +55,19 @@ describe('variable-resolver-service', () => {
         variables.forEach(v => variableRegistry.registerVariable(v));
     });
 
-    it('should resolve known variables', async () => {
+    it('should resolve known variables in a text', async () => {
         const resolved = await variableResolverService.resolve('file: ${file}; line: ${lineNumber}');
         expect(resolved).is.equal('file: package.json; line: 6');
     });
 
-    it('shouldn\'t resolve unknown variables', async () => {
+    it('should resolve known variables in a string array', async () => {
+        const resolved = await variableResolverService.resolveArray(['file: ${file}', 'line: ${lineNumber}']);
+        expect(resolved.length).to.be.equal(2);
+        expect(resolved).to.contain('file: package.json');
+        expect(resolved).to.contain('line: 6');
+    });
+
+    it('should skip unknown variables', async () => {
         const resolved = await variableResolverService.resolve('workspace: ${workspaceRoot}; file: ${file}; line: ${lineNumber}');
         expect(resolved).is.equal('workspace: ${workspaceRoot}; file: package.json; line: 6');
     });

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -21,7 +21,7 @@ export class VariableResolverService {
     ) { }
 
     /**
-	 * Resolve variables in the given string.
+	 * Resolve the variables in the given string.
 	 * @returns promise resolved to the provided string with already resolved variables.
      * Never reject.
 	 */
@@ -32,6 +32,19 @@ export class VariableResolverService {
             return value ? value : match;
         });
         return resolvedText;
+    }
+
+    /**
+     * Resolve the variables in the given string array.
+     * @returns promise resolved to the provided string array with already resolved variables.
+     * Never reject.
+     */
+    async resolveArray(arr: string[]): Promise<string[]> {
+        const result: string[] = [];
+        for (let i = 0; i < arr.length; i++) {
+            result[i] = await this.resolve(arr[i]);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
This PR adds support for the Variables in `tasks.json`. So the Task Extension is the first customer for Variable API )
Fixes #1596