### PR TITLE
file-search: Allow searching for hidden files

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -65,7 +65,7 @@ export class QuickFileOpenService implements QuickOpenModel {
         let placeholderText = "File name to search.";
         const keybinding = this.getKeyCommand();
         if (keybinding) {
-            placeholderText += ` (Press ${keybinding} to show/hide .gitignore files)`;
+            placeholderText += ` (Press ${keybinding} to show/hide ignored files)`;
         }
 
         // Triggering the keyboard shortcut while the dialog is open toggles

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -37,7 +37,7 @@ export class FileSearchServiceImpl implements FileSearchService {
             '--sort-files',
         ];
         if (!options.useGitIgnore) {
-            args.push('-u');
+            args.push('-uu');
         }
         const process = this.rawProcessFactory({
             command: rgPath,


### PR DESCRIPTION
When in the mode to search even .gitignored files, I think it would also
make sense to let the user search for hidden files.  For example, if you
want to open ".travis.yml".  This is easily achieved by passing a second
-u to ripgrep.  If we passed a third -u, it would also search through
binary files, I don't think we want to go there (yet).

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>