### PR TITLE
Preference proxy and service "ready" fixes

### DIFF
--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -7,6 +7,7 @@
 
 import { injectable } from 'inversify';
 import { Disposable, DisposableCollection, Emitter, Event } from '../../common';
+import { Deferred } from '../../common/promise-util';
 
 @injectable()
 export class PreferenceProvider implements Disposable {
@@ -14,6 +15,12 @@ export class PreferenceProvider implements Disposable {
     readonly onDidPreferencesChanged: Event<void> = this.onDidPreferencesChangedEmitter.event;
 
     protected readonly toDispose = new DisposableCollection();
+
+    /**
+     * Resolved when the preference provider is ready to provide preferences
+     * It should be resolved by subclasses.
+     */
+    protected readonly _ready = new Deferred<void>();
 
     constructor() {
         this.toDispose.push(this.onDidPreferencesChangedEmitter);
@@ -33,5 +40,10 @@ export class PreferenceProvider implements Disposable {
 
     setPreference(key: string, value: any): Promise<void> {
         return Promise.resolve();
+    }
+
+    /** See `_ready`.  */
+    get ready() {
+        return this._ready.promise;
     }
 }

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { createPreferenceProxy } from "./preference-proxy";
+import { MockPreferenceService } from "./test/mock-preference-service";
+import { expect } from 'chai';
+
+describe('preference proxy', function() {
+    /** Verify the return type of the ready property.  */
+    it('.ready should return a promise', function() {
+
+        const proxy = createPreferenceProxy(new MockPreferenceService(), {
+            properties: {}
+        });
+        const proto = Object.getPrototypeOf(proxy.ready);
+        expect(proto).to.equal(Promise.prototype);
+    });
+});

--- a/packages/core/src/browser/preferences/preference-proxy.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.ts
@@ -74,7 +74,7 @@ export function createPreferenceProxy<T extends Configuration>(preferences: Pref
                 return () => toDispose.dispose();
             }
             if (property === 'ready') {
-                return () => preferences.ready;
+                return preferences.ready;
             }
             throw new Error('unexpected property: ' + property);
         },

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -74,12 +74,16 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     protected _ready: Promise<void> | undefined;
     get ready(): Promise<void> {
         if (!this._ready) {
-            this._ready = new Promise((resolve, reject) => {
+            this._ready = new Promise(async (resolve, reject) => {
                 this.toDispose.push(Disposable.create(() => reject()));
                 for (const preferenceProvider of this.preferenceProviders) {
                     this.toDispose.push(preferenceProvider);
                     preferenceProvider.onDidPreferencesChanged(event => this.reconcilePreferences());
                 }
+
+                // Wait until all the providers are ready to provide preferences.
+                await Promise.all(this.preferenceProviders.map(p => p.ready));
+
                 this.reconcilePreferences();
                 resolve();
             });

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -19,6 +19,6 @@ export class MockPreferenceService implements PreferenceService {
         return undefined;
     }
     set(preferenceName: string, value: any): Promise<void> { return Promise.resolve(); }
-    ready: Promise<void>;
+    ready: Promise<void> = Promise.resolve();
     readonly onPreferenceChanged: Event<PreferenceChange> = new Emitter<PreferenceChange>().event;
 }

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -26,7 +26,13 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     protected async init(): Promise<void> {
         const uri = await this.getUri();
         this.resource = this.resourceProvider(uri);
-        this.readPreferences();
+
+        // Try to read the initial content of the preferences.  The provider
+        // becomes ready even if we fail reading the preferences, so we don't
+        // hang the preference service.
+        this.readPreferences()
+            .then(() => this._ready.resolve())
+            .catch(() => this._ready.resolve());
 
         const resource = await this.resource;
         this.toDispose.push(resource);


### PR DESCRIPTION
These patches fix some issues about waiting for the preference service to be ready.  More information in the commit log of each patch.