### PR TITLE
[git-history] Wait for open-handlers to process the requested URI

### DIFF
--- a/packages/core/src/browser/opener-service.ts
+++ b/packages/core/src/browser/opener-service.ts
@@ -94,9 +94,9 @@ export class DefaultOpenerService implements OpenerService {
     }
 
     protected async prioritize(uri: URI, options?: OpenerOptions): Promise<OpenHandler[]> {
-        const prioritized = await Prioritizeable.prioritizeAll(this.getHandlers(), handler => {
+        const prioritized = await Prioritizeable.prioritizeAll(this.getHandlers(), async handler => {
             try {
-                return handler.canHandle(uri, options);
+                return await handler.canHandle(uri, options);
             } catch {
                 return 0;
             }

--- a/packages/git/src/browser/history/git-history-widget.ts
+++ b/packages/git/src/browser/history/git-history-widget.ts
@@ -64,7 +64,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         (async () => {
             const sc = await this.getScrollContainer();
             const listener = (e: UIEvent) => {
-                const el = (e.srcElement as HTMLElement);
+                const el = (e.srcElement || e.target) as HTMLElement;
                 if (el.scrollTop + el.clientHeight > el.scrollHeight - 83) {
                     const ll = this.node.getElementsByClassName('history-lazy-loading')[0];
                     ll.className = "history-lazy-loading show";


### PR DESCRIPTION
Fixes #1843

Also fixes a compatibility problem with Firefox, see: https://developer.mozilla.org/fr/docs/Web/API/Event/srcElement

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>