### PR TITLE
GH-2043: Skipped the URI encoding in the WS label provider contribution.

### DIFF
--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -21,7 +21,7 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
         super();
         wsService.root.then(root => {
             if (root) {
-                this.wsRoot = root.uri;
+                this.wsRoot = new URI(root.uri).toString(true);
             }
         });
     }
@@ -81,12 +81,12 @@ export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProvid
      */
     getLongName(element: URI | FileStat): string {
         const uri = this.getUri(element);
-        const uriStr = uri.toString();
+        const uriStr = uri.toString(true);
         if (!this.wsRoot || !uriStr.startsWith(this.wsRoot)) {
             return super.getLongName(uri);
         }
 
-        const short = uri.toString().substr(this.wsRoot.length);
+        const short = uriStr.substr(this.wsRoot.length);
         if (short[0] === '/') {
             return short.substr(1);
         }


### PR DESCRIPTION
This tiny patch makes the paths human readble on the UI:
 - Before: `node_modules/%40phosphor/blabla`
 - After: `node_modules/@phosphor/blabla`

Closes #2043.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Before:
![screen shot 2018-06-12 at 09 23 01](https://user-images.githubusercontent.com/1405703/41276078-518bce60-6e23-11e8-9521-35866a6bb41b.jpg)


After:
![screen shot 2018-06-12 at 09 25 42](https://user-images.githubusercontent.com/1405703/41276072-4d9f56fa-6e23-11e8-9ccd-fbcaed472dcb.jpg)
