### PR TITLE
[terminal] handle reconnection

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -12,7 +12,7 @@ import { TerminalFrontendContribution } from './terminal-frontend-contribution';
 import { TerminalWidget, TerminalWidgetOptions, TERMINAL_WIDGET_FACTORY_ID } from './terminal-widget';
 import { ITerminalServer, terminalPath } from '../common/terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
-import { IShellTerminalServer, shellTerminalPath } from '../common/shell-terminal-protocol';
+import { IShellTerminalServer, shellTerminalPath, ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
 import { TerminalActiveContext } from './terminal-keybinding-contexts';
 import { createCommonBindings } from '../common/terminal-common-module';
 
@@ -54,11 +54,12 @@ export default new ContainerModule(bind => {
         return connection.createProxy<ITerminalServer>(terminalPath, terminalWatcher.getTerminalClient());
     }).inSingletonScope();
 
-    bind(IShellTerminalServer).toDynamicValue(ctx => {
+    bind(ShellTerminalServerProxy).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
         const terminalWatcher = ctx.container.get(TerminalWatcher);
-        return connection.createProxy<ITerminalServer>(shellTerminalPath, terminalWatcher.getTerminalClient());
+        return connection.createProxy<IShellTerminalServer>(shellTerminalPath, terminalWatcher.getTerminalClient());
     }).inSingletonScope();
+    bind(IShellTerminalServer).toService(ShellTerminalServerProxy);
 
     createCommonBindings(bind);
 });

--- a/packages/terminal/src/browser/terminal-widget.ts
+++ b/packages/terminal/src/browser/terminal-widget.ts
@@ -5,20 +5,19 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { inject, injectable, named } from "inversify";
-import { Disposable, ILogger } from '@theia/core/lib/common';
+import * as Xterm from 'xterm';
+import { inject, injectable, named, postConstruct } from "inversify";
+import { Disposable, DisposableCollection, ILogger } from '@theia/core/lib/common';
 import { Widget, BaseWidget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox } from '@theia/core/lib/browser';
 import { WorkspaceService } from "@theia/workspace/lib/browser";
