### PR TITLE
GH-2027: Fixed failing test case on OS X.

### DIFF
--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -330,6 +330,7 @@ describe("keys api", () => {
     });
 
     it("should parse a string containing special modifiers to a KeyCode correctly", () => {
+        const stub = sinon.stub(os, 'isOSX').value(false);
         const keycode = KeyCode.parse("ctrl+b");
         expect(keycode.ctrl).to.be.true;
         expect(keycode.key).is.equal(Key.KEY_B);
@@ -344,6 +345,7 @@ describe("keys api", () => {
         expect(keycodeCtrlOrCommand.meta).to.be.false;
         expect(keycodeCtrlOrCommand.ctrl).to.be.true;
         expect(keycodeCtrlOrCommand.key).is.equal(Key.KEY_B);
+        stub.restore();
     });
 
     it("should parse a string containing special modifiers to a KeyCode correctly (macOS)", () => {


### PR DESCRIPTION
The tests are OS agnostic, so we need to set `isOSX` to `false` on OS X.
Otherwise, the test fails.

Closes: #2027.
Signed-off-by: Akos Kitta <kittaakos@gmail.com>