### PR TITLE
Add editor relative Variables available for substitution

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -4,7 +4,9 @@
   "description": "Theia - Editor Extension",
   "dependencies": {
     "@theia/core": "^0.3.8",
-    "@theia/languages": "^0.3.8"
+    "@theia/languages": "^0.3.8",
+    "@theia/variable-resolver": "^0.3.8",
+    "@theia/workspace": "^0.3.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -8,6 +8,7 @@
 import { ContainerModule } from 'inversify';
 import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
 import { OpenHandler, WidgetFactory, FrontendApplicationContribution, KeybindingContext, KeybindingContribution } from '@theia/core/lib/browser';
+import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { EditorManager } from './editor-manager';
 import { EditorContribution } from './editor-contribution';
 import { EditorMenuContribution } from './editor-menu';
@@ -21,6 +22,7 @@ import { EditorNavigationContribution } from './editor-navigation-contribution';
 import { NavigationLocationUpdater } from './navigation/navigation-location-updater';
 import { NavigationLocationService } from './navigation/navigation-location-service';
 import { NavigationLocationSimilarity } from './navigation/navigation-location-similarity';
+import { EditorVariableContribution } from './editor-variable-contribution';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -48,4 +50,6 @@ export default new ContainerModule(bind => {
     bind(NavigationLocationService).toSelf().inSingletonScope();
     bind(NavigationLocationUpdater).toSelf().inSingletonScope();
     bind(NavigationLocationSimilarity).toSelf().inSingletonScope();
+
+    bind(VariableContribution).to(EditorVariableContribution).inSingletonScope();
 });

--- a/packages/editor/src/browser/editor-variable-contribution.ts
+++ b/packages/editor/src/browser/editor-variable-contribution.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { VariableRegistry, VariableContribution } from '@theia/variable-resolver/lib/browser';
+import { TextEditor } from './editor';
+import { EditorManager } from './editor-manager';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+@injectable()
+export class EditorVariableContribution implements VariableContribution {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    registerVariables(variables: VariableRegistry): void {
+        variables.registerVariable({
+            name: 'file',
+            description: 'The path of the currently opened file',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.path.toString();
+            }
+        });
+        variables.registerVariable({
+            name: 'fileBasename',
+            description: 'The basename of the currently opened file',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.path.base;
+            }
+        });
+        variables.registerVariable({
+            name: 'fileBasenameNoExtension',
+            description: "The currently opened file's name without extension",
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.path.name;
+            }
+        });
+        variables.registerVariable({
+            name: 'fileDirname',
+            description: "The name of the currently opened file's directory",
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.path.dir.toString();
+            }
+        });
+        variables.registerVariable({
+            name: 'fileExtname',
+            description: 'The extension of the currently opened file',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.path.ext;
+            }
+        });
+        variables.registerVariable({
+            name: 'relativeFile',
+            description: "The currently opened file's path relative to the workspace root",
+            resolve: async () => {
+                const workspaceRootUri = await this.getWorkspaceRootUri();
+                const currentEditor = this.getCurrentEditor();
+                if (!workspaceRootUri || !currentEditor) {
+                    return undefined;
+                }
+                return currentEditor.uri.toString().slice(workspaceRootUri.length + 1); // + 1 so that it removes the beginning slash
+            }
+        });
+        variables.registerVariable({
+            name: 'lineNumber',
+            description: 'The current line number in the currently opened file',
+            resolve: () => {
+                const currentEditor = this.getCurrentEditor();
+                if (!currentEditor) {
+                    return undefined;
+                }
+                return `${currentEditor.cursor.line + 1}`;
+            }
+        });
+    }
+
+    protected getCurrentEditor(): TextEditor | undefined {
+        const currentEditor = this.editorManager.currentEditor;
+        if (!currentEditor) {
+            return undefined;
+        }
+        return currentEditor.editor;
+    }
+
+    protected async getWorkspaceRootUri(): Promise<string | undefined> {
+        const wsRoot = await this.workspaceService.root;
+        if (!wsRoot) {
+            return undefined;
+        }
+        return wsRoot.uri;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>
Closes #1598 

This PR adds the editor relative Variables available for substitution:
`${file}` - resolved to the path of the currently opened file;
`${fileBasename}` - resolved to the basename of the currently opened file;
`${fileBasenameNoExtension}` - resolved to the currently opened file's name without extension;
`${fileDirname}` - resolved to the name of the currently opened file's directory;
`${fileExtname}` - resolved to the extension of the currently opened file;
`${relativeFile}` - resolved to the currently opened file's path relative to the workspace root;
`${lineNumber}` - resolved to the current line number in the currently opened file.