### PR TITLE
Made the navigator search box reusable by other widgets

### DIFF
--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -16,7 +16,7 @@ import { bindFileNavigatorPreferences } from './navigator-preferences';
 import { FileNavigatorFilter } from './navigator-filter';
 import { FuzzySearch } from './fuzzy-search';
 import { SearchBox, SearchBoxProps, SearchBoxFactory } from './search-box';
-import { SearchBoxDebounce, SearchBoxDebounceOptions } from './search-box-debounce';
+import { SearchBoxDebounce } from './search-box-debounce';
 import '../../src/browser/style/index.css';
 
 export default new ContainerModule(bind => {
@@ -28,16 +28,10 @@ export default new ContainerModule(bind => {
     bind(KeybindingContext).to(NavigatorActiveContext).inSingletonScope();
 
     bind(FuzzySearch).toSelf().inSingletonScope();
-    bind(SearchBoxDebounceOptions).toConstantValue(SearchBoxDebounceOptions.DEFAULT);
-    bind(SearchBoxDebounce).toSelf();
-    bind(SearchBox).toSelf();
     bind(SearchBoxFactory).toFactory(context =>
-        (props: SearchBoxProps) => {
-            const { container } = context;
-            const { delay } = props;
-            container.bind(SearchBoxDebounceOptions).toConstantValue({ delay });
-            container.bind(SearchBoxProps).toConstantValue(props);
-            return container.get(SearchBox);
+        (options: SearchBoxProps) => {
+            const debounce = new SearchBoxDebounce(options);
+            return new SearchBox(options, debounce);
         }
     );
 

--- a/packages/navigator/src/browser/search-box-debounce.ts
+++ b/packages/navigator/src/browser/search-box-debounce.ts
@@ -5,7 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { inject, injectable } from 'inversify';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { debounce } from 'throttle-debounce';
@@ -13,8 +12,7 @@ import { debounce } from 'throttle-debounce';
 /**
  * Options for the search term debounce.
  */
-@injectable()
-export class SearchBoxDebounceOptions {
+export interface SearchBoxDebounceOptions {
 
     /**
      * The delay (in milliseconds) before the debounce notifies clients about its content change.
@@ -37,7 +35,6 @@ export namespace SearchBoxDebounceOptions {
 /**
  * It notifies the clients, once if the underlying search term has changed after a given amount of delay.
  */
-@injectable()
 export class SearchBoxDebounce implements Disposable {
 
     protected readonly disposables = new DisposableCollection();
@@ -46,7 +43,7 @@ export class SearchBoxDebounce implements Disposable {
 
     protected state: string | undefined;
 
-    constructor(@inject(SearchBoxDebounceOptions) protected readonly options: SearchBoxDebounceOptions) {
+    constructor(protected readonly options: SearchBoxDebounceOptions) {
         this.disposables.push(this.emitter);
         this.handler = debounce(this.options.delay, () => this.fireChanged(this.state)).bind(this);
     }

--- a/packages/navigator/src/browser/search-box.ts
+++ b/packages/navigator/src/browser/search-box.ts
@@ -5,22 +5,15 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { inject, injectable } from 'inversify';
 import { KeyCode, Key } from '@theia/core/lib/browser';
 import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
 import { Event, Emitter } from '@theia/core/lib/common/event';
-import { SearchBoxDebounce } from './search-box-debounce';
+import { SearchBoxDebounce, SearchBoxDebounceOptions } from './search-box-debounce';
 
 /**
  * Initializer properties for the search box widget.
  */
-@injectable()
-export class SearchBoxProps {
-
-    /**
-     * Debounce delay (in milliseconds) that is used before notifying clients about search data updates.
-     */
-    readonly delay: number;
+export interface SearchBoxProps extends SearchBoxDebounceOptions {
 
     /**
      * If `true`, the `Previous`, `Next`, and `Clone` buttons will be visible. Otherwise, `false`. Defaults to `false`.
@@ -34,16 +27,13 @@ export namespace SearchBoxProps {
     /**
      * The default search box widget option.
      */
-    export const DEFAULT: SearchBoxProps = {
-        delay: 50
-    };
+    export const DEFAULT: SearchBoxProps = SearchBoxDebounceOptions.DEFAULT;
 
 }
 
 /**
  * The search box widget.
  */
-@injectable()
 export class SearchBox extends BaseWidget {
 
     private static SPECIAL_KEYS = [
@@ -57,9 +47,8 @@ export class SearchBox extends BaseWidget {
     protected readonly textChangeEmitter = new Emitter<string | undefined>();
     protected readonly input: HTMLInputElement;
 
-    constructor(
-        @inject(SearchBoxProps) protected readonly props: SearchBoxProps,
-        @inject(SearchBoxDebounce) protected readonly debounce: SearchBoxDebounce) {
+    constructor(protected readonly props: SearchBoxProps,
+        protected readonly debounce: SearchBoxDebounce) {
 
         super();
         this.toDispose.pushAll([


### PR DESCRIPTION
The way the navigator search box is configured in the Inversify container module does not allow it to be created more than once. This PR changes the search box factory so it can be called arbitrarily often.