### PR TITLE
Introduce quick pick Plugin API

### DIFF
--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -2,7 +2,7 @@
 ## Theia Plugin system description
 
 ### Command API
- A command is a unique identifier of a function which 
+ A command is a unique identifier of a function which
  can be executed by a user via a keyboard shortcut, a
  menu action or directly.
 
@@ -25,4 +25,29 @@ Simple example that invoke command:
 
 ```javascript
 theia.commands.executeCommand('core.about');
+```
+
+### window
+
+Common namespace for dealing with window and editor, showing messages and user input.
+
+#### Quick Pick
+
+Function to ask user select some value from the list.
+
+Example of using:
+
+```javascript
+//configure quick pick options
+ const option: theia.QuickPickOptions = {
+        machOnDescription: true,
+        machOnDetail: true,
+        canPickMany: false,
+        placeHolder: "Select string:",
+        onDidSelectItem: (item) => console.log(`Item ${item} is selected`)
+    };
+ // call Theia api to show quick pick
+theia.window.showQuickPick(["foo", "bar", "foobar"], option).then((val: string[] | undefined) => {
+        console.log(`Quick Pick Selected: ${val}`);
+    });
 ```

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -15,7 +15,7 @@
   "keywords": [
     "theia-extension"
   ],
-  "license": "EPL-1.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/theia-ide/theia.git"

--- a/packages/plugin/src/api/async-util.ts
+++ b/packages/plugin/src/api/async-util.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
+
+export function hookCancellationToken<T>(token: CancellationToken, promise: Promise<T>): PromiseLike<T> {
+    return new Promise<T>((resolve, reject) => {
+        const sub = token.onCancellationRequested(() => reject("This promise is cancelled"));
+        promise.then(value => {
+            sub.dispose();
+            resolve(value);
+        }).catch(err => {
+            sub.dispose();
+            reject(err);
+        });
+    });
+}

