### PR TITLE
Fix the backend throwing an error when trying to reload a deleted

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -120,9 +120,12 @@ export class WorkspaceService implements FrontendApplicationContribution {
             return undefined;
         }
         try {
-            const fileStat = await this.fileSystem.getFileStat(uri);
-            if (fileStat.isDirectory) {
-                return fileStat;
+            if (await this.fileSystem.exists(uri)) {
+                const fileStat = await this.fileSystem.getFileStat(uri);
+
+                if (fileStat.isDirectory) {
+                    return fileStat;
+                }
             }
             return undefined;
         } catch (error) {


### PR DESCRIPTION
workspace

Fixes #1695. The issue is that the server could be referencing an
invalid (now deleted) root. When a frontend starts and asks the server
for a root, it calls `getFileStat` on the filesystem service. This
throws an error on the backend because we're referencing a deleted
folder. The frontend correctly catches the error and returns undefined
but the backend throws an error, which seems like something is wrong
although the frontend correctly displays an empty workspace. To fix this
the frontend simply checks to make sure that the path exist before
getting the filestat.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>