### PR TITLE
[workspace] Better localstorage keys #904

### DIFF
--- a/packages/core/src/browser/storage-service.ts
+++ b/packages/core/src/browser/storage-service.ts
@@ -35,7 +35,9 @@ interface LocalStorage {
 export class LocalStorageService implements StorageService {
     private storage: LocalStorage;
 
-    constructor(@inject(ILogger) protected logger: ILogger) {
+    constructor(
+        @inject(ILogger) protected logger: ILogger
+    ) {
         if (typeof window !== 'undefined' && window.localStorage) {
             this.storage = window.localStorage;
         } else {
@@ -62,6 +64,7 @@ export class LocalStorageService implements StorageService {
     }
 
     protected prefix(key: string): string {
-        return 'theia:' + key;
+        const pathname = typeof window === 'undefined' ? '' : window.location.pathname;
+        return `theia:${pathname}:${key}`;
     }
 }


### PR DESCRIPTION
Adds the current `window.location.pathname` in the key used to store data into the local storage.

This fixes an issue where multiple theia behind a proxy would share the same local storage domain.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>