### PR TITLE
Call tab bar context menu actions with the right context

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -14,7 +14,10 @@ import { SelectionService } from "../common/selection-service";
 import { MessageService } from '../common/message-service';
 import { OpenerService, open } from '../browser/opener-service';
 import { ApplicationShell } from './shell/application-shell';
-import { SHELL_TABBAR_CONTEXT_MENU } from './shell/tab-bars';
+import {
+    MAIN_PANEL_TABBAR_CONTEXT_MENU, BOTTOM_PANEL_TABBAR_CONTEXT_MENU, LEFT_PANEL_TABBAR_CONTEXT_MENU,
+    RIGHT_PANEL_TABBAR_CONTEXT_MENU
+} from './shell/tab-bars';
 import { AboutDialog } from './about-dialog';
 import * as browser from './browser';
 import URI from '../common/uri';
@@ -207,31 +210,112 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
             order: '1'
         });
 
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(MAIN_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_TAB.id,
             label: 'Close',
-            order: '0'
+            order: '0',
+            args: ['main']
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(MAIN_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
             label: 'Close Others',
-            order: '1'
+            order: '1',
+            args: ['main']
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(MAIN_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
             label: 'Close to the Right',
-            order: '2'
+            order: '2',
+            args: ['main']
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(MAIN_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_ALL_TABS.id,
             label: 'Close All',
-            order: '3'
+            order: '3',
+            args: ['main']
         });
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_TAB.id,
+            label: 'Close',
+            order: '0',
+            args: ['bottom']
+        });
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_OTHER_TABS.id,
+            label: 'Close Others',
+            order: '1',
+            args: ['bottom']
+        });
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
+            label: 'Close to the Right',
+            order: '2',
+            args: ['bottom']
+        });
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_ALL_TABS.id,
+            label: 'Close All',
+            order: '3',
+            args: ['bottom']
+        });
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.COLLAPSE_PANEL.id,
             label: 'Collapse',
-            order: '4'
+            order: '4',
+            args: ['bottom']
         });
+
+        registry.registerMenuAction(LEFT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_TAB.id,
+            label: 'Close',
+            order: '0',
+            args: ['left']
+        });
+        registry.registerMenuAction(LEFT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_OTHER_TABS.id,
+            label: 'Close Others',
+            order: '1',
+            args: ['left']
+        });
+        registry.registerMenuAction(LEFT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_ALL_TABS.id,
+            label: 'Close All',
+            order: '3',
+            args: ['left']
+        });
+        registry.registerMenuAction(LEFT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.COLLAPSE_PANEL.id,
+            label: 'Collapse',
+            order: '4',
+            args: ['left']
+        });
+
+        registry.registerMenuAction(RIGHT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_TAB.id,
+            label: 'Close',
+            order: '0',
+            args: ['right']
+        });
+        registry.registerMenuAction(RIGHT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_OTHER_TABS.id,
+            label: 'Close Others',
+            order: '1',
+            args: ['right']
+        });
+        registry.registerMenuAction(RIGHT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.CLOSE_ALL_TABS.id,
+            label: 'Close All',
+            order: '3',
+            args: ['right']
+        });
+        registry.registerMenuAction(RIGHT_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.COLLAPSE_PANEL.id,
+            label: 'Collapse',
+            order: '4',
+            args: ['right']
+        });
+
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
             label: 'About',
@@ -277,69 +361,79 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         commandRegistry.registerCommand(CommonCommands.FIND);
         commandRegistry.registerCommand(CommonCommands.REPLACE);
 