--- a/packages/plugin/src/api/extended-promise.ts
+++ b/packages/plugin/src/api/extended-promise.ts
@@ -1,18 +1,14 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export class ExtendedPromise implements Promise<any> {
-    private delegate: Promise<any>;
-    private resolveDelegate: (value?: any) => void;
-    private rejectDelegate: (reason?: any) => void;
+export class ExtendedPromise<T> implements Promise<T> {
+    private delegate: Promise<T>;
+    private resolveDelegate: (value?: T) => void;
+    private rejectDelegate: (reason?: T) => void;
     constructor() {
         this.delegate = new Promise((resolve, reject) => {
             this.resolveDelegate = resolve;
@@ -20,7 +16,7 @@ export class ExtendedPromise implements Promise<any> {
         });
     }
 
-    resolve(value: any): void {
+    resolve(value: T): void {
         this.resolveDelegate(value);
     }
 
@@ -28,8 +24,8 @@ export class ExtendedPromise implements Promise<any> {
         this.rejectDelegate(err);
     }
 
-    then<TResult1 = any, TResult2 = never>(onfulfilled?: (value: any) => TResult1 | PromiseLike<TResult1>,
-        onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2> {
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
+        onrejected?: (reason: T) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2> {
         return this.delegate.then(onfulfilled, onrejected);
     }
     catch<TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<any> {
@@ -37,4 +33,19 @@ export class ExtendedPromise implements Promise<any> {
     }
     [Symbol.toStringTag]: "Promise";
 
+    public static any<T>(promises: PromiseLike<T>[]): ExtendedPromise<{ key: number; value: PromiseLike<T>; }> {
+        const result = new ExtendedPromise<{ key: number; value: PromiseLike<T>; }>();
+        if (promises.length === 0) {
+            result.resolveDelegate();
+        }
+
+        promises.forEach((val, key) => {
+            Promise.resolve(promises[key]).then(() => {
+                result.resolveDelegate({ key: key, value: promises[key] });
+            }, err => {
+                result.resolveDelegate({ key: key, value: promises[key] });
+            });
+        });
+        return result;
+    }
 }

--- a/packages/plugin/src/api/plugin-api.ts
+++ b/packages/plugin/src/api/plugin-api.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { createProxyIdentifier, ProxyIdentifier } from './rpc-protocol';
 import * as theia from '@theia/plugin';
@@ -35,11 +31,49 @@ export interface CommandRegistryExt {
     $executeCommand<T>(id: string, ...ars: any[]): PromiseLike<T>;
 }
 
+export interface AutoFocus {
+    autoFocusFirstEntry?: boolean;
+    // TODO
+}
+
+export interface PickOptions {
+    placeHolder?: string;
+    autoFocus?: AutoFocus;
+    matchOnDescription?: boolean;
+    matchOnDetail?: boolean;
+    ignoreFocusLost?: boolean;
+    quickNavigationConfiguration?: {}; // TODO
+    contextKey?: string;
+    canSelectMany?: boolean;
+}
+
+export interface PickOpenItem {
+    handle: number;
+    id?: string;
+    label: string;
+    description?: string;
+    detail?: string;
+    picked?: boolean;
+}
+export interface QuickOpenExt {
+    $onItemSelected(handle: number): void;
+    $validateInput(input: string): PromiseLike<string> | undefined;
+}
+
+export interface QuickOpenMain {
+    $show(options: PickOptions): PromiseLike<number | number[]>;
+    $setItems(items: PickOpenItem[]): PromiseLike<any>;
+    $setError(error: Error): PromiseLike<any>;
+    $input(options: theia.InputBoxOptions, validateInput: boolean): PromiseLike<string>;
+}
+
 export const PLUGIN_RPC_CONTEXT = {
-    COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>("CommandRegistryMain")
+    COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
+    QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain')
 };
 
 export const MAIN_RPC_CONTEXT = {
-    HOSTED_PLUGIN_MANAGER_EXT: createProxyIdentifier<HostedPluginManagerExt>("HostedPluginManagerExt"),
-    COMMAND_REGISTRY_EXT: createProxyIdentifier<CommandRegistryExt>("CommandRegistryExt")
+    HOSTED_PLUGIN_MANAGER_EXT: createProxyIdentifier<HostedPluginManagerExt>('HostedPluginManagerExt'),
+    COMMAND_REGISTRY_EXT: createProxyIdentifier<CommandRegistryExt>('CommandRegistryExt'),
+    QUICK_OPEN_EXT: createProxyIdentifier<QuickOpenExt>('QuickOpenExt')
 };

--- a/packages/plugin/src/api/rpc-protocol.ts
+++ b/packages/plugin/src/api/rpc-protocol.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
@@ -54,7 +50,7 @@ export class RPCProtocolImpl implements RPCProtocol {
     private readonly proxies: { [id: string]: any; };
     private lastMessageId: number;
     private readonly invokedHandlers: { [req: string]: Promise<any>; };
-    private readonly pendingRPCReplies: { [msgId: string]: ExtendedPromise; };
+    private readonly pendingRPCReplies: { [msgId: string]: ExtendedPromise<any>; };
     private readonly multiplexor: RPCMultiplexer;
 
     constructor(connection: MessageConnection) {

--- a/packages/plugin/src/browser/command-registry-main.ts
+++ b/packages/plugin/src/browser/command-registry-main.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { CommandRegistryExt, MAIN_RPC_CONTEXT, CommandRegistryMain } from '../api/plugin-api';
 import { interfaces } from "inversify";

--- a/packages/plugin/src/browser/hosted-plugin-watcher.ts
+++ b/packages/plugin/src/browser/hosted-plugin-watcher.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { injectable } from "inversify";
 import { Emitter, Event } from '@theia/core/lib/common/event';

--- a/packages/plugin/src/browser/hosted-plugin.ts
+++ b/packages/plugin/src/browser/hosted-plugin.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { injectable, inject, interfaces } from 'inversify';
 import { HostedPluginServer, Plugin } from '../common/plugin-protocol';

--- a/packages/plugin/src/browser/main-context.ts
+++ b/packages/plugin/src/browser/main-context.ts
@@ -1,19 +1,19 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { interfaces } from 'inversify';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { CommandRegistryMainImpl } from './command-registry-main';
 import { PLUGIN_RPC_CONTEXT } from '../api/plugin-api';
+import { QuickOpenMainImpl } from './quick-open-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.COMMAND_REGISTRY_MAIN, commandRegistryMain);
+
+    const quickOpenMain = new QuickOpenMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.QUICK_OPEN_MAIN, quickOpenMain);
 }

--- a/packages/plugin/src/browser/plugin-api-frontend-module.ts
+++ b/packages/plugin/src/browser/plugin-api-frontend-module.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { ContainerModule } from "inversify";
 import { FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser";

--- a/packages/plugin/src/browser/plugin-worker.ts
+++ b/packages/plugin/src/browser/plugin-worker.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { injectable } from "inversify";
 import { RPCProtocolImpl, RPCProtocol } from '../api/rpc-protocol';

--- a/packages/plugin/src/browser/quick-open-main.ts
+++ b/packages/plugin/src/browser/quick-open-main.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { QuickOpenMain, PickOptions, PickOpenItem, MAIN_RPC_CONTEXT, QuickOpenExt } from '../api/plugin-api';
+import { InputBoxOptions } from '@theia/plugin';
+import { interfaces } from 'inversify';
+import { RPCProtocol } from '../api/rpc-protocol';
+import { QuickOpenService } from '@theia/core/lib/browser/quick-open/quick-open-service';
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/quick-open-model';
+
+export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
+
+    private doResolve: (value?: number | number[] | PromiseLike<number | number[]> | undefined) => void;
+    private proxy: QuickOpenExt;
+    private delegate: QuickOpenService;
+    private acceptor: ((items: QuickOpenItem[]) => void) | undefined;
+    private items: QuickOpenItem[] | undefined;
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT);
+        this.delegate = container.get(QuickOpenService);
+    }
+
+    private cleanUp() {
+        this.items = undefined;
+        this.acceptor = undefined;
+    }
+
+    $show(options: PickOptions): PromiseLike<number | number[]> {
+
+        this.delegate.open(this, {
+            fuzzyMatchDescription: options.matchOnDescription,
+            fuzzyMatchLabel: true,
+            fuzzyMatchDetail: options.matchOnDetail,
+            placeholder: options.placeHolder,
+            onClose: () => {
+                this.cleanUp();
+            }
+        });
+
+        return new Promise((resolve, reject) => {
+            this.doResolve = resolve;
+        });
+
+    }
+    $setItems(items: PickOpenItem[]): PromiseLike<any> {
+        this.items = [];
+        for (const i of items) {
+            this.items.push(new QuickOpenItem({
+                label: i.label,
+                description: i.description,
+                detail: i.detail,
+                run: mode => {
+                    if (mode === QuickOpenMode.PREVIEW) {
+                        this.proxy.$onItemSelected(i.handle);
+                    } else if (mode === QuickOpenMode.OPEN) {
+                        this.doResolve(i.handle);
+                        this.cleanUp();
+                    }
+                    return true;
+                }
+            }));
+        }
+        if (this.acceptor) {
+            this.acceptor(this.items);
+        }
+        return Promise.resolve();
+    }
+    $setError(error: Error): PromiseLike<any> {
+        throw new Error("Method not implemented.");
+    }
+    $input(options: InputBoxOptions, validateInput: boolean): PromiseLike<string> {
+        throw new Error("Method not implemented.");
+    }
+
+    onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+        this.acceptor = acceptor;
+        if (this.items) {
+            acceptor(this.items);
+        }
+    }
+}

--- a/packages/plugin/src/common/plugin-protocol.ts
+++ b/packages/plugin/src/common/plugin-protocol.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 

--- a/packages/plugin/src/node/hosted-plugin.ts
+++ b/packages/plugin/src/node/hosted-plugin.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import * as path from 'path';
 import * as cp from "child_process";

--- a/packages/plugin/src/node/plugin-api-backend-module.ts
+++ b/packages/plugin/src/node/plugin-api-backend-module.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 import { ContainerModule } from "inversify";

--- a/packages/plugin/src/node/plugin-host.ts
+++ b/packages/plugin/src/node/plugin-host.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 import { RPCProtocolImpl } from '../api/rpc-protocol';

--- a/packages/plugin/src/node/plugin-reader.ts
+++ b/packages/plugin/src/node/plugin-reader.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2015-2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { injectable } from "inversify";

--- a/packages/plugin/src/node/plugin-service.ts
+++ b/packages/plugin/src/node/plugin-service.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import * as express from 'express';
 import { injectable, inject } from "inversify";

--- a/packages/plugin/src/plugin/command-registry.ts
+++ b/packages/plugin/src/plugin/command-registry.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { CommandRegistryExt, PLUGIN_RPC_CONTEXT as Ext, CommandRegistryMain } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';

--- a/packages/plugin/src/plugin/hosted-plugin-manager.ts
+++ b/packages/plugin/src/plugin/hosted-plugin-manager.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { HostedPluginManagerExt, Plugin } from '../api/plugin-api';
 

--- a/packages/plugin/src/plugin/quick-open.ts
+++ b/packages/plugin/src/plugin/quick-open.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import { QuickOpenExt, PLUGIN_RPC_CONTEXT as Ext, QuickOpenMain, PickOpenItem } from '../api/plugin-api';
+import { RPCProtocol } from '../api/rpc-protocol';
+import { QuickPickOptions, QuickPickItem } from '@theia/plugin';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
+import { ExtendedPromise } from '../api/extended-promise';
+import { hookCancellationToken } from '../api/async-util';
+
+export type Item = string | QuickPickItem;
+
+export class QuickOpenExtImpl implements QuickOpenExt {
+    private proxy: QuickOpenMain;
+    private selectItemHandler: undefined | ((handle: number) => void);
+    private validateInputHandler: undefined | ((input: string) => string | PromiseLike<string>);
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(Ext.QUICK_OPEN_MAIN);
+    }
+    $onItemSelected(handle: number): void {
+        if (this.selectItemHandler) {
+            this.selectItemHandler(handle);
+        }
+    }
+    $validateInput(input: string): PromiseLike<string> | undefined {
+        if (this.validateInputHandler) {
+            return Promise.resolve(this.validateInputHandler(input));
+        }
+        return undefined;
+    }
+
+    showQuickPick(promiseOrItems: QuickPickItem[] | PromiseLike<QuickPickItem[]>, options?: QuickPickOptions, token?: CancellationToken): PromiseLike<QuickPickItem | undefined>;
+    // tslint:disable-next-line:max-line-length
+    showQuickPick(promiseOrItems: QuickPickItem[] | PromiseLike<QuickPickItem[]>, options?: QuickPickOptions & { canSelectMany: true; }, token?: CancellationToken): PromiseLike<QuickPickItem[] | undefined>;
+    showQuickPick(promiseOrItems: string[] | PromiseLike<string[]>, options?: QuickPickOptions, token?: CancellationToken): PromiseLike<string | undefined>;
+    // tslint:disable-next-line:max-line-length
+    showQuickPick(promiseOrItems: Item[] | PromiseLike<Item[]>, options?: QuickPickOptions, token: CancellationToken = CancellationToken.None): PromiseLike<Item | Item[] | undefined> {
+        this.selectItemHandler = undefined;
+        const itemPromise = Promise.resolve(promiseOrItems);
+        const widgetPromise = this.proxy.$show({
+            canSelectMany: options && options.canPickMany,
+            placeHolder: options && options.placeHolder,
+            autoFocus: { autoFocusFirstEntry: true },
+            matchOnDescription: options && options.machOnDescription,
+            matchOnDetail: options && options.machOnDetail,
+            ignoreFocusLost: options && options.ignoreFocusOut
+        });
+
+        const promise = ExtendedPromise.any(<PromiseLike<number | Item[]>[]>[widgetPromise, itemPromise]).then(values => {
+            if (values.key === 0) {
+                return undefined;
+            }
+            return itemPromise.then(items => {
+                const pickItems: PickOpenItem[] = [];
+                for (let handle = 0; handle < items.length; handle++) {
+                    const item = items[handle];
+                    let label: string;
+                    let description: string | undefined;
+                    let detail: string | undefined;
+                    let picked: boolean | undefined;
+                    if (typeof item === 'string') {
+                        label = item;
+                    } else {
+                        ({ label, description, detail, picked } = item);
+                    }
+                    pickItems.push({
+                        label,
+                        description,
+                        handle,
+                        detail,
+                        picked
+                    });
+                }
+
+                if (options && typeof options.onDidSelectItem === 'function') {
+                    this.selectItemHandler = handle => {
+                        options.onDidSelectItem!(items[handle]);
+                    };
+                }
+
+                this.proxy.$setItems(pickItems);
+
+                return widgetPromise.then(handle => {
+                    if (typeof handle === 'number') {
+                        return items[handle];
+                    } else if (Array.isArray(handle)) {
+                        return handle.map(h => items[h]);
+                    }
+                    return undefined;
+                });
+            }, err => {
+                this.proxy.$setError(err);
+                return Promise.reject(err);
+            });
+        });
+        return hookCancellationToken<Item | Item[] | undefined>(token, promise);
+    }
+}

--- a/packages/plugin/src/plugin/types-impl.ts
+++ b/packages/plugin/src/plugin/types-impl.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 export class Disposable {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 declare module '@theia/plugin' {
@@ -56,6 +52,139 @@ declare module '@theia/plugin' {
     export interface TextEditorEdit {
         // TODO implement TextEditorEdit
     }
+
+    /**
+     * Represents a typed event.
+     */
+    export interface Event<T> {
+
+        /**
+         *
+         * @param listener The listener function will be call when the event happens.
+         * @param thisArgs The 'this' which will be used when calling the event listener.
+         * @param disposables An array to which a {{IDisposable}} will be added.
+         * @return a disposable to remove the listener again.
+         */
+        (listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]): Disposable;
+    }
+
+    /**
+     * An event emitter used to create and fire an [event](#Event) or to subscribe to.
+     */
+    export class EventEmitter<T> {
+        /**
+         * The event listeners can subscribe to
+         */
+        event: Event<T>;
+
+        /**
+         * Fire the event and pass data object
+         * @param data 
+         */
+        fire(data?: T): void;
+
+        /**
+         * Dispose this object
+         */
+        dispose(): void;
+    }
+
+    /**
+     * A cancellation token used to request cancellation on long running 
+     * or asynchronous task.
+     */
+    export interface CancellationToken {
+        readonly isCancellationRequested: boolean;
+        /*
+         * An event emitted when cancellation is requested
+         * @event
+         */
+        readonly onCancellationRequested: Event<void>;
+    }
+
+    /**
+     * A cancellation token source create and manage a [cancellation token](#CancellationToken)
+     */
+    export class CancellationTokenSource {
+        token: CancellationToken;
+        cancel(): void;
+        dispose(): void;
+    }
+
+    /**
+     * Something that can be selected from a list of items.
+     */
+    export interface QuickPickItem {
+
+        /**
+         * The item label
+         */
+        label: string;
+
+        /**
+         * The item description
+         */
+        description?: string;
+
+        /**
+         * The item detail
+         */
+        detail?: string;
+
+        /**
+         * Used for [QuickPickOptions.canPickMany](#QuickPickOptions.canPickMany)
+         * not implemented yet
+         */
+        picked?: boolean;
+    }
+
+    /**
+     * Options for configuration behavior of the quick pick
+     */
+    export interface QuickPickOptions {
+        /**
+         * A flag to include the description when filtering
+         */
+        machOnDescription?: boolean;
+
+        /**
+         *  A flag to include the detail when filtering
+         */
+        machOnDetail?: boolean;
+
+        /**
+         * The place holder in input box 
+         */
+        placeHolder?: string;
+
+        /**
+         * If `true` prevent picker closing when it's loses focus
+         */
+        ignoreFocusOut?: boolean;
+
+        /**
+         * If `true` make picker accept multiple selections.
+         * Not implemented yet
+         */
+        canPickMany?: boolean;
+
+        /**
+         * Function that is invoked when item selected
+         */
+        onDidSelectItem?(item: QuickPickItem | string): any;
+    }
+
+    export interface InputBoxOptions {
+        value?: string;
+
+        valueSelection?: [number, number];
+        prompt?: string;
+        placeHolder?: string;
+        password?: boolean;
+        ignoreFocusOut?: boolean;
+        validateInput?(value: string): string | undefined | null | PromiseLike<string | undefined | null>;
+    }
+
     /**
 	 * Namespace for dealing with commands. In short, a command is a function with a
 	 * unique identifier. The function is sometimes also called _command handler_.
@@ -111,5 +240,39 @@ declare module '@theia/plugin' {
          * Reject if a command cannot be executed.
          */
         export function executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined>
+    }
+
+    /**
+     * Common namespace for dealing with window and editor, showing messages and user input.
+     */
+    export namespace window {
+
+        /**
+         * Shows a selection list.
+         * @param items 
+         * @param options 
+         * @param token 
+         */
+        export function showQuickPick(items: string[] | PromiseLike<string[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<string[] | undefined>;
+
+        /**
+         * Shows a selection list with multiple selection allowed.
+         */
+        export function showQuickPick(items: string[] | PromiseLike<string[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<string[] | undefined>;
+
+        /**
+         * Shows a selection list.
+         * @param items 
+         * @param options 
+         * @param token 
+         */
+        export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<T[] | undefined>;
+
+        /**
+         * Shows a selection list with multiple selection allowed.
+         */
+        export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<T[] | undefined>;
+
+
     }
 }

--- a/packages/plugin/src/worker/worker-main.ts
+++ b/packages/plugin/src/worker/worker-main.ts
@@ -1,12 +1,8 @@
 /*
- * Copyright (C) 2018 Red Hat, Inc.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
 import { RPCProtocolImpl } from '../api/rpc-protocol';


### PR DESCRIPTION
Quick pick API similar to VSCode [window#showQuickPick](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window)

Also this pull request changes all license headers to Apache in `@theia/plugin` code