### PR TITLE
Remove extra '...' in git action labels

### DIFF
--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -128,7 +128,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
         commands.forEach(command =>
             menus.registerMenuAction(GIT_WIDGET_CONTEXT_MENU, {
                 commandId: command.id,
-                label: command.label.slice('Git: '.length) + '...'
+                label: command.label.slice('Git: '.length)
             })
         );
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {


### PR DESCRIPTION
There are '...' included in the labels, and some extra dots are added
afterwards, leading to labels like 'Fetch......'.  Remove those that are
added afterwards.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>