### PR TITLE
GH-2030: Aligned the command labels.

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -20,7 +20,7 @@ import { Command } from '@theia/core/lib/common';
 
 export const quickFileOpen: Command = {
     id: 'file-search.openFile',
-    label: 'Open File ...'
+    label: 'Open File...'
 };
 
 @injectable()

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -23,7 +23,7 @@ import { Git } from "../../common";
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
         id: 'git-diff:open-file-diff',
-        label: 'Diff: Compare With ...'
+        label: 'Diff: Compare With...'
     };
 }
 

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -22,7 +22,7 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
 
     private command: Command = {
         id: 'languages.workspace.symbol',
-        label: 'Open Workspace Symbol ...'
+        label: 'Open Workspace Symbol...'
     };
 
     constructor(@inject(Languages) protected languages: Languages,


### PR DESCRIPTION
According to our [constraint](https://github.com/theia-ide/theia/issues/1119#issuecomment-370547715), there should not be a leading whitespace
before the ellipses in the command label.

Closes #2030.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>