### PR TITLE
GH-1924: Fire a selection change event when calling `addSelection`.

### DIFF
--- a/packages/core/src/browser/tree/tree-selection-impl.ts
+++ b/packages/core/src/browser/tree/tree-selection-impl.ts
@@ -68,9 +68,6 @@ export class TreeSelectionServiceImpl implements TreeSelectionService {
 
         const toUnselect = this.difference(oldNodes, newNodes);
         const toSelect = this.difference(newNodes, oldNodes);
-        if (toUnselect.length === 0 && toSelect.length === 0) {
-            return;
-        }
 
         this.unselect(toUnselect);
         this.select(toSelect);

--- a/packages/core/src/browser/tree/tree-widget.ts
+++ b/packages/core/src/browser/tree/tree-widget.ts
@@ -125,6 +125,7 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
+        this.node.focus();
         if (this.model.selectedNodes.length === 0) {
             const root = this.model.root;
             if (SelectableTreeNode.is(root)) {
@@ -136,7 +137,6 @@ export class TreeWidget extends VirtualWidget implements StatefulWidget {
                 }
             }
         }
-        this.node.focus();
     }
 
     protected onUpdateRequest(msg: Message): void {


### PR DESCRIPTION
Even if the selection does not change under the hood. This is to ensure that
the selection is correctly propagated to the selection service at
application start up. With this change we get the correct context menu
contribution in the navigator.

Closes #1924.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>