### PR TITLE
Set the root workspace when opening a new workspace

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -90,6 +90,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
             // The same window has to be preserved too (instead of opening a new one), if the workspace root is not yet available and we are setting it for the first time.
             const preserveWindow = options ? options.preserveWindow : !(await this.root);
             await this.server.setRoot(rootUri);
+            if (preserveWindow) {
+                this._root = valid;
+            }
             this.openWindow(uri, { preserveWindow });
             return;
         }


### PR DESCRIPTION
Right now you can open a new workspace with the preserveWindow option.
However when you set this one to true, it now reloads the current window
after having set the root in the default workspace server, but without
having updated the private _root property of the workspace service.

The problem arises when you the reload takes place, the onStop() hook
gets called and the service sets the root again for the server, however
as its root wasn't updated when open() was called, it sets the old root
in its place. The fix makes sure that the service has the appropriate
root set up before, so that the onStop hook can save the currently
opening workspace.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>