### PR TITLE
GH-1711: Enhanced the `git commit` and `git branch` support.

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -12,7 +12,7 @@
     "@types/diff": "^3.2.2",
     "@types/fs-extra": "^4.0.2",
     "diff": "^3.4.0",
-    "dugite-extra": "0.0.1-alpha.20",
+    "dugite-extra": "0.0.1-alpha.22",
     "find-git-repositories": "^0.1.0",
     "fs-extra": "^4.0.2",
     "moment": "^2.21.0",

--- a/packages/git/src/browser/git-decorator.ts
+++ b/packages/git/src/browser/git-decorator.ts
@@ -136,9 +136,9 @@ export class GitDecorator implements TreeDecorator {
 
     protected getDecorationColor(status: GitFileStatus, staged?: boolean): string {
         switch (status) {
-            case GitFileStatus.New: return !!staged ? 'var(--theia-success-color0)' : 'var(--theia-disabled-color0)';
+            case GitFileStatus.New: return 'var(--theia-success-color0)';
             case GitFileStatus.Renamed: // Fall through.
-            case GitFileStatus.Copied: return ' var(--theia-disabled-color0)';
+            case GitFileStatus.Copied: // Fall through.
             case GitFileStatus.Modified: return 'var(--theia-brand-color0)';
             case GitFileStatus.Deleted: return 'var(--theia-warn-color0)';
             case GitFileStatus.Conflicted: return 'var(--theia-error-color0)';

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -10,7 +10,7 @@ import { DisposableCollection, CommandRegistry, MenuModelRegistry } from '@theia
 import { AbstractViewContribution, StatusBar, StatusBarAlignment, DiffUris } from '@theia/core/lib/browser';
 import { EditorManager, EditorWidget, EditorOpenerOptions, EditorContextMenu, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { GitFileChange } from '../common';
-import { GitWidget, GIT_WIDGET_CONTEXT_MENU } from './git-widget';
+import { GitWidget } from './git-widget';
 import { GitRepositoryTracker } from './git-repository-tracker';
 import { GitQuickOpenService } from './git-quick-open-service';
 
@@ -42,6 +42,12 @@ export namespace GIT_COMMANDS {
     export const CHECKOUT = {
         id: 'git.checkout',
         label: 'Git: Checkout'
+    };
+    export const COMMIT_AMEND = {
+        id: 'git.commit.amend'
+    };
+    export const COMMIT_SIGN_OFF = {
+        id: 'git.commit.signOff'
     };
     export const CHANGE_REPOSITORY = {
         id: 'git.change.repository',
@@ -124,13 +130,20 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
 
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
-        const commands = [GIT_COMMANDS.FETCH, GIT_COMMANDS.PULL, GIT_COMMANDS.PUSH, GIT_COMMANDS.MERGE];
-        commands.forEach(command =>
-            menus.registerMenuAction(GIT_WIDGET_CONTEXT_MENU, {
+        [GIT_COMMANDS.FETCH, GIT_COMMANDS.PULL, GIT_COMMANDS.PUSH, GIT_COMMANDS.MERGE].forEach(command =>
+            menus.registerMenuAction(GitWidget.ContextMenu.OTHER_GROUP, {
                 commandId: command.id,
                 label: command.label.slice('Git: '.length)
             })
         );
+        menus.registerMenuAction(GitWidget.ContextMenu.COMMIT_GROUP, {
+            commandId: GIT_COMMANDS.COMMIT_AMEND.id,
+            label: 'Commit (Amend)'
+        });
+        menus.registerMenuAction(GitWidget.ContextMenu.COMMIT_GROUP, {
+            commandId: GIT_COMMANDS.COMMIT_SIGN_OFF.id,
+            label: 'Commit (Signed Off)'
+        });
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {
             commandId: GIT_COMMANDS.OPEN_FILE.id
         });
@@ -161,6 +174,27 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
             execute: () => this.quickOpenService.checkout(),
             isEnabled: () => !!this.repositoryTracker.selectedRepository
         });
+        registry.registerCommand(GIT_COMMANDS.COMMIT_SIGN_OFF, {
+            execute: () => this.tryGetWidget()!.commit(this.repositoryTracker.selectedRepository, 'sign-off'),
+            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository
+        });
+        registry.registerCommand(GIT_COMMANDS.COMMIT_AMEND, {
+            execute: async () => {
+                const widget = this.tryGetWidget();
+                const { selectedRepository } = this.repositoryTracker;
+                if (!!widget && !!selectedRepository) {
+                    try {
+                        const message = await this.quickOpenService.commitMessageForAmend();
+                        widget.commit(selectedRepository, 'amend', message);
+                    } catch (e) {
+                        if (!(e instanceof Error) || e.message !== 'User abort.') {
+                            throw e;
+                        }
+                    }
+                }
+            },
+            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository
+        });
         registry.registerCommand(GIT_COMMANDS.CHANGE_REPOSITORY, {
             execute: () => this.quickOpenService.changeRepository(),
             isEnabled: () => this.hasMultipleRepositories()
@@ -181,6 +215,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
         const options = this.openFileOptions;
         return options && this.editorManager.open(options.uri, options.options);
     }
+
     protected get openFileOptions(): { uri: URI, options?: EditorOpenerOptions } | undefined {
         const widget = this.editorManager.currentEditor;
         if (widget && DiffUris.isDiffUri(widget.editor.uri)) {
@@ -200,6 +235,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
         }
         return undefined;
     }
+
     protected get openChangesOptions(): { change: GitFileChange, options?: EditorOpenerOptions } | undefined {
         const view = this.tryGetWidget();
         if (!view) {

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -74,7 +74,7 @@
 }
 
 .theia-git .gitItem .status.new {
-    color: var(--theia-disabled-color0);
+    color: var(--theia-success-color0);
 }
 
 .theia-git .gitItem .status.new.staged {
@@ -90,7 +90,7 @@
 }
 
 .theia-git .gitItem .status.renamed {
-    color: var(--theia-disabled-color0);
+    color: var(--theia-brand-color0);
 }
 
 .theia-git .gitItem .status.conflicted {
@@ -98,7 +98,7 @@
 }
 
 .theia-git .gitItem .status.copied {
-    color: var(--theia-disabled-color0);
+    color: var(--theia-brand-color0);
 }
 
 #theia-gitContainer .buttons {

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -231,6 +231,25 @@ export namespace Git {
         }
 
         /**
+         * Options for the `git commit` command refinement.
+         */
+        export interface Commit {
+
+            /**
+             * If `true` replaces the tip of the current branch by creating a new commit.
+             * The recorded tree is prepared as usual, and the message from the original commit is used as the starting point, instead of an empty message,
+             * when no other message is specified. The new commit has the same parents and author as the current one. Defaults to `false`.
+             */
+            readonly amend?: boolean;
+
+            /**
+             * Adds the `Signed-off-by` line by the committer at the end of the commit log message. `false` by default.
+             */
+            readonly signOff?: boolean;
+
+        }
+
+        /**
          * Options for further refining the `git show` command.
          */
         export interface Show {
@@ -278,7 +297,7 @@ export namespace Git {
             readonly localBranch?: string;
 
             /**
-             * The name of the remote branch to push to. If not given then teh changes will be pushed to the remote branch associated with the
+             * The name of the remote branch to push to. If not given then the changes will be pushed to the remote branch associated with the
              * local branch.
              *
              * `git push <remote> <localBranch>:<remoteBranch>`
@@ -572,7 +591,7 @@ export interface Git extends Disposable {
      * @param repository the repository where the staged changes has to be committed.
      * @param message the optional commit message.
      */
-    commit(repository: Repository, message?: string): Promise<void>;
+    commit(repository: Repository, message?: string, options?: Git.Options.Commit): Promise<void>;
 
     /**
      * Fetches branches and/or tags (collectively, `refs`) from the repository, along with the objects necessary to complete their histories.

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -702,6 +702,27 @@ describe('git', async function () {
 
     });
 
+    describe('branch', () => {
+
+        it('should list the branch in chronological order', async () => {
+            const root = track.mkdirSync('branch-order');
+            const localUri = FileUri.create(root).toString();
+            const repository = { localUri };
+            const git = await createGit();
+
+            await createTestRepository(root);
+            await git.exec(repository, ['checkout', '-b', 'a']);
+            await git.exec(repository, ['checkout', 'master']);
+            await git.exec(repository, ['checkout', '-b', 'b']);
+            await git.exec(repository, ['checkout', 'master']);
+            await git.exec(repository, ['checkout', '-b', 'c']);
+            await git.exec(repository, ['checkout', 'master']);
+
+            expect((await git.branch(repository, { type: 'local' })).map(b => b.nameWithoutRemote)).to.be.deep.equal(['master', 'c', 'b', 'a']);
+        });
+
+    });
+
     describe('ls-files', () => {
 
         let git: Git;

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -395,9 +395,11 @@ export class DugiteGit implements Git {
         });
     }
 
-    async commit(repository: Repository, message?: string): Promise<void> {
+    async commit(repository: Repository, message?: string, options?: Git.Options.Commit): Promise<void> {
+        const signOff = options && options.signOff;
+        const amend = options && options.amend;
         return this.manager.run(repository, () =>
-            createCommit(this.getFsPath(repository), message || '')
+            createCommit(this.getFsPath(repository), message || '', signOff, amend)
         );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,9 +2967,9 @@ dtrace-provider@~0.8:
   dependencies:
     nan "^2.3.3"
 
-dugite-extra@0.0.1-alpha.20:
-  version "0.0.1-alpha.20"
-  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.0.1-alpha.20.tgz#fb2912442579d9f8e3d9ca15af027fd9e68394d6"
+dugite-extra@0.0.1-alpha.22:
+  version "0.0.1-alpha.22"
+  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.0.1-alpha.22.tgz#adda956ad757952199e9ab8d1bd1710d6d0bd0ec"
   dependencies:
     byline "^5.0.0"
     dugite "1.42.0"


### PR DESCRIPTION
 - Fixed branch the branch ordering. Closes #1519.
 - Implemented `git commit --amend`. Closes #602.
 - Implemented `git commit --signoff`. Closes #620.
 - Adjusted Git file status decoration colors. Closes #1507.

Closes #1711.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>