### PR TITLE
Align visibility/enablement checks of "Open With" commands

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -90,8 +90,8 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
                 registry.registerCommand(openWithCommand, this.newUriAwareCommandHandler({
                     execute: uri => opener.open(uri),
-                    isEnabled: uri => opener.canHandle(uri) !== 0,
-                    isVisible: uri => opener.canHandle(uri) !== 0
+                    isEnabled: uri => opener.canHandle(uri) > 0,
+                    isVisible: uri => opener.canHandle(uri) > 0
                 }));
             }
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,9 +8807,9 @@ tslint-language-service@^0.9.9:
   dependencies:
     mock-require "^2.0.2"
 
-tslint@^5.7.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
According to the JSDoc of `OpenHandler.canHandle` only positive numbers mean, that handlers can open a resource. Current implementation would enable commands with negative priorities.

Closes #2101