### PR TITLE
GH-2020: Specified a highlighting color for the quick open widget.

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -40,3 +40,7 @@
 .monaco-tree-row  {
     padding-right: 11px;
 }
+
+.quick-open-entry .quick-open-row .monaco-icon-label .monaco-icon-label-description-container .monaco-highlighted-label .highlight {
+    color: var(--theia-accent-color1);
+}


### PR DESCRIPTION
Closes #2020.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

With the proposed changes:

![quick_open_highlight](https://user-images.githubusercontent.com/1405703/40958689-7e227f52-689a-11e8-80c0-0647a5486863.gif)
