### PR TITLE
GH-1746: Undo last commit

### DIFF
--- a/packages/core/src/browser/widgets/virtual-widget.ts
+++ b/packages/core/src/browser/widgets/virtual-widget.ts
@@ -26,7 +26,7 @@ export class VirtualWidget extends BaseWidget {
         if (!this.childContainer) {
             // if we are adding scrolling, we need to wrap the contents in its own div, to not conflict with the virtual dom algo.
             if (this.scrollOptions) {
-                this.childContainer = document.createElement('div');
+                this.childContainer = this.createChildContainer();
                 this.node.appendChild(this.childContainer);
             } else {
                 this.childContainer = this.node;
@@ -39,6 +39,10 @@ export class VirtualWidget extends BaseWidget {
     protected render(): h.Child {
         // tslint:disable-next-line:no-null-keyword
         return null;
+    }
+
+    protected createChildContainer(): HTMLElement {
+        return document.createElement('div');
     }
 
 }

--- a/packages/git/src/browser/git-commit-message-validator.ts
+++ b/packages/git/src/browser/git-commit-message-validator.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from 'inversify';
+import { MaybePromise } from '@theia/core/lib/common/types';
+
+@injectable()
+export class GitCommitMessageValidator {
+
+    static readonly MAX_CHARS_PER_LINE = 72;
+
+    /**
+     * Validates the input and returns with either a validation result with the status and message, or `undefined` if everything went fine.
+     */
+    validate(input: string | undefined): MaybePromise<GitCommitMessageValidator.Result | undefined> {
+        if (input) {
+            const lines = input.split(/\r?\n/);
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+                const result = this.isLineValid(line, i);
+                if (!!result) {
+                    return result;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    protected isLineValid(line: string, index: number): GitCommitMessageValidator.Result | undefined {
+        if (index === 1 && line.length !== 0) {
+            return {
+                status: 'warning',
+                message: 'The second line should be empty to separate the commit message from the body'
+            };
+        }
+        const diff = line.length - this.maxCharsPerLine();
+        if (diff > 0) {
+            return {
+                status: 'warning',
+                message: `${diff} characters over ${this.maxCharsPerLine()} in current line`
+            };
+        }
+        return undefined;
+    }
+
+    protected maxCharsPerLine(): number {
+        return GitCommitMessageValidator.MAX_CHARS_PER_LINE;
+    }
+
+}
+
+export namespace GitCommitMessageValidator {
+
+    /**
+     * Type for the validation result with a status and a corresponding message.
+     */
+    export type Result = Readonly<{ message: string, status: 'info' | 'success' | 'warning' | 'error' }>;
+
+    export namespace Result {
+
+        /**
+         * `true` if the `message` and the `status` properties are the same on both `left` and `right`. Or both arguments are `undefined`. Otherwise, `false`.
+         */
+        export function equal(left: Result | undefined, right: Result | undefined): boolean {
+            if (left && right) {
+                return left.message === right.message && left.status === right.status;
+            }
+            return left === right;
+        }
+
+    }
+
+}

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -23,6 +23,7 @@ import { bindGitPreferences } from './git-preferences';
 import { bindDirtyDiff } from './dirty-diff/dirty-diff-module';
 import { bindBlame } from './blame/blame-module';
 import { GitRepositoryTracker } from './git-repository-tracker';
+import { GitCommitMessageValidator } from './git-commit-message-validator';
 
 import '../../src/browser/style/index.css';
 
@@ -53,4 +54,6 @@ export default new ContainerModule(bind => {
 
     bind(LabelProviderContribution).to(GitUriLabelProviderContribution).inSingletonScope();
     bind(NavigatorTreeDecorator).to(GitDecorator).inSingletonScope();
+
+    bind(GitCommitMessageValidator).toSelf().inSingletonScope();
 });

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -10,8 +10,6 @@
     padding: 5px;
     box-sizing: border-box;
     background: var(--theia-layout-color0);
-    display: flex;
-    flex-direction: column;
 }
 
 .theia-git:focus {
@@ -103,7 +101,6 @@
 
 #theia-gitContainer .buttons {
     display: flex;
-    margin-left: 5px;
 }
 
 #theia-gitContainer .buttons .toolbar-button {
@@ -139,20 +136,6 @@
     position: relative;
 }
 
-#theia-gitContainer #repositoryListContainer #repositoryList,
-#theia-gitContainer #messageInputContainer input,
-#theia-gitContainer #messageTextareaContainer textarea {
-    flex: 1;
-    line-height: var(--theia-content-line-height);
-    font-size: var(--theia-ui-font-size1);
-    padding-left: 8px;
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--theia-border-color1);
-    background: var(--theia-layout-color2);
-    color: var(--theia-ui-font-color1);
-}
-
 #theia-gitContainer #repositoryListContainer {
     display: flex;
     margin-bottom: 5px;
@@ -166,7 +149,8 @@
 
 #theia-gitContainer .changesOuterContainer {
     overflow-y: auto;
-    padding-right: 5px;
+    border-top: 1px solid var(--theia-layout-color4);
+    width: 100%;
     flex-grow: 1;
 }
 
@@ -185,3 +169,130 @@
 .theia-git .theia-mod-selected{
     background: var(--theia-accent-color4);
 }
+
+.theia-git-main-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.theia-git-last-commit-container {
+    display: flex;
+    border-top: 1px solid var(--theia-layout-color4);
+    width: 100%;
+    padding-top: 6px;
+}
+
+.theia-git-last-commit-container img {
+    width: 27px;
+}
+
+.theia-git-last-commit-details {
+    display: flex;
+    flex-direction: column;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+}
+
+.theia-git-last-commit-message-avatar {
+    margin-right: 5px;
+}
+
+.theia-git-last-commit-message-summary {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.theia-git-last-commit-message-time {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--theia-ui-font-color2);
+    font-size: smaller;
+}
+
+.theia-git-commit-message-container {
+    display: flex;
+    flex-direction: column;
+    margin: 0px 0px 7px 0px;
+}
+
+.flex-container-center {
+    display: flex;
+    align-items: center;
+}
+
+.theia-git-commit-message-container textarea {
+    line-height: var(--theia-content-line-height);
+    font-size: var(--theia-ui-font-size1);
+    color: var(--theia-ui-font-color1);
+    background: var(--theia-layout-color2);
+    border-style: solid;
+    border-width: 1px;
+    resize: none;
+	overflow: hidden;
+    box-sizing: border-box;
+    height: 25px;
+    padding-left: 4px;
+}
+
+.theia-git-commit-message {
+    width: 100%;
+}
+
+.theia-git-commit-message-idle {
+    border-color: var(--theia-border-color0);
+}
+
+.theia-git-commit-message-info {
+    border-color: var(--theia-info-color0);
+}
+
+.theia-git-commit-message-success {
+    border-color: var(--theia-success-color0);
+}
+
+.theia-git-commit-message-warning {
+    border-color: var(--theia-warn-color0);
+}
+
+.theia-git-commit-message-error {
+    border-color: var(--theia-error-color0) !important;
+}
+
+.theia-git-validation-message-idle {
+    background-color: var(--theia-border-color0) !important;
+}
+
+.theia-git-validation-message-info {
+    background-color: var(--theia-info-color0) !important;
+}
+
+.theia-git-validation-message-success {
+    background-color: var(--theia-success-color0) !important;
+}
+
+.theia-git-validation-message-warning {
+    background-color: var(--theia-warn-color0) !important;
+}
+
+.theia-git-validation-message-error {
+    background-color: var(--theia-error-color0) !important;
+}
+
+.no-select {
+    cursor: default;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    -o-user-select: none;
+ }
+ 
+ .no-select:focus {
+    outline: none;
+ }


### PR DESCRIPTION
This PR contains the followings:
 - Support to undo the last commit.
 - Merged the two commit message input fields into one.
 - Added commit message input validation.
 - Toggle `Signed-off-by`.
 - Minor styling updates.

Closes: #1746.
Closes: #590.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Input resize:
![resize](https://user-images.githubusercontent.com/1405703/39289498-b44fe49e-492c-11e8-83a7-4bb25678657a.gif)

Signed-off-by:
![signoff](https://user-images.githubusercontent.com/1405703/39289503-b9cb40ee-492c-11e8-97c1-66d5d652c494.gif)

Error:
![error](https://user-images.githubusercontent.com/1405703/39289508-bec0cfc4-492c-11e8-90b4-1b37b3662f5d.gif)

Warning:
![warning](https://user-images.githubusercontent.com/1405703/39289615-261590a6-492d-11e8-8b1b-990675c7d986.gif)

Undo:
![undo](https://user-images.githubusercontent.com/1405703/39289531-da7514be-492c-11e8-8de5-2ccda6d1247f.gif)

