### PR TITLE
 [core/cluster] Try to close each process gracefully

### DIFF
--- a/packages/core/src/node/cluster.spec.ts
+++ b/packages/core/src/node/cluster.spec.ts
@@ -50,7 +50,7 @@ describe('master-process', () => {
         const master = new MasterProcess();
 
         prepareTestWorker('restart');
-        const restartWorker = master.start();
+        const restartWorker = await master.start();
 
         prepareTestWorker('timeout next worker');
         await master.restarting;

--- a/packages/core/src/node/cluster/main.ts
+++ b/packages/core/src/node/cluster/main.ts
@@ -36,6 +36,10 @@ export interface Address {
 export async function start(serverPath: string): Promise<Address> {
     if (isMaster) {
         const master = new MasterProcess();
+        master.on('exit', () =>
+            Object.keys(cluster.workers).length === 0
+            && process.exit(0)
+        );
         return master.start().listening;
     }
     const server = await require(serverPath)();

--- a/packages/core/src/node/cluster/server-worker.ts
+++ b/packages/core/src/node/cluster/server-worker.ts
@@ -19,7 +19,7 @@ export class ServerWorker {
     readonly listening: Promise<cluster.Address>;
     readonly initialized: Promise<void>;
     readonly disconnect: Promise<void>;
-    readonly exit: Promise<string>;
+    readonly exit: Promise<number>;
 
     constructor(restart: () => Promise<void>) {
         let onDidInitialize: () => void = () => { };

--- a/packages/core/src/node/test/cluster-test-worker.ts
+++ b/packages/core/src/node/test/cluster-test-worker.ts
@@ -15,9 +15,9 @@ const jobs: { [id: string]: (() => Promise<void>) | undefined } = {
         try {
             await server.restart();
             firstRestartFailed = false;
-        } catch (e) {
-            if ((e as Error).message.indexOf('failed to restart') === -1) {
-                throw e;
+        } catch (error) {
+            if (!/failed to start/.test(error.message)) {
+                throw error;
             }
         }
         if (firstRestartFailed) {


### PR DESCRIPTION
When the backend closes, processes spawned when running in cluster mode don't always close properly, making the terminal where Theia was started hang.
Cause can be unfulfilled promises keeping the event-loop alive.

Solution was to make sure that in case an error happens, it is detected and call `process.exit()`.

Fixes #1883

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>