### PR TITLE
Added language/status for java

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -20,20 +20,24 @@ import {
     Window, ILanguageClient, BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory, LanguageClientOptions
 } from '@theia/languages/lib/browser';
 import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME } from '../common';
-import { ActionableNotification, ActionableMessage } from "./java-protocol";
+import { ActionableNotification, ActionableMessage, StatusReport, StatusNotification } from "./java-protocol";
+import { StatusBar, StatusBarEntry, StatusBarAlignment } from "@theia/core/lib/browser";
 
 @injectable()
 export class JavaClientContribution extends BaseLanguageClientContribution {
 
     readonly id = JAVA_LANGUAGE_ID;
     readonly name = JAVA_LANGUAGE_NAME;
+    private readonly statusNotificationName = "java-status-notification";
+    private statusBarTimeout: number | undefined;
 
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
         @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
         @inject(Window) protected readonly window: Window,
-        @inject(CommandService) protected readonly commandService: CommandService
+        @inject(CommandService) protected readonly commandService: CommandService,
+        @inject(StatusBar) protected readonly statusBar: StatusBar
     ) {
         super(workspace, languages, languageClientFactory);
     }
@@ -44,7 +48,25 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
 
     protected onReady(languageClient: ILanguageClient): void {
         languageClient.onNotification(ActionableNotification.type, this.showActionableMessage.bind(this));
+        languageClient.onNotification(StatusNotification.type, this.showStatusMessage.bind(this));
         super.onReady(languageClient);
+    }
+
+    protected showStatusMessage(message: StatusReport) {
+        if (this.statusBarTimeout) {
+            window.clearTimeout(this.statusBarTimeout);
+            this.statusBarTimeout = undefined;
+        }
+        const statusEntry = {
+            alignment: StatusBarAlignment.LEFT,
+            priority: 1,
+            text: "$(refresh~spin) " + message.message
+        } as StatusBarEntry;
+        this.statusBar.setElement(this.statusNotificationName, statusEntry);
+        this.statusBarTimeout = window.setTimeout(() => {
+            this.statusBar.removeElement(this.statusNotificationName);
+            this.statusBarTimeout = undefined;
+        }, 5000);
     }
 
     protected showActionableMessage(message: ActionableMessage): void {

--- a/packages/java/src/browser/java-protocol.ts
+++ b/packages/java/src/browser/java-protocol.ts
@@ -17,6 +17,15 @@
 import { RequestType, NotificationType } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, Command, MessageType } from "@theia/languages/lib/common";
 
+export interface StatusReport {
+    message: string;
+    type: string;
+}
+
+export namespace StatusNotification {
+    export const type = new NotificationType<StatusReport, void>('language/status');
+}
+
 export interface ActionableMessage {
     severity: MessageType;
     message: string;


### PR DESCRIPTION
Adds the language/status protocol extension to java plugin and displays the current status to console.

For: https://github.com/eclipse/che/issues/9970

Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>