### PR TITLE
[preview] hide the menu item if a file cannot be handled

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -86,7 +86,7 @@ export class EditorManager extends WidgetOpenHandler<EditorWidget> {
         }
     }
 
-    canHandle(uri: URI, options?: WidgetOpenerOptions): number | Promise<number> {
+    canHandle(uri: URI, options?: WidgetOpenerOptions): number {
         return 100;
     }
 

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -139,11 +139,11 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
         previewWidget.disposed.connect(() => disposable.dispose());
     }
 
-    async canHandle(uri: URI): Promise<number> {
+    canHandle(uri: URI): number {
         if (!this.previewHandlerProvider.canHandle(uri)) {
             return 0;
         }
-        const editorPriority = await this.editorManager.canHandle(uri);
+        const editorPriority = this.editorManager.canHandle(uri);
         if (editorPriority === 0) {
             return 200;
         }


### PR DESCRIPTION
This PR unpromisifies `canHandle` that the context menu item can be hidden.