### PR TITLE
[context-menu] Do not render `CompositeMenuNode`s with zero children

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -139,7 +139,7 @@ class DynamicMenuWidget extends MenuWidget {
     private updateSubMenus(parent: MenuWidget, menu: CompositeMenuNode, commands: PhosphorCommandRegistry): void {
         for (const item of menu.children) {
             if (item instanceof CompositeMenuNode) {
-                if (item.label) {
+                if (item.label && item.children.length > 0) {
                     parent.addItem({
                         type: 'submenu',
                         submenu: new DynamicMenuWidget(item, this.options)

--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -92,7 +92,6 @@
   padding: 4px 0px;
   background: var(--theia-menu-color1);
   color: var(--theia-ui-font-color1);
-  border: var(--theia-border-width) solid var(--theia-border-color1);
   font-size: var(--theia-ui-font-size1);
   box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/1996

- [x] Context menu items without children should not show up in the context menu
- ~[ ] Fix this in electron too~ Moved to https://github.com/theia-ide/theia/issues/2669
- [x] fix the context menu moving glitch