### PR TITLE
Add an "Attach by Process ID" launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,12 @@
     "configurations": [
         {
             "type": "node",
+            "request": "attach",
+            "name": "Attach by Process ID",
+            "processId": "${command:PickProcess}"
+        },
+        {
+            "type": "node",
             "request": "launch",
             "name": "Launch Electron Backend",
             "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",


### PR DESCRIPTION
I find myself often adding this launch to attach to an already running
backend, so I thought it would be useful to add it to our launch.json,
so it would already be there for everybody.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>