### PR TITLE
Change the getFileStat api to return union of Filestat | undefined

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -39,10 +39,12 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
     set location(uri: URI | undefined) {
         if (uri) {
             this.fileSystem.getFileStat(uri.toString()).then(async fileStat => {
-                const label = this.labelProvider.getName(uri);
-                const icon = await this.labelProvider.getIcon(fileStat);
-                const node = DirNode.createRoot(fileStat, label, icon);
-                this.navigateTo(node);
+                if (fileStat) {
+                    const label = this.labelProvider.getName(uri);
+                    const icon = await this.labelProvider.getIcon(fileStat);
+                    const node = DirNode.createRoot(fileStat, label, icon);
+                    this.navigateTo(node);
+                }
             });
         } else {
             this.navigateTo(undefined);
@@ -201,8 +203,8 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
         const uri = base.toString();
         const encoding = 'base64';
         const content = base64.fromByteArray(new Uint8Array(fileContent));
-        if (await this.fileSystem.exists(uri)) {
-            const stat = await this.fileSystem.getFileStat(uri);
+        const stat = await this.fileSystem.getFileStat(uri);
+        if (stat) {
             if (!stat.isDirectory) {
                 await this.fileSystem.setContent(stat, content, { encoding });
             }
@@ -210,5 +212,4 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
             await this.fileSystem.createFile(uri, { content, encoding });
         }
     }
-
 }

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -21,15 +21,22 @@ export class FileTree extends TreeImpl {
     async resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
         if (FileStatNode.is(parent)) {
             const fileStat = await this.resolveFileStat(parent);
-            return this.toNodes(fileStat, parent);
+            if (fileStat) {
+                return this.toNodes(fileStat, parent);
+            }
+
+            return [];
         }
         return super.resolveChildren(parent);
     }
 
-    protected resolveFileStat(node: FileStatNode): Promise<FileStat> {
+    protected resolveFileStat(node: FileStatNode): Promise<FileStat | undefined> {
         return this.fileSystem.getFileStat(node.fileStat.uri).then(fileStat => {
-            node.fileStat = fileStat;
-            return fileStat;
+            if (fileStat) {
+                node.fileStat = fileStat;
+                return fileStat;
+            }
+            return undefined;
         });
     }
 

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -21,7 +21,7 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
      *
      * Reject if a file for the given uri does not exist.
      */
-    getFileStat(uri: string): Promise<FileStat>;
+    getFileStat(uri: string): Promise<FileStat | undefined>;
 
     /**
      * Finds out if a file identified by the resource exists.
@@ -104,7 +104,7 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
     /**
      * Returns a promise the resolves to a file stat representing the current user's home directory.
      */
-    getCurrentUserHome(): Promise<FileStat>;
+    getCurrentUserHome(): Promise<FileStat | undefined>;
 
 }
 

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -46,12 +46,9 @@ export class FileSystemNode implements FileSystem {
         this.client = client;
     }
 
-    async getFileStat(uri: string): Promise<FileStat> {
+    async getFileStat(uri: string): Promise<FileStat | undefined> {
         const uri_ = new URI(uri);
         const stat = await this.doGetStat(uri_, 1);
-        if (!stat) {
-            throw new Error(`Cannot find file under the given URI. URI: ${uri}.`);
-        }
         return stat;
     }
 
@@ -311,7 +308,7 @@ Actual: ${JSON.stringify(file)}.`);
         return [];
     }
 
-    async getCurrentUserHome(): Promise<FileStat> {
+    async getCurrentUserHome(): Promise<FileStat | undefined> {
         return this.getFileStat(FileUri.create(os.homedir()).toString());
     }
 

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -68,8 +68,10 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
                                 fromRevision
                             }
                         };
-                        if (fileStat.isDirectory) {
-                            this.showWidget(options);
+                        if (fileStat) {
+                            if (fileStat.isDirectory) {
+                                this.showWidget(options);
+                            }
                         } else {
                             const fromURI = fileUri.withScheme(GIT_RESOURCE_SCHEME).withQuery(fromRevision);
                             const toURI = fileUri;

--- a/packages/git/src/browser/history/git-history-widget.ts
+++ b/packages/git/src/browser/history/git-history-widget.ts
@@ -89,7 +89,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         this.ready = false;
         if (options && options.uri) {
             const fileStat = await this.fileSystem.getFileStat(options.uri);
-            this.singleFileMode = !fileStat.isDirectory;
+            this.singleFileMode = !!fileStat && !fileStat.isDirectory;
         }
         this.addCommits(options);
         this.update();

--- a/packages/navigator/src/browser/navigator-widget.ts
+++ b/packages/navigator/src/browser/navigator-widget.ts
@@ -12,7 +12,7 @@ import URI from '@theia/core/lib/common/uri';
 import { SelectionService, CommandService } from '@theia/core/lib/common';
 import { CommonCommands } from '@theia/core/lib/browser/common-frontend-contribution';
 import { ContextMenuRenderer, TreeProps, TreeModel, TreeNode, LabelProvider, Widget, SelectableTreeNode } from '@theia/core/lib/browser';
-import { FileTreeWidget, DirNode } from '@theia/filesystem/lib/browser';
+import { FileTreeWidget, DirNode, FileNode } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { FileNavigatorModel } from './navigator-model';
@@ -89,15 +89,9 @@ export class FileNavigatorWidget extends FileTreeWidget {
         const mainPanelNode = this.shell.mainPanel.node;
         this.addEventListener(mainPanelNode, 'drop', async e => {
             const treeNode = this.getTreeNodeFromData(e.dataTransfer);
-            if (treeNode) {
-                const { id } = treeNode;
-                const exists = await this.fileSystem.exists(id);
-                if (exists) {
-                    const fileStat = await this.fileSystem.getFileStat(id);
-                    if (!fileStat.isDirectory) {
-                        this.commandService.executeCommand(CommonCommands.OPEN.id, new URI(id));
-                    }
-                }
+
+            if (FileNode.is(treeNode)) {
+                this.commandService.executeCommand(CommonCommands.OPEN.id, treeNode.uri);
             }
         });
         const handler = (e: DragEvent) => {

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -20,7 +20,7 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
 
     protected readonly toDispose = new DisposableCollection();
     protected readonly onUserStorageChangedEmitter = new Emitter<UserStorageChangeEvent>();
-    protected readonly userStorageFolder: Promise<URI>;
+    protected readonly userStorageFolder: Promise<URI | undefined>;
 
     constructor(
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
@@ -29,13 +29,14 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
 
     ) {
         this.userStorageFolder = this.fileSystem.getCurrentUserHome().then(home => {
-
-            const userStorageFolderUri = new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);
-            watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
-                this.toDispose.push(disposable)
-            );
-            this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
-            return new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);
+            if (home) {
+                const userStorageFolderUri = new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);
+                watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
+                    this.toDispose.push(disposable)
+                );
+                this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
+                return new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);
+            }
         });
 
         this.toDispose.push(this.onUserStorageChangedEmitter);
@@ -49,35 +50,39 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
     onDidFilesChanged(fileChanges: FileChange[]): void {
         const uris: URI[] = [];
         this.userStorageFolder.then(folder => {
-            for (const change of fileChanges) {
-                const userStorageUri = UserStorageServiceFilesystemImpl.toUserStorageUri(folder, change.uri);
-                uris.push(userStorageUri);
+            if (folder) {
+                for (const change of fileChanges) {
+                    const userStorageUri = UserStorageServiceFilesystemImpl.toUserStorageUri(folder, change.uri);
+                    uris.push(userStorageUri);
+                }
+                this.onUserStorageChangedEmitter.fire({ uris });
             }
-            this.onUserStorageChangedEmitter.fire({ uris });
         });
     }
 
-    async readContents(uri: URI) {
+    async readContents(uri: URI): Promise<string> {
         const folderUri = await this.userStorageFolder;
-        const filesystemUri = UserStorageServiceFilesystemImpl.toFilesystemURI(folderUri, uri);
-        const exists = await this.fileSystem.exists(filesystemUri.toString());
+        if (folderUri) {
+            const filesystemUri = UserStorageServiceFilesystemImpl.toFilesystemURI(folderUri, uri);
+            const exists = await this.fileSystem.exists(filesystemUri.toString());
 
-        if (exists) {
-            return this.fileSystem.resolveContent(filesystemUri.toString()).then(({ stat, content }) => content);
+            if (exists) {
+                return this.fileSystem.resolveContent(filesystemUri.toString()).then(({ stat, content }) => content);
+            }
         }
-
         return "";
     }
 
-    async saveContents(uri: URI, content: string) {
+    async saveContents(uri: URI, content: string): Promise<void> {
         const folderUri = await this.userStorageFolder;
+        if (!folderUri) {
+            return;
+        }
         const filesystemUri = UserStorageServiceFilesystemImpl.toFilesystemURI(folderUri, uri);
-        const exists = await this.fileSystem.exists(filesystemUri.toString());
 
-        if (exists) {
-            this.fileSystem.getFileStat(filesystemUri.toString()).then(fileStat => {
-                this.fileSystem.setContent(fileStat, content).then(() => Promise.resolve());
-            });
+        const fileStat = await this.fileSystem.getFileStat(filesystemUri.toString());
+        if (fileStat) {
+            this.fileSystem.setContent(fileStat, content).then(() => Promise.resolve());
         } else {
             this.fileSystem.createFile(filesystemUri.toString(), { content });
         }

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -50,15 +50,17 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
         this.workspaceService.root.then(async resolvedRoot => {
             const root = resolvedRoot || await this.fileSystem.getCurrentUserHome();
             if (root) {
-                const rootUri = new URI(root.uri).parent;
-                const rootStat = await this.fileSystem.getFileStat(rootUri.toString());
-                const name = this.labelProvider.getName(rootUri);
-                const label = await this.labelProvider.getIcon(root);
-                const rootNode = DirNode.createRoot(rootStat, name, label);
-                const dialog = this.fileDialogFactory({ title: WorkspaceCommands.OPEN.label! });
-                dialog.model.navigateTo(rootNode);
-                const node = await dialog.open();
-                this.openFile(node);
+                const parentUri = new URI(root.uri).parent;
+                const parentStat = await this.fileSystem.getFileStat(parentUri.toString());
+                if (parentStat) {
+                    const name = this.labelProvider.getName(parentUri);
+                    const label = await this.labelProvider.getIcon(root);
+                    const rootNode = DirNode.createRoot(parentStat, name, label);
+                    const dialog = this.fileDialogFactory({ title: WorkspaceCommands.OPEN.label! });
+                    dialog.model.navigateTo(rootNode);
+                    const node = await dialog.open();
+                    this.openFile(node);
+                }
             }
         });
     }

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -121,6 +121,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
         }
         try {
             const fileStat = await this.fileSystem.getFileStat(uri);
+            if (!fileStat) {
+                return undefined;
+            }
             if (fileStat.isDirectory) {
                 return fileStat;
             }

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -16,8 +16,7 @@ import { MaybePromise } from "@theia/core";
 export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProviderContribution {
 
     wsRoot: string;
-
-    constructor( @inject(WorkspaceService) wsService: WorkspaceService,
+    constructor(@inject(WorkspaceService) wsService: WorkspaceService,
         @inject(FileSystem) protected fileSystem: FileSystem) {
         super();
         wsService.root.then(root => {
@@ -41,7 +40,7 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
         return new URI(element.toString());
     }
 
-    private getStat(element: URI | FileStat): MaybePromise<FileStat> {
+    private getStat(element: URI | FileStat): MaybePromise<FileStat | undefined> {
         if (FileStat.is(element)) {
             return element;
         }
@@ -57,8 +56,12 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
         if (!icon) {
             try {
                 const stat = await this.getStat(element);
-                if (stat.isDirectory) {
-                    return 'fa fa-folder';
+                if (stat) {
+                    if (stat.isDirectory) {
+                        return 'fa fa-folder';
+                    } else {
+                        return 'fa fa-file';
+                    }
                 } else {
                     return 'fa fa-file';
                 }


### PR DESCRIPTION
In this case, we also avoid race conditions where asking if the file
exists then executing something with that file could fail if the file
was deleted in between those two operations.

Signed-off-by: Patrick-Jeffrey Pollo Guilbert <patrick.pollo.guilbert@ericsson.com>