### PR TITLE
align logger with console api + support errors logging for all levels

### DIFF
--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -14,7 +14,7 @@ export const loggerPath = '/services/logger';
 export interface ILoggerServer extends JsonRpcServer<ILoggerClient> {
     setLogLevel(name: string, logLevel: number): Promise<void>;
     getLogLevel(name: string): Promise<number>;
-    log(name: string, logLevel: number, message: string, params: any[]): Promise<void>;
+    log(name: string, logLevel: number, message: any, params: any[]): Promise<void>;
     child(name: string): Promise<void>;
 }
 

--- a/packages/core/src/node/bunyan-logger-server.ts
+++ b/packages/core/src/node/bunyan-logger-server.ts
@@ -134,7 +134,7 @@ export class BunyanLoggerServer implements ILoggerServer {
     }
 
     /* Log a message to a logger.  */
-    log(name: string, logLevel: number, message: string, params: any[]): Promise<void> {
+    log(name: string, logLevel: number, message: any, params: any[]): Promise<void> {
         const logger = this.loggers.get(name);
         if (logger === undefined) {
             throw new Error(`No logger named ${name}.`);


### PR DESCRIPTION
I've noticed that frontend errors are logged properly on the backend only in some cases, for example when an error logged as a warning there is no stacktrace. This PR makes sure that there are properly logged in all cases.