### PR TITLE
Few improvements in editor API and URI class

### DIFF
--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -176,4 +176,16 @@ export default class URI {
         return this.codeUri.toString(skipEncoding);
     }
 
+    static revive(data: UriComponents): URI {
+        return new URI(Uri.revive(data));
+    }
+
+}
+
+export interface UriComponents {
+    scheme?: string;
+    authority?: string;
+    path?: string;
+    query?: string;
+    fragment?: string;
 }

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -55,6 +55,11 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     selection: Range;
     readonly onSelectionChanged: Event<Range>;
 
+    /**
+     * Get a unique id for this editor instance
+     */
+    getId(): string;
+
     focus(): void;
     blur(): void;
     isFocused(): boolean;

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -150,6 +150,14 @@ export class MonacoEditor implements TextEditor, IEditorReference {
         return this.onSelectionChangedEmitter.event;
     }
 
+    getId(): string {
+        return this.editor.getId();
+    }
+
+    getModel(): monaco.editor.IModel {
+        return this.editor.getModel();
+    }
+
     revealPosition(raw: Position, options: RevealPositionOptions = { vertical: 'center' }): void {
         const position = this.p2m.asPosition(raw);
         switch (options.vertical) {

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -43,6 +43,10 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
         return this._models.onDidCreate;
     }
 
+    get onWillDispose(): Event<MonacoEditorModel> {
+        return this._models.onWillDispose;
+    }
+
     createModelReference(raw: monaco.Uri | URI): monaco.Promise<monaco.editor.IReference<MonacoEditorModel>> {
         return monaco.Promise.wrap(this._models.acquire(raw.toString()));
     }


### PR DESCRIPTION
Basically this pull request do:

- add `getId` method to the Editor interface and implementation in MonacoEditor that delegates to Monaco `getId` method
- add `revive` method to URI class and `UriComponents` interface, which represent URI in structured way and used to pass URI to new plugin model
- add access to Monaco `IModel` interface in `MonacoEditor` class
- add `onWillDispose` event in `MonacoTextModelService`

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>