### PR TITLE
Rename CppClientContribution to CppLanguageClientContribution

### DIFF
--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -10,7 +10,7 @@ import { SelectionService } from '@theia/core/lib/common';
 import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common';
 import URI from "@theia/core/lib/common/uri";
 import { open, OpenerService } from '@theia/core/lib/browser';
-import { CppClientContribution } from "./cpp-client-contribution";
+import { CppLanguageClientContribution } from "./cpp-language-client-contribution";
 import { SwitchSourceHeaderRequest } from "./cpp-protocol";
 import { TextDocumentIdentifier } from "@theia/languages/lib/common";
 import { EditorManager } from "@theia/editor/lib/browser";
@@ -40,7 +40,7 @@ export function editorContainsCppFiles(editorManager: EditorManager | undefined)
 export class CppCommandContribution implements CommandContribution {
 
     constructor(
-        @inject(CppClientContribution) protected readonly clientContribution: CppClientContribution,
+        @inject(CppLanguageClientContribution) protected readonly clientContribution: CppLanguageClientContribution,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(EditorManager) private editorService: EditorManager,
         protected readonly selectionService: SelectionService

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -11,7 +11,7 @@ import { KeybindingContribution, KeybindingContext } from '@theia/core/lib/brows
 import { CppCommandContribution } from './cpp-commands';
 
 import { LanguageClientContribution } from "@theia/languages/lib/browser";
-import { CppClientContribution } from "./cpp-client-contribution";
+import { CppLanguageClientContribution } from "./cpp-language-client-contribution";
 import { CppKeybindingContribution, CppKeybindingContext } from "./cpp-keybinding";
 
 export default new ContainerModule(bind => {
@@ -20,7 +20,7 @@ export default new ContainerModule(bind => {
     bind(KeybindingContext).toDynamicValue(context => context.container.get(CppKeybindingContext));
     bind(KeybindingContribution).to(CppKeybindingContribution).inSingletonScope();
 
-    bind(CppClientContribution).toSelf().inSingletonScope();
-    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppClientContribution));
+    bind(CppLanguageClientContribution).toSelf().inSingletonScope();
+    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppLanguageClientContribution));
 
 });

--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -13,7 +13,7 @@ import { MessageService } from '@theia/core/lib/common/message-service';
 import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 @injectable()
-export class CppClientContribution extends BaseLanguageClientContribution {
+export class CppLanguageClientContribution extends BaseLanguageClientContribution {
 
     readonly id = CPP_LANGUAGE_ID;
     readonly name = CPP_LANGUAGE_NAME;


### PR DESCRIPTION
I think it's clearer that way, since there can be other kinds of clients
in other contexts.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>