### PR TITLE
add "getPreferences" method to PreferenceServiceImpl

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -29,6 +29,7 @@ export interface PreferenceChange {
 export const PreferenceService = Symbol('PreferenceService');
 export interface PreferenceService extends Disposable {
     readonly ready: Promise<void>;
+    getPreferences(): { [key: string]: any };
     get<T>(preferenceName: string): T | undefined;
     get<T>(preferenceName: string, defaultValue: T): T;
     get<T>(preferenceName: string, defaultValue?: T): T | undefined;
@@ -135,6 +136,10 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
 
     has(preferenceName: string): boolean {
         return this.preferences[preferenceName] !== undefined;
+    }
+
+    getPreferences(): { [key: string]: any } {
+        return this.preferences;
     }
 
     get<T>(preferenceName: string): T | undefined;

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -13,6 +13,9 @@ import { Emitter, Event } from '../../../common';
 export class MockPreferenceService implements PreferenceService {
     constructor() { }
     dispose() { }
+    getPreferences(): { [key: string]: any; } {
+        return {};
+    }
     get<T>(preferenceName: string): T | undefined;
     get<T>(preferenceName: string, defaultValue: T): T;
     get<T>(preferenceName: string, defaultValue?: T): T | undefined {


### PR DESCRIPTION
The implementation of new extensibility model needs to grab
all the properties to expose access to them from within a plugin
via proxy object.

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>