### PR TITLE
Add notification manager API

### DIFF
--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -26,6 +26,10 @@ export interface Message {
 
 export interface MessageOptions {
     timeout?: number;
+    /**
+     * Indicates that this message should be modal.
+     */
+    modal?: boolean;
 }
 
 @injectable()

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -26,7 +26,6 @@ Simple example that invoke command:
 ```javascript
 theia.commands.executeCommand('core.about');
 ```
-
 ### window
 
 Common namespace for dealing with window and editor, showing messages and user input.
@@ -50,4 +49,23 @@ Example of using:
 theia.window.showQuickPick(["foo", "bar", "foobar"], option).then((val: string[] | undefined) => {
         console.log(`Quick Pick Selected: ${val}`);
     });
+```
+#### Notification API
+ A notification shows an information message to users.
+ Optionally provide an array of items which will be presented as clickable buttons.
+ 
+ Notifications can be shown using the [showInformationMessage](#window.showInformationMessage),
+ [showWarningMessage](#window.showWarningMessage) and [showErrorMessage](#window.showErrorMessage) functions.
+ 
+
+Simple example that show an information message:
+```javascript
+theia.window.showInformationMessage('Information message');
+```
+
+Simple example that show an information message with buttons:
+```javascript
+theia.window.showInformationMessage('Information message', 'Btn1', 'Btn2').then(result => {
+    console.log("Click button", result);
+});
 ```

--- a/packages/plugin/src/api/plugin-api.ts
+++ b/packages/plugin/src/api/plugin-api.ts
@@ -55,6 +55,18 @@ export interface PickOpenItem {
     detail?: string;
     picked?: boolean;
 }
+
+export interface MessageRegistryMain {
+    $showInformationMessage (message: string,
+                             optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                             items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
+    $showWarningMessage (message: string,
+                         optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                         items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
+    $showErrorMessage (message: string,
+                       optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                       items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
+}
 export interface QuickOpenExt {
     $onItemSelected(handle: number): void;
     $validateInput(input: string): PromiseLike<string> | undefined;
@@ -69,11 +81,13 @@ export interface QuickOpenMain {
 
 export const PLUGIN_RPC_CONTEXT = {
     COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
-    QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain')
+    QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
+    MESSAGE_REGISTRY_MAIN: <ProxyIdentifier<MessageRegistryMain>>createProxyIdentifier<MessageRegistryMain>('MessageRegistryMain')
 };
 
 export const MAIN_RPC_CONTEXT = {
     HOSTED_PLUGIN_MANAGER_EXT: createProxyIdentifier<HostedPluginManagerExt>('HostedPluginManagerExt'),
     COMMAND_REGISTRY_EXT: createProxyIdentifier<CommandRegistryExt>('CommandRegistryExt'),
-    QUICK_OPEN_EXT: createProxyIdentifier<QuickOpenExt>('QuickOpenExt')
+    QUICK_OPEN_EXT: createProxyIdentifier<QuickOpenExt>('QuickOpenExt'),
+    MESSAGE_REGISTRY_EXT: createProxyIdentifier('MessageRegistryExt')
 };

--- a/packages/plugin/src/browser/main-context.ts
+++ b/packages/plugin/src/browser/main-context.ts
@@ -9,6 +9,7 @@ import { RPCProtocol } from '../api/rpc-protocol';
 import { CommandRegistryMainImpl } from './command-registry-main';
 import { PLUGIN_RPC_CONTEXT } from '../api/plugin-api';
 import { QuickOpenMainImpl } from './quick-open-main';
+import { MessageRegistryMainImpl } from './message-registry-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
@@ -16,4 +17,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const quickOpenMain = new QuickOpenMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.QUICK_OPEN_MAIN, quickOpenMain);
+
+    const messageRegistryMain = new MessageRegistryMainImpl(container);
+    rpc.set(PLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN, messageRegistryMain);
 }

--- a/packages/plugin/src/browser/message-registry-main.ts
+++ b/packages/plugin/src/browser/message-registry-main.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {interfaces} from 'inversify';
+import {MessageRegistryMain} from '../api/plugin-api';
+import {MessageItem, MessageOptions} from "@theia/plugin";
+import {MessageService} from '@theia/core/lib/common/message-service';
+
+export enum MessageType {
+    Error = 1,
+    Warning,
+    Info
+}
+
+export class MessageRegistryMainImpl implements MessageRegistryMain {
+    private delegate: MessageService;
+
+    constructor(container: interfaces.Container) {
+        this.delegate = container.get(MessageService);
+    }
+
+    $showInformationMessage (message: string,
+        optionsOrFirstItem: MessageOptions | string | MessageItem,
+        items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.showMessage(MessageType.Info, message, optionsOrFirstItem, ...items);
+    }
+
+    $showWarningMessage (message: string,
+                             optionsOrFirstItem: MessageOptions | string | MessageItem,
+                             items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.showMessage(MessageType.Warning, message, optionsOrFirstItem, ...items);
+    }
+
+    $showErrorMessage (message: string,
+                             optionsOrFirstItem: MessageOptions | string | MessageItem,
+                             items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.showMessage(MessageType.Error, message, optionsOrFirstItem, ...items);
+    }
+
+    protected showMessage(type: MessageType, message: string, ...args: any[]): PromiseLike<string | MessageItem | undefined> {
+        const actionsMap = new Map<string, any>();
+        const actionTitles: string[] = [];
+
+        let options: MessageOptions | undefined;
+        if (!!args && args.length > 0) {
+            const first = args[0];
+            options = first && first.modal !== undefined ? <MessageOptions>first : undefined;
+            args.forEach(arg => {
+                if (!arg) {
+                    return;
+                }
+                let actionTitle: string;
+                if (typeof arg === 'string') {
+                    actionTitle = arg;
+                } else if (arg !== options && arg.title) {
+                    actionTitle = <string>arg.title;
+                    actionsMap.set(actionTitle, arg);
+                } else {
+                    return;
+                }
+                actionTitles.push(actionTitle);
+            });
+        }
+
+        if (options && options.modal === true) {
+            return Promise.reject(new Error('Modal message is not supported yet!'));
+        }
+
+        let promise: Promise<string | undefined>;
+
+        try {
+            switch (type) {
+                case MessageType.Info:
+                    promise = this.delegate.info(message, ...actionTitles);
+                    break;
+                case MessageType.Warning:
+                    promise = this.delegate.warn(message, ...actionTitles);
+                    break;
+                case MessageType.Error:
+                    promise = this.delegate.error(message, ...actionTitles);
+                    break;
+                default:
+                    return Promise.reject(new Error(`Message type '${type}' is not supported yet!`));
+            }
+        } catch (e) {
+            return Promise.reject(e);
+        }
+
+        return Promise.resolve(promise.then(result => !!result && actionsMap.has(result) ? actionsMap.get(result) : result));
+    }
+}

--- a/packages/plugin/src/node/hosted-plugin.ts
+++ b/packages/plugin/src/node/hosted-plugin.ts
@@ -57,12 +57,12 @@ export class HostedPluginSupport {
     }
 
     private terminatePluginServer(cp: cp.ChildProcess) {
-        const emmitter = new Emitter();
+        const emitter = new Emitter();
         cp.on('message', message => {
-            emmitter.fire(JSON.parse(message));
+            emitter.fire(JSON.parse(message));
         });
         const rpc = new RPCProtocolImpl({
-            onMessage: emmitter.event,
+            onMessage: emitter.event,
             send: (m: {}) => {
                 if (cp.send) {
                     cp.send(JSON.stringify(m));

--- a/packages/plugin/src/plugin/message-registry.ts
+++ b/packages/plugin/src/plugin/message-registry.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {
+    PLUGIN_RPC_CONTEXT as Ext, MessageRegistryMain
+} from '../api/plugin-api';
+import {RPCProtocol} from '../api/rpc-protocol';
+import {MessageItem, MessageOptions} from "@theia/plugin";
+
+export class MessageRegistryExt {
+
+    private proxy: MessageRegistryMain;
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(Ext.MESSAGE_REGISTRY_MAIN);
+    }
+
+    showInformationMessage(message: string,
+                           optionsOrFirstItem: MessageOptions | string | MessageItem,
+                           items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.proxy.$showInformationMessage(message, optionsOrFirstItem, items);
+    }
+
+    showWarningMessage(message: string,
+                           optionsOrFirstItem: MessageOptions | string | MessageItem,
+                           items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.proxy.$showWarningMessage(message, optionsOrFirstItem, items);
+    }
+
+    showErrorMessage(message: string,
+                           optionsOrFirstItem: MessageOptions | string | MessageItem,
+                           items: string[] | MessageItem[]): PromiseLike<string | MessageItem | undefined> {
+        return this.proxy.$showErrorMessage(message, optionsOrFirstItem, items);
+    }
+}

--- a/packages/plugin/src/plugin/plugin-context.ts
+++ b/packages/plugin/src/plugin/plugin-context.ts
@@ -12,10 +12,12 @@ import { Disposable } from './types-impl';
 import { Emitter } from '@theia/core/lib/common/event';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { QuickOpenExtImpl } from './quick-open';
+import { MessageRegistryExt } from './message-registry';
 
 export function createAPI(rpc: RPCProtocol): typeof theia {
     const commandRegistryExt = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
     const quickOpenExt = rpc.set(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT, new QuickOpenExtImpl(rpc));
+    const messageRegistryExt = rpc.set(MAIN_RPC_CONTEXT.MESSAGE_REGISTRY_EXT, new MessageRegistryExt(rpc));
 
     const commands: typeof theia.commands = {
         registerCommand(command: theia.Command, handler?: <T>(...args: any[]) => T | Thenable<T>): Disposable {
@@ -35,6 +37,21 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
     const window: typeof theia.window = {
         showQuickPick(items: any, options: theia.QuickPickOptions, token?: theia.CancellationToken): any {
             return quickOpenExt.showQuickPick(items, options, token);
+        },
+        showInformationMessage(message: string,
+                               optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                               ...items: any[]): PromiseLike<any> {
+            return messageRegistryExt.showInformationMessage(message, optionsOrFirstItem, items);
+        },
+        showWarningMessage(message: string,
+                           optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                           ...items: any[]): PromiseLike<any> {
+            return messageRegistryExt.showWarningMessage(message, optionsOrFirstItem, items);
+        },
+        showErrorMessage(message: string,
+                         optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
+                         ...items: any[]): PromiseLike<any> {
+            return messageRegistryExt.showErrorMessage(message, optionsOrFirstItem, items);
         }
     };
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -47,7 +47,7 @@ declare module '@theia/plugin' {
     }
 
     /**
-     * 
+     *
      */
     export interface TextEditorEdit {
         // TODO implement TextEditorEdit
@@ -79,7 +79,7 @@ declare module '@theia/plugin' {
 
         /**
          * Fire the event and pass data object
-         * @param data 
+         * @param data
          */
         fire(data?: T): void;
 
@@ -90,7 +90,7 @@ declare module '@theia/plugin' {
     }
 
     /**
-     * A cancellation token used to request cancellation on long running 
+     * A cancellation token used to request cancellation on long running
      * or asynchronous task.
      */
     export interface CancellationToken {
@@ -153,7 +153,7 @@ declare module '@theia/plugin' {
         machOnDetail?: boolean;
 
         /**
-         * The place holder in input box 
+         * The place holder in input box
          */
         placeHolder?: string;
 
@@ -186,60 +186,90 @@ declare module '@theia/plugin' {
     }
 
     /**
-	 * Namespace for dealing with commands. In short, a command is a function with a
-	 * unique identifier. The function is sometimes also called _command handler_.
-     * 
+     * Namespace for dealing with commands. In short, a command is a function with a
+     * unique identifier. The function is sometimes also called _command handler_.
+     *
      * Commands can be added using the [registerCommand](#commands.registerCommand) and
      * [registerTextEditorCommand](#commands.registerTextEditorCommand) functions.
-     * Registration can be split in two step: first register command without handler, 
+     * Registration can be split in two step: first register command without handler,
      * second register handler by command id.
-     * 
-     * Any contributed command are available to any plugin, command can be invoked 
+     *
+     * Any contributed command are available to any plugin, command can be invoked
      * by [executeCommand](#commands.executeCommand) function.
-     * 
+     *
      * Simple example that register command:
      * ```javascript
      * theia.commands.registerCommand({id:'say.hello.command'}, ()=>{
      *     console.log("Hello World!");
      * });
      * ```
-     * 
+     *
      * Simple example that invoke command:
-     * 
+     *
      * ```javascript
      * theia.commands.executeCommand('core.about');
      * ```
-	 */
+     */
     export namespace commands {
         /**
          * Register the given command and handler if present.
          *
          * Throw if a command is already registered for the given command identifier.
          */
-        export function registerCommand(command: Command, handler?: (...args: any[]) => any): Disposable
+        export function registerCommand(command: Command, handler?: (...args: any[]) => any): Disposable;
 
         /**
          * Register the given handler for the given command identifier.
-         * 
+         *
          * @param commandId a given command id
          * @param handler a command handler
          */
-        export function registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable
+        export function registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable;
 
         /**
-         * Register a text editor command which can execute only if active editor present and command has access to the active editor 
-         * 
-         * @param command a command description 
-         * @param handler a command handler with access to text editor 
+         * Register a text editor command which can execute only if active editor present and command has access to the active editor
+         *
+         * @param command a command description
+         * @param handler a command handler with access to text editor
          */
-        export function registerTextEditorCommand(command: Command, handler: (textEditor: TextEditor, edit: TextEditorEdit, ...arg: any[]) => void): Disposable
+        export function registerTextEditorCommand(command: Command, handler: (textEditor: TextEditor, edit: TextEditorEdit, ...arg: any[]) => void): Disposable;
 
         /**
          * Execute the active handler for the given command and arguments.
          *
          * Reject if a command cannot be executed.
          */
-        export function executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined>
+        export function executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined>;
+    }
+
+    /**
+     * Represents an action that is shown with a message.
+     */
+    export interface MessageItem {
+
+        /**
+         * A message title.
+         */
+        title: string;
+
+        /**
+         * Indicates that the item should be triggered
+         * when the user cancels the dialog.
+         *
+         * Note: this option is ignored for non-modal messages.
+         */
+        isCloseAffordance?: boolean;
+    }
+
+    /**
+     * Options to configure the message behavior.
+     */
+    export interface MessageOptions {
+
+        /**
+         * Indicates that this message should be modal.
+         */
+        modal?: boolean;
     }
 
     /**
@@ -249,9 +279,9 @@ declare module '@theia/plugin' {
 
         /**
          * Shows a selection list.
-         * @param items 
-         * @param options 
-         * @param token 
+         * @param items
+         * @param options
+         * @param token
          */
         export function showQuickPick(items: string[] | PromiseLike<string[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<string[] | undefined>;
 
@@ -262,9 +292,9 @@ declare module '@theia/plugin' {
 
         /**
          * Shows a selection list.
-         * @param items 
-         * @param options 
-         * @param token 
+         * @param items
+         * @param options
+         * @param token
          */
         export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions, token?: CancellationToken): PromiseLike<T[] | undefined>;
 
@@ -273,6 +303,118 @@ declare module '@theia/plugin' {
          */
         export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<T[] | undefined>;
 
+        /**
+         * Show an information message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showInformationMessage(message: string, ...items: string[]): PromiseLike<string | undefined>;
 
+        /**
+         * Show an information message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showInformationMessage(message: string, options: MessageOptions, ...items: string[]): PromiseLike<string | undefined>;
+
+        /**
+         * Show an information message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showInformationMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>
+
+        /**
+         * Show an information message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showInformationMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
+
+        /**
+         * Show a warning message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>
+
+        /**
+         * Show a warning message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showWarningMessage(message: string, options: MessageOptions, ...items: string[]): PromiseLike<string | undefined>;
+
+        /**
+         * Show a warning message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showWarningMessage<T extends MessageItem>(message: string, ...items: T[]): PromiseLike<T | undefined>;
+
+        /**
+         * Show a warning message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
+
+        /**
+         * Show an error message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showErrorMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>
+
+        /**
+         * Show an error message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showErrorMessage(message: string, options: MessageOptions, ...items: string[]): PromiseLike<string | undefined>;
+
+        /**
+         * Show an error message.
+         *
+         * @param message a message to show.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showErrorMessage<T extends MessageItem>(message: string, ...items: T[]): PromiseLike<T | undefined>;
+
+        /**
+         * Show an error message.
+         *
+         * @param message a message to show.
+         * @param options Configures the behaviour of the message.
+         * @param items A set of items that will be rendered as actions in the message.
+         * @return A promise that resolves to the selected item or `undefined` when being dismissed.
+         */
+        export function showErrorMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
     }
 }

--- a/packages/plugin/src/worker/worker-main.ts
+++ b/packages/plugin/src/worker/worker-main.ts
@@ -14,15 +14,15 @@ import { HostedPluginManagerExtImpl } from '../plugin/hosted-plugin-manager';
 const ctx = self as any;
 const plugins = new Array<() => void>();
 
-const emmitter = new Emitter();
+const emitter = new Emitter();
 const rpc = new RPCProtocolImpl({
-    onMessage: emmitter.event,
+    onMessage: emitter.event,
     send: (m: {}) => {
         ctx.postMessage(m);
     }
 });
 addEventListener('message', (message: any) => {
-    emmitter.fire(message.data);
+    emitter.fire(message.data);
 });
 
 const theia = createAPI(rpc);


### PR DESCRIPTION
Add notification manager API to the new plugin system.
Discussion about architecture and principles can be found here:  https://github.com/theia-ide/theia/issues/1482
This API allows implementation of notifications to show an information message. Optionally provide an array of items which will be presented as clickable buttons and can be shown using the [showInformationMessage](#window.showInformationMessage),
 [showWarningMessage](#window.showWarningMessage) and [showErrorMessage](#window.showErrorMessage) functions.

Simple example that show an information message:
```
theia.window.showInformationMessage('Information message');
```
Simple example that show an information message with buttons:
```
theia.window.showInformationMessage('Information message', 'Btn1', 'Btn2').then(result => {
    console.log("Click button", result);
});
```