+        const getTabBar = (area?: ApplicationShell.Area) => {
+            if (area) {
+                return this.shell.getTabBarFor(area);
+            } else {
+                return this.shell.currentTabBar;
+            }
+        };
+        const isNotEmpty = (area?: ApplicationShell.Area) => {
+            const tabBar = getTabBar(area);
+            return tabBar !== undefined && tabBar.titles.length > 0;
+        };
+
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB, {
-            isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activateNextTab()
+            isEnabled: isNotEmpty,
+            execute: (area?: ApplicationShell.Area) => this.shell.activateNextTab(getTabBar(area)!)
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
-            isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activatePreviousTab()
+            isEnabled: isNotEmpty,
+            execute: (area?: ApplicationShell.Area) => this.shell.activatePreviousTab(getTabBar(area)!)
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_TAB, {
-            isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => {
-                const tabBar = this.shell.currentTabBar!;
+            isEnabled: isNotEmpty,
+            execute: (area?: ApplicationShell.Area) => {
+                const tabBar = getTabBar(area)!;
                 const currentTitle = tabBar.currentTitle;
                 this.shell.closeTabs(tabBar, (title, index) => title === currentTitle);
             }
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_OTHER_TABS, {
-            isEnabled: () => {
-                const tabBar = this.shell.currentTabBar;
-                if (tabBar) {
-                    return tabBar.titles.length > 1;
-                }
-                return false;
+            isEnabled: (area?: ApplicationShell.Area) => {
+                const tabBar = getTabBar(area);
+                return tabBar !== undefined && tabBar.titles.length > 1;
             },
-            execute: () => {
-                const tabBar = this.shell.currentTabBar!;
+            execute: (area?: ApplicationShell.Area) => {
+                const tabBar = getTabBar(area)!;
                 const currentTitle = tabBar.currentTitle;
-                this.shell.closeTabs(this.shell.currentTabArea!, (title, index) => title !== currentTitle);
+                this.shell.closeTabs(area || this.shell.currentTabArea!, (title, index) => title !== currentTitle);
             }
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_RIGHT_TABS, {
-            isEnabled: () => {
-                const tabBar = this.shell.currentTabBar;
-                if (tabBar) {
-                    return tabBar.currentIndex < tabBar.titles.length - 1;
-                }
-                return false;
+            isEnabled: (area?: ApplicationShell.Area) => {
+                const tabBar = getTabBar(area);
+                return tabBar !== undefined && tabBar.currentIndex < tabBar.titles.length - 1;
             },
-            isVisible: () => {
-                const area = this.shell.currentTabArea;
-                return area !== 'left' && area !== 'right';
+            isVisible: (area?: ApplicationShell.Area) => {
+                const currentArea = area || this.shell.currentTabArea;
+                return currentArea !== 'left' && currentArea !== 'right';
             },
-            execute: () => {
-                const tabBar = this.shell.currentTabBar!;
+            execute: (area?: ApplicationShell.Area) => {
+                const tabBar = getTabBar(area)!;
                 const currentIndex = tabBar.currentIndex;
                 this.shell.closeTabs(tabBar, (title, index) => index > currentIndex);
             }
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_ALL_TABS, {
-            isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.closeTabs(this.shell.currentTabArea!)
+            isEnabled: isNotEmpty,
+            execute: (area?: ApplicationShell.Area) => this.shell.closeTabs(getTabBar(area)!)
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_PANEL, {
-            isEnabled: () => ApplicationShell.isSideArea(this.shell.currentTabArea),
-            isVisible: () => ApplicationShell.isSideArea(this.shell.currentTabArea),
-            execute: () => {
-                const currentArea = this.shell.currentTabArea;
+            isEnabled: (area?: ApplicationShell.Area) => {
+                const currentArea = area || this.shell.currentTabArea;
+                return ApplicationShell.isSideArea(currentArea) && this.shell.isExpanded(currentArea);
+            },
+            isVisible: (area?: ApplicationShell.Area) => ApplicationShell.isSideArea(area || this.shell.currentTabArea),
+            execute: (area?: ApplicationShell.Area) => {
+                const currentArea = area || this.shell.currentTabArea;
                 if (ApplicationShell.isSideArea(currentArea)) {
                     this.shell.collapsePanel(currentArea);
                 }
             }
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_ALL_PANELS, {
+            isEnabled: () => this.shell.isExpanded('left') || this.shell.isExpanded('right') || this.shell.isExpanded('bottom'),
             execute: () => {
                 this.shell.collapsePanel('left');
                 this.shell.collapsePanel('right');

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -70,12 +70,13 @@ export class BrowserMainMenuFactory {
         if (!command) {
             return;
         }
+        const args = menu.action.args || [];
         commands.addCommand(command.id, {
-            execute: () => this.commandRegistry.executeCommand(command.id),
+            execute: () => this.commandRegistry.executeCommand(command.id, ...args),
             label: menu.label,
             icon: command.iconClass,
-            isEnabled: () => this.commandRegistry.isEnabled(command.id),
-            isVisible: () => this.commandRegistry.isVisible(command.id)
+            isEnabled: () => this.commandRegistry.isEnabled(command.id, ...args),
+            isVisible: () => this.commandRegistry.isVisible(command.id, ...args)
         });
 
         const bindings = this.keybindingRegistry.getKeybindingsForCommand(command.id);

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -14,11 +14,11 @@ import {
 } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { RecursivePartial } from '../../common';
+import { RecursivePartial, MenuPath } from '../../common';
 import { Saveable } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory, TheiaDockPanel } from './side-panel-handler';
-import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar } from './tab-bars';
+import { TabBarRendererFactory, TabBarRenderer, ScrollableTabBar, MAIN_PANEL_TABBAR_CONTEXT_MENU, BOTTOM_PANEL_TABBAR_CONTEXT_MENU } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
 import { FrontendApplicationStateService } from '../frontend-application-state';
 
@@ -45,6 +45,7 @@ export const DockPanelRendererFactory = Symbol('DockPanelRendererFactory');
 export class DockPanelRenderer implements DockLayout.IRenderer {
 
     readonly tabBarClasses: string[] = [];
+    contextMenuPath?: MenuPath;
 
     constructor(
         @inject(TabBarRendererFactory) protected readonly tabBarRendererFactory: () => TabBarRenderer
@@ -62,7 +63,7 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
         });
         this.tabBarClasses.forEach(c => tabBar.addClass(c));
         renderer.tabBar = tabBar;
-        renderer.contextMenuPath = SHELL_TABBAR_CONTEXT_MENU;
+        renderer.contextMenuPath = this.contextMenuPath;
         tabBar.currentChanged.connect(this.onCurrentTabChanged, this);
         return tabBar;
     }
@@ -349,6 +350,7 @@ export class ApplicationShell extends Widget {
         const renderer = this.dockPanelRendererFactory();
         renderer.tabBarClasses.push(MAIN_BOTTOM_AREA_CLASS);
         renderer.tabBarClasses.push(MAIN_AREA_CLASS);
+        renderer.contextMenuPath = MAIN_PANEL_TABBAR_CONTEXT_MENU;
         const dockPanel = new TheiaDockPanel({
             mode: 'multiple-document',
             renderer,
@@ -365,6 +367,7 @@ export class ApplicationShell extends Widget {
         const renderer = this.dockPanelRendererFactory();
         renderer.tabBarClasses.push(MAIN_BOTTOM_AREA_CLASS);
         renderer.tabBarClasses.push(BOTTOM_AREA_CLASS);
+        renderer.contextMenuPath = BOTTOM_PANEL_TABBAR_CONTEXT_MENU;
         const dockPanel = new TheiaDockPanel({
             mode: 'multiple-document',
             renderer,
@@ -1124,8 +1127,13 @@ export class ApplicationShell extends Widget {
     /*
      * Activate the next tab in the current tab bar.
      */
-    activateNextTab(): void {
-        const current = this.currentTabBar;
+    activateNextTab(tabBarOrArea: TabBar<Widget> | ApplicationShell.Area): void {
+        let current: TabBar<Widget> | undefined;
+        if (typeof tabBarOrArea === 'string') {
+            current = this.getTabBarFor(tabBarOrArea);
+        } else {
+            current = tabBarOrArea;
+        }
         if (current) {
             const ci = current.currentIndex;
             if (ci !== -1) {
@@ -1169,8 +1177,13 @@ export class ApplicationShell extends Widget {
     /*
      * Activate the previous tab in the current tab bar.
      */
-    activatePreviousTab(): void {
-        const current = this.currentTabBar;
+    activatePreviousTab(tabBarOrArea: TabBar<Widget> | ApplicationShell.Area): void {
+        let current: TabBar<Widget> | undefined;
+        if (typeof tabBarOrArea === 'string') {
+            current = this.getTabBarFor(tabBarOrArea);
+        } else {
+            current = tabBarOrArea;
+        }
         if (current) {
             const ci = current.currentIndex;
             if (ci !== -1) {

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -12,7 +12,7 @@ import { Signal } from '@phosphor/signaling';
 import { MimeData } from '@phosphor/coreutils';
 import { Drag } from '@phosphor/dragdrop';
 import { AttachedProperty } from '@phosphor/properties';
-import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, SideTabBar } from './tab-bars';
+import { TabBarRendererFactory, TabBarRenderer, SideTabBar, LEFT_PANEL_TABBAR_CONTEXT_MENU, RIGHT_PANEL_TABBAR_CONTEXT_MENU } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
 import { FrontendApplicationStateService } from '../frontend-application-state';
 
@@ -111,7 +111,11 @@ export class SidePanelHandler {
             suppressScrollX: true
         });
         tabBarRenderer.tabBar = sideBar;
-        tabBarRenderer.contextMenuPath = SHELL_TABBAR_CONTEXT_MENU;
+        if (side === 'left') {
+            tabBarRenderer.contextMenuPath = LEFT_PANEL_TABBAR_CONTEXT_MENU;
+        } else if (side === 'right') {
+            tabBarRenderer.contextMenuPath = RIGHT_PANEL_TABBAR_CONTEXT_MENU;
+        }
         sideBar.addClass('theia-app-' + side);
         sideBar.addClass(LEFT_RIGHT_AREA_CLASS);
 

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -18,8 +18,11 @@ import { ElementExt } from '@phosphor/domutils';
 /** The class name added to hidden content nodes, which are required to render vertical side bars. */
 const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
 
-/** Menu path for tab bars used throughout the application shell. */
-export const SHELL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-tabbar-context-menu'];
+/** Menu paths for tab bars used throughout the application shell. */
+export const MAIN_PANEL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-main-panel-tabbar'];
+export const BOTTOM_PANEL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-bottom-panel-tabbar'];
+export const LEFT_PANEL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-left-panel-tabbar'];
+export const RIGHT_PANEL_TABBAR_CONTEXT_MENU: MenuPath = ['shell-right-panel-tabbar'];
 
 export const TabBarRendererFactory = Symbol('TabBarRendererFactory');
 

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -15,6 +15,7 @@ export interface MenuAction {
     label?: string
     icon?: string
     order?: string
+    args?: any[]
 }
 
 export type MenuPath = string[];

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -71,12 +71,13 @@ export class ElectronMainMenuFactory {
                     accelerator = this.acceleratorFor(binding);
                 }
 
+                const args = menu.action.args || [];
                 items.push({
                     label: menu.label,
                     icon: menu.icon,
                     enabled: true, // https://github.com/theia-ide/theia/issues/446
                     visible: true,
-                    click: () => this.execute(menu.action.commandId),
+                    click: () => this.execute(menu.action.commandId, ...args),
                     accelerator
                 });
             }
@@ -141,8 +142,8 @@ export class ElectronMainMenuFactory {
         return result;
     }
 
-    protected execute(command: string): void {
-        this.commandRegistry.executeCommand(command).catch(() => { /* no-op */ });
+    protected execute(command: string, ...args: any[]): void {
+        this.commandRegistry.executeCommand(command, ...args).catch(() => { /* no-op */ });
     }
 
     protected createOSXMenu(): Electron.MenuItemConstructorOptions {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -8,8 +8,10 @@
 import { injectable, inject, postConstruct } from "inversify";
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { CommandRegistry, MenuModelRegistry, MenuPath, isOSX } from "@theia/core/lib/common";
-import { Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands, OpenerService } from "@theia/core/lib/browser";
-import { SHELL_TABBAR_CONTEXT_MENU } from "@theia/core/lib/browser";
+import {
+    Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands, OpenerService,
+    MAIN_PANEL_TABBAR_CONTEXT_MENU, BOTTOM_PANEL_TABBAR_CONTEXT_MENU
+} from "@theia/core/lib/browser";
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorPreferences } from "./navigator-preferences";
@@ -82,10 +84,15 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     registerMenus(registry: MenuModelRegistry): void {
         super.registerMenus(registry);
-        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+        registry.registerMenuAction(MAIN_PANEL_TABBAR_CONTEXT_MENU, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
             label: 'Reveal in Files',
-            order: '5'
+            order: '10'
+        });
+        registry.registerMenuAction(BOTTOM_PANEL_TABBAR_CONTEXT_MENU, {
+            commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
+            label: 'Reveal in Files',
+            order: '10'
         });
 
         registry.registerMenuAction(NavigatorContextMenu.OPEN, {


### PR DESCRIPTION
Fixes #1923.

 - Defined separate context menu paths for application areas.
 - Added args property to menu action.
 - Pass args from menu action to command handler.
