### PR TITLE
Catch exception when cleaning up search-in-workspace test dir

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -124,7 +124,11 @@ beforeEach(() => {
 });
 
 after(() => {
-    track.cleanupSync();
+    try {
+        track.cleanupSync();
+    } catch (ex) {
+        console.log("Couldn't cleanup search-in-workspace temp directory.", ex);
+    }
 });
 
 // Compare expected and actual search results.


### PR DESCRIPTION
On Windows (e.g. Appveyor), we get this error:

     Error: ENOTEMPTY: directory not empty, rmdir 'C:\Users\appveyor\AppData\Local\Temp\1\d-118418-5080-twp95u.rw1e'
      at Object.fs.rmdirSync (fs.js:846:18)
      at rmkidsSync (C:\projects\theia\node_modules\temp\node_modules\rimraf\rimraf.js:247:11)
      at rmdirSync (C:\projects\theia\node_modules\temp\node_modules\rimraf\rimraf.js:237:7)
      at fixWinEPERMSync (C:\projects\theia\node_modules\temp\node_modules\rimraf\rimraf.js:150:5)
      at rimrafSync (C:\projects\theia\node_modules\temp\node_modules\rimraf\rimraf.js:216:26)
      at cleanupDirsSync (C:\projects\theia\node_modules\temp\lib\temp.js:143:5)
      at Object.cleanupSync (C:\projects\theia\node_modules\temp\lib\temp.js:196:19)
      at Context.<anonymous> (src\node\ripgrep-search-in-workspace-server.slow-spec.ts:127:11)

rimraf fails to delete the temporary directory.  When I manually look in
the directory after the test runs, it is empty.  If I add a
fs.readdirSync in the catch clause though, I can somtimes see that there
is still the 'lots-of-matches' file present (it probably depends on the
timing).  This might be a bug in rimraf.  In any case, failing to remove
the test directory should not fail the test, that's why I opted to catch
the error and just log the error.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>