### PR TITLE
Re-add tslint.json file to use when building

### DIFF
--- a/configs/build.tslint.json
+++ b/configs/build.tslint.json
@@ -1,0 +1,7 @@
+// Lint rules to use when building.  We don't include warnings to avoid
+// polluting the build output.
+{
+  "extends": [
+    "./errors.tslint.json"
+  ]
+}

--- a/dev-packages/ext-scripts/package.json
+++ b/dev-packages/ext-scripts/package.json
@@ -21,7 +21,7 @@
     "ext:build": "concurrently -n compile,lint -c blue,green \"theiaext compile\" \"theiaext lint\"",
     "ext:compile": "tsc -p compile.tsconfig.json",
     "ext:compile:clean": "rimraf lib",
-    "ext:lint": "tslint --project compile.tsconfig.json",
+    "ext:lint": "tslint -c ../../configs/build.tslint.json --project compile.tsconfig.json",
     "ext:watch": "tsc -w -p compile.tsconfig.json",
     "ext:docs": "typedoc --tsconfig compile.tsconfig.json --options ../../configs/typedoc.json",
     "ext:docs:clean": "rimraf docs/api",

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,4 @@
+// Lint rules expected to be used in interactive editors.
 {
   "extends": [
     "./configs/errors.tslint.json",


### PR DESCRIPTION
This patch restores the previous behavior, which was to not have
warnings in the build output.  The rationale is that they are useful to
have in your editor, where you can fix them, but they're not really
interesting in the build output, since you probably won't do something
about it when seeing a warning there.

It adds some comments to the files to explain what they are used for.
Even if they are JSON files, the tslint.json format states that comments
are allowed:

https://palantir.github.io/tslint/usage/configuration/
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>