### PR TITLE
Adjust our tslint config to tslint defaultSeverity behavior change

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -24,6 +24,7 @@
     ],
     "no-consecutive-blank-lines": true,
     "no-shadowed-variable": true,
+    "no-string-throw": true,
     "no-trailing-whitespace": true,
     "no-var-keyword": true,
     "one-line": [

--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -1,30 +1,52 @@
 {
-  "defaultSeverity": "warning",
   "rules": {
-    "arrow-parens": [
-      true,
-      "ban-single-arg-parens"
-    ],
-    "arrow-return-shorthand": [
-      true,
-      "multiline"
-    ],
-    "curly": [
-      true,
-      "ignore-same-line"
-    ],
-    "indent": [
-      true,
-      "spaces",
-      4
-    ],
-    "interface-over-type-literal": true,
-    "no-any": true,
+    "arrow-parens": {
+      "severity": "warning",
+      "options": [
+        true,
+        "ban-single-arg-parens"
+      ]
+    },
+    "arrow-return-shorthand": {
+      "severity": "warning",
+      "options": [
+        true,
+        "multiline"
+      ]
+    },
+    "indent": {
+      "severity": "warning",
+      "options": [
+        true,
+        "spaces",
+        4
+      ]
+    },
+    "interface-over-type-literal": {
+      "severity": "warning",
+      "options": true
+    },
+    "no-any": {
+      "severity": "warning",
+      "options": true
+    },
     "no-console": false,
-    "no-construct": true,
+    "no-construct": {
+      "severity": "warning",
+      "options": true
+    },
     "no-magic-numbers": false,
-    "no-null-keyword": true,
-    "no-unused-expression": true,
-    "one-variable-per-declaration": true
+    "no-null-keyword": {
+      "severity": "warning",
+      "options": true
+    },
+    "no-unused-expression": {
+      "severity": "warning",
+      "options": true
+    },
+    "one-variable-per-declaration": {
+      "severity": "warning",
+      "options": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sinon": "^3.3.0",
     "temp": "^0.8.3",
     "ts-node": "^3.2.0",
-    "tslint": "^5.7.0",
+    "tslint": "^5.10.0",
     "tslint-language-service": "^0.9.9",
     "typedoc": "^0.8",
     "typescript": "^2.7.2",

--- a/packages/core/src/browser/diff-uris.ts
+++ b/packages/core/src/browser/diff-uris.ts
@@ -26,7 +26,7 @@ export namespace DiffUris {
 
     export function decode(uri: URI): URI[] {
         if (uri.scheme !== DIFF_SCHEME) {
-            throw (`The URI must have scheme "diff". The URI was: ${uri}.`);
+            throw new Error((`The URI must have scheme "diff". The URI was: ${uri}.`));
         }
         const diffUris: string[] = JSON.parse(uri.query);
         return diffUris.map(s => new URI(s));

--- a/packages/git/src/browser/dirty-diff/content-lines.ts
+++ b/packages/git/src/browser/dirty-diff/content-lines.ts
@@ -35,7 +35,7 @@ export namespace ContentLines {
             length: lineStarts.length,
             getLineContent: line => {
                 if (line >= lineStarts.length) {
-                    throw 'line index out of bounds';
+                    throw new Error('line index out of bounds');
                 }
                 const start = lineStarts[line];
                 const end = (line === lineStarts.length - 1) ? undefined : lineStarts[line + 1] - 1;
@@ -84,7 +84,7 @@ export namespace ContentLines {
                         return undefined;
                     }
                 }
-                throw `get ${p} not implemented`;
+                throw new Error(`get ${p} not implemented`);
             }
         };
     }


### PR DESCRIPTION
We have two set of lint rules that we want as either warnings or errors
in configs/warnings.tslint.json and configs/errors.tslint.json.  Each
file specifies the "defaultSeverity".  With tslint < 5.9.0, the
defaultSeverity would be applied to rules in that file, so everything
worked happily, we had warnings and errors reported in the IDE.

Starting with 5.9.0 [1], tslint changed how it handles defaultSeverity
in extended-from config files.  Now, the defaultSeverity of the last
included file wins.  So with our config and tslint 5.9.0, rules
specified in errors.tslint.json appear as warnings, since
warnings.tslint.json is included last in the top-level tslint.json.

To fix this, removed the defaultSeverity from warnings.tslint.json and
specified it explicitly for each rule.  It's more verbose, but the
number of rules we want as warning should decrease with time (when we
fix all the violations of a rule, we move it to errors.tslint.json).

I verified this by introducing an error (removed the copyright comment
from a file) and running tslint before and after.  This is the
difference:

-WARNING: (file-header) /home/emaisin/src/theia/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts[1, 1]: missing file header
+ERROR: (file-header) /home/emaisin/src/theia/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts[1, 1]: missing file header

[1] https://github.com/palantir/tslint/releases/tag/5.9.0

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>