### PR TITLE
Task, process and terminal tests clean up

### DIFF
--- a/packages/core/src/node/messaging/test/test-web-socket-channel.ts
+++ b/packages/core/src/node/messaging/test/test-web-socket-channel.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as ws from 'ws';
+import * as http from 'http';
+import * as https from 'https';
+import { WebSocketChannel } from '../../../common/messaging/web-socket-channel';
+import { Disposable } from '../../../common/disposable';
+
+export class TestWebSocketChannel extends WebSocketChannel {
+
+    constructor({ server, path }: {
+        server: http.Server | https.Server,
+        path: string
+    }) {
+        super(0, content => socket.send(content));
+        const socket = new ws(`ws://localhost:${server.address().port}${WebSocketChannel.wsPath}`);
+        socket.on('error', error =>
+            this.fireError(error)
+        );
+        socket.on('close', (code, reason) =>
+            this.fireClose(code, reason)
+        );
+        socket.on('message', data =>
+            this.handleMessage(JSON.parse(data.toString()))
+        );
+        socket.on('open', () =>
+            this.open(path)
+        );
+        this.toDispose.push(Disposable.create(() => socket.close()));
+    }
+
+}

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -7,7 +7,7 @@
 import * as chai from 'chai';
 import * as process from 'process';
 import * as stream from 'stream';
-import { testContainer } from './inversify.spec-config';
+import { createProcessTestContainer } from './test/process-test-container';
 import { RawProcessFactory } from './raw-process';
 import * as temp from 'temp';
 import * as fs from 'fs';
