### PR TITLE
Introduce Task API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## v0.3.12
-- Task API. Note, the format of tasks.json has been changed. For details, see the Task extension's [README.md](https://github.com/theia-ide/theia/blob/master/packages/task/README.md).
+- Task API. Note, the format of tasks.json has been changed. For details, see the Task extension's README.md.
 
 ## v0.3.11
 - Delete files on OSX with cmd+backspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## v0.3.12
+- Task API. Note, the format of tasks.json has been changed. For details, see the Task extension's [README.md](https://github.com/theia-ide/theia/blob/master/packages/task/README.md).
 
 ## v0.3.11
 - Delete files on OSX with cmd+backspace

--- a/packages/task/README.md
+++ b/packages/task/README.md
@@ -1,64 +1,58 @@
 # Theia - Task Extension
 
-This extension permits executing scripts or binaries in Theia's backend. 
+This extension permits executing scripts or binaries in Theia's backend.
 
-Tasks launch configurations can be defined independently for each workspace, under `.theia/tasks.json`. When present, they are automatically picked-up when a client opens a workspace, and watches for changes. A task can be executed by triggering the "Run Task" command (shortcut F1). A list of known tasks will then be available, one of which can be selected to trigger execution. 
+Tasks launch configurations can be defined independently for each workspace, under `.theia/tasks.json`. When present, they are automatically picked-up when a client opens a workspace, and watches for changes. A task can be executed by triggering the "Run Task" command (shortcut F1). A list of known tasks will then be available, one of which can be selected to trigger execution.
 
 Each task configuration looks like this:
 ``` json
-     {
-        "label": "Test task - list workspace files recursively",
-        "processType": "terminal",
-        "cwd": "${workspaceFolder}",
-        "processOptions": {
-            "command": "ls",
-            "args": [
-                "-alR"
-            ]
-        },
-        "windowsProcessOptions": {
-            "command": "cmd.exe",
-            "args": [
-                "/c",
-                "dir",
-                "/s"
-            ]
-       }
+{
+    "label": "Test task - list workspace files recursively",
+    "type": "shell",
+    "cwd": "${workspaceFolder}",
+    "command": "ls",
+    "args": [
+        "-alR"
+    ],
+    "windows": {
+        "command": "cmd.exe",
+        "args": [
+            "/c",
+            "dir",
+            "/s"
+        ]
     }
+}
 ```
 
-*label*: A unique string that identifies the task. That's what's shown to the user, when it's time to chose one task configuration to run.
+*label*: a unique string that identifies the task. That's what's shown to the user, when it's time to chose one task configuration to run.
 
-*processType*: Determines what type of process will be used to execute the task. Can be "raw" or "terminal". Terminal processes can be shown in Theia's frontend, in a terminal widget. Raw processes are run without their output being shown. 
+*type*: determines what type of process will be used to execute the task. Can be "process" or "shell". Terminal processes can be shown in Theia's frontend, in a terminal widget. Raw processes are run without their output being shown.
 
-*cwd*: The current working directory, in which the task's command will execute. This is the equivalent of doing a "cd" to that directory, on the command-line, before running the command. This can contain the variable *${workspaceFolder}*, which will be replaced at execution time by the path of the current workspace. If left undefined, will by default be set to workspace root. 
+*cwd*: the current working directory, in which the task's command will execute. This is the equivalent of doing a "cd" to that directory, on the command-line, before running the command. This can contain the variable *${workspaceFolder}*, which will be replaced at execution time by the path of the current workspace. If left undefined, will by default be set to workspace root.
 
-*processOptions.command*: the actual command or script to execute. The command can have no path (e.g. "ls") if it can be found in the system path. Else it can have an absolute path, in which case there is no confusion. Or it can have a relative path, in which case it will be interpreted to be relative to cwd. e.g. "./task" would be interpreted to mean a script or binary called "task", right under the workspace root directory.
+*command*: the actual command or script to execute. The command can have no path (e.g. "ls") if it can be found in the system path. Else it can have an absolute path, in which case there is no confusion. Or it can have a relative path, in which case it will be interpreted to be relative to cwd. e.g. "./task" would be interpreted to mean a script or binary called "task", right under the workspace root directory.
 
-*processOptions.args*: a list of strings, each one being one argument to pass to the command. 
+*args*: a list of strings, each one being one argument to pass to the command.
 
-*windowsProcessOptions*: By default, *processOptions* above is used on all platforms. However it's not always possible to express a task in the same way, both on Unix and Windows. The command and/or arguments may be different, for example. If a task needs to work on both Linux/MacOS and Windows, it can be better to have two separate process options. If *windowsProcessOptions* is defined, it will be used instead of *processOptions*, when a task is executed on a Windows backend.
+*windows*: by default, *command* and *ars* above is used on all platforms. However it's not always possible to express a task in the same way, both on Unix and Windows. The command and/or arguments may be different, for example. If a task needs to work on both Linux/MacOS and Windows, it can be better to have two separate process options. If *windows* is defined, it will be used instead of *command* and *ars*, when a task is executed on a Windows backend.
 
-
-
-Here is a sample tasks.json that can be used to test tasks. Just add this content under the theia source directory, in directory `.theia`: 
+Here is a sample tasks.json that can be used to test tasks. Just add this content under the theia source directory, in directory `.theia`:
 ``` json
 {
     // Some sample Theia tasks
     "tasks": [
         {
             "label": "[Task] short running test task (~3s)",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}/packages/task/src/node/test-resources/",
-            "processOptions": {
-                "command": "./task",
-                "args": [
-                    "1",
-                    "2",
-                    "3"
-                ]
-            },
-            "windowsProcessOptions": {
+            "command": "./task",
+            "args": [
+                "1",
+                "2",
+                "3"
+            ],
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",
@@ -69,13 +63,11 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
         },
         {
             "label": "[Task] long running test task (~300s)",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}/packages/task/src/node/test-resources/",
-            "processOptions": {
-                "command": "./task-long-running",
-                "args": []
-            },
-            "windowsProcessOptions": {
+            "command": "./task-long-running",
+            "args": [],
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",
@@ -85,15 +77,13 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
         },
         {
             "label": "[Task] recursively list files from workspace root",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}",
-            "processOptions": {
-                "command": "ls",
-                "args": [
-                    "-alR"
-                ]
-            },
-            "windowsProcessOptions": {
+            "command": "ls",
+            "args": [
+                "-alR"
+            ],
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",
@@ -104,29 +94,43 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
         },
         {
             "label": "[Task] Echo a string",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}",
-            "processOptions": {
-                "command": "bash",
-                "args": [
-                    "-c",
-                    "echo 1 2 3"
-                ]
-            }
+            "command": "bash",
+            "args": [
+                "-c",
+                "echo 1 2 3"
+            ]
         }
     ]
 }
 ```
 
-### Variables
+## Variables substitution
 The variables are supported in the following properties, using `${variableName}` syntax:
 - `cwd`
