### PR TITLE
GH-2042: Added a default `Mini Browser` endpoint handler.

### DIFF
--- a/packages/mini-browser/package.json
+++ b/packages/mini-browser/package.json
@@ -5,6 +5,8 @@
   "dependencies": {
     "@theia/core": "^0.3.10",
     "@theia/filesystem": "^0.3.10",
+    "@types/mime-types": "^2.1.0",
+    "mime-types": "^2.1.18",
     "pdfobject": "^2.0.201604172"
   },
   "publishConfig": {

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -9,9 +9,11 @@ import { ContainerModule } from 'inversify';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/ws-connection-provider';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application';
-import { MiniBrowser, MiniBrowserProps, MiniBrowserMouseClickTracker } from './mini-browser';
 import { MiniBrowserOpenHandler } from './mini-browser-open-handler';
+import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
+import { MiniBrowser, MiniBrowserProps, MiniBrowserMouseClickTracker } from './mini-browser';
 import { LocationMapperService, FileLocationMapper, HttpLocationMapper, HttpsLocationMapper, LocationMapper } from './location-mapper-service';
 
 import '../../src/browser/style/index.css';
@@ -40,4 +42,6 @@ export default new ContainerModule(bind => {
     bind(LocationMapper).to(HttpLocationMapper).inSingletonScope();
     bind(LocationMapper).to(HttpsLocationMapper).inSingletonScope();
     bind(LocationMapperService).toSelf().inSingletonScope();
+
+    bind(MiniBrowserService).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, MiniBrowserServicePath)).inSingletonScope();
 });

--- a/packages/mini-browser/src/common/mini-browser-service.ts
+++ b/packages/mini-browser/src/common/mini-browser-service.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export const MiniBrowserServicePath = '/services/mini-browser-service';
+export const MiniBrowserService = Symbol('MiniBrowserService');
+export interface MiniBrowserService {
+
+    /**
+     * Resolves to an array of file extensions supported by the `Mini Browser`.
+     *
+     * The extensions start with the leading dot (`.`) and should be treated in a case-insensitive way. This means,
+     * if the `Mini Browser` supports `['.jpg']`, then it can open the `MyPicture.JPG` file.
+     */
+    supportedFileExtensions(): Promise<string[]>;
+
+}

--- a/packages/mini-browser/src/node/mini-browser-backend-module.ts
+++ b/packages/mini-browser/src/node/mini-browser-backend-module.ts
@@ -8,11 +8,15 @@
 import { ContainerModule } from 'inversify';
 import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
+import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
 import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, ImageHandler, PdfHandler, SvgHandler } from './mini-browser-endpoint';
 
 export default new ContainerModule(bind => {
     bind(MiniBrowserEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(MiniBrowserEndpoint);
+    bind(MiniBrowserService).toDynamicValue(context => context.container.get(MiniBrowserEndpoint));
+    bind(ConnectionHandler).toDynamicValue(context => new JsonRpcConnectionHandler(MiniBrowserServicePath, () => context.container.get(MiniBrowserService))).inSingletonScope();
     bindContributionProvider(bind, MiniBrowserEndpointHandler);
     bind(MiniBrowserEndpointHandler).to(HtmlHandler).inSingletonScope();
     bind(MiniBrowserEndpointHandler).to(ImageHandler).inSingletonScope();

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,6 +253,10 @@
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.0.28.tgz#44ba754e9fa51432583e8eb30a7c4dd249b52faa"
 
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
@@ -5755,7 +5759,7 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:


### PR DESCRIPTION
So even if a given file cannot be opened in the `Mini Browser`
it can be still handled by sending back its content to the frontend.

This fixes the issue when trying to load the CSS files for a local HTML.

This commit also fixes the `.gif` support and uses a proxy service (over
JSON-RPC) to populate the supported file extensions, instead of calling
a static endpoint from a browser `fetch`.

Closes #2042.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Before the change:
<img width="698" alt="screen shot 2018-06-05 at 15 36 49" src="https://user-images.githubusercontent.com/1405703/40979530-5a5dfa74-68d6-11e8-8833-a3263d5d8d83.png">

After the change:
<img width="697" alt="screen shot 2018-06-05 at 15 36 14" src="https://user-images.githubusercontent.com/1405703/40979550-65b53108-68d6-11e8-8c49-aea63dfaf5c5.png">


An example project:
```
  adding: tmp-ws/ (stored 0%)
  adding: tmp-ws/index.html (deflated 46%)
  adding: tmp-ws/clouds.jpg (deflated 1%)
  adding: tmp-ws/styles/ (stored 0%)
  adding: tmp-ws/styles/index.css (deflated 16%)
```
[tmp-ws.zip](https://github.com/theia-ide/theia/files/2072554/tmp-ws.zip)