### PR TITLE
[editorconfig] make npm package published as public

### DIFF
--- a/packages/editorconfig/package.json
+++ b/packages/editorconfig/package.json
@@ -8,6 +8,9 @@
     "@theia/monaco": "0.3.8",
     "editorconfig": "^0.15.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "theia-extension"
   ],


### PR DESCRIPTION
There is a lerna setting for packages, to make it publish npm
packages as public. it was missed from this new extension,
preventing it from correctly publishing successfully to npm,
in the post-merge build.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>