### PR TITLE
[java] Revert removal of "jdt.ls.download.path" property

### DIFF
--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -53,5 +53,6 @@
   ],
   "nyc": {
     "extends": "../../configs/nyc.json"
-  }
+  },
+  "jdt.ls.download.path": "/jdtls/milestones/0.18.0/jdt-language-server-0.18.0-201805010001.tar.gz"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8807,9 +8807,9 @@ tslint-language-service@^0.9.9:
   dependencies:
     mock-require "^2.0.2"
 
-tslint@^5.7.0:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
This reverts a mistake made in PR #1861:

https://github.com/theia-ide/theia/pull/1861/files#diff-fcdcfe7b5151a8028bda0828e13c84c2L55

Without this property the latest version of JDT LS will be downloaded. Current latest version seems to have some issues, so it makes sense to go back to the tested version.

Closes #2107