### PR TITLE
Log LSP messages

### DIFF
--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -7,7 +7,7 @@
 
 import * as net from 'net';
 import * as cp from 'child_process';
-import { injectable, inject } from "inversify";
+import { injectable, inject, named } from "inversify";
 import { Message, isRequestMessage } from 'vscode-ws-jsonrpc';
 import { InitializeParams, InitializeRequest } from 'vscode-languageserver-protocol';
 import {
@@ -16,7 +16,7 @@ import {
     forward,
     IConnection
 } from 'vscode-ws-jsonrpc/lib/server';
-import { MaybePromise } from "@theia/core/lib/common";
+import { MaybePromise, ILogger } from "@theia/core/lib/common";
 import { LanguageContribution } from "../common";
 import { RawProcess, RawProcessFactory } from '@theia/process/lib/node/raw-process';
 import { ProcessManager } from '@theia/process/lib/node/process-manager';
@@ -42,6 +42,8 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
     @inject(ProcessManager)
     protected readonly processManager: ProcessManager;
 
+    @inject(ILogger) @named('languages') protected readonly logger: ILogger;
+
     abstract start(clientConnection: IConnection): void;
 
     protected forward(clientConnection: IConnection, serverConnection: IConnection): void {
@@ -55,6 +57,9 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
                 initializeParams.processId = process.pid;
             }
         }
+
+        this.logger.debug(JSON.stringify(message));
+
         return message;
     }
 

--- a/packages/languages/src/node/languages-backend-contribution.ts
+++ b/packages/languages/src/node/languages-backend-contribution.ts
@@ -20,7 +20,7 @@ export class LanguagesBackendContribution implements BackendApplicationContribut
 
     constructor(
         @inject(ContributionProvider) @named(LanguageServerContribution) protected readonly contributors: ContributionProvider<LanguageServerContribution>,
-        @inject(ILogger) protected logger: ILogger
+        @inject(ILogger) @named('languages') protected logger: ILogger
     ) { }
 
     onStart(server: http.Server | https.Server): void {

--- a/packages/languages/src/node/languages-backend-module.ts
+++ b/packages/languages/src/node/languages-backend-module.ts
@@ -6,7 +6,7 @@
  */
 
 import { ContainerModule } from "inversify";
-import { bindContributionProvider } from '@theia/core/lib/common';
+import { bindContributionProvider, ILogger } from '@theia/core/lib/common';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { LanguagesBackendContribution } from "./languages-backend-contribution";
 import { LanguageServerContribution } from "./language-server-contribution";
@@ -14,4 +14,9 @@ import { LanguageServerContribution } from "./language-server-contribution";
 export default new ContainerModule(bind => {
     bind(BackendApplicationContribution).to(LanguagesBackendContribution).inSingletonScope();
     bindContributionProvider(bind, LanguageServerContribution);
+
+    bind(ILogger).toDynamicValue(ctx => {
+        const logger = ctx.container.get<ILogger>(ILogger);
+        return logger.child({ 'module': 'languages' });
+    }).inSingletonScope().whenTargetNamed('languages');
 });


### PR DESCRIPTION
When working with language servers, it's often useful to be able to look
at the communication between Theia and the LS.  This patch sends all
transferred messages as debug output on a new 'languages' logger.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>