### PR TITLE
Consume che-ls-jdt

### DIFF
--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -23,7 +23,8 @@
     "build": "theiaext build",
     "watch": "theiaext watch",
     "test": "theiaext test",
-    "docs": "theiaext docs"
+    "docs": "theiaext docs",
+    "dev-server": "node ./scripts/get-dev-server.js"
   },
   "publishConfig": {
     "access": "public"
@@ -54,5 +55,8 @@
   "nyc": {
     "extends": "../../configs/nyc.json"
   },
-  "jdt.ls.download.path": "/jdtls/milestones/0.18.0/jdt-language-server-0.18.0-201805010001.tar.gz"
+  "ls": {
+    "download.base": "https://www.eclipse.org/downloads/download.php?file=",
+    "download.path": "/che/che-ls-jdt/snapshots/che-jdt-language-server-latest.tar.gz"
+  }
 }

--- a/packages/java/scripts/get-dev-server.js
+++ b/packages/java/scripts/get-dev-server.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// @ts-check
+
+const fs = require('fs');
+const process = require('child_process');
+const path = require('path');
+const https = require('https');
+
+
+// @ts-ignore
+const package = require('../package.json');
+const shared = require('./shared');
+
+const devVersion = package.ls.dev.version;
+const packagePath = path.join(__dirname, "..");
+const targetPath = path.join(packagePath, 'server');
+const archiveName = `jdt.ls.extension.product-${devVersion}.tar.gz`;
+const downloadDir = 'download';
+const downloadPath = path.join(packagePath, downloadDir);
+const archivePath = path.join(downloadPath, archiveName);
+
+function getDevServer() {
+    return new Promise((resolve, reject) => {
+        const command = 'mvn dependency:copy ';
+        console.log('executing ' + command);
+        process.exec(command, { cwd: __dirname }, () => {
+            if (fs.existsSync(archivePath)) {
+                resolve(archivePath);
+            } else {
+                reject(new Error('Archive file not found: ' + archivePath));
+            }
+        });
+    });
+}
+
+getDevServer().then((archivePath) => {
+    shared.decompressArchive(archivePath, targetPath);
+});

--- a/packages/java/scripts/pom.xml
+++ b/packages/java/scripts/pom.xml
@@ -1,0 +1,39 @@
+<!--
+
+ * Copyright (C) 2018 RedHat and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>theia</groupId>
+	<artifactId>java.package</artifactId>
+	<version>3.1.0</version>
+	<name>Helper pom for dev</name>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<artifactItems>
+						<artifactItem>
+							<groupId>org.eclipse.che.ls.jdt</groupId>
+							<artifactId>jdt.ls.extension.product</artifactId>
+							<version>0.0.1-SNAPSHOT</version>
+							<type>tar.gz</type>
+							<overWrite>true</overWrite>
+							<outputDirectory>../download</outputDirectory>
+						</artifactItem>
+					</artifactItems>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<packaging>pom</packaging>
+</project>

--- a/packages/java/scripts/shared.js
+++ b/packages/java/scripts/shared.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+const tar = require('tar');
+const zlib = require('zlib');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+
+exports.decompressArchive = function (archivePath, targetPath) {
+    return new Promise((resolve, reject) => {
+        if (!fs.existsSync(archivePath)) {
+            reject(new Error("archive not found"));
+            return;
+        }
+        if (!fs.existsSync(targetPath)) {
+            mkdirp.sync(targetPath);
+        }
+        const gunzip = zlib.createGunzip({ finishFlush: zlib.Z_SYNC_FLUSH, flush: zlib.Z_SYNC_FLUSH });
+        console.log(targetPath);
+        const untar = tar.x({ cwd: targetPath });
+        fs.createReadStream(archivePath).pipe(gunzip).pipe(untar)
+            .on("error", e => reject(e))
+            .on("end", () => resolve());
+    });
+}


### PR DESCRIPTION
This PR is about consuming the che-ls-jdt project instead of jdt.ls directly. Che-ls-jdt contains a bunch of extensions for jdt.ls that allow things like showing libraries for java projects, improved file structure or finding junit tests in projects.
The PR currently consumes snapshot builds, since che-ls-jdt has only been consumed in Che so far. I'll change that to a proper build once we have one and we have agreement on the principle of the PR.