### PR TITLE
Set diagnosticCollectionName in client options

### DIFF
--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -102,7 +102,8 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                 const detail = err instanceof Error ? `: ${err.message}` : '.';
                 this.messageService.error(`Failed to start ${this.name} language server${detail}`);
                 return false;
-            }
+            },
+            diagnosticCollectionName: this.id,
         };
     }
 


### PR DESCRIPTION
Setting this property will make it appear in the problems, to show where
warnings/errors comes from.  Right now, it says "[default]", after the
patch it would say "[typescript]", for example.  This will also help
when adding a second language server for the same language (e.g. tslint,
in addition to tsc).  Without this flag, the diagnostics from the second
LS to send a publishDiagnostics would overwrite the diagnostics from the
first one to send it.  With different names, they end up with a
different owner in "MarkerManager", so don't overwrite each other.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>