### PR TITLE
Move Variable API to '@theia/core'

### DIFF
--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -28,3 +28,4 @@ export * from './label-provider';
 export * from './widget-open-handler';
 export * from './navigatable';
 export * from './diff-uris';
+export * from './variable';

--- a/packages/core/src/browser/variable/index.ts
+++ b/packages/core/src/browser/variable/index.ts
@@ -5,5 +5,4 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export * from './variable-quick-open-service';
-export * from './variable-resolver-service';
+export * from './variable';

--- a/packages/core/src/browser/variable/variable.spec.ts
+++ b/packages/core/src/browser/variable/variable.spec.ts
@@ -7,9 +7,9 @@
 
 import * as chai from 'chai';
 import { Container, ContainerModule } from 'inversify';
-import { ILogger, Disposable } from '@theia/core/lib/common';
-import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { Variable, VariableRegistry } from './variable';
+import { ILogger, Disposable } from '../../common';
+import { MockLogger } from '../../common/test/mock-logger';
 
 const expect = chai.expect;
 let variableRegistry: VariableRegistry;

--- a/packages/core/src/browser/variable/variable.ts
+++ b/packages/core/src/browser/variable/variable.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { ILogger, Disposable, DisposableCollection, MaybePromise } from '@theia/core';
+import { ILogger, Disposable, DisposableCollection, MaybePromise } from '../../common';
 
 /**
  * Variable can be used inside of strings using ${variableName} syntax.

--- a/packages/variable-resolver/README.md
+++ b/packages/variable-resolver/README.md
@@ -3,7 +3,7 @@
 The extension provides variable substitution mechanism inside of strings using `${variableName}` syntax.
 
 ## Variable Contribution Point
-Extension provides a hook that allows any extensions to contribute its own variables.
+Variable API defined in `@theia/core` provides a hook that allows any extensions to contribute its own variables.
 Here's the example of contributing two variables:
 - `${file}` - returns the name of the file opened in the current editor
 - `${lineNumber}` - returns the current line number in the current file

--- a/packages/variable-resolver/src/browser/variable-quick-open-service.ts
+++ b/packages/variable-resolver/src/browser/variable-quick-open-service.ts
@@ -6,8 +6,7 @@
  */
 
 import { inject, injectable } from 'inversify';
-import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/';
-import { VariableRegistry } from './variable';
+import { VariableRegistry, QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/';
 
 @injectable()
 export class VariableQuickOpenService implements QuickOpenModel {

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
@@ -11,10 +11,9 @@ let disableJSDOM = enableJSDOM();
 
 import * as chai from 'chai';
 import { Container, ContainerModule } from 'inversify';
-import { QuickOpenService } from '@theia/core/lib/browser';
+import { VariableContribution, VariableRegistry, QuickOpenService } from '@theia/core/lib/browser';
 import { ILogger, bindContributionProvider } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
-import { VariableContribution, VariableRegistry } from './variable';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
 

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
@@ -6,9 +6,8 @@
  */
 
 import { injectable, inject, named } from 'inversify';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, VariableContribution, VariableRegistry } from '@theia/core/lib/browser';
 import { Command, CommandContribution, CommandRegistry, ContributionProvider } from '@theia/core/lib/common';
-import { VariableContribution, VariableRegistry } from './variable';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 
 export const LIST_VARIABLES: Command = {

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
@@ -7,8 +7,7 @@
 
 import { ContainerModule } from 'inversify';
 import { bindContributionProvider, CommandContribution } from '@theia/core';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { VariableRegistry, VariableContribution } from './variable';
+import { FrontendApplicationContribution, VariableRegistry, VariableContribution } from '@theia/core/lib/browser';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
 import { VariableResolverService } from './variable-resolver-service';

--- a/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
@@ -7,9 +7,9 @@
 
 import * as chai from 'chai';
 import { Container, ContainerModule } from 'inversify';
+import { Variable, VariableRegistry } from '@theia/core/lib/browser';
 import { ILogger } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
-import { Variable, VariableRegistry } from './variable';
 import { VariableResolverService } from './variable-resolver-service';
 
 const expect = chai.expect;

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { Variable, VariableRegistry } from './variable';
+import { VariableRegistry, Variable } from '@theia/core/lib/browser';
 
 /**
  * The variable resolver service should be used to resolve variables in strings.

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@theia/core": "^0.3.8",
     "@theia/filesystem": "^0.3.8",
-    "@theia/variable-resolver": "^0.3.8",
     "@types/fs-extra": "^4.0.2",
     "fs-extra": "^4.0.2",
     "valid-filename": "^2.0.1"

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -7,11 +7,10 @@
 
 import { ContainerModule, interfaces } from 'inversify';
 import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
-import { WebSocketConnectionProvider, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, FrontendApplicationContribution, VariableContribution } from '@theia/core/lib/browser';
 import { FileDialogFactory, createFileDialog, FileDialogProps } from '@theia/filesystem/lib/browser';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
-import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceServer, workspacePath } from '../common';
 import { WorkspaceFrontendContribution } from "./workspace-frontend-contribution";
 import { WorkspaceService } from './workspace-service';

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { VariableContribution, VariableRegistry } from '@theia/variable-resolver/lib/browser';
+import { VariableContribution, VariableRegistry } from '@theia/core/lib/browser';
 import { WorkspaceService } from './workspace-service';
 import URI from '@theia/core/lib/common/uri';
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsarynnyy@codenvy.com>

PR moves Variable API to `@theia/core` to not force the extensions that contribute Variables to depend on `@theia/variable-resolver`.
This is a follow up on https://github.com/theia-ide/theia/pull/1620#issuecomment-377612975. 