@@ -25,7 +25,11 @@ const expect = chai.expect;
 describe('RawProcess', function () {
 
     this.timeout(5000);
-    const rawProcessFactory = testContainer.get<RawProcessFactory>(RawProcessFactory);
+    let rawProcessFactory: RawProcessFactory;
+
+    beforeEach(() => {
+        rawProcessFactory = createProcessTestContainer().get<RawProcessFactory>(RawProcessFactory);
+    });
 
     it('test error on non-existent path', async function () {
         const p = new Promise((resolve, reject) => {

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -7,7 +7,7 @@
 import * as chai from 'chai';
 import * as process from 'process';
 import * as stream from 'stream';
-import { testContainer } from './inversify.spec-config';
+import { createProcessTestContainer } from './test/process-test-container';
 import { TerminalProcessFactory } from './terminal-process';
 import { isWindows } from "@theia/core/lib/common";
 
@@ -20,7 +20,11 @@ const expect = chai.expect;
 describe('TerminalProcess', function () {
 
     this.timeout(5000);
-    const terminalProcessFactory = testContainer.get<TerminalProcessFactory>(TerminalProcessFactory);
+    let terminalProcessFactory: TerminalProcessFactory;
+
+    beforeEach(() => {
+        terminalProcessFactory = createProcessTestContainer().get<TerminalProcessFactory>(TerminalProcessFactory);
+    });
 
     it('test error on non existent path', async function () {
 

--- a/packages/process/src/node/test/process-test-container.ts
+++ b/packages/process/src/node/test/process-test-container.ts
@@ -6,11 +6,13 @@
  */
 import { Container } from 'inversify';
 import { loggerBackendModule } from '@theia/core/lib/node/logger-backend-module';
-import processBackendModule from './process-backend-module';
+import processBackendModule from '../process-backend-module';
 
-const testContainer = new Container();
+export function createProcessTestContainer() {
+    const testContainer = new Container();
 
-testContainer.load(loggerBackendModule);
-testContainer.load(processBackendModule);
+    testContainer.load(loggerBackendModule);
+    testContainer.load(processBackendModule);
 
-export { testContainer };
+    return testContainer;
+}

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { testContainer } from './test-resources/inversify.spec-config';
+import { createTaskTestContainer } from './test/task-test-container';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
 import { TaskExitedEvent, TaskInfo, TaskServer, TaskOptions, ProcessType } from '../common/task-protocol';
 import { TaskWatcher } from '../common/task-watcher';
@@ -17,6 +17,7 @@ import URI from "@theia/core/lib/common/uri";
 import { FileUri } from "@theia/core/lib/node";
 import { terminalsPath } from '@theia/terminal/lib/common/terminal-protocol';
 import { expectThrowsAsync } from '@theia/core/lib/common/test/expect';
+import { WebSocketChannel } from '@theia/core/lib/common/messaging/web-socket-channel';
 
 /**
  * Globals
@@ -40,19 +41,28 @@ const wsRoot: string = FileUri.fsPath(new URI(__dirname).resolve('test-resources
 
 describe('Task server / back-end', function () {
     this.timeout(10000);
+
     let server: http.Server | https.Server;
-
     let taskServer: TaskServer;
-    const taskWatcher = testContainer.get(TaskWatcher);
-    let application;
+    let taskWatcher: TaskWatcher;
 
-    before(async function () {
+    beforeEach(async () => {
         process.argv.push(`--root-dir=${wsRoot}`);
 
-        application = testContainer.get(BackendApplication);
+        const testContainer = createTaskTestContainer();
+        taskWatcher = testContainer.get(TaskWatcher);
         taskServer = testContainer.get(TaskServer);
-        taskServer.setClient(taskWatcher.getTaskClient());
-        server = await application.start();
+        taskServer!.setClient(taskWatcher.getTaskClient());
+        server = await testContainer.get(BackendApplication).start();
+    });
+
+    afterEach(() => {
+        process.argv.pop();
+        taskServer = undefined!;
+        taskWatcher = undefined!;
+        const s = server;
+        server = undefined!;
+        s.close();
     });
 
     it("task running in terminal - expected data is received from the terminal ws server", async function () {
@@ -69,9 +79,13 @@ describe('Task server / back-end', function () {
         const terminalId = taskInfo.terminalId;
 
         // hook-up to terminal's ws and confirm that it outputs expected tasks' output
-        const p = new Promise((resolve, reject) => {
-            const socket = new ws(`ws://localhost:${server.address().port}${terminalsPath}/${terminalId}`);
-            socket.on('message', msg => {
+        await new Promise((resolve, reject) => {
+            const socket = new ws(`ws://localhost:${server.address().port}/services`);
+            socket.on('error', reject);
+            socket.on('close', (code, reason) => reject(`socket is closed with '${code}' code and '${reason}' reason`));
+
+            const channel = new WebSocketChannel(0, content => socket.send(content));
+            channel.onMessage(msg => {
                 // check output of task on terminal is what we expect
                 const expected = `tasking... ${someString}`;
                 if (msg.toString().indexOf(expected) !== -1) {
@@ -79,15 +93,15 @@ describe('Task server / back-end', function () {
                 } else {
                     reject(`expected sub-string not found in terminal output. Expected: "${expected}" vs Actual: "${msg.toString()}"`);
                 }
-
                 socket.close();
             });
-            socket.on('error', error => {
-                reject(error);
-            });
+            socket.on('message', data =>
+                channel.handleMessage(JSON.parse(data.toString()))
+            );
+            socket.on('open', () =>
+                channel.open(`${terminalsPath}/${terminalId}`)
+            );
         });
-
-        await p;
     });
 
     it("task using raw process - task server success response shall not contain a terminal id", async function () {

--- a/packages/task/src/node/test/task-test-container.ts
+++ b/packages/task/src/node/test/task-test-container.ts
@@ -12,15 +12,19 @@ import terminalBackendModule from '@theia/terminal/lib/node/terminal-backend-mod
 import taskBackendModule from '../task-backend-module';
 import filesystemBackendModule from '@theia/filesystem/lib/node/filesystem-backend-module';
 import workspaceServer from '@theia/workspace/lib/node/workspace-backend-module';
+import { messagingBackendModule } from '@theia/core/lib/node/messaging/messaging-backend-module';
 
-const testContainer = new Container();
+export function createTaskTestContainer(): Container {
+    const testContainer = new Container();
 
-testContainer.load(backendApplicationModule);
-testContainer.load(loggerBackendModule);
-testContainer.load(processBackendModule);
-testContainer.load(taskBackendModule);
-testContainer.load(filesystemBackendModule);
-testContainer.load(workspaceServer);
-testContainer.load(terminalBackendModule);
+    testContainer.load(backendApplicationModule);
+    testContainer.load(loggerBackendModule);
+    testContainer.load(messagingBackendModule);
+    testContainer.load(processBackendModule);
+    testContainer.load(taskBackendModule);
+    testContainer.load(filesystemBackendModule);
+    testContainer.load(workspaceServer);
+    testContainer.load(terminalBackendModule);
 
-export { testContainer };
+    return testContainer;
+}

--- a/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.slow-spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -7,12 +7,11 @@
 
 import { createTerminalTestContainer } from './test/terminal-test-container';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
-import { WebSocketChannel } from '@theia/core/lib/common/messaging/web-socket-channel';
 import { IShellTerminalServer } from '../common/shell-terminal-protocol';
-import * as ws from 'ws';
 import * as http from 'http';
 import * as https from 'https';
 import { terminalsPath } from '../common/terminal-protocol';
+import { TestWebSocketChannel } from '@theia/core/lib/node/messaging/test/test-web-socket-channel';
 
 describe('Terminal Backend Contribution', function () {
 
@@ -27,24 +26,23 @@ describe('Terminal Backend Contribution', function () {
         server = await application.start();
     });
 
+    afterEach(() => {
+        const s = server;
+        server = undefined!;
+        shellTerminalServer = undefined!;
+        s.close();
+    });
+
     it("is data received from the terminal ws server", async () => {
         const terminalId = await shellTerminalServer.create({});
         await new Promise((resolve, reject) => {
-            const socket = new ws(`ws://localhost:${server.address().port}/services`);
-            socket.on('error', reject);
-            socket.on('close', (code, reason) => reject(`socket is closed with '${code}' code and '${reason}' reason`));
-
-            const channel = new WebSocketChannel(0, content => socket.send(content));
+            const channel = new TestWebSocketChannel({ server, path: `${terminalsPath}/${terminalId}` });
+            channel.onError(reject);
+            channel.onClose((code, reason) => reject(`channel is closed with '${code}' code and '${reason}' reason`));
             channel.onOpen(() => {
                 resolve();
-                socket.close();
+                channel.dispose();
             });
-            socket.on('message', data =>
-                channel.handleMessage(JSON.parse(data.toString()))
-            );
-            socket.on('open', () =>
-                channel.open(`${terminalsPath}/${terminalId}`)
-            );
         });
     });
 });


### PR DESCRIPTION
This PR:
- fixes #1784 
- make sure that task, process and terminal tests run with isolated containers and clean up after themselves