### PR TITLE
GH-2095: Fixed the failing Git test due to a change in the upstream.

### DIFF
--- a/packages/git/src/node/dugite-git.slow-spec.ts
+++ b/packages/git/src/node/dugite-git.slow-spec.ts
@@ -31,7 +31,7 @@ describe('git-slow', async function () {
             const repository = { localUri };
 
             const git = await createGit();
-            await git.clone('https://github.com/eclipse/eclipse.jdt.ls.git', { localUri });
+            await git.clone('https://github.com/kittaakos/eclipse.jdt.ls.git', { localUri });
             await git.checkout(repository, { branch: 'Java9' });
             await git.checkout(repository, { branch: 'docker' });
 


### PR DESCRIPTION
We switched to one of our fork instead.

Closes #2095.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>