### PR TITLE
Use tslint-language-service typescript plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "temp": "^0.8.3",
     "ts-node": "^3.2.0",
     "tslint": "^5.7.0",
+    "tslint-language-service": "^0.9.9",
     "typedoc": "^0.8",
     "typescript": "^2.7.2",
     "uuid": "^3.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -85,7 +85,12 @@
       "@theia/variable-resolver/lib/*": [
         "packages/variable-resolver/src/*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "tslint-language-service"
+      }
+    ]
   },
   "include": [
     "dev-packages/*/src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,6 +1670,12 @@ caching-transform@^1.0.0:
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
 
+caller-id@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
+  dependencies:
+    stack-trace "~0.0.7"
+
 camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -6237,6 +6243,12 @@ mocha@^4.0.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
+mock-require@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-2.0.2.tgz#1eaa71aad23013773d127dc7e91a3fbb4837d60d"
+  dependencies:
+    caller-id "^0.1.0"
+
 modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
@@ -8653,7 +8665,7 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
-stack-trace@0.0.x:
+stack-trace@0.0.x, stack-trace@~0.0.7:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
@@ -9217,6 +9229,12 @@ tsconfig@^6.0.0:
 tslib@^1.7.1, tslib@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
+tslint-language-service@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/tslint-language-service/-/tslint-language-service-0.9.9.tgz#f546dc38483979e6fb3cfa59584ad8525b3ad4da"
+  dependencies:
+    mock-require "^2.0.2"
 
 tslint@^5.7.0:
   version "5.8.0"


### PR DESCRIPTION
When developing Theia in Theia, we don't have tslint errors/warnings.
Instead of using tslint separately, it's possible to use it through a
tsserver (the typescript language server) plugin, this is what this
patch does.

Refs #892

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>