### PR TITLE
[travis] adding missing node_module directories to cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
   - packages/callhierarchy/node_modules
   - packages/core/node_modules
   - packages/cpp/node_modules
+  - packages/editorconfig/node_modules
   - packages/editor/node_modules
   - packages/extension-manager/node_modules
   - packages/file-search/node_modules
@@ -28,6 +29,7 @@ cache:
   - packages/merge-conflicts/node_modules
   - packages/messages/node_modules
   - packages/metrics/node_modules
+  - packages/mini-browser/node_modules
   - packages/monaco/node_modules
   - packages/navigator/node_modules
   - packages/outline-view/node_modules


### PR DESCRIPTION
A couple of recent extension's node_module directories were missing
from the cache section of the travis config, potentially making the
Travis CI builds somewhat slower. This commit adds them.