### PR TITLE
Add ability to toggle hidden files in navigator

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -14,11 +14,16 @@ import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-comman
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorPreferences } from "./navigator-preferences";
 import { NavigatorKeybindingContexts } from './navigator-keybinding-context';
+import { FileNavigatorFilter } from "./navigator-filter";
 
 export namespace FileNavigatorCommands {
     export const REVEAL_IN_NAVIGATOR = {
         id: 'navigator.reveal',
         label: 'Reveal in Files'
+    };
+    export const TOGGLE_HIDDEN_FILES = {
+        id: 'navigator.toggle.hidden.files',
+        label: 'Toggle Hidden Files'
     };
 }
 
@@ -38,7 +43,8 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     constructor(
         @inject(FileNavigatorPreferences) protected readonly fileNavigatorPreferences: FileNavigatorPreferences,
-        @inject(OpenerService) protected readonly openerService: OpenerService
+        @inject(OpenerService) protected readonly openerService: OpenerService,
+        @inject(FileNavigatorFilter) protected readonly fileNavigatorFilter: FileNavigatorFilter
     ) {
         super({
             widgetId: FILE_NAVIGATOR_ID,
@@ -64,6 +70,13 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             execute: () => this.openView({ activate: true }).then(() => this.selectWidgetFileNode(this.shell.currentWidget)),
             isEnabled: () => Navigatable.is(this.shell.currentWidget),
             isVisible: () => Navigatable.is(this.shell.currentWidget)
+        });
+        registry.registerCommand(FileNavigatorCommands.TOGGLE_HIDDEN_FILES, {
+            execute: () => {
+                this.fileNavigatorFilter.toggleHiddenFiles();
+            },
+            isEnabled: () => true,
+            isVisible: () => true
         });
     }
 
@@ -140,6 +153,12 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_RENAME.id,
             keybinding: "f2",
+            context: NavigatorKeybindingContexts.navigatorActive
+        });
+
+        registry.registerKeybinding({
+            command: FileNavigatorCommands.TOGGLE_HIDDEN_FILES.id,
+            keybinding: "ctrlcmd+i",
             context: NavigatorKeybindingContexts.navigatorActive
         });
     }

--- a/packages/navigator/src/browser/navigator-filter.ts
+++ b/packages/navigator/src/browser/navigator-filter.ts
@@ -23,6 +23,8 @@ export class FileNavigatorFilter {
 
     protected filterPredicate: FileNavigatorFilter.Predicate;
 
+    protected showHiddenFiles: boolean;
+
     constructor(@inject(FileNavigatorPreferences) protected readonly preferences: FileNavigatorPreferences) {
         this.emitter = new Emitter<void>();
         this.filterPredicate = this.createFilterPredicate(this.preferences['navigator.exclude']);
@@ -58,7 +60,20 @@ export class FileNavigatorFilter {
     }
 
     protected createFilterPredicate(exclusions: FileNavigatorFilter.Exclusions): FileNavigatorFilter.Predicate {
-        return new FileNavigatorFilterPredicate(exclusions);
+        return new FileNavigatorFilterPredicate(this.interceptExclusions(exclusions));
+    }
+
+    toggleHiddenFiles(): void {
+        this.showHiddenFiles = !this.showHiddenFiles;
+        this.filterPredicate = this.createFilterPredicate(this.preferences['navigator.exclude'] || {});
+        this.fireFilterChanged();
+    }
+
+    protected interceptExclusions(exclusions: FileNavigatorFilter.Exclusions): FileNavigatorFilter.Exclusions {
+        return {
+            ...exclusions,
+            '**/.*': this.showHiddenFiles
+        };
     }
 
 }


### PR DESCRIPTION
This changes proposal adds an ability to toggle hidden files in Theia by provided command and key binding: `i` (in navigator context). Atom editor also provides key binding `i` for this operation.

![toggle_hidden_files](https://user-images.githubusercontent.com/1968177/39662935-a3858edc-5072-11e8-92b5-631ec8a20f5c.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>