### PR TITLE
Do no show `Merge Conflicts` commands in Quick Open

### DIFF
--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-contribution.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-contribution.ts
@@ -41,8 +41,8 @@ export class MergeConflictsFrontendContribution implements FrontendApplicationCo
     }
 
     registerCommands(registry: CommandRegistry): void {
-        registry.registerCommand(Commands.AcceptCurrent, this.mergeConflictResolver.acceptCurrent);
-        registry.registerCommand(Commands.AcceptIncoming, this.mergeConflictResolver.acceptIncoming);
-        registry.registerCommand(Commands.AcceptBoth, this.mergeConflictResolver.acceptBoth);
+        registry.registerCommand({ id: Commands.AcceptCurrent.id }, this.mergeConflictResolver.acceptCurrent);
+        registry.registerCommand({ id: Commands.AcceptIncoming.id }, this.mergeConflictResolver.acceptIncoming);
+        registry.registerCommand({ id: Commands.AcceptBoth.id }, this.mergeConflictResolver.acceptBoth);
     }
 }


### PR DESCRIPTION
`Merge Conflicts` commands were registered with labels, but then they appear in Quick Open. Their purpose is just to be references for code lenses. This PR removes commands labels. 

Closes #1667