### PR TITLE
[plugin] add some lifecycle hooks

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@theia/core": "^0.3.8"
   },
+  "main": "./src/index.js",
+  "types": "./src/theia.d.ts",
   "publishConfig": {
     "access": "public"
   },
@@ -45,3 +47,4 @@
     "extends": "../../configs/nyc.json"
   }
 }
+

--- a/packages/plugin/src/api/plugin-api.ts
+++ b/packages/plugin/src/api/plugin-api.ts
@@ -9,7 +9,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 import { createProxyIdentifier, ProxyIdentifier } from './rpc-protocol';
-import * as theia from 'theia';
+import * as theia from '@theia/plugin';
 
 export interface HostedPluginManagerExt {
     $loadPlugin(ext: Plugin): void;

--- a/packages/plugin/src/browser/command-registry-main.ts
+++ b/packages/plugin/src/browser/command-registry-main.ts
@@ -11,7 +11,7 @@
 import { CommandRegistryExt, MAIN_RPC_CONTEXT, CommandRegistryMain } from '../api/plugin-api';
 import { interfaces } from "inversify";
 import { CommandRegistry } from '@theia/core/lib/common/command';
-import * as theia from 'theia';
+import * as theia from '@theia/plugin';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { RPCProtocol } from '../api/rpc-protocol';
 

--- a/packages/plugin/src/index.js
+++ b/packages/plugin/src/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var empty = {}
+
+exports.default = empty;
+module.exports = exports['default'];

--- a/packages/plugin/src/plugin/command-registry.ts
+++ b/packages/plugin/src/plugin/command-registry.ts
@@ -10,7 +10,7 @@
  */
 import { CommandRegistryExt, PLUGIN_RPC_CONTEXT as Ext, CommandRegistryMain } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
-import * as theia from 'theia';
+import * as theia from '@theia/plugin';
 import { Disposable } from './types-impl';
 
 export type Handler = <T>(...args: any[]) => T | PromiseLike<T>;

--- a/packages/plugin/src/plugin/plugin-context.ts
+++ b/packages/plugin/src/plugin/plugin-context.ts
@@ -10,7 +10,7 @@
  */
 import { MAIN_RPC_CONTEXT } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
-import * as theia from 'theia';
+import * as theia from '@theia/plugin';
 import { CommandRegistryImpl } from './command-registry';
 import { Disposable } from './types-impl';
 
@@ -36,4 +36,16 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
         Disposable: Disposable
     };
 
+}
+
+export function startExtension(plugin: any, plugins: Array<() => void>): void {
+    if (typeof plugin.doStartThings === 'function') {
+        plugin.doStartThings.apply(global, []);
+    } else {
+        console.log('there is no doStart method on plugin');
+    }
+
+    if (typeof plugin.doStopThings === 'function') {
+        plugins.push(plugin.doStopThings);
+    }
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -9,7 +9,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-declare module 'theia' {
+declare module '@theia/plugin' {
 
     export class Disposable {
 

--- a/packages/plugin/src/worker/worker-main.ts
+++ b/packages/plugin/src/worker/worker-main.ts
@@ -11,7 +11,7 @@
 
 import { RPCProtocolImpl } from '../api/rpc-protocol';
 import { Emitter } from '@theia/core/lib/common/event';
-import { createAPI } from '../plugin/plugin-context';
+import { createAPI, startExtension } from '../plugin/plugin-context';
 import { MAIN_RPC_CONTEXT } from '../api/plugin-api';
 import { HostedPluginManagerExtImpl } from '../plugin/hosted-plugin-manager';
 
@@ -38,12 +38,14 @@ addEventListener('message', (message: any) => {
 
 const theia = createAPI(rpc);
 if (registerPlugin) {
-    ctx['registerPlugin'] = registerPlugin;
+    ctx['theia'] = theia;
 }
 
 rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, new HostedPluginManagerExtImpl({
     loadPlugin(path: string): void {
         ctx.importScripts('/hostedPlugin/' + path);
+        // FIXME: simplePlugin should come from metadata
+        startExtension(ctx['simplePlugin'], plugins);
     },
     stopPlugins(): void {
         for (const s of plugins) {


### PR DESCRIPTION
allow to reuse .d.ts from external npm modules (which are plugins)
rename the module to be @theia/plugin
allow to do the start/stop of an extension automatically after loading the plugin

Change-Id: I235b0f460df01af04ec0a5530c920e6d3da66168
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>