### PR TITLE
add a possibility to set an entry color for each status bar item

### DIFF
--- a/packages/core/src/browser/status-bar/status-bar.ts
+++ b/packages/core/src/browser/status-bar/status-bar.ts
@@ -7,7 +7,7 @@
 
 import { VirtualRenderer, VirtualWidget } from '../widgets';
 import { CommandService } from '../../common';
-import { h } from '@phosphor/virtualdom';
+import { h , ElementInlineStyle } from '@phosphor/virtualdom';
 import { LabelParser, LabelIcon } from '../label-parser';
 import { injectable, inject } from 'inversify';
 import { FrontendApplicationStateService } from '../frontend-application-state';
@@ -26,6 +26,7 @@ export interface StatusBarEntry {
      */
     text: string;
     alignment: StatusBarAlignment;
+    color?: string;
     tooltip?: string;
     command?: string;
     // tslint:disable-next-line:no-any
@@ -38,6 +39,7 @@ export enum StatusBarAlignment {
 }
 
 export interface StatusBarEntryAttributes {
+    style?: ElementInlineStyle;
     className?: string;
     title?: string;
     onclick?: () => void;
@@ -135,6 +137,12 @@ export class StatusBarImpl extends VirtualWidget implements StatusBar {
 
         if (entry.tooltip) {
             attrs.title = entry.tooltip;
+        }
+
+        if (entry.color) {
+            attrs.style = {
+                color: entry.color
+            };
         }
 
         return attrs;


### PR DESCRIPTION
Add a possibility to set an entry color for each status bar item.
It needs to realize for API for https://github.com/theia-ide/theia/issues/1482

We can change the background color for the status bar, but sometimes it hard to read:
![selection_005](https://user-images.githubusercontent.com/6310786/40365052-6d5aa398-5ddc-11e8-973e-3e7a3af318df.png)

A sample with a custom  color for status bar item:
![selection_004](https://user-images.githubusercontent.com/6310786/40365306-e78984f4-5ddc-11e8-9f61-ad610afb911d.png)

Signed-off-by: Oleksii Orel <oorel@redhat.com>