### PR TITLE
[travis] Add the yarn --verbose flag for publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ jobs:
       - yarn
     deploy:
       provider: script
-      script: yarn run publish:next
+      script: yarn run publish:next --loglevel verbose
       on:
         branch: master
       skip_cleanup: true


### PR DESCRIPTION
This might help troubleshooting issue #1856, where the publish of next
version fails without details.