### PR TITLE
Add C/C++ build configurations

### DIFF
--- a/packages/core/src/browser/test/mock-storage-service.ts
+++ b/packages/core/src/browser/test/mock-storage-service.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { StorageService } from '../storage-service';
+import { injectable } from 'inversify';
+
+/**
+ * A StorageService suitable to use during tests.
+ */
+@injectable()
+export class MockStorageService implements StorageService {
+    readonly data = new Map<string, {} | undefined>();
+
+    setData<T>(key: string, data?: T): Promise<void> {
+        this.data.set(key, data);
+
+        return Promise.resolve();
+    }
+
+    getData<T>(key: string, defaultValue?: T): Promise<T | undefined> {
+        return Promise.resolve(this.data.get(key) as T);
+    }
+}

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -1,17 +1,41 @@
 # Theia - Cpp Extension
 
-This extension uses [Clangd](https://clang.llvm.org/extra/clangd.html) to provide LSP features.
+This extension uses [Clangd](https://clang.llvm.org/extra/clangd.html) to
+provide LSP features.
 
 To install Clangd on Ubuntu 16.04:
 
-```
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >  /etc/apt/sources.list.d/llvm.list
-sudo apt-get update && sudo apt-get install -y clang-tools-7
-sudo ln -s /usr/bin/clangd-7 /usr/bin/clangd
-```
+    $ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    $ sudo echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >  /etc/apt/sources.list.d/llvm.list
+    $ sudo apt-get update && sudo apt-get install -y clang-tools-7
+    $ sudo ln -s /usr/bin/clangd-7 /usr/bin/clangd
 
-See [here](https://clang.llvm.org/extra/clangd.html#id4) for detailed  installation instructions.
+See [here](https://clang.llvm.org/extra/clangd.html#id4) for detailed installation instructions.
+
+To get accurate diagnostics, it helps to...
+
+1. ... have the build system of the C/C++ project generate a
+   [`compile_commands.json`](https://clang.llvm.org/docs/JSONCompilationDatabase.html)
+   file and...
+2. ... point Clangd to the build directory containing said
+   `compile_commands.json`.
+
+\#2 can be done using the `cpp.buildConfigurations` preference.  In your home
+or your project `.theia/settings.json`, define one or more build
+configurations:
+
+    {
+        "cpp.buildConfigurations": [{
+            "name": "Release",
+            "directory": "/path/to/my/release/build"
+        },{
+            "name": "Debug",
+            "directory": "/path/to/my/debug/build"
+        }]
+    }
+
+You can then select an active configuration using the
+`C/C++: Change Build Configuration` command from the command palette.
 
 ## License
 [Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/cpp/src/browser/cpp-build-configurations.spec.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule, Container } from "inversify";
+import { expect } from 'chai';
+import { FileSystem } from "@theia/filesystem/lib/common";
+import { StorageService } from "@theia/core/lib/browser/storage-service";
+import { MockStorageService } from "@theia/core/lib/browser/test/mock-storage-service";
+import sinon = require("sinon");
+import { CppBuildConfigurationManager, CppBuildConfiguration } from "./cpp-build-configurations";
+import { FileSystemNode } from "@theia/filesystem/lib/node/node-filesystem";
+import { bindCppPreferences } from "./cpp-preferences";
+import { PreferenceService } from "@theia/core/lib/browser/preferences/preference-service";
+import { MockPreferenceService } from "@theia/core/lib/browser/preferences/test/mock-preference-service";
+
+let container: Container;
+
+beforeEach(function() {
+    const m = new ContainerModule(bind => {
+        bind(CppBuildConfigurationManager).toSelf().inSingletonScope();
+        bind(StorageService).to(MockStorageService).inSingletonScope();
+        bind(FileSystem).to(FileSystemNode).inSingletonScope();
+        bindCppPreferences(bind);
+        bind(PreferenceService).to(MockPreferenceService).inSingletonScope();
+    });
+
+    container = new Container();
+    container.load(m);
+});
+
+/**
+ * Create the .theia/builds.json file with `buildsJsonContent` as its content
+ * and create/return an instance of the build configuration service.  If
+ * `buildsJsonContent` is undefined, don't create .theia/builds.json.
+ * If `activeBuildConfigName` is not undefined, also create an entrty in the
+ * storage service representing the saved active build config.
+ */
+async function initializeTest(buildConfigurations: CppBuildConfiguration[] | undefined,
+    activeBuildConfigName: string | undefined)
+    : Promise<CppBuildConfigurationManager> {
+
+    if (buildConfigurations !== undefined) {
+        const prefService = container.get<PreferenceService>(PreferenceService);
+        sinon.stub(prefService, 'get').callsFake((preferenceName: string) => {
+            if (preferenceName === 'cpp.buildConfigurations') {
+                return buildConfigurations;
+            }
+
+            return undefined;
+        });
+    }
+
+    // Save active build config
+    if (activeBuildConfigName !== undefined) {
+        const storage = container.get<StorageService>(StorageService);
+        storage.setData('cpp.active-build-configuration', {
+            configName: activeBuildConfigName,
+        });
+    }
+
+    const configs = container.get<CppBuildConfigurationManager>(CppBuildConfigurationManager);
+    await configs.ready;
+    return configs;
+}
+
+describe("build-configurations", function() {
+    it("should work with no preferences", async function() {
+        const cppBuildConfigurations = await initializeTest(undefined, undefined);
+
+        const configs = cppBuildConfigurations.getConfigs();
+        const active = cppBuildConfigurations.getActiveConfig();
+
+        expect(active).eq(undefined);
+        expect(configs).lengthOf(0);
+    });
+
+    it("should work with an empty list of builds", async function() {
+        const cppBuildConfigurations = await initializeTest([], undefined);
+
+        const configs = cppBuildConfigurations.getConfigs();
+        const active = cppBuildConfigurations.getActiveConfig();
+
+        expect(active).eq(undefined);
+        expect(configs).lengthOf(0);
+    });
+
+    it("should work with a simple list of builds", async function() {
+        const builds = [{
+            name: 'Release',
+            directory: '/tmp/builds/release',
+        }, {
+            name: 'Debug',
+            directory: '/tmp/builds/debug',
+        }];
+        const cppBuildConfigurations = await initializeTest(builds, undefined);
+
+        const configs = cppBuildConfigurations.getConfigs();
+        const active = cppBuildConfigurations.getActiveConfig();
+
+        expect(active).eq(undefined);
+        expect(configs).to.be.an('array').of.lengthOf(2);
+        expect(configs).to.have.deep.members(builds);
+    });
+
+    it("should work with a simple list of builds and an active config", async function() {
+        const builds = [{
+            name: 'Release',
+            directory: '/tmp/builds/release',
+        }, {
+            name: 'Debug',
+            directory: '/tmp/builds/debug',
+        }];
+        const cppBuildConfigurations = await initializeTest(builds, 'Debug');
+
+        const configs = cppBuildConfigurations.getConfigs();
+        const active = cppBuildConfigurations.getActiveConfig();
+
+        expect(active).to.be.deep.eq(builds[1]);
+        expect(configs).to.be.an('array').of.lengthOf(2);
+        expect(configs).to.have.deep.members(builds);
+    });
+
+    it("should ignore an active config that doesn't exist", async function() {
+        const builds = [{
+            name: 'Release',
+            directory: '/tmp/builds/release',
+        }, {
+            name: 'Debug',
+            directory: '/tmp/builds/debug',
+        }];
+        const cppBuildConfigurations = await initializeTest(builds, 'foobar');
+
+        const configs = cppBuildConfigurations.getConfigs();
+        const active = cppBuildConfigurations.getActiveConfig();
+
+        expect(active).to.be.eq(undefined);
+        expect(configs).to.be.an('array').of.lengthOf(2);
+        expect(configs).to.have.deep.members(builds);
+    });
+});

--- a/packages/cpp/src/browser/cpp-build-configurations.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { Command, CommandContribution, CommandRegistry, Event, Emitter } from "@theia/core";
+import { injectable, inject, postConstruct } from "inversify";
+import { QuickOpenService } from "@theia/core/lib/browser/quick-open/quick-open-service";
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode, } from "@theia/core/lib/browser/quick-open/quick-open-model";
+import { StorageService } from "@theia/core/lib/browser/storage-service";
+import { CppPreferences } from "./cpp-preferences";
+
+export interface CppBuildConfiguration {
+    name: string;
+    directory: string;
+}
+
+/** What we save in the local storage.  */
+class SavedActiveBuildConfiguration {
+    configName?: string;
+}
+
+/**
+ * Entry point to get the list of build configurations and get/set the active
+ * build configuration.
+ */
+@injectable()
+export class CppBuildConfigurationManager {
+    @inject(StorageService)
+    protected readonly storageService: StorageService;
+
+    @inject(CppPreferences)
+    protected readonly cppPreferences: CppPreferences;
+
+    /**
+     * The current active build configuration.  undefined means there's not
+     * current active configuration.
+     */
+    protected activeConfig: CppBuildConfiguration | undefined;
+
+    /** Emitter for when the active build configuration changes.  */
+    protected readonly activeConfigChangeEmitter = new Emitter<CppBuildConfiguration | undefined>();
+
+    readonly ACTIVE_BUILD_CONFIGURATION_STORAGE_KEY = 'cpp.active-build-configuration';
+    readonly BUILD_CONFIGURATIONS_PREFERENCE_KEY = 'cpp.buildConfigurations';
+
+    /**
+     * Promise resolved when the list of build configurations has been read
+     * once, and the active configuration has been set, if relevant.
+     */
+    public ready: Promise<void>;
+
+    @postConstruct()
+    async init() {
+        // Try to read the active build config from local storage.
+        this.ready = new Promise(async resolve => {
+            await this.cppPreferences.ready;
+            this.loadActiveConfiguration().then(resolve);
+        });
+    }
+
+    /** Load the active build config from the persistent storage.  */
+    protected async loadActiveConfiguration() {
+        const savedConfig =
+            await this.storageService.getData<SavedActiveBuildConfiguration>(
+                this.ACTIVE_BUILD_CONFIGURATION_STORAGE_KEY);
+
+        if (savedConfig !== undefined && savedConfig.configName !== undefined) {
+            // Try to find an existing config with that name.
+            const configs = this.getConfigs();
+            const config = configs.find(cfg => savedConfig.configName === cfg.name);
+            if (config) {
+                this.setActiveConfig(config);
+            }
+        }
+    }
+
+    /**
+     * Save the active build config name to persistent storage.
+     */
+    protected saveActiveConfiguration(config: CppBuildConfiguration | undefined) {
+        this.storageService.setData<SavedActiveBuildConfiguration>(
+            this.ACTIVE_BUILD_CONFIGURATION_STORAGE_KEY, {
+                configName: config ? config.name : undefined,
+            });
+    }
+
+    /** Get the active build configuration.  */
+    getActiveConfig(): CppBuildConfiguration | undefined {
+        return this.activeConfig;
+    }
+
+    /** Change the active build configuration.  */
+    setActiveConfig(config: CppBuildConfiguration | undefined) {
+        this.activeConfig = config;
+        this.saveActiveConfiguration(config);
+        this.activeConfigChangeEmitter.fire(config);
+    }
+
+    /** Event emitted when the active build configuration changes.  */
+    get onActiveConfigChange(): Event<CppBuildConfiguration | undefined> {
+        return this.activeConfigChangeEmitter.event;
+    }
+
+    /** Get the list of defined build configurations.  */
+    getConfigs(): CppBuildConfiguration[] {
+        return this.cppPreferences[this.BUILD_CONFIGURATIONS_PREFERENCE_KEY] || [];
+    }
+}
+
+@injectable()
+export class CppBuildConfigurationChanger implements QuickOpenModel {
+
+    @inject(QuickOpenService)
+    protected readonly quickOpenService: QuickOpenService;
+
+    @inject(CppBuildConfigurationManager)
+    protected readonly cppBuildConfigurations: CppBuildConfigurationManager;
+
+    async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
+        const items: QuickOpenItem[] = [];
+        const active: CppBuildConfiguration | undefined = this.cppBuildConfigurations.getActiveConfig();
+
+        // Add one item per build config.
+        this.cppBuildConfigurations.getConfigs().forEach(config => {
+            items.push(new QuickOpenItem({
+                label: config.name,
+                description: config === active ? 'active' : '',
+                run: (mode: QuickOpenMode): boolean => {
+                    if (mode !== QuickOpenMode.OPEN) {
+                        return false;
+                    }
+
+                    this.cppBuildConfigurations.setActiveConfig(config);
+                    return true;
+                },
+            }));
+        });
+
+        acceptor(items);
+    }
+
+    open() {
+        this.quickOpenService.open(this, {
+            placeholder: 'Choose a build configuration...',
+        });
+    }
+}
+
+/**
+ * Open the quick open menu to let the user change the active build
+ * configuration.
+ */
+export const CPP_CHANGE_BUILD_CONFIGURATION: Command = {
+    id: 'cpp.change-build-configuration',
+    label: 'C/C++: Change Build Configuration'
+};
+
+@injectable()
+export class CppBuildConfigurationsContributions implements CommandContribution {
+
+    @inject(CppBuildConfigurationChanger)
+    protected readonly cppChangeBuildConfiguration: CppBuildConfigurationChanger;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(CPP_CHANGE_BUILD_CONFIGURATION, {
+            execute: () => this.cppChangeBuildConfiguration.open()
+        });
+    }
+}

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -13,6 +13,8 @@ import { CppCommandContribution } from './cpp-commands';
 import { LanguageClientContribution } from "@theia/languages/lib/browser";
 import { CppLanguageClientContribution } from "./cpp-language-client-contribution";
 import { CppKeybindingContribution, CppKeybindingContext } from "./cpp-keybinding";
+import { bindCppPreferences } from "./cpp-preferences";
+import { CppBuildConfigurationsContributions, CppBuildConfigurationChanger, CppBuildConfigurationManager } from "./cpp-build-configurations";
 
 export default new ContainerModule(bind => {
     bind(CommandContribution).to(CppCommandContribution).inSingletonScope();
@@ -23,4 +25,10 @@ export default new ContainerModule(bind => {
     bind(CppLanguageClientContribution).toSelf().inSingletonScope();
     bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppLanguageClientContribution));
 
+    bind(CppBuildConfigurationManager).toSelf().inSingletonScope();
+    bind(CppBuildConfigurationChanger).toSelf().inSingletonScope();
+    bind(CppBuildConfigurationsContributions).toSelf().inSingletonScope();
+    bind(CommandContribution).to(CppBuildConfigurationsContributions).inSingletonScope();
+
+    bindCppPreferences(bind);
 });

--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { PreferenceSchema, PreferenceProxy, PreferenceService, createPreferenceProxy, PreferenceContribution } from "@theia/core/lib/browser/preferences";
+import { interfaces } from "inversify";
+import { CppBuildConfiguration } from "./cpp-build-configurations";
+
+export const cppPreferencesSchema: PreferenceSchema = {
+    type: "object",
+    properties: {
+        "cpp.buildConfigurations": {
+            description: "List of build configurations",
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    "name": {
+                        type: "string"
+                    },
+                    "directory": {
+                        type: "string"
+                    }
+                },
+                required: ["name", "directory"],
+            }
+        }
+    }
+};
+
+export class CppConfiguration {
+    "cpp.buildConfigurations": CppBuildConfiguration[];
+}
+
+export const CppPreferences = Symbol("CppPreferences");
+export type CppPreferences = PreferenceProxy<CppConfiguration>;
+
+export function createCppPreferences(preferences: PreferenceService): CppPreferences {
+    return createPreferenceProxy(preferences, cppPreferencesSchema);
+}
+
+export function bindCppPreferences(bind: interfaces.Bind): void {
+    bind(CppPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createCppPreferences(preferences);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: cppPreferencesSchema });
+}

