### PR TITLE
GH-1730: A disposable listener can be attached to the Window object too.

### DIFF
--- a/packages/core/src/browser/endpoint.ts
+++ b/packages/core/src/browser/endpoint.ts
@@ -8,7 +8,7 @@
 import URI from "../common/uri";
 
 /**
- * An endpoint provides URLs for http and ws, based on configuration ansd defaults.
+ * An endpoint provides URLs for http and ws, based on configuration and defaults.
  */
 export class Endpoint {
     static readonly PROTO_HTTPS: string = "https:";
@@ -102,7 +102,7 @@ export namespace Endpoint {
         path?: string;
     }
 
-    // Necessary for running tests with dependecy on TS lib on node
+    // Necessary for running tests with dependency on TS lib on node
     // FIXME figure out how to mock with ts-node
     export class Location {
         host: string;

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -147,7 +147,7 @@ export namespace EventListenerObject {
 }
 export type EventListenerOrEventListenerObject<K extends keyof HTMLElementEventMap> = EventListener<K> | EventListenerObject<K>;
 export function addEventListener<K extends keyof HTMLElementEventMap>(
-    element: HTMLElement, type: K, listener: EventListenerOrEventListenerObject<K>, useCapture?: boolean
+    element: HTMLElement | Window, type: K, listener: EventListenerOrEventListenerObject<K>, useCapture?: boolean
 ): Disposable {
     element.addEventListener(type, listener, useCapture);
     return Disposable.create(() =>
@@ -156,7 +156,7 @@ export function addEventListener<K extends keyof HTMLElementEventMap>(
 }
 
 export function addKeyListener<K extends keyof HTMLElementEventMap>(
-    element: HTMLElement,
+    element: HTMLElement | Window,
     keysOrKeyCodes: KeyCode.Predicate | KeysOrKeyCodes,
     action: (event: KeyboardEvent) => void, ...additionalEventTypes: K[]): Disposable {
 

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -52,7 +52,7 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
     @inject(PreviewPreferences)
     protected readonly preferences: PreviewPreferences;
 
-    protected readonly syncronizedUris = new Set<string>();
+    protected readonly synchronizedUris = new Set<string>();
 
     protected readonly defaultOpenFromEditorOptions: PreviewOpenerOptions = {
         widgetOptions: { area: 'main', mode: 'split-right' },
@@ -90,7 +90,7 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
         if (!previewWidget || !editorWidget || !uri) {
             return;
         }
-        if (this.syncronizedUris.has(uri)) {
+        if (this.synchronizedUris.has(uri)) {
             return;
         }
         const syncDisposables = new DisposableCollection();
@@ -101,8 +101,8 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
         syncDisposables.push(editor.onCursorPositionChanged(position => this.revealSourceLineInPreview(previewWidget!, position)));
         syncDisposables.push(this.synchronizeScrollToEditor(previewWidget, editor));
 
-        this.syncronizedUris.add(uri);
-        syncDisposables.push(Disposable.create(() => this.syncronizedUris.delete(uri)));
+        this.synchronizedUris.add(uri);
+        syncDisposables.push(Disposable.create(() => this.synchronizedUris.delete(uri)));
     }
 
     protected revealSourceLineInPreview(previewWidget: PreviewWidget, position: Position): void {


### PR DESCRIPTION
Fixed a few typos here and there.

Closes #1730.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>