### PR TITLE
Add 'workspaceFolder' and 'workspaceFolderBasename' variables

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "^0.3.8",
     "@theia/filesystem": "^0.3.8",
+    "@theia/variable-resolver": "^0.3.8",
     "@types/fs-extra": "^4.0.2",
     "fs-extra": "^4.0.2",
     "valid-filename": "^2.0.1"

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -11,10 +11,12 @@ import { WebSocketConnectionProvider, FrontendApplicationContribution } from '@t
 import { FileDialogFactory, createFileDialog, FileDialogProps } from '@theia/filesystem/lib/browser';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
+import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceServer, workspacePath } from '../common';
 import { WorkspaceFrontendContribution } from "./workspace-frontend-contribution";
 import { WorkspaceService } from './workspace-service';
 import { WorkspaceCommandContribution, FileMenuContribution } from './workspace-commands';
+import { WorkspaceVariableContribution } from './workspace-variable-contribution';
 import { WorkspaceStorageService } from './workspace-storage-service';
 import { WorkspaceUriLabelProviderContribution } from './workspace-uri-contribution';
 
@@ -43,4 +45,5 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     rebind(StorageService).to(WorkspaceStorageService).inSingletonScope();
 
     bind(LabelProviderContribution).to(WorkspaceUriLabelProviderContribution).inSingletonScope();
+    bind(VariableContribution).to(WorkspaceVariableContribution).inSingletonScope();
 });

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { VariableContribution, VariableRegistry } from '@theia/variable-resolver/lib/browser';
+import { WorkspaceService } from './workspace-service';
+import URI from '@theia/core/lib/common/uri';
+
+@injectable()
+export class WorkspaceVariableContribution implements VariableContribution {
+
+    constructor(
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+    ) { }
+
+    registerVariables(variables: VariableRegistry): void {
+        variables.registerVariable({
+            name: 'workspaceFolder',
+            description: 'The path of the workspace root folder',
+            resolve: async () => {
+                const uri = await this.getWorkspaceRootUri();
+                return uri ? uri.path.toString() : undefined;
+            }
+        });
+        variables.registerVariable({
+            name: 'workspaceFolderBasename',
+            description: 'The name of the workspace root folder',
+            resolve: async () => {
+                const uri = await this.getWorkspaceRootUri();
+                return uri ? uri.displayName : undefined;
+            }
+        });
+    }
+
+    protected async getWorkspaceRootUri(): Promise<URI | undefined> {
+        const wsRoot = await this.workspaceService.root;
+        if (wsRoot) {
+            return new URI(wsRoot.uri);
+        }
+        return undefined;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsarynnyy@codenvy.com>
Fixes partially #1598 

This PR adds a couple of Variables contributed by the Workspace Extension:
- `${workspaceFolder}` (the most neede one) resolves to the path of the workspace root folder;
- `${workspaceFolderBasename}` resolves to the name of the workspace root folder.

Note, these variables will work with the Tasks (tasks.json) once #1606 is merged.