### PR TITLE
GH-2068: Do not handle the `.md` resources with `diff` scheme.

### DIFF
--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -27,7 +27,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
     protected readonly openerService: OpenerService;
 
     canHandle(uri: URI): number {
-        return uri.path.ext === '.md' ? 500 : 0;
+        return uri.scheme === 'file' && uri.path.ext === '.md' ? 500 : 0;
     }
 
     renderContent(params: RenderContentParams): HTMLElement {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,9 +8807,9 @@ tslint-language-service@^0.9.9:
   dependencies:
     mock-require "^2.0.2"
 
-tslint@^5.7.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
But fall back to the default text editor. So that compare does not fail.

This commit also makes the `tslint` version update in the `yarnl.lock`.
See: a119c0cf365ad9c24c2b0bd0e3d3747c3234fead

Closes #2068.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>