### PR TITLE
fix workspace preference provider

### DIFF
--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -25,6 +25,13 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     @postConstruct()
     protected async init(): Promise<void> {
         const uri = await this.getUri();
+
+        // In case if no workspace is opened there are no workspace settings.
+        // There is nothing to contribute to preferences and we just skip it.
+        if (!uri) {
+            this._ready.resolve();
+            return;
+        }
         this.resource = this.resourceProvider(uri);
 
         // Try to read the initial content of the preferences.  The provider
@@ -41,7 +48,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         }
     }
 
-    abstract getUri(): MaybePromise<URI>;
+    abstract getUri(): MaybePromise<URI | undefined>;
 
     getPreferences(): { [key: string]: any } {
         return this.preferences;

--- a/packages/preferences/src/browser/preference-frontend-contribution.ts
+++ b/packages/preferences/src/browser/preference-frontend-contribution.ts
@@ -66,6 +66,9 @@ export class PreferenceFrontendContribution implements CommandContribution, Menu
 
     protected async openWorkspacePreferences(): Promise<void> {
         const wsUri = await this.workspacePreferenceProvider.getUri();
+        if (!wsUri) {
+            return;
+        }
         if (!(await this.filesystem.exists(wsUri.toString()))) {
             await this.filesystem.createFile(wsUri.toString(), { content: this.getPreferenceTemplateForScope('workspace') });
         }

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -16,13 +16,13 @@ export class WorkspacePreferenceProvider extends AbstractResourcePreferenceProvi
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
-    async getUri(): Promise<URI> {
+    async getUri(): Promise<URI | undefined> {
         const root = await this.workspaceService.root;
         if (root) {
             const rootUri = new URI(root.uri);
             return rootUri.resolve('.theia').resolve('settings.json');
         }
-        return new Promise<URI>(() => { });
+        return undefined;
     }
 
 }


### PR DESCRIPTION
If Theia starts without opened workspace then method `getUri()` of WorkspacePreferenceProvider returns a promise which never becomes resolved. Hence, WorkspacePreferenceProvider can't be initialized as well.

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>