### PR TITLE
Removed dependency to @types/perfect-scrollbar

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,6 @@
     "@types/express": "^4.0.36",
     "@types/lodash.debounce": "4.0.3",
     "@types/lodash.throttle": "^4.1.3",
-    "@types/perfect-scrollbar": "^1.3.0",
     "@types/route-parser": "^0.1.1",
     "@types/ws": "^3.0.2",
     "@types/yargs": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,12 +257,6 @@
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.0.tgz#f5d649cc49af8ed6507d15dc6e9b43fe8b927540"
 
-"@types/perfect-scrollbar@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/perfect-scrollbar/-/perfect-scrollbar-1.3.0.tgz#3db3f5564ad31399ac90ad78906aedc511ea00b1"
-  dependencies:
-    perfect-scrollbar "*"
-
 "@types/request@^2.0.3":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.0.9.tgz#125b8a60d8a439e8d87e6d1335c61cccdc18343a"
@@ -7258,7 +7252,7 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
-perfect-scrollbar@*, perfect-scrollbar@^1.3.0:
+perfect-scrollbar@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.3.0.tgz#61da56f94b58870d8e0a617bce649cee17d1e3b2"
 


### PR DESCRIPTION
Fixes #1617. The typings are included in the perfect-scrollbar package.