### PR TITLE
[core/keybinding] Fixing OSX test failure

### DIFF
--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -85,9 +85,9 @@ describe('keybindings', () => {
     });
 
     beforeEach(() => {
+        stub = sinon.stub(os, 'isOSX').value(false);
         keybindingRegistry = testContainer.get<KeybindingRegistry>(KeybindingRegistry);
         keybindingRegistry.onStart();
-        stub = sinon.stub(os, 'isOSX').value(false);
     });
 
     afterEach(() => {

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -516,9 +516,9 @@ export namespace KeybindingRegistry {
          * @return this
          */
         merge(other: KeybindingsResult): KeybindingsResult {
-            this.full = this.full.concat(other.full);
-            this.partial = this.partial.concat(other.partial);
-            this.shadow = this.shadow.concat(other.shadow);
+            this.full.push(...other.full);
+            this.partial.push(...other.partial);
+            this.shadow.push(...other.shadow);
             return this;
         }
 

--- a/packages/core/src/browser/keys.ts
+++ b/packages/core/src/browser/keys.ts
@@ -301,7 +301,7 @@ export class KeyCode {
             return new KeyCode(sequence.join('+'), KeyCode.toCharacter(event));
         } else {
             const key = event.first ? [event.first.code] : [];
-            return new KeyCode(([] as string[]).concat(key)
+            return new KeyCode(key
                 .concat((event.modifiers || []).sort().map(modifier => `${modifier}`))
                 .join('+'));
         }


### PR DESCRIPTION
Since the last refactoring of the keybindings, the tests fails under OSX.
Fixes #1932.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

Because I don't have access to any OSX machine, I am pushing on this branch in order to check the Travis build.