--- a/packages/cpp/src/node/cpp-contribution.ts
+++ b/packages/cpp/src/node/cpp-contribution.ts
@@ -28,10 +28,6 @@ export class CppContribution extends BaseLanguageServerContribution {
             args = parseArgs(envArgs);
         }
 
-        const envCompilationDatabase = process.env.CPP_CLANGD_COMPILATION_DB_DIRECTORY;
-        if (envCompilationDatabase) {
-            args.push("-compile-commands-dir=" + envCompilationDatabase);
-        }
         const serverConnection = this.createProcessStreamConnection(command, args);
         this.forward(clientConnection, serverConnection);
     }


### PR DESCRIPTION
To get a good experience when editing C/C++ (get accurate diagnostics,
locate includes, etc), one needs to inform the language server (e.g.
clangd) where the build resides.  The language server will then read the
compile_commands.json file from that directory, indicating, for each
file, how it has been compiled.  It is possible and common to have
multiple builds using the same source tree.

We therefore need a way in Theia to let the user select which build will
be used by the language server to get the compilation commands for the
files being edited.  Instead of doing something very C/C++ specific, I
added a build configurations service, that reads a list of build
configurations from the file .theia/builds.json, if it is present in the
workspace.  The user can then make a build active using the quick open
menu.

The C/C++ extension listens for build configuration changes and informs
clangd of the change.  The name of the active configuration is saved to
the local storage and restored when the frontend starts (if a config
with that name still exists).

The build configuration concept can be re-used for other languages if
necessary, and will be useful when we actually add the support to build
C/C++ code from Theia.

The old way of specifying the compile_commands.json path (through an env
var) is removed in favor of this new method.

Not part of this patch, but on the roadmap are:

- status bar icon to show the active build configuration
- watch .theia/builds.json to update the list of build configurations at
  runtime (currently, it is only read at startup)
- validate the builds.json file with a schema

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>