-- `processOptions.command`
-- `processOptions.args`
-- `windowsProcessOptions.command`
-- `windowsProcessOptions.args`
+- `command`
+- `args`
+- `windows.command`
+- `windows.args`
 
 See [here](https://github.com/theia-ide/theia) for other Theia documentation.
+
+## Contribution points
+The extension provides contribution points:
+- `browser/TaskContribution` - allows an extension to provide its own Task format and/or to provide the Tasks programmatically to the system
+```typescript
+export interface TaskContribution {
+    registerResolvers?(resolvers: TaskResolverRegistry): void;
+    registerProviders?(providers: TaskProviderRegistry): void;
+}
+```
+- `node/TaskRunnerContribution` - allows an extension to provide its own way of running/killing a Task
+```typescript
+export interface TaskRunnerContribution {
+    registerRunner(runners: TaskRunnerRegistry): void;
+}
+```
 
 ## License
 [Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/task/src/browser/process/process-task-contribution.ts
+++ b/packages/task/src/browser/process/process-task-contribution.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { ProcessTaskResolver } from './process-task-resolver';
+import { TaskContribution, TaskResolverRegistry } from '../task-contribution';
+
+@injectable()
+export class ProcessTaskContribution implements TaskContribution {
+
+    @inject(ProcessTaskResolver)
+    protected readonly processTaskResolver: ProcessTaskResolver;
+
+    registerResolvers(resolvers: TaskResolverRegistry): void {
+        resolvers.register('process', this.processTaskResolver);
+        resolvers.register('shell', this.processTaskResolver);
+    }
+}

--- a/packages/task/src/browser/process/process-task-frontend-module.ts
+++ b/packages/task/src/browser/process/process-task-frontend-module.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces } from 'inversify';
+import { ProcessTaskContribution } from './process-task-contribution';
+import { ProcessTaskResolver } from './process-task-resolver';
+import { TaskContribution } from '../task-contribution';
+
+export function bindProcessTaskModule(bind: interfaces.Bind) {
+
+    bind(ProcessTaskResolver).toSelf().inSingletonScope();
+    bind(ProcessTaskContribution).toSelf().inSingletonScope();
+    bind(TaskContribution).toService(ProcessTaskContribution);
+}

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
+import { TaskResolver } from '../task-contribution';
+import { TaskConfiguration } from '../../common/task-protocol';
+import { ProcessTaskConfiguration } from '../../common/process/task-protocol';
+
+@injectable()
+export class ProcessTaskResolver implements TaskResolver {
+
+    @inject(VariableResolverService)
+    protected readonly variableResolverService: VariableResolverService;
+
+    /**
+     * Perform some adjustments to the task launch configuration, before sending
+     * it to the backend to be executed. We can make sure that parameters that
+     * are optional to the user but required by the server will be defined, with
+     * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
+     */
+    async resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration> {
+        if (taskConfig.type !== 'process' && taskConfig.type !== 'shell') {
+            throw new Error('Unsupported task configuration type.');
+        }
+        const processTaskConfig = taskConfig as ProcessTaskConfiguration;
+        const result: ProcessTaskConfiguration = {
+            type: processTaskConfig.type,
+            label: processTaskConfig.label,
+            command: await this.variableResolverService.resolve(processTaskConfig.command),
+            args: processTaskConfig.args ? await this.variableResolverService.resolveArray(processTaskConfig.args) : undefined,
+            options: processTaskConfig.options,
+            windows: processTaskConfig.windows ? {
+                command: await this.variableResolverService.resolve(processTaskConfig.windows.command),
+                args: processTaskConfig.args ? await this.variableResolverService.resolveArray(processTaskConfig.args) : undefined,
+                options: processTaskConfig.windows.options
+            } : undefined,
+            cwd: await this.variableResolverService.resolve(processTaskConfig.cwd ? processTaskConfig.cwd : '${workspaceFolder}')
+        };
+        return result;
+    }
+}

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -5,10 +5,11 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { inject, injectable } from "inversify";
-import { TaskService } from './task-service';
-import { TaskInfo } from '../common/task-protocol';
+import { inject, injectable } from 'inversify';
 import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/';
+import { TaskService } from './task-service';
+import { TaskConfigurations } from "./task-configurations";
+import { TaskInfo, TaskConfiguration } from '../common/task-protocol';
 
 @injectable()
 export class QuickOpenTask implements QuickOpenModel {
@@ -17,16 +18,23 @@ export class QuickOpenTask implements QuickOpenModel {
 
     constructor(
         @inject(TaskService) protected readonly taskService: TaskService,
+        @inject(TaskConfigurations) protected readonly taskConfigurations: TaskConfigurations,
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService
     ) { }
 
-    open(): void {
+    async open(): Promise<void> {
         this.items = [];
 
-        const tasks: string[] = this.taskService.getTasks();
-        for (const task of tasks) {
-            this.items.push(new TaskRunQuickOpenItem(task, this.taskService));
+        const configuredTasks = await this.taskConfigurations.getTasks();
+        for (const task of configuredTasks) {
+            this.items.push(new TaskRunQuickOpenItem(task, this.taskService, false));
         }
+
+        const providedTasks = await this.taskService.getProvidedTasks();
+        for (const task of providedTasks) {
+            this.items.push(new TaskRunQuickOpenItem(task, this.taskService, true));
+        }
+
         this.quickOpenService.open(this, {
             placeholder: 'Type the name of a task you want to execute',
             fuzzyMatchLabel: true,
@@ -67,7 +75,7 @@ export class QuickOpenTask implements QuickOpenModel {
     }
 
     protected getRunningTaskLabel(task: TaskInfo): string {
-        return `Task id: ${task.taskId}, label: ${task.label}`;
+        return `Task id: ${task.taskId}, label: ${task.config.label}`;
     }
 
 }
@@ -75,21 +83,26 @@ export class QuickOpenTask implements QuickOpenModel {
 export class TaskRunQuickOpenItem extends QuickOpenItem {
 
     constructor(
-        protected readonly taskLabel: string,
-        protected taskService: TaskService
+        protected readonly task: TaskConfiguration,
+        protected taskService: TaskService,
+        protected readonly provided: boolean
     ) {
         super();
     }
 
     getLabel(): string {
-        return this.taskLabel!;
+        return `${this.task.type}: ${this.task.label}`;
+    }
+
+    getDescription(): string {
+        return this.provided ? 'provided' : '';
     }
 
     run(mode: QuickOpenMode): boolean {
         if (mode !== QuickOpenMode.OPEN) {
             return false;
         }
-        this.taskService.run(this.taskLabel);
+        this.taskService.run(this.task.type, this.task.label);
 
         return true;
     }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -6,7 +6,7 @@
  */
 
 import { inject, injectable, named } from 'inversify';
-import { TaskOptions } from '../common/task-protocol';
+import { TaskConfiguration } from '../common/task-protocol';
 import { ILogger, Disposable, DisposableCollection } from '@theia/core/lib/common/';
 import URI from "@theia/core/lib/common/uri";
 import { FileSystemWatcherServer, FileChange, FileChangeType } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
@@ -29,7 +29,7 @@ export interface TaskConfigurationClient {
 export class TaskConfigurations implements Disposable {
 
     protected readonly toDispose = new DisposableCollection();
-    protected tasksMap = new Map<string, TaskOptions>();
+    protected tasksMap = new Map<string, TaskConfiguration>();
     protected watchedConfigFileUri: string;
 
     /** last directory element under which we look for task config */
@@ -103,8 +103,13 @@ export class TaskConfigurations implements Disposable {
         return [...this.tasksMap.keys()];
     }
 
-    /** returns the task configuration for a given label */
-    getTask(taskLabel: string): TaskOptions | undefined {
+    /** returns the list of known tasks */
+    getTasks(): TaskConfiguration[] {
+        return [...this.tasksMap.values()];
+    }
+
+    /** returns the task configuration for a given label or undefined if none */
+    getTask(taskLabel: string): TaskConfiguration | undefined {
         return this.tasksMap.get(taskLabel);
     }
 
@@ -131,22 +136,22 @@ export class TaskConfigurations implements Disposable {
      * If reading a config file wasn't success then does nothing.
      */
     protected async refreshTasks() {
-        const tasksOptionsArray = await this.readTasks(this.watchedConfigFileUri);
-        if (tasksOptionsArray) {
+        const tasksConfigsArray = await this.readTasks(this.watchedConfigFileUri);
+        if (tasksConfigsArray) {
             // only clear tasks map when successful at parsing the config file
             // this way we avoid clearing and re-filling it multiple times if the
             // user is editing the file in the auto-save mode, having momentarily
             // non-parsing JSON.
             this.tasksMap.clear();
 
-            for (const task of tasksOptionsArray) {
+            for (const task of tasksConfigsArray) {
                 this.tasksMap.set(task.label, task);
             }
         }
     }
 
     /** parses a config file and extracts the tasks launch configurations */
-    protected async readTasks(uri: string): Promise<TaskOptions[] | undefined> {
+    protected async readTasks(uri: string): Promise<TaskConfiguration[] | undefined> {
         if (!await this.fileSystem.exists(uri)) {
             return undefined;
         } else {
@@ -170,8 +175,8 @@ export class TaskConfigurations implements Disposable {
         }
     }
 
-    protected filterDuplicates(tasks: TaskOptions[]): TaskOptions[] {
-        const filteredTasks: TaskOptions[] = [];
+    protected filterDuplicates(tasks: TaskConfiguration[]): TaskConfiguration[] {
+        const filteredTasks: TaskConfiguration[] = [];
         for (const task of tasks) {
             if (filteredTasks.some(t => t.label === task.label)) {
                 // TODO: create a problem marker so that this issue will be visible in the editor?

--- a/packages/task/src/browser/task-contribution.ts
+++ b/packages/task/src/browser/task-contribution.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, postConstruct } from 'inversify';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { TaskConfiguration } from '../common/task-protocol';
+
+export const TaskContribution = Symbol('TaskContribution');
+
+/** Allows to contribute custom Task Resolvers, Task Providers. */
+export interface TaskContribution {
+    registerResolvers?(resolvers: TaskResolverRegistry): void;
+    registerProviders?(providers: TaskProviderRegistry): void;
+}
+
+export interface TaskResolver {
+    /** Resolves a Task Configuration before sending it for execution to the Task Server. */
+    resolveTask(taskConfig: TaskConfiguration): Promise<TaskConfiguration>;
+}
+
+export interface TaskProvider {
+    /** Returns the Task Configurations which are provides programmatically to the system. */
+    provideTasks(): Promise<TaskConfiguration[]>;
+}
+
+@injectable()
+export class TaskResolverRegistry {
+
+    protected resolvers: Map<string, TaskResolver>;
+
+    @postConstruct()
+    protected init(): void {
+        this.resolvers = new Map();
+    }
+
+    /** Registers the given Task Resolver to resolve the Task Configurations of the specified type. */
+    register(type: string, resolver: TaskResolver): Disposable {
+        this.resolvers.set(type, resolver);
+        return {
+            dispose: () => this.resolvers.delete(type)
+        };
+    }
+
+    getResolver(type: string): TaskResolver | undefined {
+        return this.resolvers.get(type);
+    }
+}
+
+@injectable()
+export class TaskProviderRegistry {
+
+    protected providers: Map<string, TaskProvider>;
+
+    @postConstruct()
+    protected init(): void {
+        this.providers = new Map();
+    }
+
+    /** Registers the given Task Provider to return Task Configurations of the specified type. */
+    register(type: string, resolver: TaskProvider): Disposable {
+        this.providers.set(type, resolver);
+        return {
+            dispose: () => this.providers.delete(type)
+        };
+    }
+
+    getProvider(type: string): TaskProvider | undefined {
+        return this.providers.get(type);
+    }
+
+    /** Returns all registered Task Providers. */
+    getProviders(): TaskProvider[] {
+        return [...this.providers.values()];
+    }
+}

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -6,22 +6,27 @@
  */
 
 import { ContainerModule } from 'inversify';
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { TaskFrontendContribution } from './task-frontend-contribution';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
+import { QuickOpenTask } from './quick-open-task';
+import { TaskContribution, TaskProviderRegistry, TaskResolverRegistry } from './task-contribution';
+import { TaskService } from './task-service';
+import { TaskConfigurations } from './task-configurations';
+import { TaskFrontendContribution } from './task-frontend-contribution';
+import { createCommonBindings } from '../common/task-common-module';
 import { TaskServer, taskPath } from '../common/task-protocol';
 import { TaskWatcher } from '../common/task-watcher';
-import { TaskService } from './task-service';
-import { QuickOpenTask } from './quick-open-task';
-import { TaskConfigurations } from './task-configurations';
-import { createCommonBindings } from '../common/task-common-module';
+import { bindProcessTaskModule } from './process/process-task-frontend-module';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
     bind(TaskService).toSelf().inSingletonScope();
-    bind(CommandContribution).to(TaskFrontendContribution).inSingletonScope();
-    bind(MenuContribution).to(TaskFrontendContribution).inSingletonScope();
-    bind(TaskWatcher).toSelf().inSingletonScope();
+
+    for (const identifier of [FrontendApplicationContribution, CommandContribution, MenuContribution]) {
+        bind(identifier).toService(TaskFrontendContribution);
+    }
+
     bind(QuickOpenTask).toSelf().inSingletonScope();
     bind(TaskConfigurations).toSelf().inSingletonScope();
 
@@ -32,4 +37,10 @@ export default new ContainerModule(bind => {
     }).inSingletonScope();
 
     createCommonBindings(bind);
+
+    bind(TaskProviderRegistry).toSelf().inSingletonScope();
+    bind(TaskResolverRegistry).toSelf().inSingletonScope();
+    bindContributionProvider(bind, TaskContribution);
+
+    bindProcessTaskModule(bind);
 });

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -5,19 +5,19 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { inject, injectable, named } from "inversify";
+import { inject, injectable, named, postConstruct } from 'inversify';
 import { ILogger } from '@theia/core/lib/common';
 import { FrontendApplication, ApplicationShell } from '@theia/core/lib/browser';
-import { TaskServer, TaskExitedEvent, TaskOptions, TaskInfo } from '../common/task-protocol';
+import { TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
 import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from '@theia/terminal/lib/browser/terminal-widget';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
-import { TaskWatcher } from '../common/task-watcher';
 import { MessageService } from '@theia/core/lib/common/message-service';
+import { TaskServer, TaskExitedEvent, TaskInfo, TaskConfiguration } from '../common/task-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import { TaskConfigurations, TaskConfigurationClient } from './task-configurations';
 import { TerminalWidget } from '@theia/terminal/lib/browser/terminal-widget';
-import { VariableResolverService } from "@theia/variable-resolver/lib/browser";
-import { ProcessOptions } from "@theia/process/lib/node";
+import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
+import { TaskWatcher } from '../common/task-watcher';
+import { TaskConfigurationClient, TaskConfigurations } from './task-configurations';
 
 @injectable()
 export class TaskService implements TaskConfigurationClient {
@@ -29,18 +29,44 @@ export class TaskService implements TaskConfigurationClient {
      */
     protected configurationFileFound: boolean = false;
 
-    constructor(
-        @inject(FrontendApplication) protected readonly app: FrontendApplication,
-        @inject(ApplicationShell) protected readonly shell: ApplicationShell,
-        @inject(TaskServer) protected readonly taskServer: TaskServer,
-        @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
-        @inject(TaskWatcher) protected readonly taskWatcher: TaskWatcher,
-        @inject(MessageService) protected readonly messageService: MessageService,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
-        @inject(TaskConfigurations) protected readonly taskConfigurations: TaskConfigurations,
-        @inject(VariableResolverService) protected readonly variableResolverService: VariableResolverService
-    ) {
+    @inject(FrontendApplication)
+    protected readonly app: FrontendApplication;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(TaskServer)
+    protected readonly taskServer: TaskServer;
+
+    @inject(ILogger) @named('task')
+    protected readonly logger: ILogger;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(TaskWatcher)
+    protected readonly taskWatcher: TaskWatcher;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(TaskConfigurations)
+    protected readonly taskConfigurations: TaskConfigurations;
+
+    @inject(VariableResolverService)
+    protected readonly variableResolverService: VariableResolverService;
+
+    @inject(TaskResolverRegistry)
+    protected readonly taskResolverRegistry: TaskResolverRegistry;
+
+    @inject(TaskProviderRegistry)
+    protected readonly taskProviderRegistry: TaskProviderRegistry;
+
+    @postConstruct()
+    protected init(): void {
         // wait for the workspace root to be set
         this.workspaceService.root.then(async root => {
             if (root) {
@@ -52,7 +78,7 @@ export class TaskService implements TaskConfigurationClient {
         // notify user that task has started
         this.taskWatcher.onTaskCreated((event: TaskInfo) => {
             if (this.isEventForThisClient(event.ctx)) {
-                this.messageService.info(`Task #${event.taskId} created - ${event.label}`);
+                this.messageService.info(`Task #${event.taskId} created - ${event.config.label}`);
             }
         });
 
@@ -89,9 +115,34 @@ export class TaskService implements TaskConfigurationClient {
         });
     }
 
-    /** returns an array of known task configuration labels */
-    getTasks(): string[] {
-        return this.taskConfigurations.getTaskLabels();
+    /** Returns an array of the task configurations configured in tasks.json and provided by the extensions. */
+    async getTasks(): Promise<TaskConfiguration[]> {
+        const configuredTasks = this.taskConfigurations.getTasks();
+        const providedTasks = await this.getProvidedTasks();
+        return [...configuredTasks, ...providedTasks];
+    }
+
+    /** Returns an array of the task configurations which are provided by the extensions. */
+    async getProvidedTasks(): Promise<TaskConfiguration[]> {
+        const providedTasks: TaskConfiguration[] = [];
+        const providers = this.taskProviderRegistry.getProviders();
+        for (const provider of providers) {
+            providedTasks.push(...await provider.provideTasks());
+        }
+        return providedTasks;
+    }
+
+    /**
+     * Returns a task configuration provided by an extension by task type and label.
+     * If there are no task configuration, returns undefined.
+     */
+    async getProvidedTask(type: string, label: string): Promise<TaskConfiguration | undefined> {
+        const provider = this.taskProviderRegistry.getProvider(type);
+        if (provider) {
+            const tasks = await provider.provideTasks();
+            return tasks.find(t => t.label === label);
+        }
+        return undefined;
     }
 
     /** Returns an array of running tasks 'TaskInfo' objects */
@@ -99,66 +150,62 @@ export class TaskService implements TaskConfigurationClient {
         return this.taskServer.getTasks(this.getContext());
     }
 
-    /** runs a task, by task configuration label */
-    async run(taskName: string): Promise<void> {
-        let taskInfo: TaskInfo;
-        const task = this.taskConfigurations.getTask(taskName);
+    /**
+     * Runs a task, by task configuration label.
+     * Note, it looks for a task configured in tasks.json only.
+     */
+    async runConfiguredTask(taskLabel: string): Promise<void> {
+        const task = this.taskConfigurations.getTask(taskLabel);
         if (!task) {
-            this.logger.error(`Can't get task launch configuration for label: ${taskName}`);
+            this.logger.error(`Can't get task launch configuration for label: ${taskLabel}`);
             return;
         }
+        this.run(task.type, task.label);
+    }
 
+    /**
+     * Runs a task, by task type and task configuration label.
+     * It looks for configured and provided tasks.
+     */
+    async run(type: string, taskLabel: string): Promise<void> {
+        let task = await this.getProvidedTask(type, taskLabel);
+        if (!task) {
+            task = this.taskConfigurations.getTask(taskLabel);
+            if (!task) {
+                this.logger.error(`Can't get task launch configuration for label: ${taskLabel}`);
+                return;
+            }
+        }
+
+        const resolver = this.taskResolverRegistry.getResolver(task.type);
+        let resolvedTask: TaskConfiguration;
         try {
-            taskInfo = await this.taskServer.run(await this.prepareTaskConfiguration(task), this.getContext());
+            resolvedTask = resolver ? await resolver.resolveTask(task) : task;
         } catch (error) {
-            this.logger.error(`Error launching task '${taskName}': ${error}`);
-            this.messageService.error(`Error launching task '${taskName}': ${error}`);
+            this.logger.error(`Error resolving task '${taskLabel}': ${error}`);
+            this.messageService.error(`Error resolving task '${taskLabel}': ${error}`);
             return;
         }
 
-        this.logger.debug(`Task created. task id: ${taskInfo.taskId}, OS ProcessId: ${taskInfo.osProcessId} `);
+        let taskInfo: TaskInfo;
+        try {
+            taskInfo = await this.taskServer.run(resolvedTask, this.getContext());
+        } catch (error) {
+            this.logger.error(`Error launching task '${taskLabel}': ${error}`);
+            this.messageService.error(`Error launching task '${taskLabel}': ${error}`);
+            return;
+        }
 
-        // open terminal widget if the task is based on a terminal process:
+        this.logger.debug(`Task created. Task id: ${taskInfo.taskId}`);
+
+        // open terminal widget if the task is based on a terminal process (type: shell)
         if (taskInfo.terminalId !== undefined) {
             this.attach(taskInfo.terminalId, taskInfo.taskId);
         }
     }
 
-    /**
-     * Perform some adjustments to the task launch configuration, before sending
-     * it to the backend to be executed. We can make sure that parameters that
-     * are optional to the user but required by the server will be defined, with
-     * sane default values. Also, resolve all known variables, e.g. `${workspaceFolder}`.
-     */
-    protected async prepareTaskConfiguration(task: TaskOptions): Promise<TaskOptions> {
-        const resultTask: TaskOptions = {
-            label: task.label,
-            processType: task.processType ? task.processType : 'terminal',
-            processOptions: await this.resolveVariablesInOptions(task.processOptions)
-        };
-        if (task.windowsProcessOptions) {
-            resultTask.windowsProcessOptions = await this.resolveVariablesInOptions(task.windowsProcessOptions);
-        }
-        resultTask.cwd = await this.variableResolverService.resolve(task.cwd ? task.cwd : '${workspaceFolder}');
-        return resultTask;
-    }
-
-    /**
-     * Resolve the variables in the given process options.
-     */
-    protected async resolveVariablesInOptions(options: ProcessOptions): Promise<ProcessOptions> {
-        const resultOptions: ProcessOptions = {
-            command: await this.variableResolverService.resolve(options.command)
-        };
-        if (options.args) {
-            resultOptions.args = await this.variableResolverService.resolveArray(options.args);
-        }
-        resultOptions.options = options.options;
-        return resultOptions;
-    }
-
     async attach(terminalId: number, taskId: number): Promise<void> {
-        // create terminal widget to display task's execution output
+        // create terminal widget to display an execution output of a Task that was launched as a command inside a shell
         const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(
             TERMINAL_WIDGET_FACTORY_ID,
             <TerminalWidgetFactoryOptions>{

--- a/packages/task/src/common/index.ts
+++ b/packages/task/src/common/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export * from './task-service';
-export * from './task-contribution';
+export * from './task-protocol';
+export * from './task-watcher';

--- a/packages/task/src/common/process/task-protocol.ts
+++ b/packages/task/src/common/process/task-protocol.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { TaskConfiguration, TaskInfo } from '../task-protocol';
+
+export type ProcessType = 'shell' | 'process';
+
+export interface CommandProperties {
+    readonly command: string;
+    readonly args?: string[];
+    readonly options?: object;
+}
+
+/** Configuration of a Task that may be run as a process or a command inside a shell. */
+export interface ProcessTaskConfiguration extends TaskConfiguration, CommandProperties {
+    readonly type: ProcessType;
+
+    /**
+     * Windows version of CommandProperties. Used in preference on Windows, if defined.
+     */
+    readonly windows?: CommandProperties;
+
+    /**
+     * The 'current working directory' the task will run in. Can be a uri-as-string
+     * or plain string path. If the cwd is meant to be somewhere under the workspace,
+     * one can use the variable `${workspaceFolder}`, which will be replaced by its path,
+     * at runtime. If not specified, defaults to the workspace root.
+     * ex:  cwd: '${workspaceFolder}/foo'
+     */
+    readonly cwd?: string;
+}
+
+export interface ProcessTaskInfo extends TaskInfo {
+    /** terminal id. Defined if task is run as a terminal process */
+    readonly terminalId?: number,
+}

--- a/packages/task/src/common/task-common-module.ts
+++ b/packages/task/src/common/task-common-module.ts
@@ -7,6 +7,7 @@
 
 import { interfaces } from "inversify";
 import { ILogger } from "@theia/core";
+import { TaskWatcher } from "./task-watcher";
 
 /**
  * Create the bindings common to node and browser.
@@ -19,4 +20,6 @@ export function createCommonBindings(bind: interfaces.Bind) {
         const logger = ctx.container.get<ILogger>(ILogger);
         return logger.child('task');
     }).inSingletonScope().whenTargetNamed('task');
+
+    bind(TaskWatcher).toSelf().inSingletonScope();
 }

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -6,58 +6,37 @@
  */
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
-import { RawProcessOptions } from '@theia/process/lib/node/raw-process';
-import { TerminalProcessOptions } from '@theia/process/lib/node/terminal-process';
 
 export const taskPath = '/services/task';
 
 export const TaskServer = Symbol('TaskServer');
 export const TaskClient = Symbol('TaskClient');
 
-export type ProcessType = 'terminal' | 'raw';
-
-export interface TaskInfo {
-    /** internal unique task id */
-    taskId: number,
-    /** terminal id. Defined if task is run as a terminal process */
-    terminalId?: number,
-    /** internal unique process id */
-    processId?: number,
-    /** OS PID of the process running the task */
-    osProcessId: number,
-    /** The command used to start this task */
-    command: string,
-    /** task label */
-    label: string,
-    /** context that was passed as part of task creation, if any */
-    ctx?: string
+export interface TaskConfiguration {
+    readonly type: string;
+    /** A label that uniquely identifies a task configuration */
+    readonly label: string;
+    /** Additional task type specific properties. */
+    readonly [key: string]: any;
 }
 
-export interface TaskOptions {
-    /** A label that uniquely identifies a task configuration */
-    label: string,
-    /** 'raw' or 'terminal' - if not specified 'terminal' is the default */
-    processType?: ProcessType,
-    /** contains 'command', 'args?', 'options?' */
-    processOptions: RawProcessOptions | TerminalProcessOptions,
-    /**
-     * windows version of processOptions. Used in preference on Windows, if
-     * defined
-     */
-    windowsProcessOptions?: RawProcessOptions | TerminalProcessOptions,
-    /**
-     * The 'current working directory' the task will run in. Can be a uri-as-string
-     * or plain string path. If the cwd is meant to be somewhere under the workspace,
-     * one can use the variable `${workspaceFolder}`, which will be replaced by its path,
-     * at runtime. If not specified, defaults to the workspace root.
-     * ex:  cwd: '${workspaceFolder}/foo'
-     */
-    cwd?: string
+/** Runtime information about Task. */
+export interface TaskInfo {
+    /** internal unique task id */
+    readonly taskId: number,
+    /** terminal id. Defined if task is run as a terminal process */
+    readonly terminalId?: number,
+    /** context that was passed as part of task creation, if any */
+    readonly ctx?: string,
+    /** task config used for launching a task */
+    readonly config: TaskConfiguration,
+    /** Additional properties specific for a particular Task Runner. */
+    readonly [key: string]: any;
 }
 
 export interface TaskServer extends JsonRpcServer<TaskClient> {
     /** Run a task. Optionally pass a context.  */
-    run(task: TaskOptions, ctx?: string): Promise<TaskInfo>;
+    run(task: TaskConfiguration, ctx?: string): Promise<TaskInfo>;
     /** Kill a task, by id. */
     kill(taskId: number): Promise<void>;
     /**
@@ -73,10 +52,10 @@ export interface TaskServer extends JsonRpcServer<TaskClient> {
 
 /** Event sent when a task has concluded its execution */
 export interface TaskExitedEvent {
-    taskId: number;
-    code: number;
-    signal?: string;
-    ctx?: string
+    readonly taskId: number;
+    readonly ctx?: string;
+    readonly code: number;
+    readonly signal?: string;
 }
 
 export interface TaskClient {

--- a/packages/task/src/node/index.ts
+++ b/packages/task/src/node/index.ts
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export * from './task-service';
-export * from './task-contribution';
+export * from './task';
+export * from './task-runner';
+export * from './task-manager';

--- a/packages/task/src/node/process/process-task-runner-backend-module.ts
+++ b/packages/task/src/node/process/process-task-runner-backend-module.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { interfaces, Container } from 'inversify';
+import { ProcessTask, TaskFactory, TaskProcessOptions } from './process-task';
+import { ProcessTaskRunner } from './process-task-runner';
+import { ProcessTaskRunnerContribution } from './process-task-runner-contribution';
+import { TaskRunnerContribution } from '../task-runner';
+
+export function bindProcessTaskRunnerModule(bind: interfaces.Bind) {
+
+    bind(ProcessTask).toSelf().inTransientScope();
+    bind(TaskFactory).toFactory(ctx =>
+        (options: TaskProcessOptions) => {
+            const child = new Container({ defaultScope: 'Singleton' });
+            child.parent = ctx.container;
+            child.bind(TaskProcessOptions).toConstantValue(options);
+            return child.get(ProcessTask);
+        }
+    );
+    bind(ProcessTaskRunner).toSelf().inSingletonScope();
+    bind(ProcessTaskRunnerContribution).toSelf().inSingletonScope();
+    bind(TaskRunnerContribution).toService(ProcessTaskRunnerContribution);
+}

--- a/packages/task/src/node/process/process-task-runner-contribution.ts
+++ b/packages/task/src/node/process/process-task-runner-contribution.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { ProcessTaskRunner } from './process-task-runner';
+import { TaskRunnerContribution, TaskRunnerRegistry } from '../task-runner';
+
+@injectable()
+export class ProcessTaskRunnerContribution implements TaskRunnerContribution {
+
+    @inject(ProcessTaskRunner)
+    protected readonly processTaskRunner: ProcessTaskRunner;
+
+    registerRunner(runners: TaskRunnerRegistry): void {
+        runners.registerRunner('process', this.processTaskRunner);
+        runners.registerRunner('shell', this.processTaskRunner);
+    }
+}

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, named } from 'inversify';
+import { isWindows, ILogger } from '@theia/core';
+import { FileUri } from '@theia/core/lib/node';
+import {
+    TerminalProcess,
+    RawProcess,
+    TerminalProcessOptions,
+    RawProcessOptions,
+    RawProcessFactory,
+    TerminalProcessFactory
+} from '@theia/process/lib/node';
+import URI from '@theia/core/lib/common/uri';
+import { TaskFactory } from './process-task';
+import { TaskRunner } from '../task-runner';
+import { Task } from '../task';
+import { TaskConfiguration } from '../../common/task-protocol';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Task runner that runs a task as a process or a command inside a shell.
+ */
+@injectable()
+export class ProcessTaskRunner implements TaskRunner {
+
+    @inject(ILogger) @named('task')
+    protected readonly logger: ILogger;
+
+    @inject(RawProcessFactory)
+    protected readonly rawProcessFactory: RawProcessFactory;
+
+    @inject(TerminalProcessFactory)
+    protected readonly terminalProcessFactory: TerminalProcessFactory;
+
+    @inject(TaskFactory)
+    protected readonly taskFactory: TaskFactory;
+
+    /**
+     * Runs a task from the given task configuration.
+     * @param taskConfig task configuration to run a task from. The provided task configuration must have a shape of `CommandProperties`.
+     */
+    async run(taskConfig: TaskConfiguration, ctx?: string): Promise<Task> {
+        if (!taskConfig.command) {
+            throw new Error(`Process task config must have 'command' property specified`);
+        }
+
+        let command;
+        let args;
+        let options;
+        // on windows, prefer windows-specific options, if available
+        if (isWindows && taskConfig.windows !== undefined) {
+            command = taskConfig.windows.command;
+            args = taskConfig.windows.args;
+            options = taskConfig.windows.options;
+        } else {
+            command = taskConfig.command;
+            args = taskConfig.args;
+            options = taskConfig.options;
+        }
+
+        // sanity checks:
+        // - we expect the cwd to be set by the client.
+        if (!taskConfig.cwd) {
+            return Promise.reject(new Error("Can't run a task when 'cwd' is not provided by the client"));
+        }
+
+        const cwd = FileUri.fsPath(taskConfig.cwd);
+        // Use task's cwd with spawned process and pass node env object to
+        // new process, so e.g. we can re-use the system path
+        options = {
+            cwd: cwd,
+            env: process.env
+        };
+
+        // When we create a process to execute a command, it's difficult to know if it failed
+        // because the executable or script was not found, or if it was found, ran, and exited
+        // unsuccessfully. So here we look to see if it seems we can find a file of that name
+        // that is likely to be the one we want, before attempting to execute it.
+        const cmd = await this.findCommand(command, cwd);
+        if (cmd) {
+            try {
+                // use terminal or raw process
+                let proc: TerminalProcess | RawProcess;
+                const processType = taskConfig.type === 'process' ? 'process' : 'shell';
+                if (processType === 'process') {
+                    this.logger.debug('Task: creating underlying raw process');
+                    proc = this.rawProcessFactory(<RawProcessOptions>{
+                        command: command,
+                        args: args,
+                        options: options
+                    });
+                } else {
+                    // all Task types without specific TaskRunner will be run as a shell process e.g.: npm, gulp, etc.
+                    this.logger.debug('Task: creating underlying terminal process');
+                    proc = this.terminalProcessFactory(<TerminalProcessOptions>{
+                        command: command,
+                        args: args,
+                        options: options
+                    });
+                }
+                return this.taskFactory(
+                    {
+                        label: taskConfig.label,
+                        command: cmd,
+                        process: proc,
+                        processType: processType,
+                        context: ctx,
+                        config: taskConfig
+                    });
+            } catch (error) {
+                this.logger.error(`Error occurred while creating task: ${error}`);
+                return Promise.reject(new Error(error));
+            }
+        } else {
+            return Promise.reject(new Error(`Command not found: ${command}`));
+        }
+    }
+
+    /**
+     * Uses heuristics to look-for a command. Will look into the system path, if the command
+     * is given without a path. Will resolve if a potential match is found, else reject. There
+     * is no guarantee that a command we find will be the one executed, if multiple commands with
+     * the same name exist.
+     * @param command command name to look for
+     * @param cwd current working directory
+     */
+    protected async findCommand(command: string, cwd: string): Promise<string | undefined> {
+        const systemPath = process.env.PATH;
+        const pathDelimiter = path.delimiter;
+
+        if (path.isAbsolute(command)) {
+            if (await this.executableFileExists(command)) {
+                return command;
+            }
+        } else {
+            // look for command relative to cwd
+            const resolvedCommand = FileUri.fsPath(new URI(cwd).resolve(command));
+
+            if (await this.executableFileExists(resolvedCommand)) {
+                return resolvedCommand;
+            } else {
+                // just a command to find in the system path?
+                if (path.basename(command) === command) {
+                    // search for this command in the system path
+                    if (systemPath !== undefined) {
+                        const pathArray: string[] = systemPath.split(pathDelimiter);
+
+                        for (const p of pathArray) {
+                            const candidate = FileUri.fsPath(new URI(p).resolve(command));
+                            if (await this.executableFileExists(candidate)) {
+                                return candidate;
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+
+    /**
+     * Checks for the existence of a file, at the provided path, and make sure that
+     * it's readable and executable.
+     */
+    protected async executableFileExists(filePath: string): Promise<boolean> {
+        return new Promise<boolean>(async (resolve, reject) => {
+            fs.access(filePath, fs.constants.F_OK | fs.constants.X_OK, err => {
+                resolve(err ? false : true);
+            });
+        });
+    }
+}

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 Ericsson and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, named } from 'inversify';
+import { ILogger, } from '@theia/core/lib/common/';
+import { Process } from "@theia/process/lib/node";
+import { Task, TaskOptions } from '../task';
+import { TaskManager } from '../task-manager';
+import { ProcessType, ProcessTaskInfo } from '../../common/process/task-protocol';
+
+export const TaskProcessOptions = Symbol("TaskProcessOptions");
+export interface TaskProcessOptions extends TaskOptions {
+    command: string,
+    process: Process,
+    processType: ProcessType
+}
+
+export const TaskFactory = Symbol("TaskFactory");
+export type TaskFactory = (options: TaskProcessOptions) => ProcessTask;
+
+/** Represents a Task launched as a process by `ProcessTaskRunner`. */
+@injectable()
+export class ProcessTask extends Task {
+
+    constructor(
+        @inject(TaskManager) protected readonly taskManager: TaskManager,
+        @inject(ILogger) @named('task') protected readonly logger: ILogger,
+        @inject(TaskProcessOptions) protected readonly options: TaskProcessOptions
+    ) {
+        super(taskManager, logger, options);
+
+        const toDispose =
+            this.process.onExit(event => {
+                toDispose.dispose();
+                this.fireTaskExited({
+                    taskId: this.taskId,
+                    ctx: this.options.context,
+                    code: event.code,
+                    signal: event.signal
+                });
+            });
+
+        this.logger.info(`Created new task, id: ${this.id}, process id: ${this.options.process.id}, OS PID: ${this.process.pid}, context: ${this.context}`);
+    }
+
+    kill(): Promise<void> {
+        return new Promise<void>(resolve => {
+            if (this.process.killed) {
+                resolve();
+            } else {
+                const toDispose = this.process.onExit(event => {
+                    toDispose.dispose();
+                    resolve();
+                });
+                this.process.kill();
+            }
+        });
+    }
+
+    getRuntimeInfo(): ProcessTaskInfo {
+        return {
+            taskId: this.id,
+            ctx: this.context,
+            config: this.options.config,
+            terminalId: (this.processType === 'shell') ? this.process.id : undefined
+        };
+    }
+    get process() {
+        return this.options.process;
+    }
+
+    get processType() {
+        return this.options.processType;
+    }
+}

--- a/packages/task/src/node/task-backend-application-contribution.ts
+++ b/packages/task/src/node/task-backend-application-contribution.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, named } from 'inversify';
+import { ContributionProvider } from '@theia/core';
+import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { TaskRunnerContribution, TaskRunnerRegistry } from './task-runner';
+
+@injectable()
+export class TaskBackendApplicationContribution implements BackendApplicationContribution {
+
+    @inject(ContributionProvider) @named(TaskRunnerContribution)
+    protected readonly contributionProvider: ContributionProvider<TaskRunnerContribution>;
+
+    @inject(TaskRunnerRegistry)
+    protected readonly taskRunnerRegistry: TaskRunnerRegistry;
+
+    onStart(): void {
+        this.contributionProvider.getContributions().forEach(contrib =>
+            contrib.registerRunner(this.taskRunnerRegistry)
+        );
+    }
+}

--- a/packages/task/src/node/task-backend-module.ts
+++ b/packages/task/src/node/task-backend-module.ts
@@ -5,24 +5,23 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { ContainerModule, Container } from 'inversify';
-import { ConnectionHandler, JsonRpcConnectionHandler } from "@theia/core/lib/common/messaging";
-import { Task, TaskFactory, TaskProcessOptions } from './task';
-import { TaskClient, TaskServer, taskPath } from '../common/task-protocol';
-import { TaskServerImpl } from './task-server';
-import { TaskManager } from './task-manager';
-import { TaskWatcher } from '../common/task-watcher';
+import { ContainerModule } from 'inversify';
+import { bindContributionProvider } from '@theia/core';
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { bindProcessTaskRunnerModule } from './process/process-task-runner-backend-module';
+import { TaskBackendApplicationContribution } from './task-backend-application-contribution';
+import { TaskManager } from './task-manager';
+import { TaskRunnerContribution, TaskRunnerRegistry } from './task-runner';
+import { TaskServerImpl } from './task-server';
 import { createCommonBindings } from '../common/task-common-module';
+import { TaskClient, TaskServer, taskPath } from '../common/task-protocol';
 
 export default new ContainerModule(bind => {
 
     bind(TaskManager).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(TaskManager)).inSingletonScope();
     bind(TaskServer).to(TaskServerImpl).inSingletonScope();
-    bind(Task).toSelf().inTransientScope();
-    bind(TaskWatcher).toSelf().inSingletonScope();
-
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler<TaskClient>(taskPath, client => {
             const taskServer = ctx.container.get<TaskServer>(TaskServer);
@@ -35,14 +34,12 @@ export default new ContainerModule(bind => {
         })
     ).inSingletonScope();
 
-    bind(TaskFactory).toFactory(ctx =>
-        (options: TaskProcessOptions) => {
-            const child = new Container({ defaultScope: 'Singleton' });
-            child.parent = ctx.container;
-            child.bind(TaskProcessOptions).toConstantValue(options);
-            return child.get(Task);
-        }
-    );
-
     createCommonBindings(bind);
+
+    bind(TaskRunnerRegistry).toSelf().inSingletonScope();
+    bindContributionProvider(bind, TaskRunnerContribution);
+    bind(TaskBackendApplicationContribution).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(TaskBackendApplicationContribution);
+
+    bindProcessTaskRunnerModule(bind);
 });

--- a/packages/task/src/node/task-manager.ts
+++ b/packages/task/src/node/task-manager.ts
@@ -6,9 +6,9 @@
  */
 import { inject, injectable, named } from 'inversify';
 import { ILogger } from '@theia/core/lib/common/';
-import { Task } from './task';
 import { Emitter, Event } from '@theia/core/lib/common';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { Task } from './task';
 
 // inspired by process-manager.ts
 

--- a/packages/task/src/node/task-manager.ts
+++ b/packages/task/src/node/task-manager.ts
@@ -5,8 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 import { inject, injectable, named } from 'inversify';
-import { ILogger } from '@theia/core/lib/common/';
-import { Emitter, Event } from '@theia/core/lib/common';
+import { Emitter, Event, ILogger } from '@theia/core/lib/common';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { Task } from './task';
 

--- a/packages/task/src/node/task-runner.ts
+++ b/packages/task/src/node/task-runner.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { ProcessTaskRunner } from './process/process-task-runner';
+import { Task } from './task';
+import { TaskConfiguration } from '../common/task-protocol';
+
+export const TaskRunnerContribution = Symbol('TaskRunnerContribution');
+
+/** Allows to contribute custom Task Runners. */
+export interface TaskRunnerContribution {
+    registerRunner(runners: TaskRunnerRegistry): void;
+}
+
+export const TaskRunner = Symbol('TaskRunner');
+/** A Task Runner knows how to run and kill a Task of a particular type. */
+export interface TaskRunner {
+    /** Runs a task based on the given task configuration. */
+    run(taskConfig: TaskConfiguration, ctx?: string): Promise<Task>;
+}
+
+@injectable()
+export class TaskRunnerRegistry {
+
+    protected runners: Map<string, TaskRunner>;
+    /** A Task Runner that will be used for executing a Task without an associated Runner. */
+    protected defaultRunner: TaskRunner;
+
+    @inject(ProcessTaskRunner)
+    protected readonly processTaskRunner: ProcessTaskRunner;
+
+    @postConstruct()
+    protected init(): void {
+        this.runners = new Map();
+        this.defaultRunner = this.processTaskRunner;
+    }
+
+    /** Registers the given Task Runner to execute the Tasks of the specified type. */
+    registerRunner(type: string, runner: TaskRunner): Disposable {
+        this.runners.set(type, runner);
+        return {
+            dispose: () => this.runners.delete(type)
+        };
+    }
+
+    /** Returns a Task Runner registered for the specified Task type or default Task Runner if none. */
+    getRunner(type: string): TaskRunner | undefined {
+        const runner = this.runners.get(type);
+        return runner ? runner : this.defaultRunner;
+    }
+}

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -7,8 +7,8 @@
 
 import { createTaskTestContainer } from './test/task-test-container';
 import { BackendApplication } from '@theia/core/lib/node/backend-application';
-import { TaskExitedEvent, TaskInfo, TaskServer, TaskOptions, ProcessType } from '../common/task-protocol';
-import { TaskWatcher } from '../common/task-watcher';
+import { TaskExitedEvent, TaskInfo, TaskServer, TaskWatcher, TaskConfiguration } from '../common';
+import { ProcessType, ProcessTaskConfiguration } from '../common/process/task-protocol';
 import * as http from 'http';
 import * as https from 'https';
 import { isWindows } from '@theia/core/lib/common/os';
@@ -67,14 +67,14 @@ describe('Task server / back-end', function () {
     it("task running in terminal - expected data is received from the terminal ws server", async function () {
         const someString = 'someSingleWordString';
 
-        // This test is flaky on Windows and fails intermitently. Disable it for now
+        // This test is flaky on Windows and fails intermittently. Disable it for now
         if (isWindows) {
             this.skip();
         }
 
         // create task using terminal process
         const command = isWindows ? commandShortrunningindows : commandShortRunning;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptions('terminal', FileUri.fsPath(command), [someString]), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfig('shell', FileUri.fsPath(command), [someString]), wsRoot);
         const terminalId = taskInfo.terminalId;
 
         // hook-up to terminal's ws and confirm that it outputs expected tasks' output
@@ -100,7 +100,7 @@ describe('Task server / back-end', function () {
         const command = isWindows ? commandShortrunningindows : commandShortRunning;
 
         // create task using raw process
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptions('raw', FileUri.fsPath(command), [someString]), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfig('process', FileUri.fsPath(command), [someString]), wsRoot);
 
         const p = new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
@@ -120,7 +120,7 @@ describe('Task server / back-end', function () {
 
     it("task is executed successfully using terminal process", async function () {
         const command = isWindows ? commandShortrunningindows : commandShortRunning;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptions('terminal', FileUri.fsPath(command), []), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfig('shell', FileUri.fsPath(command), []), wsRoot);
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
@@ -129,7 +129,7 @@ describe('Task server / back-end', function () {
 
     it("task is executed successfully using raw process", async function () {
         const command = isWindows ? commandShortrunningindows : commandShortRunning;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptions('raw', FileUri.fsPath(command), []));
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfig('process', FileUri.fsPath(command), []));
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
@@ -139,7 +139,7 @@ describe('Task server / back-end', function () {
     it("task can successfully execute command found in system path using a terminal process", async function () {
         const command = isWindows ? commandToFindInPathWindows : commandToFindInPathUnix;
 
-        const opts: TaskOptions = createTaskOptions('terminal', command, []);
+        const opts: TaskConfiguration = createTaskConfig('shell', command, []);
         const taskInfo: TaskInfo = await taskServer.run(opts, wsRoot);
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
@@ -149,7 +149,7 @@ describe('Task server / back-end', function () {
 
     it("task can successfully execute command found in system path using a raw process", async function () {
         const command = isWindows ? commandToFindInPathWindows : commandToFindInPathUnix;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptions('raw', command, []), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfig('process', command, []), wsRoot);
 
         const p = checkSuccessfullProcessExit(taskInfo, taskWatcher);
 
@@ -158,7 +158,7 @@ describe('Task server / back-end', function () {
 
     it("task using terminal process can be killed", async function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptionsTaskLongRunning('terminal'), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('shell'), wsRoot);
 
         const p = new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
@@ -176,7 +176,7 @@ describe('Task server / back-end', function () {
 
     it("task using raw process can be killed", async function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
-        const taskInfo: TaskInfo = await taskServer.run(createTaskOptionsTaskLongRunning('raw'), wsRoot);
+        const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('process'), wsRoot);
 
         const p = new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
@@ -193,12 +193,12 @@ describe('Task server / back-end', function () {
     });
 
     it("task using terminal process can handle command that does not exist", async function () {
-        const p = taskServer.run(createTaskOptions2('terminal', bogusCommand, []), wsRoot);
+        const p = taskServer.run(createTaskConfig2('shell', bogusCommand, []), wsRoot);
         await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
     });
 
     it("task using raw process can handle command that does not exist", async function () {
-        const p = taskServer.run(createTaskOptions2('raw', bogusCommand, []), wsRoot);
+        const p = taskServer.run(createTaskConfig2('process', bogusCommand, []), wsRoot);
         await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
     });
 
@@ -207,12 +207,12 @@ describe('Task server / back-end', function () {
         const context2 = "anotherContext";
 
         // create some tasks: 4 for context1, 2 for context2
-        const task1 = await taskServer.run(createTaskOptionsTaskLongRunning('terminal'), context1);
-        const task2 = await taskServer.run(createTaskOptionsTaskLongRunning('raw'), context2);
-        const task3 = await taskServer.run(createTaskOptionsTaskLongRunning('terminal'), context1);
-        const task4 = await taskServer.run(createTaskOptionsTaskLongRunning('raw'), context2);
-        const task5 = await taskServer.run(createTaskOptionsTaskLongRunning('terminal'), context1);
-        const task6 = await taskServer.run(createTaskOptionsTaskLongRunning('raw'), context1);
+        const task1 = await taskServer.run(createTaskConfigTaskLongRunning('shell'), context1);
+        const task2 = await taskServer.run(createTaskConfigTaskLongRunning('process'), context2);
+        const task3 = await taskServer.run(createTaskConfigTaskLongRunning('shell'), context1);
+        const task4 = await taskServer.run(createTaskConfigTaskLongRunning('process'), context2);
+        const task5 = await taskServer.run(createTaskConfigTaskLongRunning('shell'), context1);
+        const task6 = await taskServer.run(createTaskConfigTaskLongRunning('process'), context1);
 
         const runningTasksCtx1 = await taskServer.getTasks(context1); // should return 4 tasks
         const runningTasksCtx2 = await taskServer.getTasks(context2); // should return 2 tasks
@@ -254,9 +254,9 @@ describe('Task server / back-end', function () {
         // create a mix of terminal and raw processes
         for (let i = 0; i < numTasks; i++) {
             if (i % 2 === 0) {
-                taskinfo.push(await taskServer.run(createTaskOptionsTaskLongRunning('terminal')));
+                taskinfo.push(await taskServer.run(createTaskConfigTaskLongRunning('shell')));
             } else {
-                taskinfo.push(await taskServer.run(createTaskOptionsTaskLongRunning('raw')));
+                taskinfo.push(await taskServer.run(createTaskConfigTaskLongRunning('process')));
             }
         }
 
@@ -285,52 +285,46 @@ describe('Task server / back-end', function () {
 
 });
 
-function createTaskOptions(processType: ProcessType, command: string, args: string[]): TaskOptions {
-    const options: TaskOptions = {
+function createTaskConfig(processType: ProcessType, command: string, args: string[]): TaskConfiguration {
+    const options: ProcessTaskConfiguration = {
         label: "test task",
-        processType: processType,
-        'processOptions': {
-            'command': command,
-            'args': args
-        },
-        "windowsProcessOptions": {
-            "command": "cmd.exe",
-            "args": [
+        type: processType,
+        command: command,
+        args: args,
+        windows: {
+            command: "cmd.exe",
+            args: [
                 "/c",
                 command
                 ,
                 (args[0] !== undefined) ? args[0] : ''
             ]
         },
-        'cwd': wsRoot
+        cwd: wsRoot
     };
     return options;
 }
 
-function createTaskOptions2(processType: ProcessType, command: string, args: string[]): TaskOptions {
-    return {
+function createTaskConfig2(processType: ProcessType, command: string, args: string[]): TaskConfiguration {
+    return <ProcessTaskConfiguration>{
         label: "test task",
-        processType: processType,
-        'processOptions': {
-            'command': command,
-            'args': args
-        },
-        'cwd': wsRoot
+        type: processType,
+        command: command,
+        args: args,
+        cwd: wsRoot
     };
 }
 
-function createTaskOptionsTaskLongRunning(processType: ProcessType): TaskOptions {
-    return {
-        "label": "[Task] long runnning test task (~300s)",
-        "processType": processType,
-        "cwd": wsRoot,
-        "processOptions": {
-            "command": commandLongRunning,
-            "args": []
-        },
-        "windowsProcessOptions": {
-            "command": "cmd.exe",
-            "args": [
+function createTaskConfigTaskLongRunning(processType: ProcessType): TaskConfiguration {
+    return <ProcessTaskConfiguration>{
+        label: "[Task] long running test task (~300s)",
+        type: processType,
+        cwd: wsRoot,
+        command: commandLongRunning,
+        args: [],
+        windows: {
+            command: "cmd.exe",
+            args: [
                 "/c",
                 commandLongRunningWindows
             ]

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -6,134 +6,60 @@
  */
 
 import { inject, injectable, named } from 'inversify';
-import { ILogger, Disposable, isWindows } from '@theia/core/lib/common/';
-import { TaskClient, TaskExitedEvent, TaskInfo, TaskOptions, TaskServer } from '../common/task-protocol';
-import { Task, TaskFactory } from './task';
-import { RawProcess, RawProcessFactory, RawProcessOptions } from '@theia/process/lib/node/';
-import { TerminalProcess, TerminalProcessFactory, TerminalProcessOptions } from '@theia/process/lib/node/';
+import { ILogger } from '@theia/core/lib/common/';
+import { TaskClient, TaskExitedEvent, TaskInfo, TaskServer, TaskConfiguration } from '../common/task-protocol';
 import { TaskManager } from './task-manager';
-import URI from "@theia/core/lib/common/uri";
-import { FileUri } from "@theia/core/lib/node";
-import * as fs from 'fs';
-import * as path from 'path';
+import { TaskRunnerRegistry } from './task-runner';
 
 @injectable()
 export class TaskServerImpl implements TaskServer {
 
     /** Task clients, to send notifications-to. */
     protected clients: TaskClient[] = [];
-    /** Map of objects to dispose-of, per running task id */
-    protected tasksToDispose = new Map<number, Disposable>();
 
-    constructor(
-        @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(RawProcessFactory) protected readonly rawProcessFactory: RawProcessFactory,
-        @inject(TerminalProcessFactory) protected readonly terminalProcessFactory: TerminalProcessFactory,
-        @inject(TaskManager) protected readonly taskManager: TaskManager,
-        @inject(TaskFactory) protected readonly taskFactory: TaskFactory
-    ) {
-        taskManager.onDelete(id => {
-            const toDispose = this.tasksToDispose.get(id);
-            if (toDispose !== undefined) {
-                toDispose.dispose();
-                this.tasksToDispose.delete(id);
-            }
-        });
-    }
+    @inject(ILogger) @named('task')
+    protected readonly logger: ILogger;
+
+    @inject(TaskManager)
+    protected readonly taskManager: TaskManager;
+
+    @inject(TaskRunnerRegistry)
+    protected readonly runnerRegistry: TaskRunnerRegistry;
 
     dispose() {
         // do nothing
     }
 
     getTasks(context?: string | undefined): Promise<TaskInfo[]> {
-        const taskinfo: TaskInfo[] = [];
+        const taskInfo: TaskInfo[] = [];
 
         const tasks = this.taskManager.getTasks(context);
         if (tasks !== undefined) {
             for (const task of tasks) {
-                taskinfo.push(task.getRuntimeInfo());
+                taskInfo.push(task.getRuntimeInfo());
             }
         }
-        this.logger.debug(`getTasks(): about to return task information for ${taskinfo.length} tasks`);
+        this.logger.debug(`getTasks(): about to return task information for ${taskInfo.length} tasks`);
 
-        return Promise.resolve(taskinfo);
+        return Promise.resolve(taskInfo);
     }
 
-    async run(options: TaskOptions, ctx?: string): Promise<TaskInfo> {
-        // on windows, prefer windows-specific options, if available
-        const processOptions = (isWindows && options.windowsProcessOptions !== undefined) ?
-            options.windowsProcessOptions : options.processOptions;
-
-        const command = processOptions.command;
-
-        // sanity checks:
-        // - we expect the cwd to be set by the client.
-        // - we expect processType to be set by the client
-        if (!options.cwd) {
-            return Promise.reject(new Error("Can't run a task when 'cwd' is not provided by the client"));
+    async run(taskConfiguration: TaskConfiguration, ctx?: string): Promise<TaskInfo> {
+        const taskType = taskConfiguration.type;
+        const runner = this.runnerRegistry.getRunner(taskType);
+        if (!runner) {
+            return Promise.reject(new Error(`No corresponding Runner found for the Task type ${taskType}`));
         }
-        if (!options.processType) {
-            return Promise.reject(new Error("Can't run a task when 'processType' is not provided by the client"));
-        }
+        const task = await runner.run(taskConfiguration, ctx);
 
-        const cwd = FileUri.fsPath(options.cwd);
-        // Use task's cwd with spawned process and pass node env object to
-        // new process, so e.g. we can re-use the system path
-        processOptions.options = {
-            cwd: cwd,
-            env: process.env
-        };
+        task.onExit(event => {
+            this.taskManager.delete(task);
+            this.fireTaskExitedEvent(event);
+        });
 
-        // When we create a process to execute a command, it's difficult to know if it failed
-        // because the executable or script was not found, or if it was found, ran, and exited
-        // unsuccessfully. So here we look to see if it seems we can find a file of that name
-        // that is likely to be the one we want, before attempting to execute it.
-        const cmd = await this.findCommand(command, cwd);
-        if (cmd) {
-            try {
-                // use terminal or raw process
-                let task: Task;
-                let proc: TerminalProcess | RawProcess;
-
-                if (options.processType === 'terminal') {
-                    this.logger.debug('Task: creating underlying terminal process');
-                    proc = this.terminalProcessFactory(<TerminalProcessOptions>processOptions);
-                } else {
-                    this.logger.debug('Task: creating underlying raw process');
-                    proc = this.rawProcessFactory(<RawProcessOptions>processOptions);
-                }
-
-                task = this.taskFactory(
-                    {
-                        label: options.label,
-                        command: cmd,
-                        process: proc,
-                        processType: options.processType,
-                        context: ctx
-                    });
-
-                this.tasksToDispose.set(task.id,
-                    proc.onExit(event => {
-                        this.fireTaskExitedEvent({
-                            'taskId': task.id,
-                            'code': event.code,
-                            'signal': event.signal,
-                            'ctx': ctx === undefined ? '' : ctx
-                        });
-                    }));
-
-                const taskInfo = task.getRuntimeInfo();
-
-                this.fireTaskCreatedEvent(taskInfo);
-                return taskInfo;
-
-            } catch (error) {
-                this.logger.error(`Error occurred while creating task: ${error}`);
-                return Promise.reject(new Error(error));
-            }
-        } else {
-            return Promise.reject(new Error(`Command not found: ${command}`));
-        }
+        const taskInfo = task.getRuntimeInfo();
+        this.fireTaskCreatedEvent(taskInfo);
+        return taskInfo;
     }
 
     protected fireTaskExitedEvent(event: TaskExitedEvent) {
@@ -177,59 +103,5 @@ export class TaskServerImpl implements TaskServer {
         if (idx > -1) {
             this.clients.splice(idx, 1);
         }
-    }
-
-    /**
-     * Uses heuristics to look-for a command. Will look into the system path, if the command
-     * is given without a path. Will resolve if a potential match is found, else reject. There
-     * is no guarantee that a command we find will be the one executed, if multiple commands with
-     * the same name exist.
-     * @param command command name to look for
-     * @param cwd current working directory
-     */
-    protected async findCommand(command: string, cwd: string): Promise<string | undefined> {
-        const systemPath = process.env.PATH;
-        const pathDelimiter = path.delimiter;
-
-        if (path.isAbsolute(command)) {
-            if (await this.executableFileExists(command)) {
-                return command;
-            }
-        } else {
-            // look for command relative to cwd
-            const resolvedCommand = FileUri.fsPath(new URI(cwd).resolve(command));
-
-            if (await this.executableFileExists(resolvedCommand)) {
-                return resolvedCommand;
-            } else {
-                // just a command to find in the system path?
-                if (path.basename(command) === command) {
-                    // search for this command in the system path
-                    if (systemPath !== undefined) {
-                        const pathArray: string[] = systemPath.split(pathDelimiter);
-
-                        for (const p of pathArray) {
-                            const candidate = FileUri.fsPath(new URI(p).resolve(command));
-                            if (await this.executableFileExists(candidate)) {
-                                return candidate;
-                            }
-                        }
-                    }
-                }
-            }
-
-        }
-    }
-
-    /**
-     * Checks for the existence of a file, at the provided path, and make sure that
-     * it's readable and executable.
-     */
-    protected async executableFileExists(filePath: string): Promise<boolean> {
-        return new Promise<boolean>(async (resolve, reject) => {
-            fs.access(filePath, fs.constants.F_OK | fs.constants.X_OK, err => {
-                resolve(err ? false : true);
-            });
-        });
     }
 }

--- a/packages/task/src/node/task.ts
+++ b/packages/task/src/node/task.ts
@@ -5,78 +5,46 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { injectable, inject, named } from 'inversify';
-import { ILogger } from '@theia/core/lib/common/';
-import { ProcessType, TaskInfo } from '../common/task-protocol';
+import { injectable } from 'inversify';
+import { ILogger, Emitter, Event } from '@theia/core/lib/common/';
 import { TaskManager } from './task-manager';
-import { Process, ProcessManager } from "@theia/process/lib/node";
+import { TaskInfo, TaskExitedEvent, TaskConfiguration } from '../common/task-protocol';
 
-export const TaskProcessOptions = Symbol("TaskProcessOptions");
-export interface TaskProcessOptions {
+export interface TaskOptions {
     label: string,
-    command: string,
-    process: Process,
-    processType: ProcessType,
+    config: TaskConfiguration
     context?: string
 }
 
-export const TaskFactory = Symbol("TaskFactory");
-export type TaskFactory = (options: TaskProcessOptions) => Task;
-
 @injectable()
-export class Task {
+export abstract class Task {
+
     protected taskId: number;
+    readonly exitEmitter: Emitter<TaskExitedEvent>;
 
     constructor(
-        @inject(TaskManager) protected readonly taskManager: TaskManager,
-        @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(TaskProcessOptions) protected readonly options: TaskProcessOptions,
-        @inject(ProcessManager) protected readonly processManager: ProcessManager
+        protected readonly taskManager: TaskManager,
+        protected readonly logger: ILogger,
+        protected readonly options: TaskOptions
     ) {
         this.taskId = this.taskManager.register(this, this.options.context);
-
-        const toDispose =
-            this.process.onExit(event => {
-                this.taskManager.delete(this);
-                toDispose.dispose();
-            });
-        this.logger.info(`Created new task, id: ${this.id}, process id: ${this.options.process.id}, OS PID: ${this.process.pid}, context: ${this.context}`);
+        this.exitEmitter = new Emitter<TaskExitedEvent>();
     }
 
-    /** terminates the task */
-    kill(): Promise<void> {
-        return new Promise<void>(resolve => {
-            if (this.process.killed) {
-                resolve();
-            } else {
-                const toDispose = this.process.onExit(event => {
-                    toDispose.dispose();
-                    resolve();
-                });
-                this.process.kill();
-            }
-        });
+    /** Terminates the task. */
+    abstract kill(): Promise<void>;
+
+    get onExit(): Event<TaskExitedEvent> {
+        return this.exitEmitter.event;
     }
 
-    /** Returns runtime information about task */
-    getRuntimeInfo(): TaskInfo {
-        return {
-            taskId: this.id,
-            osProcessId: this.process.pid,
-            terminalId: (this.processType === 'terminal') ? this.process.id : undefined,
-            processId: (this.processType === 'raw') ? this.process.id : undefined,
-            command: this.command,
-            label: this.label,
-            ctx: this.context
-        };
+    /** Has to be called when a task has concluded its execution. */
+    protected fireTaskExited(event: TaskExitedEvent): void {
+        this.exitEmitter.fire(event);
     }
 
-    get command() {
-        return this.options.command;
-    }
-    get process() {
-        return this.options.process;
-    }
+    /** Returns runtime information about task. */
+    abstract getRuntimeInfo(): TaskInfo;
 
     get id() {
         return this.taskId;
@@ -84,10 +52,6 @@ export class Task {
 
     get context() {
         return this.options.context;
-    }
-
-    get processType() {
-        return this.options.processType;
     }
 
     get label() {

--- a/packages/task/src/node/test-resources/.theia/tasks.json
+++ b/packages/task/src/node/test-resources/.theia/tasks.json
@@ -3,16 +3,14 @@
     "tasks": [
         {
             "label": "test task",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}",
-            "processOptions": {
-                "command": "./task",
-                "args": [
-                    "test"
-                ],
-                "options": {}
-            },
-            "windowsProcessOptions": {
+            "command": "./task",
+            "args": [
+                "test"
+            ],
+            "options": {},
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",
@@ -23,14 +21,12 @@
         },
         {
             "label": "long running test task",
-            "processType": "terminal",
+            "type": "shell",
             "cwd": "${workspaceFolder}",
-            "processOptions": {
-                "command": "./task-long-running",
-                "args": [],
-                "options": {}
-            },
-            "windowsProcessOptions": {
+            "command": "./task-long-running",
+            "args": [],
+            "options": {},
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",
@@ -41,16 +37,14 @@
         },
         {
             "label": "list all files",
-            "processType": "terminal",
+            "type": "terminal",
             "cwd": "${workspaceFolder}",
-            "processOptions": {
-                "command": "ls",
-                "args": [
-                    "-alR",
-                    "/"
-                ]
-            },
-            "windowsProcessOptions": {
+            "command": "ls",
+            "args": [
+                "-alR",
+                "/"
+            ],
+            "windows": {
                 "command": "cmd.exe",
                 "args": [
                     "/c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,9 +8807,9 @@ tslint-language-service@^0.9.9:
   dependencies:
     mock-require "^2.0.2"
 
-tslint@^5.7.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
This PR closes #1698 by introducing the Task API.
One of the interesting advantages of the Task API is that it allows Theia to consume VSCode's tasks.json.

The main concepts are:
#### Task Type
A Task Type is used to define which Task Resolver, Task Provider or Task Runner should be used with a particular Task Configuration.

#### Task Resolver (frontend contribution point)
Resolves a Task Configuration before sending it for execution to the Task Server. For example, this makes it possible to hide the actual complex command line from the user.

#### Task Provider (frontend contribution point)
It allows an extension to contribute the Tasks programmatically to the system.

#### Task Runner (backend contribution point)
A Task Runner knows how to run and kill a Task of a particular type. If contribution provides a Task Runner then it will be used to run a Task of a particular type otherwise, the default Task Runner is used.
That contribution point won't be so widely used as a Task Resolver and a Task Provider. But it's necessary for the extensions like Che, whose Tasks aren't running as the processes on Theia backend.
The Task extension provides `ProcessTaskRunner` implementation that can run a Task as a process or a command inside a shell (Tasks of type `process` or `shell`). It also serves as a default runner.
***
#### Here are some demos of using the Task API
Running a Task from the VSCode sources:
1/ Just open VSCode repo as Theia workspace and copy the tasks.json from .vscode into .theia folder.
2/ Now you can run, for example, `Run tests` task.
![vscode](https://user-images.githubusercontent.com/1636395/41208374-6022f7b2-6d2b-11e8-979b-c4add8aa8c19.gif)

---
Theia npm extension (not a part of this PR) that contributes:
- [npm Task Resolver](https://github.com/theia-ide/theia/blob/artem/task-api_ext-npm/packages/npm/src/browser/npm-task-resolver.ts) to allow its own format of a Task for describing npm script;
- [npm Task Provider](https://github.com/theia-ide/theia/blob/artem/task-api_ext-npm/packages/npm/src/browser/npm-task-provider.ts) to provide the scripts detected in a package.json as the Theia Tasks.
![npm](https://user-images.githubusercontent.com/1636395/41208365-517331fa-6d2b-11e8-89d8-5debddc25867.gif)

---
Che Task extensions (not a part of this PR) that contributes:
- [Che Task Resolver](https://github.com/theia-ide/theia/blob/artem/task-api_ext-che/packages/che/src/browser/che-task-resolver.ts) to allow its own format of a Task;
- [Che Task Runner](https://github.com/theia-ide/theia/blob/artem/task-api_ext-che/packages/che/src/node/che-task-runner.ts) to execute a command in any machine (docker container) of a Che Workspace;
- [Che Task Provider](https://github.com/theia-ide/theia/blob/artem/task-api_ext-che/packages/che/src/browser/che-task-provider.ts) to provide the known Che Workspace's commands as the Theia Tasks.

![che](https://user-images.githubusercontent.com/1636395/41208361-423777a0-6d2b-11e8-8bc7-b093ba0ec489.gif)
