### PR TITLE
Workaround for broken `Refactor` keybinding

### DIFF
--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -34,7 +34,12 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             if (command) {
                 const raw = item.keybinding;
                 if (raw.type === monaco.keybindings.KeybindingType.Simple) {
-                    const keybinding = raw as monaco.keybindings.SimpleKeybinding;
+                    let keybinding = raw as monaco.keybindings.SimpleKeybinding;
+                    if (command === 'monaco.editor.action.refactor') {
+                        // todo: remove the temporary workaround after updating to monaco 0.13.x
+                        // see: https://github.com/Microsoft/vscode/issues/49225
+                        keybinding = this.fixRefactorKeybinding(keybinding);
+                    }
                     registry.registerKeybinding({
                         command,
                         keybinding: this.keyCode(keybinding).toString(),
@@ -55,6 +60,14 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                 context: EditorKeybindingContexts.editorTextFocus
             });
         }
+    }
+
+    // todo: remove the temporary workaround after updating to monaco 0.13.x
+    protected fixRefactorKeybinding(original: monaco.keybindings.SimpleKeybinding): monaco.keybindings.SimpleKeybinding {
+        if (monaco.platform.OS !== monaco.platform.OperatingSystem.Macintosh) {
+            return { ...original, ctrlKey: true, metaKey: false };
+        }
+        return original;
     }
 
     protected keyCode(keybinding: monaco.keybindings.SimpleKeybinding): KeyCode {


### PR DESCRIPTION
On Win/Lin capital `R` will be blocked by a conflict with the broken `Refactor` keybinding. 

This is a bug in monaco 0.12.0 and might be fixed with next release, for sure it is already fixed in vscode, cf. https://github.com/Microsoft/monaco-editor/issues/865.

This PR adds a dirty workaround by patching the modifiers for the broken `Refactor` binding in `monaco-keybinding.ts`. It is meant to be a temporary fix, and it should not have other side effects. 

I've tested by switching the user-agent on mac, but it would be nice to verify that on the affected platforms, too.

Closes #1866