### PR TITLE
GH-1689: Implemented go to last edit location.

### DIFF
--- a/packages/core/src/browser/keys.ts
+++ b/packages/core/src/browser/keys.ts
@@ -302,7 +302,15 @@ export class KeyCode {
         }
     }
 
-    public static toCode(event: KeyboardEvent): string {
+    // keyIdentifier is used to access this deprecated field:
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier
+    public static toCode(event: KeyboardEvent & { readonly keyIdentifier?: string }): string {
+        // The `event.keyCode` can vary in different browsers.
+        // Check if we can recognize the `event.code` string. If yes, we are done.
+        const candidateKey = Key.getKey(event.code);
+        if (!!candidateKey && candidateKey.code === event.code) {
+            return candidateKey.code;
+        }
         if (event.keyCode) {
             const key = Key.getKey(event.keyCode);
             if (key) {
@@ -312,10 +320,8 @@ export class KeyCode {
         if (event.code) {
             return event.code;
         }
-        // tslint:disable-next-line:no-any
-        const e = event as any;
-        if (e.keyIdentifier) {
-            return e.keyIdentifier;
+        if (event.keyIdentifier !== undefined) {
+            return event.keyIdentifier;
         }
         if (event.which) {
             const key = Key.getKey(event.which);
@@ -578,7 +584,7 @@ export namespace Key {
         return !!arg && ('code' in arg) && ('keyCode' in arg);
     }
 
-    export function getKey(arg: string | number): Key {
+    export function getKey(arg: string | number): Key | undefined {
         if (typeof arg === "number") {
             return KEY_CODE_TO_KEY[arg] || {
                 code: 'unknown',

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -34,16 +34,23 @@ export namespace EditorCommands {
     /**
      * Command for going back to the last editor navigation location.
      */
-    export const BACK: Command = {
-        id: 'textEditor.commands.back',
+    export const GO_BACK: Command = {
+        id: 'textEditor.commands.go.back',
         label: 'Go Back'
     };
     /**
      * Command for going to the forthcoming editor navigation location.
      */
-    export const FORWARD: Command = {
-        id: 'textEditor.commands.forward',
+    export const GO_FORWARD: Command = {
+        id: 'textEditor.commands.go.forward',
         label: 'Go Forward'
+    };
+    /**
+     * Command that reveals the last text edit location, if any.
+     */
+    export const GO_LAST_EDIT: Command = {
+        id: 'textEditor.commands.go.lastEdit',
+        label: 'Go to Last Edit Location'
     };
 }
 
@@ -56,7 +63,8 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.INDENT_USING_SPACES);
         registry.registerCommand(EditorCommands.INDENT_USING_TABS);
 
-        registry.registerCommand(EditorCommands.BACK);
-        registry.registerCommand(EditorCommands.FORWARD);
+        registry.registerCommand(EditorCommands.GO_BACK);
+        registry.registerCommand(EditorCommands.GO_FORWARD);
+        registry.registerCommand(EditorCommands.GO_LAST_EDIT);
     }
 }

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -6,6 +6,7 @@
  */
 
 import { injectable } from 'inversify';
+import { isOSX, isWindows } from '@theia/core/lib/common/os';
 import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { EditorCommands } from './editor-command';
 
@@ -15,12 +16,16 @@ export class EditorKeybindingContribution implements KeybindingContribution {
     registerKeybindings(registry: KeybindingRegistry): void {
         registry.registerKeybindings(
             {
-                command: EditorCommands.BACK.id,
-                keybinding: 'alt+left'
+                command: EditorCommands.GO_BACK.id,
+                keybinding: isOSX ? 'ctrl+-' : isWindows ? 'alt+left' : /*isLinux*/ 'ctrl+alt+-'
             },
             {
-                command: EditorCommands.FORWARD.id,
-                keybinding: 'alt+right'
+                command: EditorCommands.GO_FORWARD.id,
+                keybinding: isOSX ? 'ctrl+shift+-' : isWindows ? 'alt+right' : /*isLinux*/ 'ctrl+shift+-'
+            },
+            {
+                command: EditorCommands.GO_LAST_EDIT.id,
+                keybinding: 'ctrl+alt+q'
             }
         );
     }

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -45,12 +45,16 @@ export class EditorMenuContribution implements MenuContribution {
         // Editor navigation. Go > Back and Go > Forward.
         registry.registerSubmenu(EditorMainMenu.GO, 'Go');
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
-            commandId: EditorCommands.BACK.id,
+            commandId: EditorCommands.GO_BACK.id,
             label: 'Back'
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
-            commandId: EditorCommands.FORWARD.id,
+            commandId: EditorCommands.GO_FORWARD.id,
             label: 'Forward'
+        });
+        registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
+            commandId: EditorCommands.GO_LAST_EDIT.id,
+            label: 'Last Edit Location'
         });
     }
 

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -48,13 +48,17 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             // This would require introducing the FS dependency in the editor extension.
             this.editorManager.onCurrentEditorChanged(this.onCurrentEditorChanged.bind(this))
         ]);
-        this.commandRegistry.registerHandler(EditorCommands.BACK.id, {
+        this.commandRegistry.registerHandler(EditorCommands.GO_BACK.id, {
             execute: () => this.locationStack.back(),
             isEnabled: () => this.locationStack.canGoBack()
         });
-        this.commandRegistry.registerHandler(EditorCommands.FORWARD.id, {
+        this.commandRegistry.registerHandler(EditorCommands.GO_FORWARD.id, {
             execute: () => this.locationStack.forward(),
             isEnabled: () => this.locationStack.canGoForward()
+        });
+        this.commandRegistry.registerHandler(EditorCommands.GO_LAST_EDIT.id, {
+            execute: () => this.locationStack.reveal(this.locationStack.lastEditLocation()),
+            isEnabled: () => !!this.locationStack.lastEditLocation()
         });
     }
 

--- a/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
@@ -15,6 +15,7 @@ import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
 import { MockOpenerService } from '@theia/core/lib/browser/test/mock-opener-service';
 import { NavigationLocationUpdater } from './navigation-location-updater';
+import { NoopNavigationLocationUpdater } from './test/mock-navigation-location-updater';
 import { NavigationLocationSimilarity } from './navigation-location-similarity';
 import { CursorLocation, Position, NavigationLocation } from './navigation-location';
 import { NavigationLocationService } from './navigation-location-service';
@@ -73,6 +74,55 @@ describe('navigation-location-service', () => {
         expect(stack.locations().length).to.be.lessThan(100);
     });
 
+    describe('last-edit-location', async () => {
+
+        it('should return with undefined if the stack contains no modifications', () => {
+            stack.register(
+                createCursorLocation(),
+                createCursorLocation({ line: 100, character: 100 })
+            );
+            expect(stack.lastEditLocation()).to.be.undefined;
+        });
+
+        it('should return with the location of the last modification', () => {
+            const expected = NavigationLocation.create('file://path/to/file', {
+                text: '',
+                range: { start: { line: 200, character: 0 }, end: { line: 500, character: 0 } },
+                rangeLength: 0
+            });
+            stack.register(
+                createCursorLocation(),
+                expected,
+                createCursorLocation({ line: 100, character: 100 })
+            );
+            expect(stack.lastEditLocation()).to.be.deep.equal(expected);
+        });
+
+        it('should return with the location of the last modification even if the pointer is not on the head', async () => {
+            const modificationLocation = NavigationLocation.create('file://path/to/file', {
+                text: '',
+                range: { start: { line: 300, character: 0 }, end: { line: 500, character: 0 } },
+                rangeLength: 0
+            });
+            const expected = NavigationLocation.create('file://path/to/file', {
+                text: '',
+                range: { start: { line: 700, character: 0 }, end: { line: 800, character: 0 } },
+                rangeLength: 0
+            });
+            stack.register(
+                createCursorLocation(),
+                modificationLocation,
+                createCursorLocation({ line: 100, character: 100 }),
+                expected
+            );
+            await stack.back();
+            await stack.back();
+            expect(stack.currentLocation()).to.be.deep.equal(modificationLocation);
+            expect(stack.lastEditLocation()).to.be.deep.equal(expected);
+        });
+
+    });
+
     function createCursorLocation(context: Position = { line: 0, character: 0, }, uri: string = 'file://path/to/file'): CursorLocation {
         return NavigationLocation.create(uri, context);
     }
@@ -84,7 +134,8 @@ describe('navigation-location-service', () => {
         container.bind(MockOpenerService).toSelf();
         container.bind(MockLogger).toSelf();
         container.bind(ILogger).toService(MockLogger);
-        container.bind(NavigationLocationUpdater).toSelf();
+        container.bind(NoopNavigationLocationUpdater).toSelf();
+        container.bind(NavigationLocationUpdater).toService(NoopNavigationLocationUpdater);
         container.bind(OpenerService).toService(MockOpenerService);
         return container.get(NavigationLocationService);
     }

--- a/packages/editor/src/browser/navigation/test/mock-navigation-location-updater.ts
+++ b/packages/editor/src/browser/navigation/test/mock-navigation-location-updater.ts
@@ -18,3 +18,15 @@ export class MockNavigationLocationUpdater extends NavigationLocationUpdater {
     }
 
 }
+
+/**
+ * NOOP navigation location updater for testing. Use this, if you want to avoid any
+ * location updates during the tests.
+ */
+export class NoopNavigationLocationUpdater extends NavigationLocationUpdater {
+
+    affects(): false {
+        return false;
+    }
+
+}


### PR DESCRIPTION
Closes #1689.

@simark, could you please try it out and verify the functionality? Thanks!
Note: the `last edit location` is not saved and not restored between the sessions.

**Update**:
Before merging it, I need to verify single deletion and insertions/deletion with a range. The insertions/deletion should work with both single and multi-line modifications.

**Update 2**:
Closes #1713 
Closes #1714

I put this PR on hold. -> `WIP`.