-import { IShellTerminalServer } from '../common/shell-terminal-protocol';
-import { ITerminalServer, terminalsPath } from '../common/terminal-protocol';
-import { IBaseTerminalErrorEvent, IBaseTerminalExitEvent } from '../common/base-terminal-protocol';
+import { ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
+import { terminalsPath } from '../common/terminal-protocol';
+import { IBaseTerminalServer } from '../common/base-terminal-protocol';
 import { TerminalWatcher } from '../common/terminal-watcher';
-import * as Xterm from 'xterm';
 import { ThemeService } from "@theia/core/lib/browser/theming";
 import { Deferred } from "@theia/core/lib/common/promise-util";
 
 Xterm.Terminal.applyAddon(require('xterm/lib/addons/fit/fit'));
-Xterm.Terminal.applyAddon(require('xterm/lib/addons/attach/attach'));
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -62,24 +61,26 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
     protected isOpeningTerm = false;
     protected isTermOpen = false;
 
-    protected waitForResized = new Deferred<void>();
-    protected waitForTermOpened = new Deferred<void>();
+    protected readonly waitForResized = new Deferred<void>();
+    protected readonly waitForTermOpened = new Deferred<void>();
 
-    constructor(
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
-        @inject(WebSocketConnectionProvider) protected readonly webSocketConnectionProvider: WebSocketConnectionProvider,
-        @inject(TerminalWidgetOptions) options: TerminalWidgetOptions,
-        @inject(IShellTerminalServer) protected readonly shellTerminalServer: ITerminalServer,
-        @inject(TerminalWatcher) protected readonly terminalWatcher: TerminalWatcher,
-        @inject(ILogger) @named('terminal') protected readonly logger: ILogger
-    ) {
-        super();
-        this.id = options.id;
-        this.title.caption = options.caption;
-        this.title.label = options.label;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(WebSocketConnectionProvider) protected readonly webSocketConnectionProvider: WebSocketConnectionProvider;
+    @inject(TerminalWidgetOptions) options: TerminalWidgetOptions;
+    @inject(ShellTerminalServerProxy) protected readonly shellTerminalServer: ShellTerminalServerProxy;
+    @inject(TerminalWatcher) protected readonly terminalWatcher: TerminalWatcher;
+    @inject(ILogger) @named('terminal') protected readonly logger: ILogger;
+
+    protected readonly toDisposeOnConnect = new DisposableCollection();
+
+    @postConstruct()
+    protected init(): void {
+        this.id = this.options.id;
+        this.title.caption = this.options.caption;
+        this.title.label = this.options.label;
         this.title.iconClass = "fa fa-terminal";
 
-        if (options.destroyTermOnClose === true) {
+        if (this.options.destroyTermOnClose === true) {
             this.toDispose.push(Disposable.create(() =>
                 this.term.destroy()
             ));
@@ -120,6 +121,25 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
                 (this.term.element.children.item(0) as HTMLElement).style.overflow = 'hidden';
             });
         }
+
+        this.toDispose.push(this.terminalWatcher.onTerminalError(({ terminalId }) => {
+            if (terminalId === this.terminalId) {
+                this.title.label = "<terminal error>";
+            }
+        }));
+        this.toDispose.push(this.terminalWatcher.onTerminalExit(({ terminalId }) => {
+            if (terminalId === this.terminalId) {
+                this.title.label = "<terminated>";
+            }
+        }));
+        this.toDispose.push(this.toDisposeOnConnect);
+        this.toDispose.push(this.shellTerminalServer.onDidCloseConnection(() => {
+            const disposable = this.shellTerminalServer.onDidOpenConnection(() => {
+                disposable.dispose();
+                this.reconnectTerminalProcess();
+            });
+            this.toDispose.push(disposable);
+        }));
     }
 
     storeState(): object {
@@ -190,7 +210,7 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
 
     protected registerResize(): void {
         this.term.on('resize', size => {
-            if (this.terminalId === undefined) {
+            if (typeof this.terminalId !== "number") {
                 return;
             }
 
@@ -209,30 +229,32 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
      * new terminal widget.
      * If id is provided attach to the terminal for this id.
      */
-    public async start(id?: number): Promise<void> {
+    async start(id?: number): Promise<void> {
         await this.waitForResized.promise;
-        if (id === undefined) {
-            const root = await this.workspaceService.root;
-            const rootURI = root !== undefined ? root.uri : undefined;
-            this.terminalId = await this.shellTerminalServer.create(
-                { rootURI, cols: this.cols, rows: this.rows });
-        } else {
-            this.terminalId = await this.shellTerminalServer.attach(id);
+        this.terminalId = typeof id !== 'number' ? await this.createTerminal() : await this.attachTerminal(id);
+        if (typeof this.terminalId === "number") {
+            await this.doResize();
+            this.connectTerminalProcess();
         }
-
-        /* An error has occurred in the backend.  */
-        if (this.terminalId === -1 || this.terminalId === undefined) {
-            this.terminalId = undefined;
-            if (id === undefined) {
-                this.logger.error("Error creating terminal widget, see the backend error log for more information.  ");
-            } else {
-                this.logger.error(`Error attaching to terminal id ${id}, the terminal is most likely gone. Starting up a new terminal instead.  `);
-                this.start();
-            }
-            return;
+    }
+    protected async attachTerminal(id: number): Promise<number | undefined> {
+        const terminalId = await this.shellTerminalServer.attach(id);
+        if (IBaseTerminalServer.validateId(terminalId)) {
+            return terminalId;
         }
-        await this.doResize();
-        this.connectTerminalProcess(this.terminalId);
+        this.logger.error(`Error attaching to terminal id ${id}, the terminal is most likely gone. Starting up a new terminal instead.`);
+        return this.createTerminal();
+    }
+    protected async createTerminal(): Promise<number | undefined> {
+        const root = await this.workspaceService.root;
+        const rootURI = root && root.uri;
+        const { cols, rows } = this;
+        const terminalId = await this.shellTerminalServer.create({ rootURI, cols, rows });
+        if (IBaseTerminalServer.validateId(terminalId)) {
+            return terminalId;
+        }
+        this.logger.error("Error creating terminal widget, see the backend error log for more information.");
+        return undefined;
     }
 
     protected async openTerm(): Promise<void> {
@@ -307,41 +329,35 @@ export class TerminalWidget extends BaseWidget implements StatefulWidget {
         }, 50);
     }
 
-    protected connectTerminalProcess(id: number): void {
-        this.monitorTerminal(id);
-        this.connectSocket(id);
-    }
-
-    protected monitorTerminal(id: number) {
-        this.toDispose.push(this.terminalWatcher.onTerminalError((event: IBaseTerminalErrorEvent) => {
-            if (event.terminalId === id) {
-                this.title.label = "<terminal error>";
-            }
-        }));
-
-        this.toDispose.push(this.terminalWatcher.onTerminalExit((event: IBaseTerminalExitEvent) => {
-            if (event.terminalId === id) {
-                this.title.label = "<terminated>";
-            }
-        }));
-    }
-
-    protected connectSocket(id: number): void {
+    protected connectTerminalProcess(): void {
+        if (typeof this.terminalId !== "number") {
+            return;
+        }
+        this.toDisposeOnConnect.dispose();
         this.webSocketConnectionProvider.listen({
-            path: `${terminalsPath}/${id}`,
+            path: `${terminalsPath}/${this.terminalId}`,
             onConnection: connection => {
                 connection.onNotification('onData', (data: string) => this.term.write(data));
-                this.term.on('data', data => data && connection.sendRequest('write', data));
-                this.toDispose.push(connection);
+
+                const sendData = (data?: string) => data && connection.sendRequest('write', data);
+                this.term.on('data', sendData);
+                connection.onDispose(() => this.term.off('data', sendData));
+
+                this.toDisposeOnConnect.push(connection);
                 connection.listen();
             }
         }, { reconnecting: false });
+    }
+    protected async reconnectTerminalProcess(): Promise<void> {
+        if (typeof this.terminalId === "number") {
+            await this.start(this.terminalId);
+        }
     }
 
     dispose(): void {
         /* Close the backend terminal only when explicitly closing the terminal
          * a refresh for example won't close it.  */
-        if (this.closeOnDispose === true && this.terminalId !== undefined) {
+        if (this.closeOnDispose === true && typeof this.terminalId === "number") {
             this.shellTerminalServer.close(this.terminalId);
         }
         super.dispose();

--- a/packages/terminal/src/browser/xterm.d.ts
+++ b/packages/terminal/src/browser/xterm.d.ts
@@ -4,11 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
-module "xterm" {
+declare module "xterm" {
     export interface Terminal {
-        _initialized: boolean;
         fit(): void
         proposeGeometry(): { cols: number, rows: number }
-        attach(socket: WebSocket): void
     }
 }

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -15,6 +15,11 @@ export interface IBaseTerminalServer extends JsonRpcServer<IBaseTerminalClient> 
     attach(id: number): Promise<number>;
     close(id: number): Promise<void>;
 }
+export namespace IBaseTerminalServer {
+    export function validateId(id?: number): boolean {
+        return typeof id === "number" && id !== -1;
+    }
+}
 
 export interface IBaseTerminalExitEvent {
     terminalId: number;

--- a/packages/terminal/src/common/shell-terminal-protocol.ts
+++ b/packages/terminal/src/common/shell-terminal-protocol.ts
@@ -5,6 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+import { JsonRpcProxy } from '@theia/core';
 import { IBaseTerminalServer, IBaseTerminalServerOptions } from './base-terminal-protocol';
 
 export const IShellTerminalServer = Symbol('IShellTerminalServer');
@@ -20,3 +21,6 @@ export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions 
     cols?: number,
     rows?: number
 }
+
+export const ShellTerminalServerProxy = Symbol('ShellTerminalServerProxy');
+export type ShellTerminalServerProxy = JsonRpcProxy<IShellTerminalServer>;


### PR DESCRIPTION
This PR makes sure that terminals get restored on reconnection. #1775

There are 2 cases to consider: (1) the server is down and (2) the connection is lost. In the first case a new terminal process should be created, in the second case the original terminal process should be used.

**When testing don't use chrome dev tool!** It is not capable to throttle web socket connections. You need to do it on the system level. I use the Charles proxy: https://www.charlesproxy.com/. You can also try to switch wifi off.
