### PR TITLE
issue #1830 Navigator doesn't show new file added initially.

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -128,6 +128,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
             return undefined;
         }
         try {
+            if (uri && uri.endsWith("/")) {
+                uri = uri.slice(0, -1);
+            }
             const fileStat = await this.fileSystem.getFileStat(uri);
             if (!fileStat) {
                 return undefined;


### PR DESCRIPTION
The FileNavigator is not showin  the workspace folder name when the workspace ends with a "/"
This prevent the Fs-watcher to kick-in when creating a new file, the file doesn't show in the naigator even the fs-watcher for the file in the editor works, but the file doesn't show in the navigator until you open the workspace a second time
This also prevent to display the name of the workspace since the labelProvider shows the name after the last "/"

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>