### PR TITLE
GH-2023: Adjusted the CSS class names to the latest `monaco` code.

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -30,8 +30,8 @@
     z-index: 0;
 }
 
-.quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon, 
-.vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
+.monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon,
+.vs-dark .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon {
     background-image: none;
     margin-bottom: 4px;
     margin-right: 0px;


### PR DESCRIPTION
Without this, we do not override the `background-image` property,
and a default icon shows up behind the desired file icons.

Closes #2023.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Before:

<img width="1063" alt="screen shot 2018-06-04 at 17 29 48" src="https://user-images.githubusercontent.com/1405703/40926863-924b5800-681d-11e8-9511-97c2da1381f1.png">

After:

<img width="641" alt="screen shot 2018-06-04 at 17 29 16" src="https://user-images.githubusercontent.com/1405703/40926878-9a01c49e-681d-11e8-8f51-2949d894d3e1.png">
