### PR TITLE
GH-2071: Fixed the bogus `unstaging` behavior in the Git widget.

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -12,7 +12,7 @@
     "@types/diff": "^3.2.2",
     "@types/fs-extra": "^4.0.2",
     "diff": "^3.4.0",
-    "dugite-extra": "0.0.1-alpha.22",
+    "dugite-extra": "0.0.1-alpha.23",
     "find-git-repositories": "^0.1.0",
     "fs-extra": "^4.0.2",
     "moment": "^2.21.0",

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -145,6 +145,23 @@ export namespace Git {
         }
 
         /**
+         * Further refinements for unstaging files from either from the index or from the working-tree. Alternatively, resetting both.
+         */
+        export interface Unstage {
+
+            /**
+             * What to reset; the state of the index, the working-tree, or both. If not given, `all` will be used.
+             */
+            readonly reset?: 'index' | 'working-tree' | 'all';
+
+            /**
+             * The treeish to reset to. Defaults to `HEAD`.
+             */
+            readonly treeish?: string;
+
+        }
+
+        /**
          * Options for further `git checkout` refinements.
          */
         export namespace Checkout {
@@ -562,10 +579,11 @@ export interface Git extends Disposable {
      * Removes the given file or files among the staged files in the working clone. The invocation will be rejected if
      * any files (given with their file URIs) is not among the staged files.
      *
-     * @param repository the repository to where the staged files have to be removed from/
-     * @param uri one or multiple file URIs to unstage in the working clone.
+     * @param repository the repository to where the staged files have to be removed from.
+     * @param uri one or multiple file URIs to unstage in the working clone. If the array is empty, all the changed files will be staged.
+     * @param options optional refinements for the the unstaging operation.
      */
-    unstage(repository: Repository, uri: string | string[]): Promise<void>;
+    unstage(repository: Repository, uri: string | string[], options?: Git.Options.Unstage): Promise<void>;
 
     /**
      * Returns with the currently active branch, or `undefined` if the current branch is in detached mode.

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -346,10 +346,12 @@ export class DugiteGit implements Git {
         );
     }
 
-    async unstage(repository: Repository, uri: string | string[]): Promise<void> {
+    async unstage(repository: Repository, uri: string | string[], options?: Git.Options.Unstage): Promise<void> {
         const paths = (Array.isArray(uri) ? uri : [uri]).map(FileUri.fsPath);
+        const treeish = options && options.treeish ? options.treeish : undefined;
+        const where = options && options.reset ? options.reset : undefined;
         return this.manager.run(repository, () =>
-            unstage(this.getFsPath(repository), paths)
+            unstage(this.getFsPath(repository), paths, treeish, where)
         );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,9 +2975,9 @@ dtrace-provider@~0.8:
   dependencies:
     nan "^2.3.3"
 
-dugite-extra@0.0.1-alpha.22:
-  version "0.0.1-alpha.22"
-  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.0.1-alpha.22.tgz#adda956ad757952199e9ab8d1bd1710d6d0bd0ec"
+dugite-extra@0.0.1-alpha.23:
+  version "0.0.1-alpha.23"
+  resolved "https://registry.yarnpkg.com/dugite-extra/-/dugite-extra-0.0.1-alpha.23.tgz#9a227a59fc8edf6b95b54b4810de2aaa3abe13a1"
   dependencies:
     byline "^5.0.0"
     dugite "1.42.0"


### PR DESCRIPTION
 - When resetting the index state, the working tree should remain as is.
 - When resetting the working tree, the index state should not change.
 - When resetting a new unstaged, it should delete the file from the FS.
 - When resetting a modified unstaged, it should be as the `HEAD`.

Closes #2071.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>