### PR TITLE
 Plugin System Command API

### DIFF
--- a/packages/isolated-extension-api/API.md
+++ b/packages/isolated-extension-api/API.md
@@ -1,0 +1,28 @@
+# Introduction
+## Theia Plugin system description
+
+### Command API
+ A command is a unique identifier of a function which 
+ can be executed by a user via a keyboard shortcut, a
+ menu action or directly.
+
+Commands can be added using the [registerCommand](#commands.registerCommand) and
+[registerTextEditorCommand](#commands.registerTextEditorCommand) functions.
+Registration can be split in two step: first register command without handler, 
+second register handler by command id.
+
+Any contributed command are available to any plugin, command can be invoked 
+by [executeCommand](#commands.executeCommand) function.
+
+Simple example that register command:
+```javascript
+theia.commands.registerCommand({id:'say.hello.command'}, ()=>{
+    console.log("Hello World!");
+});
+```
+
+Simple example that invoke command:
+
+```javascript
+theia.commands.executeCommand('core.about');
+```

--- a/packages/isolated-extension-api/src/api/extension-api.ts
+++ b/packages/isolated-extension-api/src/api/extension-api.ts
@@ -12,8 +12,8 @@ import { createProxyIdentifier, ProxyIdentifier } from './rpc-protocol';
 import * as theia from 'theia';
 
 export interface HostedExtensionManagerExt {
-    loadExtension(ext: Extension): void;
-    stopExtensions(): PromiseLike<void>;
+    $loadExtension(ext: Extension): void;
+    $stopExtensions(): PromiseLike<void>;
 }
 
 export interface Extension {
@@ -23,43 +23,16 @@ export interface Extension {
     extPath: string;
 }
 
-/**
- * A command handler is an implementation of a command.
- *
- * A command can have multiple handlers
- * but they should be active in different contexts,
- * otherwise first active will be executed.
- */
-export interface CommandHandler {
-    /**
-     * Execute this handler.
-     */
-    execute(...args: any[]): any;
-    /**
-     * Test whether this handler is enabled (active).
-     */
-    isEnabled?(...args: any[]): boolean;
-    /**
-     * Test whether menu items for this handler should be visible.
-     */
-    isVisible?(...args: any[]): boolean;
-}
-
 export interface CommandRegistryMain {
-    /**
-     * Register the given command and handler if present.
-     *
-     * Throw if a command is already registered for the given command identifier.
-     */
-    registerCommand(command: theia.Command): void;
+    $registerCommand(command: theia.Command): void;
 
-    unregisterCommand(id: string): void;
-    executeCommand<T>(id: string, args: any[]): PromiseLike<T>;
-    getCommands(): PromiseLike<string[]>;
+    $unregisterCommand(id: string): void;
+    $executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined>;
+    $getCommands(): PromiseLike<string[]>;
 }
 
 export interface CommandRegistryExt {
-    executeCommand<T>(id: string): PromiseLike<T>;
+    $executeCommand<T>(id: string, ...ars: any[]): PromiseLike<T>;
 }
 
 export const EXTENSION_RPC_CONTEXT = {

--- a/packages/isolated-extension-api/src/api/rpc-protocol.ts
+++ b/packages/isolated-extension-api/src/api/rpc-protocol.ts
@@ -81,7 +81,7 @@ export class RPCProtocolImpl implements RPCProtocol {
     private createProxy<T>(proxyId: string): T {
         const handler = {
             get: (target: any, name: string) => {
-                if (!target[name] /*&& name.charCodeAt(0) === 36 */ /* CharCode.DollarSign */) {
+                if (!target[name] && name.charCodeAt(0) === 36 /* CharCode.DollarSign */) {
                     target[name] = (...myArgs: any[]) =>
                         this.remoteCall(proxyId, name, myArgs);
                 }

--- a/packages/isolated-extension-api/src/browser/command-registry-main.ts
+++ b/packages/isolated-extension-api/src/browser/command-registry-main.ts
@@ -24,28 +24,32 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
         this.delegate = container.get(CommandRegistry);
     }
 
-    registerCommand(command: theia.Command): void {
+    $registerCommand(command: theia.Command): void {
         this.disposables.set(
             command.id,
             this.delegate.registerCommand(command, {
                 execute: (...args: any[]) => {
-                    this.proxy.executeCommand(command.id);
+                    this.proxy.$executeCommand(command.id);
                 },
                 isEnabled() { return true; },
                 isVisible() { return true; }
             }));
     }
-    unregisterCommand(id: string): void {
+    $unregisterCommand(id: string): void {
         const dis = this.disposables.get(id);
         if (dis) {
             dis.dispose();
             this.disposables.delete(id);
         }
     }
-    executeCommand<T>(id: string, args: any[]): PromiseLike<T> {
-        throw new Error("Method not implemented.");
+    $executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined> {
+        try {
+            return Promise.resolve(this.delegate.executeCommand(id, args));
+        } catch (e) {
+            return Promise.reject(e);
+        }
     }
-    getCommands(): PromiseLike<string[]> {
+    $getCommands(): PromiseLike<string[]> {
         throw new Error("Method not implemented.");
     }
 

--- a/packages/isolated-extension-api/src/browser/hosted-extension.ts
+++ b/packages/isolated-extension-api/src/browser/hosted-extension.ts
@@ -37,7 +37,7 @@ export class HostedExtensionSupport {
             this.worker = new ExtensionWorker();
             setUpExtensionApi(this.worker.rpc, container);
             const hostedExtManager = this.worker.rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_EXTENSION_MANAGER_EXT);
-            hostedExtManager.loadExtension({
+            hostedExtManager.$loadExtension({
                 extPath: extension.theiaExtension.worker!,
                 name: extension.name,
                 publisher: extension.publisher,
@@ -48,7 +48,7 @@ export class HostedExtensionSupport {
             const rpc = this.createServerRpc();
             setUpExtensionApi(rpc, container);
             const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_EXTENSION_MANAGER_EXT);
-            hostedExtManager.loadExtension({
+            hostedExtManager.$loadExtension({
                 extPath: extension.theiaExtension.node!,
                 name: extension.name,
                 publisher: extension.publisher,

--- a/packages/isolated-extension-api/src/extension/command-registry.ts
+++ b/packages/isolated-extension-api/src/extension/command-registry.ts
@@ -23,30 +23,57 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
     }
-    registerCommand(command: theia.Command, handler: Handler): Disposable {
+    registerCommand(command: theia.Command, handler?: Handler): Disposable {
         if (this.commands.has(command.id)) {
             throw new Error(`Command ${command.id} already exist`);
         }
-        this.commands.set(command.id, handler);
-        this.proxy.registerCommand(command);
+        if (handler) {
+            this.commands.set(command.id, handler);
+        }
+        this.proxy.$registerCommand(command);
 
         return Disposable.create(() => {
-            this.proxy.unregisterCommand(command.id);
+            this.proxy.$unregisterCommand(command.id);
         });
 
+    }
+
+    registerHandler(commandId: string, handler: Handler): Disposable {
+        if (this.commands.has(commandId)) {
+            throw new Error(`Command ${commandId} already has handler`);
+        }
+        this.commands.set(commandId, handler);
+        return Disposable.create(() => {
+            this.proxy.$unregisterCommand(commandId);
+        });
     }
 
     dispose(): void {
         throw new Error("Method not implemented.");
     }
 
-    executeCommand<T>(id: string): PromiseLike<T> {
+    $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
+        if (this.commands.has(id)) {
+            return this.executeLocalCommand(id, args);
+        } else {
+            return Promise.reject(`Command: ${id} does not exist.`);
+        }
+    }
+
+    executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
+        if (this.commands.has(id)) {
+            return this.executeLocalCommand(id, args);
+        } else {
+            return this.proxy.$executeCommand(id, args);
+        }
+    }
+
+    private executeLocalCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
         const handler = this.commands.get(id);
         if (handler) {
-            return Promise.resolve(handler());
+            return Promise.resolve(handler(args));
         } else {
             return Promise.reject(new Error(`Command ${id} doesn't exist`));
         }
     }
-
 }

--- a/packages/isolated-extension-api/src/extension/extension-context.ts
+++ b/packages/isolated-extension-api/src/extension/extension-context.ts
@@ -11,15 +11,24 @@
 import { MAIN_RPC_CONTEXT } from '../api/extension-api';
 import { RPCProtocol } from '../api/rpc-protocol';
 import * as theia from 'theia';
-import { CommandRegistryImpl } from './comand-registry';
+import { CommandRegistryImpl } from './command-registry';
 import { Disposable } from './types-impl';
 
 export function createAPI(rpc: RPCProtocol): typeof theia {
     const commandRegistryExt = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
 
     const commands: typeof theia.commands = {
-        registerCommand(command: theia.Command, callback: <T>(...args: any[]) => T | Thenable<T>): Disposable {
-            return commandRegistryExt.registerCommand(command, callback);
+        registerCommand(command: theia.Command, handler?: <T>(...args: any[]) => T | Thenable<T>): Disposable {
+            return commandRegistryExt.registerCommand(command, handler);
+        },
+        executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined> {
+            return commandRegistryExt.executeCommand<T>(commandId, args);
+        },
+        registerTextEditorCommand(command: theia.Command, callback: (textEditor: theia.TextEditor, edit: theia.TextEditorEdit, ...arg: any[]) => void): Disposable {
+            throw new Error("Function registerTextEditorCommand is not implemented");
+        },
+        registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable {
+            return commandRegistryExt.registerHandler(commandId, handler);
         }
     };
     return <typeof theia>{

--- a/packages/isolated-extension-api/src/extension/hosted-extension-manager.ts
+++ b/packages/isolated-extension-api/src/extension/hosted-extension-manager.ts
@@ -21,11 +21,11 @@ export class HostedExtensionManagerExtImpl implements HostedExtensionManagerExt 
     constructor(private readonly host: PluginHost) {
     }
 
-    loadExtension(ext: Extension): void {
+    $loadExtension(ext: Extension): void {
         this.host.loadExtension(ext.extPath);
     }
 
-    stopExtensions(): PromiseLike<void> {
+    $stopExtensions(): PromiseLike<void> {
         this.host.stopExtensions();
         return Promise.resolve();
     }

--- a/packages/isolated-extension-api/src/node/hosted-extension.ts
+++ b/packages/isolated-extension-api/src/node/hosted-extension.ts
@@ -74,7 +74,7 @@ export class HostedExtensionSupport {
             }
         });
         const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_EXTENSION_MANAGER_EXT);
-        hostedExtManager.stopExtensions().then(() => {
+        hostedExtManager.$stopExtensions().then(() => {
             cp.kill();
         });
     }

--- a/packages/isolated-extension-api/src/theia.d.ts
+++ b/packages/isolated-extension-api/src/theia.d.ts
@@ -42,7 +42,74 @@ declare module 'theia' {
          */
         iconClass?: string;
     }
+
+    /**
+     * Represents a text editor.
+     */
+    export interface TextEditor {
+        // TODO implement TextEditor
+    }
+
+    /**
+     * 
+     */
+    export interface TextEditorEdit {
+        // TODO implement TextEditorEdit
+    }
+    /**
+	 * Namespace for dealing with commands. In short, a command is a function with a
+	 * unique identifier. The function is sometimes also called _command handler_.
+     * 
+     * Commands can be added using the [registerCommand](#commands.registerCommand) and
+     * [registerTextEditorCommand](#commands.registerTextEditorCommand) functions.
+     * Registration can be split in two step: first register command without handler, 
+     * second register handler by command id.
+     * 
+     * Any contributed command are available to any plugin, command can be invoked 
+     * by [executeCommand](#commands.executeCommand) function.
+     * 
+     * Simple example that register command:
+     * ```javascript
+     * theia.commands.registerCommand({id:'say.hello.command'}, ()=>{
+     *     console.log("Hello World!");
+     * });
+     * ```
+     * 
+     * Simple example that invoke command:
+     * 
+     * ```javascript
+     * theia.commands.executeCommand('core.about');
+     * ```
+	 */
     export namespace commands {
-        export function registerCommand(command: Command, callback: (...args: any[]) => any): Disposable
+        /**
+         * Register the given command and handler if present.
+         *
+         * Throw if a command is already registered for the given command identifier.
+         */
+        export function registerCommand(command: Command, handler?: (...args: any[]) => any): Disposable
+
+        /**
+         * Register the given handler for the given command identifier.
+         * 
+         * @param commandId a given command id
+         * @param handler a command handler
+         */
+        export function registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable
+
+        /**
+         * Register a text editor command which can execute only if active editor present and command has access to the active editor 
+         * 
+         * @param command a command description 
+         * @param handler a command handler with access to text editor 
+         */
+        export function registerTextEditorCommand(command: Command, handler: (textEditor: TextEditor, edit: TextEditorEdit, ...arg: any[]) => void): Disposable
+
+        /**
+         * Execute the active handler for the given command and arguments.
+         *
+         * Reject if a command cannot be executed.
+         */
+        export function executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined>
     }
 }


### PR DESCRIPTION
Origin issue eclipse/che#9283

Commands can be added using the [registerCommand](#commands.registerCommand) and
[registerTextEditorCommand](#commands.registerTextEditorCommand) functions.
Registration can be split in two step: first register command without handler, 
second register handler by command id.

Any contributed command are available to any plugin, command can be invoked 
by [executeCommand](#commands.executeCommand) function.

Simple example that register command:
```javascript
theia.commands.registerCommand({id:'say.hello.command'}, ()=>{
    console.log("Hello World!");
});
```

Simple example that invoke command:

```javascript
theia.commands.executeCommand('core.about');
```