### PR TITLE
CHE-9525 add modal notifications

### DIFF
--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -26,6 +26,7 @@ export interface Message {
 
 export interface MessageOptions {
     timeout?: number;
+    modal?: boolean;
 }
 
 @injectable()

--- a/packages/messages/src/browser/modal-notification.ts
+++ b/packages/messages/src/browser/modal-notification.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {injectable, inject} from 'inversify';
+import {Message} from '@phosphor/messaging';
+import {AbstractDialog} from '@theia/core/lib/browser/dialogs';
+import {NOTIFICATION, ICON, TEXT, Notification, NotificationProperties, NotificationAction} from './notifications';
+
+@injectable()
+export class ModalNotificationsProps implements NotificationProperties {
+    icon: string;
+    text: string;
+    actions?: NotificationAction[];
+    timeout: number | undefined;
+}
+
+export class ModalNotification extends AbstractDialog<boolean> {
+
+    protected confirmed = true;
+
+    constructor(@inject(ModalNotificationsProps) protected readonly properties: ModalNotificationsProps) {
+        super({title: 'Theia'});
+        this.contentNode.appendChild(this.createMessageNode(properties));
+    }
+
+    protected onCloseRequest(msg: Message): void {
+        this.confirmed = false;
+        this.accept();
+    }
+
+    get value(): boolean {
+        return this.confirmed;
+    }
+
+    protected createMessageNode(properties: NotificationProperties): HTMLElement {
+        const messageNode = document.createElement('div');
+        messageNode.classList.add(NOTIFICATION);
+
+        const iconContainer = messageNode.appendChild(document.createElement('div'));
+        iconContainer.classList.add(ICON);
+        const icon = iconContainer.appendChild(document.createElement('i'));
+        icon.classList.add('fa', this.toIconClass(properties.icon), 'fa-fw', properties.icon);
+
+        const textContainer = messageNode.appendChild(document.createElement('div'));
+        textContainer.textContent = properties.text;
+        textContainer.classList.add(TEXT);
+
+        if (!properties.actions) {
+            this.appendCloseButton();
+            return messageNode;
+        }
+
+        const handler = <Notification>{element: messageNode, properties};
+
+        properties.actions.forEach((action: NotificationAction) => {
+            const button = this.createButton(action.label);
+            button.classList.add(this.toButtonClass(action));
+            this.controlPanel.appendChild(button);
+            button.addEventListener('click', () => {
+                action.fn(handler);
+            });
+
+            this.addAcceptAction(button, 'click');
+        });
+
+        return messageNode;
+    }
+
+    protected toIconClass(icon: string): string {
+        if (icon === 'error') {
+            return 'fa-times-circle';
+        }
+        if (icon === 'warning') {
+            return 'fa-warning';
+        }
+        return 'fa-info-circle';
+    }
+
+    protected toButtonClass(action: NotificationAction): string {
+        const label = action.label.toLowerCase();
+        if (label === 'close' || label === 'cancel') {
+            return 'secondary';
+        }
+        return 'main';
+    }
+}

--- a/packages/messages/src/browser/notifications-message-client.ts
+++ b/packages/messages/src/browser/notifications-message-client.ts
@@ -12,7 +12,8 @@ import {
     Message
 } from '@theia/core/lib/common';
 import { Notifications, NotificationAction } from './notifications';
-import { NotificationPreferences } from "./notification-preferences";
+import { NotificationPreferences } from './notification-preferences';
+import { ModalNotification } from './modal-notification';
 
 @injectable()
 export class NotificationsMessageClient extends MessageClient {
@@ -47,12 +48,27 @@ export class NotificationsMessageClient extends MessageClient {
             label: 'Close',
             fn: element => onCloseFn(undefined)
         });
-        this.notifications.show({
-            icon,
-            text,
-            actions,
-            timeout
-        });
+
+        if (message.options && message.options.modal) {
+            const modalNotification = new ModalNotification({
+                icon,
+                text,
+                actions,
+                timeout
+            });
+            modalNotification.open().then((confirmed: boolean) => {
+                if (!confirmed) {
+                    onCloseFn(undefined);
+                }
+            });
+        } else {
+            this.notifications.show({
+                icon,
+                text,
+                actions,
+                timeout
+            });
+        }
     }
 
     protected iconFor(type: MessageType): string {

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -46,11 +46,22 @@
     color: var(--theia-ui-dialog-font-color);
 }
 
+.dialogContent .theia-Notification {
+    min-width: inherit;
+    box-shadow: none;
+    animation: none;
+}
+
 .theia-Notification .icon {
     display: inline-block;
     width: 35px;
     order: 1;
     padding: 10px 15px;
+}
+
+.dialogContent .theia-Notification .icon {
+    font-size: 20px;
+    padding: 5px 0;
 }
 
 .theia-Notification .icon .fa {


### PR DESCRIPTION
Add modal notifications.
It needs to realize for API for https://github.com/theia-ide/theia/issues/1482
This modal notification message optionally provide an array of items which will be presented as clickable buttons and can be shown using the **warn**,
**info** and **error** functions in **MessageService**.

Simple example that show a modal information message:
```
messageService.info('Information message', { modal: true });
```
Simple example that show a modal information message with buttons:

```
messageService.info('Information message', { modal: true }, 'Btn1', 'Btn2').then(result => {
    console.log("Click button", result);
});
```

![selection_141](https://user-images.githubusercontent.com/6310786/39586374-9162c19e-4eff-11e8-9711-e98474c09934.png)
![selection_148](https://user-images.githubusercontent.com/6310786/39586443-ba21bdc4-4eff-11e8-9f69-299bf69f73ca.png)
![selection_154](https://user-images.githubusercontent.com/6310786/39586502-e2982eb4-4eff-11e8-8c69-5c1a06e470a3.png)
Both kind of notifications with buttons:
![selection_136](https://user-images.githubusercontent.com/6310786/39585642-f7e521de-4efd-11e8-91dc-866f5ba80685.png)

Signed-off-by: Oleksii Orel <oorel@redhat.com>