### PR TITLE
Umbrella PR for various Mini Browser issues

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -247,7 +247,7 @@ export class FrontendApplication {
     }
 
     /**
-     * Stop the frontent application contributions. This is called when the window is unloaded.
+     * Stop the frontend application contributions. This is called when the window is unloaded.
      */
     protected stopContributions(): void {
         for (const contribution of this.contributions.getContributions()) {

--- a/packages/core/src/browser/keys.ts
+++ b/packages/core/src/browser/keys.ts
@@ -270,7 +270,7 @@ export class KeyCode {
     }
 
     public static createKeyCode(event: KeyboardEvent | Keystroke): KeyCode {
-        if (event instanceof KeyboardEvent) {
+        if (KeyCode.isKeyboardEvent(event)) {
             const code = KeyCode.toCode(event);
 
             const sequence: string[] = [];
@@ -432,6 +432,26 @@ export namespace KeyCode {
      * Determines a `true` of `false` value for the key code argument.
      */
     export type Predicate = (keyCode: KeyCode) => boolean;
+
+    /**
+     * Different scopes have different execution environments. This means that they have different built-ins
+     * (different global object, different constructors, etc.). This may result in unexpected results. For instance,
+     * `[] instanceof window.frames[0].Array` will return `false`, because `Array.prototype !== window.frames[0].Array`
+     * and arrays inherit from the former.
+     * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof
+     *
+     * Note: just add another check if the current `event.type` checking is insufficient.
+     */
+    export function isKeyboardEvent(event: object & Readonly<{ type?: string }>): event is KeyboardEvent {
+        if (event instanceof KeyboardEvent) {
+            return true;
+        }
+        const { type } = event;
+        if (type) {
+            return type === 'keypress' || type === 'keydown' || type === 'keyup';
+        }
+        return false;
+    }
 
 }
 

--- a/packages/mini-browser/src/browser/location-mapper-service.ts
+++ b/packages/mini-browser/src/browser/location-mapper-service.ts
@@ -107,17 +107,7 @@ export class FileLocationMapper implements LocationMapper {
     }
 
     map(location: string): MaybePromise<string> {
-        return FileLocationMapper.toURL(new URI(location));
-    }
-
-}
-
-export namespace FileLocationMapper {
-
-    /**
-     * Maps the `file` URI to an URL.
-     */
-    export function toURL(uri: URI, endpointPath: string = 'mini-browser'): MaybePromise<string> {
+        const uri = new URI(location);
         if (uri.scheme !== 'file') {
             throw new Error(`Only URIs with 'file' scheme can be mapped to an URL. URI was: ${uri}.`);
         }
@@ -125,7 +115,7 @@ export namespace FileLocationMapper {
         if (rawLocation.charAt(0) === '/') {
             rawLocation = rawLocation.substr(1);
         }
-        return new Endpoint().getRestUrl().resolve(`${endpointPath}/${rawLocation}`).toString();
+        return new Endpoint().getRestUrl().resolve(`mini-browser/${rawLocation}`).toString();
     }
 
 }

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -33,6 +33,7 @@ export default new ContainerModule(bind => {
 
     bind(MiniBrowserOpenHandler).toSelf().inSingletonScope();
     bind(OpenHandler).toService(MiniBrowserOpenHandler);
+    bind(FrontendApplicationContribution).toService(MiniBrowserOpenHandler);
 
     bindContributionProvider(bind, LocationMapper);
     bind(LocationMapper).to(FileLocationMapper).inSingletonScope();

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -7,12 +7,13 @@
 
 import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
+import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { ApplicationShell } from '@theia/core/lib/browser/shell';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { WidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser/widget-open-handler';
-import { FileLocationMapper } from './location-mapper-service';
 import { MiniBrowser, MiniBrowserProps } from './mini-browser';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 
 /**
  * Further options for opening a new `Mini Browser` widget.
@@ -22,7 +23,19 @@ export interface MiniBrowserOpenerOptions extends WidgetOpenerOptions, MiniBrows
 }
 
 @injectable()
-export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> {
+export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> implements FrontendApplicationContribution {
+
+    /**
+     * This is a **hack**.
+     *
+     * Instead of going to the backend with each file URI to ask whether it can handle the current file or not,
+     * we have this array of extensions that we populate at application startup. The real advantage of this
+     * approach is the following: [Phosphor cannot run async code when invoking `isEnabled`/`isVisible`
+     * for the command handlers](https://github.com/theia-ide/theia/issues/1958#issuecomment-392829371)
+     * so the menu item would be always visible for the user even if the file type cannot be handled eventually.
+     * Hopefully, we could get rid of this hack once we have migrated the existing Phosphor code to [React](https://github.com/theia-ide/theia/issues/1915).
+     */
+    protected readonly supportedExtensions: string[] = [];
 
     readonly id = 'mini-browser-open-handler';
     readonly label = 'Mini Browser';
@@ -36,10 +49,21 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> {
     @inject(LabelProvider)
     protected readonly labelProvider: LabelProvider;
 
-    async canHandle(uri: URI): Promise<number> {
-        const url = await FileLocationMapper.toURL(uri, 'mini-browser-check');
+    async onStart(): Promise<void> {
+        const url = new Endpoint().getRestUrl().resolve('mini-browser-supported-extensions').toString();
         const response = await fetch(url);
-        return response.status === 200 ? 1 : 0;
+        if (response.status === 200) {
+            const body = await response.json();
+            if (body && body.extensions && Array.isArray(body.extensions)) {
+                this.supportedExtensions.push(...body.extensions);
+            }
+        }
+    }
+
+    canHandle(uri: URI): number {
+        // The priority is `101` instead of `1` to make sure if we handle, for instance, an SVG,
+        // then the Mini Browser with the image will show up instead of the Code Editor with the binary/text content. See `EditorManager#canHandle`.
+        return this.supportedExtensions.some(extension => uri.toString().toLocaleLowerCase().endsWith(extension.toLocaleLowerCase())) ? 101 : 0;
     }
 
     async open(uri?: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
@@ -67,7 +91,7 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> {
                 name,
                 iconClass,
                 // Make sure the toolbar is not visible. We have the `iframe.src` anyway.
-                toolbar: 'read-only'
+                toolbar: 'hide'
             };
         }
         if (options) {

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -26,8 +26,6 @@ export interface MiniBrowserOpenerOptions extends WidgetOpenerOptions, MiniBrows
 export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> implements FrontendApplicationContribution {
 
     /**
-     * This is a **hack**.
-     *
      * Instead of going to the backend with each file URI to ask whether it can handle the current file or not,
      * we have this array of extensions that we populate at application startup. The real advantage of this
      * approach is the following: [Phosphor cannot run async code when invoking `isEnabled`/`isVisible`
@@ -85,13 +83,16 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> imple
             const startPage = uri.toString();
             const name = await this.labelProvider.getName(uri);
             const iconClass = `${await this.labelProvider.getIcon(uri)} file-icon`;
+            // The background has to be reset to white only for "real" web-pages but not for images, for instance.
+            const resetBackground = 'file' === uri.scheme && uri.toString().endsWith('.html');
             result = {
                 ...result,
                 startPage,
                 name,
                 iconClass,
                 // Make sure the toolbar is not visible. We have the `iframe.src` anyway.
-                toolbar: 'hide'
+                toolbar: 'hide',
+                resetBackground
             };
         }
         if (options) {

--- a/packages/mini-browser/src/browser/mini-browser.ts
+++ b/packages/mini-browser/src/browser/mini-browser.ts
@@ -56,6 +56,11 @@ export class MiniBrowserProps {
      */
     readonly name?: string;
 
+    /**
+     * `true` if the `iFrame`'s background has to be reset to the default white color. Otherwise, `false`. `false` is the default.
+     */
+    readonly resetBackground?: boolean;
+
 }
 
 export namespace MiniBrowserProps {
@@ -396,10 +401,14 @@ export class MiniBrowser extends BaseWidget {
 
     protected focus(): void {
         const contentDocument = this.contentDocument();
-        if (contentDocument !== null) {
+        if (contentDocument !== null && contentDocument.body) {
             contentDocument.body.focus();
-        } else {
+        } else if (this.pdfContainer.style.display !== 'none') {
+            this.pdfContainer.focus();
+        } else if (this.getToolbarProps() !== 'hide') {
             this.input.focus();
+        } else if (this.frame.parentElement) {
+            this.frame.parentElement.focus();
         }
     }
 
@@ -554,7 +563,9 @@ export class MiniBrowser extends BaseWidget {
                     });
                     this.hideLoadIndicator();
                 } else {
-                    this.frame.addEventListener('load', () => this.frame.style.backgroundColor = 'white', { once: true });
+                    if (this.props.resetBackground === true) {
+                        this.frame.addEventListener('load', () => this.frame.style.backgroundColor = 'white', { once: true });
+                    }
                     this.pdfContainer.style.display = 'none';
                     this.frame.style.display = 'block';
                     this.frame.src = url;

--- a/packages/mini-browser/src/node/mini-browser-backend-module.ts
+++ b/packages/mini-browser/src/node/mini-browser-backend-module.ts
@@ -8,14 +8,14 @@
 import { ContainerModule } from 'inversify';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, JpgHandler, PdfHandler, SvgHandler } from './mini-browser-endpoint';
+import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, ImageHandler, PdfHandler, SvgHandler } from './mini-browser-endpoint';
 
 export default new ContainerModule(bind => {
     bind(MiniBrowserEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(MiniBrowserEndpoint);
     bindContributionProvider(bind, MiniBrowserEndpointHandler);
     bind(MiniBrowserEndpointHandler).to(HtmlHandler).inSingletonScope();
-    bind(MiniBrowserEndpointHandler).to(JpgHandler).inSingletonScope();
+    bind(MiniBrowserEndpointHandler).to(ImageHandler).inSingletonScope();
     bind(MiniBrowserEndpointHandler).to(PdfHandler).inSingletonScope();
     bind(MiniBrowserEndpointHandler).to(SvgHandler).inSingletonScope();
 });

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -69,7 +69,8 @@ export abstract class BaseMiniBrowserEndpointHandler implements MiniBrowserEndpo
 
     priority(uri: string): number {
         const extensions = this.supportedExtensions();
-        return (Array.isArray(extensions) ? extensions : [extensions]).some(extension => uri.endsWith(extension)) ? 1 : 0;
+        // The handler for the extension should be case insensitive. For example; the handler accepts `'.jpg'` and the file extension is `.JPG`.
+        return (Array.isArray(extensions) ? extensions : [extensions]).some(extension => uri.toLocaleLowerCase().endsWith(extension.toLocaleLowerCase())) ? 1 : 0;
     }
 
 }


### PR DESCRIPTION
 - [x] [[Navigator] Images should open in preview](https://github.com/theia-ide/theia/issues/1973)
 - [x] [[navigator] Using "Open with -> Mini browser" on a file generates warning and shows empty on the client side](https://github.com/theia-ide/theia/issues/1959)
 - [x] [[mini-browser] Add refresh button](https://github.com/theia-ide/theia/issues/1972)
 - [x] [[mini-browser] The Mini Browser cannot be closed with the `Alt+Shift+W` binding](https://github.com/theia-ide/theia/issues/1997)

Closes #1973.
Closes #1959.
Closes #1972.
Closes #1997.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>