### PR TITLE
Fix premature firing of a theme change event

### DIFF
--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -85,10 +85,10 @@ export class ThemeService {
         }
         newTheme.activate();
         this.activeTheme = newTheme;
+        window.localStorage.setItem('theme', themeId);
         this.themeChange.fire({
             newTheme, oldTheme
         });
-        window.localStorage.setItem('theme', themeId);
     }
 
     getCurrentTheme(): Theme {


### PR DESCRIPTION
The current theme should be updated before firing an event that it is updated. Otherwise accessing the current theme in the event callback returns an old theme