### PR TITLE
Misc fixes related to @theia/java

### DIFF
--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -101,6 +101,10 @@ export class CommandRegistry implements CommandService {
      * Throw if a command is already registered for the given command identifier.
      */
     registerCommand(command: Command, handler?: CommandHandler): Disposable {
+        if (this._commands[command.id]) {
+            console.warn(`A command ${command.id} is already registered.`);
+            return Disposable.NULL;
+        }
         if (handler) {
             const toDispose = new DisposableCollection();
             toDispose.push(this.doRegisterCommand(command));
@@ -111,9 +115,6 @@ export class CommandRegistry implements CommandService {
     }
 
     protected doRegisterCommand(command: Command): Disposable {
-        if (this._commands[command.id]) {
-            throw Error(`A command ${command.id} is already registered.`);
-        }
         this._commands[command.id] = command;
         return {
             dispose: () => {


### PR DESCRIPTION
This PR resolves following issues

1. JDT LS tries to register `java.edit.organizeImports` command, which is already done in [java-commands.ts](https://github.com/theia-ide/theia/blob/574236ee83e8bb1a6c31011ac7fc73876cc81a0c/packages/java/src/browser/java-commands.ts#L60)
1. on reload with opened java editor, many rejected promise errors from `monaco-outline-contribution.ts` were logged.
* it happened due to frequent calls of [updateOutline](https://github.com/theia-ide/theia/blob/947a7e79ddbdbf69d87d0e24f7acfaa290d223db/packages/monaco/src/browser/monaco-outline-contribution.ts#L69)
* call of [`provideDocumentSymbols`](https://github.com/theia-ide/theia/blob/947a7e79ddbdbf69d87d0e24f7acfaa290d223db/packages/monaco/src/browser/monaco-outline-contribution.ts#L105-L116) throws with rejected promise errors on cancellation