### PR TITLE
Define terminal api.

### DIFF
--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -17,19 +17,15 @@
 import { injectable } from 'inversify';
 import { EnvVariable, EnvVariablesServer } from '../../common/env-variables';
 
-interface ProcessEnv {
-    [key: string]: string | undefined;
-}
-
 @injectable()
 export class EnvVariablesServerImpl implements EnvVariablesServer {
 
     protected readonly envs: { [key: string]: EnvVariable } = {};
 
     constructor() {
-        const prEnv: ProcessEnv = process.env;
+        const prEnv = process.env;
         Object.keys(prEnv).forEach((key: string) => {
-            this.envs[key] = {"name" : key, "value" : prEnv[key]};
+            this.envs[key] = {'name' : key, 'value' : prEnv[key]};
         });
     }
 

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -18,13 +18,13 @@ import { inject, injectable, named } from "inversify";
 import { ILogger } from '@theia/core/lib/common';
 import { FrontendApplication, ApplicationShell } from '@theia/core/lib/browser';
 import { TaskServer, TaskExitedEvent, TaskOptions, TaskInfo } from '../common/task-protocol';
-import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from '@theia/terminal/lib/browser/terminal-widget';
+import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from '@theia/terminal/lib/browser/terminal-widget-impl';
+import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskWatcher } from '../common/task-watcher';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { TaskConfigurations, TaskConfigurationClient } from './task-configurations';
-import { TerminalWidget } from '@theia/terminal/lib/browser/terminal-widget';
 import { VariableResolverService } from "@theia/variable-resolver/lib/browser";
 import { ProcessOptions } from "@theia/process/lib/node";
 

--- a/packages/terminal/src/browser/base/terminal-service.ts
+++ b/packages/terminal/src/browser/base/terminal-service.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,25 +13,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { TerminalWidgetOptions, TerminalWidget } from './terminal-widget';
 
-import { JsonRpcProxy } from '@theia/core';
-import { IBaseTerminalServer, IBaseTerminalServerOptions } from './base-terminal-protocol';
+/**
+ * Service manipulating terminal widgets.
+ */
+export const TerminalService = Symbol("TerminalService");
+export interface TerminalService {
+    /**
+     * Create new terminal with predefined options.
+     * @param options - terminal options.
+     */
+    newTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget>;
 
-export const IShellTerminalServer = Symbol('IShellTerminalServer');
-
-export interface IShellTerminalServer extends IBaseTerminalServer {
+    /**
+     * Display new terminal widget.
+     * @param termWidget - widget to attach.
+     */
+    activateTerminal(termWidget: TerminalWidget): void;
 }
-
-export const shellTerminalPath = '/services/shell-terminal';
-
-export interface IShellTerminalServerOptions extends IBaseTerminalServerOptions {
-    shell?: string,
-    args?: string[],
-    rootURI?: string,
-    cols?: number,
-    rows?: number,
-    env?: { [key: string]: string | null };
-}
-
-export const ShellTerminalServerProxy = Symbol('ShellTerminalServerProxy');
-export type ShellTerminalServerProxy = JsonRpcProxy<IShellTerminalServer>;

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Event } from '@theia/core';
+import { BaseWidget } from '@theia/core/lib/browser';
+
+/**
+ * Terminal UI widget.
+ */
+export abstract class TerminalWidget extends BaseWidget {
+
+    /**
+     * Start terminal and return terminal id.
+     * @param id - terminal id.
+     */
+   abstract start(id?: number): Promise<number>;
+
+   /**
+    * Send text to the terminal server.
+    * @param text - text content.
+    */
+   abstract sendText(text: string): void;
+
+   /**
+    * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
+    */
+   abstract onTerminalDidClose: Event<TerminalWidget>;
+}
+
+/**
+ * Terminal widget options.
+ */
+export const TerminalWidgetOptions = Symbol('TerminalWidgetOptions');
+export interface TerminalWidgetOptions {
+
+    /**
+     * Human readable terminal representation on the UI.
+     */
+    readonly title?: string;
+
+    /**
+     * Path to the executable shell. For example: `/bin/bash`, `bash`, `sh`.
+     */
+    readonly shellPath?: string;
+
+    /**
+     * Shell arguments to executable shell, for example: [`-l`] - without login.
+     */
+    readonly shellArgs?: string[];
+
+    /**
+     * Current working directory.
+     */
+    readonly cwd?: string;
+
+    /**
+     * Environment variables for terminal.
+     */
+    readonly env?: { [key: string]: string | null };
+
+    /**
+     * In case `destroyTermOnClose` is true - terminal process will be destroyed on close terminal widget, otherwise will be kept
+     * alive.
+     */
+    readonly destroyTermOnClose?: boolean;
+
+    /**
+     * Terminal server side can send to the client `terminal title` to display this value on the UI. If
+     * useServerTitle = true then display this title, otherwise display title defined by 'title' argument.
+     */
+    readonly useServerTitle?: boolean;
+
+    /**
+     * Terminal id. Should be unique for all DOM.
+     */
+    readonly id?: string;
+}

--- a/packages/terminal/src/browser/terminal-keybinding-contexts.ts
+++ b/packages/terminal/src/browser/terminal-keybinding-contexts.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from "inversify";
 import { KeybindingContext, ApplicationShell } from "@theia/core/lib/browser";
-import { TerminalWidget } from "./terminal-widget";
+import { TerminalWidget } from './base/terminal-widget';
 
 export namespace TerminalKeybindingContexts {
     export const terminalActive = 'terminalActive';


### PR DESCRIPTION
Define terminal api.
Support set-up more parameters on terminal creation:
 - current working directory (cwd);
 - environment variables;
 - terminal shell path;
 - terminal shell arguments.

Related issue: https://github.com/eclipse/che/issues/9595
Related pull request: https://github.com/theia-demo-plugins/wiptheia/pull/24
How it works with plugin model: https://youtu.be/_Y0zU7rYPpQ

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>