### PR TITLE
[workspace] Better localstorage keys #904

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -54,6 +54,17 @@ export class WorkspaceService implements FrontendApplicationContribution {
         this.deferredRoot.resolve(this._root);
     }
 
+    async getTheiaId(): Promise<string | undefined> {
+        return await this.server.getTheiaId();
+    }
+
+    async getWorkspaceId(): Promise<string | undefined> {
+        const stat = await this.root;
+        return stat ?
+            new URI(stat.uri).path.toString() :
+            undefined;
+    }
+
     protected updateTitle(uri: URI): void {
         document.title = uri.displayName;
     }

--- a/packages/workspace/src/common/test/mock-workspace-server.ts
+++ b/packages/workspace/src/common/test/mock-workspace-server.ts
@@ -10,6 +10,8 @@ import { WorkspaceServer } from '../workspace-protocol';
 @injectable()
 export class MockWorkspaceServer implements WorkspaceServer {
 
+    getTheiaId(): Promise<string | undefined> { return Promise.resolve('mock'); }
+
     getRoot(): Promise<string | undefined> { return Promise.resolve(''); }
 
     setRoot(uri: string): Promise<void> { return Promise.resolve(); }

--- a/packages/workspace/src/common/workspace-protocol.ts
+++ b/packages/workspace/src/common/workspace-protocol.ts
@@ -14,6 +14,11 @@ export const WorkspaceServer = Symbol('WorkspaceServer');
 export interface WorkspaceServer {
 
     /**
+     * Returns the random identifier to the running theia instance
+     */
+    getTheiaId(): Promise<string | undefined>;
+
+    /**
      * Returns with a promise that resolves to the workspace root URI as a string. Resolves to `undefined` if the workspace root is not yet set.
      */
     getRoot(): Promise<string | undefined>;

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -10,7 +10,7 @@ import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 
-import { injectable, inject } from "inversify";
+import { injectable, inject, guid, postConstruct } from "inversify";
 import { FileUri } from '@theia/core/lib/node';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { Deferred } from '@theia/core/lib/common/promise-util';
@@ -50,18 +50,28 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
 
     protected root: Promise<string | undefined>;
 
-    constructor(
-        @inject(WorkspaceCliContribution) protected readonly cliParams: WorkspaceCliContribution
-    ) {
+    @inject(WorkspaceCliContribution)
+    protected readonly cliParams: WorkspaceCliContribution;
+
+    @postConstruct()
+    protected async init(): Promise<void> {
         this.root = this.getRootURIFromCli();
-        this.root.then(async root => {
-            if (!root) {
-                const data = await this.readFromUserHome();
-                if (data && data.recentRoots) {
-                    this.root = Promise.resolve(data.recentRoots[0]);
-                }
+        if (!await this.root) {
+            const data = await this.readFromUserHome();
+            if (data && data.recentRoots) {
+                this.root = Promise.resolve(data.recentRoots[0]);
             }
-        });
+        }
+    }
+
+    async getTheiaId(): Promise<string | undefined> {
+        const file = path.join(os.homedir(), '.theia', 'instance.id');
+        if (!await fs.pathExists(file)) {
+            const id = guid();
+            await fs.writeFile(file, id);
+            return id;
+        }
+        return (await fs.readFile(file)).toString();
     }
 
     getRoot(): Promise<string | undefined> {


### PR DESCRIPTION
Because Theia is both meant to roll on a local machine and in the cloud, this commit adds better browser localstorage keys, so that Theia gets less confused as to what is being displayed in case that some URI points to different remotes (reverse proxying the same URL -at different times- to different theia instances).

This ensures that despite sharing the same local storage domain (host:port), multiple Theias won't mix up their data, unless you move the `~/.theia/instance.id` file around.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

LocalStorage key format: (`theia:guid:workspace:actual-key`)
![localstorage-keys](https://user-images.githubusercontent.com/14182238/38995096-1f168214-43b6-11e8-98c2-6b8ef369cde2.png)
(don't mind the `file://...` it is from past tests, my bad)