### PR TITLE
multi-root workspace support, minimal patch

### DIFF
--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -50,7 +50,7 @@ export interface Tree extends Disposable {
      */
     refresh(parent: Readonly<CompositeTreeNode>): Promise<void>;
     /**
-     * Emit when the children of the give node are refreshed.
+     * Emit when the children of the given node are refreshed.
      */
     readonly onNodeRefreshed: Event<Readonly<CompositeTreeNode>>;
 }

--- a/packages/filesystem/src/browser/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog-service.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { FileSystem, FileStat } from '../common';
+import { FileStatNode, DirNode } from './file-tree';
+import { FileDialogFactory, FileDialogProps } from './file-dialog';
+import URI from '@theia/core/lib/common/uri';
+import { LabelProvider } from '@theia/core/lib/browser';
+
+@injectable()
+export class FileDialogService {
+    @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(FileDialogFactory) protected readonly fileDialogFactory: FileDialogFactory;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+
+    async show(props: FileDialogProps, folder?: FileStat): Promise<FileStatNode | undefined> {
+        const title = props && props.title ? props.title : 'Open';
+        const folderToOpen = folder || await this.fileSystem.getCurrentUserHome();
+        if (folderToOpen) {
+            const rootUri = new URI(folderToOpen.uri).parent;
+            const name = this.labelProvider.getName(rootUri);
+            const [rootStat, label] = await Promise.all([
+                this.fileSystem.getFileStat(rootUri.toString()),
+                this.labelProvider.getIcon(folderToOpen)
+            ]);
+            if (rootStat) {
+                const rootNode = DirNode.createRoot(rootStat, name, label);
+                const dialog = this.fileDialogFactory({ title });
+                dialog.model.navigateTo(rootNode);
+                const nodes = await dialog.open();
+                return Array.isArray(nodes) ? nodes[0] : nodes;
+            }
+        }
+    }
+}

--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -64,8 +64,8 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
         return this.selectedNodes.filter(FileStatNode.is);
     }
 
-    protected onFilesChanged(changes: FileChange[]): void {
-        const affectedNodes = this.getAffectedNodes(changes);
+    protected async onFilesChanged(changes: FileChange[]): Promise<void> {
+        const affectedNodes = await this.getAffectedNodes(changes);
         if (affectedNodes.length !== 0) {
             affectedNodes.forEach(node => this.refresh(node));
         } else if (this.isRootAffected(changes)) {
@@ -83,15 +83,15 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
         return false;
     }
 
-    protected getAffectedNodes(changes: FileChange[]): CompositeTreeNode[] {
+    protected async getAffectedNodes(changes: FileChange[]): Promise<CompositeTreeNode[]> {
         const nodes = new Map<string, CompositeTreeNode>();
         for (const change of changes) {
-            this.collectAffectedNodes(change, node => nodes.set(node.id, node));
+            await this.collectAffectedNodes(change, node => nodes.set(node.id, node));
         }
         return [...nodes.values()];
     }
 
-    protected collectAffectedNodes(change: FileChange, accept: (node: CompositeTreeNode) => void): void {
+    protected async collectAffectedNodes(change: FileChange, accept: (node: CompositeTreeNode) => void): Promise<void> {
         if (this.isFileContentChanged(change)) {
             return;
         }
@@ -133,6 +133,10 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
                     await this.fileSystem.move(sourceUri, targetUri, { overwrite: true });
                     // to workaround https://github.com/Axosoft/nsfw/issues/42
                     this.refresh(target);
+
+                    if (source.parent) {
+                        this.refresh(source.parent);
+                    }
                 }
             }
         }

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -19,7 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { TreeNode, CompositeTreeNode, SelectableTreeNode, ExpandableTreeNode, TreeImpl } from '@theia/core/lib/browser';
 import { FileSystem, FileStat } from '../../common';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
-import { UriSelection } from '@theia/core/lib/common//selection';
+import { UriSelection } from '@theia/core/lib/common/selection';
 
 @injectable()
 export class FileTree extends TreeImpl {
@@ -33,7 +33,6 @@ export class FileTree extends TreeImpl {
             if (fileStat) {
                 return this.toNodes(fileStat, parent);
             }
-
             return [];
         }
         return super.resolveChildren(parent);
@@ -63,7 +62,7 @@ export class FileTree extends TreeImpl {
         const uri = new URI(fileStat.uri);
         const name = await this.labelProvider.getName(uri);
         const icon = await this.labelProvider.getIcon(fileStat);
-        const id = fileStat.uri;
+        const id = this.toNodeId(fileStat, parent);
         const node = this.getNode(id);
         if (fileStat.isDirectory) {
             if (DirNode.is(node)) {
@@ -87,6 +86,9 @@ export class FileTree extends TreeImpl {
         };
     }
 
+    protected toNodeId(fileStat: FileStat, parent: CompositeTreeNode): string {
+        return fileStat.uri;
+    }
 }
 
 export interface FileStatNode extends SelectableTreeNode, UriSelection {
@@ -95,6 +97,13 @@ export interface FileStatNode extends SelectableTreeNode, UriSelection {
 export namespace FileStatNode {
     export function is(node: object | undefined): node is FileStatNode {
         return !!node && 'fileStat' in node;
+    }
+
+    export function getUri(node: TreeNode | undefined): string | undefined {
+        if (is(node)) {
+            return node.fileStat.uri;
+        }
+        return undefined;
     }
 }
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -26,6 +26,7 @@ import { FileResourceResolver } from './file-resource';
 import { FileSystemListener } from './filesystem-listener';
 import { bindFileSystemPreferences } from './filesystem-preferences';
 import { FileSystemWatcher } from './filesystem-watcher';
+import { FileDialogService } from './file-dialog-service';
 
 import '../../src/browser/style/index.css';
 
@@ -47,4 +48,6 @@ export default new ContainerModule(bind => {
 
     bind(FileResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toDynamicValue(ctx => ctx.container.get(FileResourceResolver));
+
+    bind(FileDialogService).toSelf().inSingletonScope();
 });

--- a/packages/filesystem/src/browser/index.ts
+++ b/packages/filesystem/src/browser/index.ts
@@ -20,3 +20,4 @@ export * from './file-dialog';
 export * from './filesystem-preferences';
 export * from './filesystem-watcher';
 export * from './file-resource';
+export * from './file-dialog-service';

--- a/packages/git/src/browser/git-decorator.ts
+++ b/packages/git/src/browser/git-decorator.ts
@@ -27,6 +27,7 @@ import { WorkingDirectoryStatus } from '../common/git-model';
 import { GitFileChange, GitFileStatus } from '../common/git-model';
 import { GitPreferences, GitConfiguration } from './git-preferences';
 import { GitRepositoryTracker } from './git-repository-tracker';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
 
 @injectable()
 export class GitDecorator implements TreeDecorator {
@@ -73,13 +74,16 @@ export class GitDecorator implements TreeDecorator {
             return result;
         }
         const markers = this.appendContainerChanges(tree, status.changes);
-        for (const { id } of new DepthFirstTreeIterator(tree.root)) {
-            const marker = markers.get(id);
-            if (marker) {
-                result.set(id, marker);
+        for (const treeNode of new DepthFirstTreeIterator(tree.root)) {
+            const uri = FileStatNode.getUri(treeNode);
+            if (uri) {
+                const marker = markers.get(uri);
+                if (marker) {
+                    result.set(treeNode.id, marker);
+                }
             }
         }
-        return new Map(Array.from(result.values()).map(m => [m.uri, this.toDecorator(m)] as [string, TreeDecoration.Data]));
+        return new Map(Array.from(result.entries()).map(m => [m[0], this.toDecorator(m[1])] as [string, TreeDecoration.Data]));
     }
 
     protected appendContainerChanges(tree: Tree, changes: GitFileChange[]): Map<string, GitFileChange> {

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -111,17 +111,23 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
 
     onStart(): void {
         this.repositoryTracker.onDidChangeRepository(repository => {
-            if (repository && this.hasMultipleRepositories()) {
-                const path = new URI(repository.localUri).path;
-                this.statusBar.setElement(GitViewContribution.GIT_SELECTED_REPOSITORY, {
-                    text: `$(database) ${path.base}`,
-                    alignment: StatusBarAlignment.LEFT,
-                    priority: 102,
-                    command: GIT_COMMANDS.CHANGE_REPOSITORY.id,
-                    tooltip: path.toString()
-                });
+            if (repository) {
+                if (this.hasMultipleRepositories()) {
+                    const path = new URI(repository.localUri).path;
+                    this.statusBar.setElement(GitViewContribution.GIT_SELECTED_REPOSITORY, {
+                        text: `$(database) ${path.base}`,
+                        alignment: StatusBarAlignment.LEFT,
+                        priority: 102,
+                        command: GIT_COMMANDS.CHANGE_REPOSITORY.id,
+                        tooltip: path.toString()
+                    });
+                } else {
+                    this.statusBar.removeElement(GitViewContribution.GIT_SELECTED_REPOSITORY);
+                }
             } else {
                 this.statusBar.removeElement(GitViewContribution.GIT_SELECTED_REPOSITORY);
+                this.statusBar.removeElement(GitViewContribution.GIT_REPOSITORY_STATUS);
+                this.statusBar.removeElement(GitViewContribution.GIT_SYNC_STATUS);
             }
         });
         this.repositoryTracker.onGitEvent(event => {

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -66,6 +66,8 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         this.scrollContainer = 'git-history-list-container';
         this.title.label = 'Git History';
         this.addClass('theia-git');
+        this.options = {};
+        this.commits = [];
     }
 
     protected onAfterAttach(msg: Message) {

--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -22,6 +22,7 @@ import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Tree } from '@theia/core/lib/browser/tree/tree';
 import { DepthFirstTreeIterator } from '@theia/core/lib/browser/tree/tree-iterator';
 import { TreeDecorator, TreeDecoration } from '@theia/core/lib/browser/tree/tree-decorator';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
 import { Marker } from '../../common/marker';
 import { ProblemManager } from './problem-manager';
 
@@ -55,13 +56,16 @@ export class ProblemDecorator implements TreeDecorator {
             return result;
         }
         const markers = this.appendContainerMarkers(tree, this.collectMarkers(tree));
-        for (const { id } of new DepthFirstTreeIterator(tree.root)) {
-            const marker = markers.get(id);
-            if (marker) {
-                result.set(id, marker);
+        for (const node of new DepthFirstTreeIterator(tree.root)) {
+            const nodeUri = FileStatNode.getUri(node);
+            if (nodeUri) {
+                const marker = markers.get(nodeUri);
+                if (marker) {
+                    result.set(node.id, marker);
+                }
             }
         }
-        return new Map(Array.from(result.values()).map(m => [m.uri, this.toDecorator(m)] as [string, TreeDecoration.Data]));
+        return new Map(Array.from(result.entries()).map(m => [m[0], this.toDecorator(m[1])] as [string, TreeDecoration.Data]));
     }
 
     protected appendContainerMarkers(tree: Tree, markers: Marker<Diagnostic>[]): Map<string, Marker<Diagnostic>> {

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -97,12 +97,14 @@ export class MonacoWorkspace implements lang.Workspace {
 
     @postConstruct()
     protected init(): void {
-        this.workspaceService.root.then(rootStat => {
+        this.workspaceService.roots.then(roots => {
+            const rootStat = roots[0];
             if (rootStat) {
                 this._rootUri = rootStat.uri;
                 this.resolveReady();
             }
         });
+
         for (const model of this.textModelService.models) {
             this.fireDidOpen(model);
         }

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -19,8 +19,12 @@ import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { SelectionService, CommandService } from '@theia/core/lib/common';
 import { CommonCommands } from '@theia/core/lib/browser/common-frontend-contribution';
-import { ContextMenuRenderer, TreeProps, TreeModel, TreeNode, LabelProvider, Widget, SelectableTreeNode, ExpandableTreeNode } from '@theia/core/lib/browser';
-import { FileTreeWidget, DirNode, FileNode } from '@theia/filesystem/lib/browser';
+import {
+    ContextMenuRenderer, ExpandableTreeNode,
+    TreeProps, TreeModel, TreeNode,
+    LabelProvider, Widget, SelectableTreeNode
+} from '@theia/core/lib/browser';
+import { FileTreeWidget, FileNode } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { FileNavigatorModel } from './navigator-model';
@@ -92,17 +96,8 @@ export class FileNavigatorWidget extends FileTreeWidget {
         ]);
     }
 
-    protected initialize(): void {
-        this.workspaceService.root.then(async resolvedRoot => {
-            if (resolvedRoot) {
-                const uri = new URI(resolvedRoot.uri);
-                const label = this.labelProvider.getName(uri);
-                const icon = await this.labelProvider.getIcon(resolvedRoot);
-                this.model.root = DirNode.createRoot(resolvedRoot, label, icon);
-            } else {
-                this.update();
-            }
-        });
+    protected async initialize(): Promise<void> {
+        await this.model.updateRoot();
     }
 
     protected enableDndOnMainPanel(): void {
@@ -180,7 +175,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
     }
 
     /**
-     * Instead of rendering the file resources form the workspace, we render a placeholder
+     * Instead of rendering the file resources from the workspace, we render a placeholder
      * button when the workspace root is not yet set.
      */
     protected renderOpenWorkspaceDiv(): React.ReactNode {
@@ -193,5 +188,4 @@ export class FileNavigatorWidget extends FileTreeWidget {
             </div>
         </div>;
     }
-
 }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
@@ -55,10 +55,11 @@ export class HostedPluginInformer implements FrontendApplicationContribution {
     protected readonly frontendApplicationStateService: FrontendApplicationStateService;
 
     public initialize(): void {
-        this.workspaceService.root.then(root => {
+        this.workspaceService.roots.then(roots => {
+            const workspaceFolder = roots[0];
             this.hostedPluginServer.getHostedPlugin().then(pluginMetadata => {
                 if (pluginMetadata) {
-                    this.updateTitle(root);
+                    this.updateTitle(workspaceFolder);
 
                     this.entry = {
                         text: `$(cube) ${HostedPluginInformer.DEVELOPMENT_HOST_TITLE}`,

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -191,19 +191,14 @@ export class HostedPluginManagerClient {
      * Creates directory choose dialog and set selected folder into pluginLocation field.
      */
     async selectPluginPath(): Promise<void> {
-        let rootStat = await this.workspaceService.root;
-
-        if (!rootStat) {
-            rootStat = await this.fileSystem.getCurrentUserHome();
-        }
-
-        if (!rootStat) {
+        const workspaceFolder = (await this.workspaceService.roots)[0] || await this.fileSystem.getCurrentUserHome();
+        if (!workspaceFolder) {
             throw new Error('Unable to find the root');
         }
 
-        const name = this.labelProvider.getName(rootStat);
-        const label = await this.labelProvider.getIcon(rootStat);
-        const rootNode = DirNode.createRoot(rootStat, name, label);
+        const name = this.labelProvider.getName(workspaceFolder);
+        const label = await this.labelProvider.getIcon(workspaceFolder);
+        const rootNode = DirNode.createRoot(workspaceFolder, name, label);
 
         const dialog = this.fileDialogFactory({
             title: HostedPluginCommands.SELECT_PATH.label!,

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -128,7 +128,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
 
         // Try to use workspace service root if there is no preconfigured URI
         if (!rootStat) {
-            rootStat = await this.workspaceService.root;
+            rootStat = (await this.workspaceService.roots)[0];
         }
 
         // Try to use current user home if root folder is still not taken

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -30,9 +30,10 @@ export class WorkspaceMain {
     constructor(rpc: RPCProtocol, workspaceService: WorkspaceService) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WORKSPACE_EXT);
 
-        workspaceService.root.then(root => {
-            if (root) {
-                this.workspaceRoot = Uri.parse(root.uri);
+        workspaceService.roots.then(roots => {
+            const workspaceFolder = roots[0];
+            if (workspaceFolder) {
+                this.workspaceRoot = Uri.parse(workspaceFolder.uri);
                 const workspacePath = new Path(this.workspaceRoot.path);
 
                 const folder: WorkspaceFolder = {

--- a/packages/preferences/src/browser/workspace-preference-provider.ts
+++ b/packages/preferences/src/browser/workspace-preference-provider.ts
@@ -26,9 +26,9 @@ export class WorkspacePreferenceProvider extends AbstractResourcePreferenceProvi
     protected readonly workspaceService: WorkspaceService;
 
     async getUri(): Promise<URI | undefined> {
-        const root = await this.workspaceService.root;
-        if (root) {
-            const rootUri = new URI(root.uri);
+        const workspaceFolder = (await this.workspaceService.roots)[0];
+        if (workspaceFolder) {
+            const rootUri = new URI(workspaceFolder.uri);
             return rootUri.resolve('.theia').resolve('settings.json');
         }
         return undefined;

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -113,7 +113,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         super.init();
         this.addClass('resultContainer');
 
-        this.workspaceService.root.then(rootFileStat => {
+        this.workspaceService.roots.then(roots => {
+            const rootFileStat = roots[0];
             if (rootFileStat) {
                 const uri = new URI(rootFileStat.uri);
                 this.workspaceRoot = uri.withoutScheme().toString();

--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -106,7 +106,7 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
 
     // Start a search of the string "what" in the workspace.
     async search(what: string, callbacks: SearchInWorkspaceCallbacks, opts?: SearchInWorkspaceOptions): Promise<number> {
-        const root = await this.workspaceService.root;
+        const root = (await this.workspaceService.roots)[0];
 
         if (!root) {
             throw new Error('Search failed: no workspace root.');

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -77,7 +77,8 @@ export class TaskService implements TaskConfigurationClient {
     @postConstruct()
     protected init(): void {
         // wait for the workspace root to be set
-        this.workspaceService.root.then(async root => {
+        this.workspaceService.roots.then(async roots => {
+            const root = roots[0];
             if (root) {
                 this.configurationFileFound = await this.taskConfigurations.watchConfigurationFile(root.uri);
                 this.workspaceRootUri = root.uri;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -239,7 +239,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected async createTerminal(): Promise<number> {
         let rootURI = this.options.cwd;
         if (!rootURI) {
-            const root = await this.workspaceService.root;
+            const root = (await this.workspaceService.roots)[0];
             rootURI = root && root.uri;
         }
         const { cols, rows } = this.term;

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -87,7 +87,8 @@ export class WorkspaceQuickOpenItem extends QuickOpenItem {
         if (mode !== QuickOpenMode.OPEN) {
             return false;
         }
-        this.workspaceService.root.then(current => {
+        this.workspaceService.roots.then(roots => {
+            const current = roots[0];
             if (current === undefined) {  // Available recent workspace(s) but closed
                 if (this.workspace && this.workspace.length > 0) {
                     this.workspaceService.open(new URI(this.workspace));

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -24,20 +24,28 @@ import {
 } from '@theia/core/lib/browser/preferences';
 
 export const workspacePreferenceSchema: PreferenceSchema = {
-    'type': 'object',
-    'properties': {
+    type: 'object',
+    properties: {
         'workspace.preserveWindow': {
-            'description': 'Enable opening workspaces in current window',
-            'additionalProperties': {
-                'type': 'boolean'
+            description: 'Enable opening workspaces in current window',
+            additionalProperties: {
+                type: 'boolean'
             },
-            'default': false
+            default: false
+        },
+        'workspace.supportMultiRootWorkspace': {
+            description: 'Enable the multi-root workspace support to test this feature internally',
+            additionalProperties: {
+                type: 'boolean'
+            },
+            default: false
         }
     }
 };
 
 export interface WorkspaceConfiguration {
-    'workspace.preserveWindow': boolean
+    'workspace.preserveWindow': boolean,
+    'workspace.supportMultiRootWorkspace': boolean
 }
 
 export const WorkspacePreferences = Symbol('WorkspacePreferences');

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -21,6 +21,7 @@ import { FileSystemWatcher } from '@theia/filesystem/lib/browser';
 import { WorkspaceServer } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { Disposable, Emitter, Event } from '@theia/core/lib/common';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { WorkspacePreferences } from './workspace-preferences';
@@ -31,11 +32,12 @@ import { WorkspacePreferences } from './workspace-preferences';
 @injectable()
 export class WorkspaceService implements FrontendApplicationContribution {
 
-    private _root: FileStat | undefined;
+    // TODO remove it with the patch where the config file becomes independent from the workspace
+    private _workspaceFolder: FileStat | undefined;
+    private _roots: FileStat[];
+    private deferredRoots = new Deferred<FileStat[]>();
 
-    private readonly deferredRoot = new Deferred<FileStat | undefined>();
-
-    readonly root = this.deferredRoot.promise;
+    private rootWatchers: { [uri: string]: Disposable } = {};
 
     private hasWorkspace: boolean = false;
 
@@ -59,18 +61,108 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     @postConstruct()
     protected async init(): Promise<void> {
-        const rootUri = await this.server.getWorkspace();
-        this._root = await this.toValidRoot(rootUri);
-        if (this._root) {
-            const uri = new URI(this._root.uri);
-            this.updateTitle(uri);
-            this.watcher.watchFileChanges(uri);
+        this._workspaceFolder = undefined;
+        this._roots = [];
+        await this.updateWorkspace();
+        this.updateTitle();
+        const configUri = this.getWorkspaceConfigFileUri();
+        if (configUri) {
+            const configUriString = configUri.toString();
+            this.watcher.onFilesChanged(changes => {
+                if (changes.some(change => change.uri.toString() === configUriString)) {
+                    this.updateWorkspace();
+                }
+            });
         }
-        this.deferredRoot.resolve(this._root);
     }
 
-    protected updateTitle(uri: URI): void {
-        document.title = uri.displayName;
+    get roots(): Promise<FileStat[]> {
+        return this.deferredRoots.promise;
+    }
+    tryGetRoots(): FileStat[] {
+        return this._roots;
+    }
+
+    protected readonly onWorkspaceChangeEmitter = new Emitter<FileStat[]>();
+    get onWorkspaceChanged(): Event<FileStat[]> {
+        return this.onWorkspaceChangeEmitter.event;
+    }
+
+    protected async updateWorkspace(): Promise<void> {
+        if (!this._workspaceFolder) {
+            const rootUri = await this.server.getMostRecentlyUsedWorkspace();
+            this._workspaceFolder = await this.toValidRoot(rootUri);
+            if (this._workspaceFolder) {
+                this._roots.push(this._workspaceFolder);
+            }
+        }
+        this.deferredRoots.resolve(this._roots);
+
+        await this.preferences.ready;
+        if (this._workspaceFolder) {
+            let roots: string[];
+            if (this.preferences['workspace.supportMultiRootWorkspace']) {
+                const rootConfig = await this.getRootConfig();
+                roots = rootConfig.roots;
+            } else {
+                roots = [this._workspaceFolder.uri];
+            }
+
+            for (const rootBeingWatched of Object.keys(this.rootWatchers)) {
+                if (roots.indexOf(rootBeingWatched) < 0) {
+                    this.stopWatch(rootBeingWatched);
+                }
+            }
+            this._roots.length = 0;
+            for (const rootToWatch of roots) {
+                const valid = await this.toValidRoot(rootToWatch);
+                if (!this.rootWatchers[rootToWatch]) {
+                    await this.startWatch(valid);
+                }
+                if (valid) {
+                    this._roots.push(valid);
+                }
+            }
+            if (!this.rootWatchers[this._workspaceFolder.uri]) {
+                // must watch the workspace folder for meta data changes, even if it is not in the workspace
+                await this.startWatch(this._workspaceFolder);
+            }
+        }
+        this.onWorkspaceChangeEmitter.fire(this._roots);
+    }
+
+    protected async getRootConfig(): Promise<{ stat: FileStat | undefined, roots: string[] }> {
+        const configUri = this.getWorkspaceConfigFileUri();
+        if (configUri) {
+            let fileStat = undefined;
+            const uriStr = configUri.path.toString();
+            if (await this.fileSystem.exists(uriStr)) {
+                const { stat, content } = await this.fileSystem.resolveContent(uriStr);
+                fileStat = stat;
+                if (content) {
+                    const roots = JSON.parse(content).roots || [];
+                    return { stat, roots: this._workspaceFolder && roots.length === 0 ? [this._workspaceFolder.uri] : roots };
+                }
+            }
+            return { stat: fileStat, roots: [this._workspaceFolder!.uri] };
+        }
+        return { stat: undefined, roots: [] };
+    }
+
+    protected getWorkspaceConfigFileUri(): URI | undefined {
+        if (this._workspaceFolder) {
+            const rootUri = new URI(this._workspaceFolder.uri);
+            return rootUri.resolve('.theia').resolve('root.json');
+        }
+    }
+
+    protected updateTitle(): void {
+        if (this._workspaceFolder) {
+            const uri = new URI(this._workspaceFolder.uri);
+            document.title = uri.displayName;
+        } else {
+            document.title = window.location.href;
+        }
     }
 
     /**
@@ -78,8 +170,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
      * @param app
      */
     onStop(app: FrontendApplication): void {
-        if (this._root) {
-            this.server.setWorkspace(this._root.uri);
+        if (this._workspaceFolder) {
+            this.server.setMostRecentlyUsedWorkspace(this._workspaceFolder.uri);
         }
     }
 
@@ -103,7 +195,15 @@ export class WorkspaceService implements FrontendApplicationContribution {
      * @returns {boolean}
      */
     get opened(): boolean {
-        return !!this._root;
+        return !!this._workspaceFolder;
+    }
+
+    /**
+     * Returns `true` if there is an opened workspace in theia, and the workspace has more than one root.
+     * @returns {boolean}
+     */
+    get isMultiRootWorkspaceOpened(): boolean {
+        return this.opened && this.preferences['workspace.supportMultiRootWorkspace'];
     }
 
     /**
@@ -119,30 +219,82 @@ export class WorkspaceService implements FrontendApplicationContribution {
         if (valid) {
             // The same window has to be preserved too (instead of opening a new one), if the workspace root is not yet available and we are setting it for the first time.
             // Option passed as parameter has the highest priority (for api developers), then the preference, then the default.
+            await this.roots;
+            const rootToOpen = this._workspaceFolder;
             const { preserveWindow } = {
-                preserveWindow: this.preferences['workspace.preserveWindow'] || !(await this.root),
+                preserveWindow: this.preferences['workspace.preserveWindow'] || !(rootToOpen),
                 ...options
             };
-            await this.server.setWorkspace(rootUri);
+            await this.server.setMostRecentlyUsedWorkspace(rootUri);
             if (preserveWindow) {
-                this._root = valid;
+                this._workspaceFolder = valid;
             }
-            this.openWindow(uri, { preserveWindow });
+            await this.openWindow({ preserveWindow });
             return;
         }
-        throw new Error(`Invalid workspace root URI. Expected an existing directory location. URI: ${rootUri}.`);
+        throw new Error('Invalid workspace root URI. Expected an existing directory location.');
     }
 
     /**
-     * Clears current workspace root and reloads window.
+     * Adds a root folder to the workspace
+     * @param uri URI of the root folder being added
      */
-    close(): void {
-        this.doClose();
+    async addRoot(uri: URI): Promise<void> {
+        await this.roots;
+        if (!this.opened || !this._workspaceFolder) {
+            throw new Error('Folder cannot be added as there is no active folder in the current workspace.');
+        }
+
+        const rootToAdd = uri.toString();
+        const valid = await this.toValidRoot(rootToAdd);
+        if (!valid) {
+            throw new Error(`Invalid workspace root URI. Expected an existing directory location. URI: ${rootToAdd}.`);
+        }
+        if (this._workspaceFolder && !this._roots.find(r => r.uri === valid.uri)) {
+            const configUri = this.getWorkspaceConfigFileUri();
+            if (configUri) {
+                if (!await this.fileSystem.exists(configUri.toString())) {
+                    await this.fileSystem.createFile(configUri.toString());
+                }
+                await this.writeRootFolderConfigFile(
+                    (await this.fileSystem.getFileStat(configUri.toString()))!,
+                    [...this._roots, valid]
+                );
+            }
+        }
     }
 
-    protected async doClose(): Promise<void> {
-        this._root = undefined;
-        await this.server.setWorkspace('');
+    /**
+     * Removes root folder(s) from workspace.
+     */
+    async removeRoots(uris: URI[]): Promise<void> {
+        if (!this.opened) {
+            throw new Error('Folder cannot be removed as there is no active folder in the current workspace.');
+        }
+        const configStat = (await this.getRootConfig()).stat;
+        if (configStat) {
+            await this.writeRootFolderConfigFile(
+                configStat, this._roots.filter(root => uris.findIndex(u => u.toString() === root.uri) < 0)
+            );
+        }
+    }
+
+    private async writeRootFolderConfigFile(rootConfigFile: FileStat, rootFolders: FileStat[]): Promise<void> {
+        const folders = rootFolders.slice();
+        if (folders.length === 0 && this._workspaceFolder) {
+            folders.push(this._workspaceFolder);
+        }
+        await this.fileSystem.setContent(rootConfigFile, JSON.stringify({ roots: folders.map(f => f.uri) }));
+    }
+
+    /**
+     * Clears current workspace root.
+     */
+    close(): void {
+        this._workspaceFolder = undefined;
+        this._roots.length = 0;
+
+        this.server.setMostRecentlyUsedWorkspace('');
         this.reloadWindow();
     }
 
@@ -170,7 +322,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
         }
     }
 
-    protected openWindow(uri: URI, options?: WorkspaceInput): void {
+    protected openWindow(options?: WorkspaceInput): void {
         if (this.shouldPreserveWindow(options)) {
             this.reloadWindow();
         } else {
@@ -178,8 +330,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
                 this.openNewWindow();
             } catch (error) {
                 // Fall back to reloading the current window in case the browser has blocked the new window
-                this._root = undefined;
-                this.logger.error(error.toString()).then(() => this.reloadWindow());
+                this._workspaceFolder = undefined;
+                this.logger.error(error.toString()).then(async () => await this.reloadWindow());
             }
         }
     }
@@ -201,9 +353,9 @@ export class WorkspaceService implements FrontendApplicationContribution {
      * NOTE: You should always explicitly use `/` as the separator between the path segments.
      */
     async containsSome(paths: string[]): Promise<boolean> {
-        const workspaceRoot = await this.root;
-        if (workspaceRoot) {
-            const uri = new URI(workspaceRoot.uri);
+        await this.roots;
+        if (this._workspaceFolder) {
+            const uri = new URI(this._workspaceFolder.uri);
             for (const path of paths) {
                 const fileUri = uri.resolve(path).toString();
                 const exists = await this.fileSystem.exists(fileUri);
@@ -215,6 +367,27 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return false;
     }
 
+    protected async startWatch(validRoot: FileStat | undefined): Promise<void> {
+        if (validRoot && !this.rootWatchers[validRoot.uri]) {
+            const uri = new URI(validRoot.uri);
+            const watcher = (await this.watcher.watchFileChanges(uri));
+            this.rootWatchers[validRoot.uri] = watcher;
+        }
+    }
+
+    protected stopWatch(uri?: string): void {
+        if (uri) {
+            if (this.rootWatchers[uri]) {
+                this.rootWatchers[uri].dispose();
+                delete this.rootWatchers[uri];
+            }
+        } else {
+            for (const watchedUri of Object.keys(this.rootWatchers)) {
+                this.rootWatchers[watchedUri].dispose();
+            }
+            this.rootWatchers = {};
+        }
+    }
 }
 
 export interface WorkspaceInput {

--- a/packages/workspace/src/browser/workspace-storage-service.ts
+++ b/packages/workspace/src/browser/workspace-storage-service.ts
@@ -18,6 +18,7 @@ import { inject, injectable, postConstruct } from 'inversify';
 import { LocalStorageService } from '@theia/core/lib/browser/storage-service';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { WorkspaceService } from './workspace-service';
+import { FileStat } from '@theia/filesystem/lib/common';
 
 /*
  * Prefixes any stored data with the current workspace path.
@@ -33,12 +34,8 @@ export class WorkspaceStorageService implements StorageService {
 
     @postConstruct()
     protected init() {
-        this.initialized = this.workspaceService.root.then(stat => {
-            if (stat) {
-                this.prefix = stat.uri;
-            } else {
-                this.prefix = '_global_';
-            }
+        this.initialized = this.workspaceService.roots.then(roots => {
+            this.prefix = this.getPrefix(roots[0]);
         });
     }
 
@@ -57,6 +54,10 @@ export class WorkspaceStorageService implements StorageService {
     }
 
     protected prefixWorkspaceURI(originalKey: string): string {
-        return this.prefix + ':' + originalKey;
+        return `${this.prefix}:${originalKey}`;
+    }
+
+    protected getPrefix(rootStat: FileStat | undefined): string {
+        return rootStat ? rootStat.uri : '_global_';
     }
 }

--- a/packages/workspace/src/browser/workspace-uri-contribution.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.ts
@@ -16,7 +16,7 @@
 
 import { DefaultUriLabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import URI from '@theia/core/lib/common/uri';
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { WorkspaceService } from './workspace-service';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
 import { MaybePromise } from '@theia/core';
@@ -24,15 +24,19 @@ import { MaybePromise } from '@theia/core';
 @injectable()
 export class WorkspaceUriLabelProviderContribution extends DefaultUriLabelProviderContribution {
 
+    @inject(WorkspaceService)
+    protected workspaceService: WorkspaceService;
+    @inject(FileSystem)
+    protected fileSystem: FileSystem;
+
     wsRoot: string;
-    constructor(@inject(WorkspaceService) wsService: WorkspaceService,
-        @inject(FileSystem) protected fileSystem: FileSystem) {
-        super();
-        wsService.root.then(root => {
-            if (root) {
-                this.wsRoot = new URI(root.uri).toString(true);
-            }
-        });
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        const root = (await this.workspaceService.roots)[0];
+        if (root) {
+            this.wsRoot = new URI(root.uri).toString(true);
+        }
     }
 
     canHandle(element: object): number {

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -96,7 +96,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
     }
 
     protected async getWorkspaceRootUri(): Promise<URI | undefined> {
-        const wsRoot = await this.workspaceService.root;
+        const wsRoot = (await this.workspaceService.roots)[0];
         if (wsRoot) {
             return new URI(wsRoot.uri);
         }

--- a/packages/workspace/src/common/test/mock-workspace-server.ts
+++ b/packages/workspace/src/common/test/mock-workspace-server.ts
@@ -19,9 +19,9 @@ import { WorkspaceServer } from '../workspace-protocol';
 @injectable()
 export class MockWorkspaceServer implements WorkspaceServer {
 
-    getWorkspace(): Promise<string | undefined> { return Promise.resolve(''); }
-
-    setWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
-
     getRecentWorkspaces(): Promise<string[]> { return Promise.resolve([]); }
+
+    getMostRecentlyUsedWorkspace(): Promise<string | undefined> { return Promise.resolve(''); }
+
+    setMostRecentlyUsedWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/workspace/src/common/workspace-protocol.ts
+++ b/packages/workspace/src/common/workspace-protocol.ts
@@ -23,18 +23,18 @@ export const WorkspaceServer = Symbol('WorkspaceServer');
 export interface WorkspaceServer {
 
     /**
-     * Returns with a promise that resolves to the workspace root URI as a string. Resolves to `undefined` if the workspace root is not yet set.
+     * Returns with a promise that resolves to the most recently used workspace folder URI as a string.
+     * Resolves to `undefined` if the workspace folder is not yet set.
      */
-    getWorkspace(): Promise<string | undefined>;
+    getMostRecentlyUsedWorkspace(): Promise<string | undefined>;
 
     /**
-     * Sets the desired string representation of the URI as the workspace root.
+     * Sets the desired string representation of the URI as the most recently used workspace folder.
      */
-    setWorkspace(uri: string): Promise<void>;
+    setMostRecentlyUsedWorkspace(uri: string): Promise<void>;
 
     /**
      * Returns list of recently opened workspaces as an array.
      */
     getRecentWorkspaces(): Promise<string[]>
-
 }


### PR DESCRIPTION
What is a workspace / workspace folder? It is a folder on the file system that serves as a container for:

- workspace configuration: in sub-folder ```.theia```
  - preferences, in ```.theia/settings.json```
  - root folders list, in ```.theia/roots.json```
- optional content in the form of other files/folders

For backward compatibility and simplicity, a workspace folder that contains no explicit root folder list configuration will use its own folder as the single root. This permits using any folder as a workspace.
If subsequently an additional root folder is added to such a workspace, then both the newly added folder and the original implicit root are added to the root folders list configuration. Either can later be removed. If all roots are removed form the configuration, the workspace falls-back to using its own folder as implicit root.

This PR is the minimal patch for #1660 

**What's included in this PR:**
- a workspace's root folders list can be modified using the navigator context menu "add/remove folder" items to add or remove a folder
- preference 'workspace.supportMultiRootWorkspace', with default value false, can be used to control if the context menu entries, used to modify the list of root folders, are shown or not. Since this is a new feature that is not supported by most Theia extensions yet, it probably makes sense to hide the UI by default for now
- previously the "current root" was a static value, obtained by each extension that needs it, at the startup of a Theia client. To change it (e.g. to switch workspace), a restart of the client was required. For this feature we did not want to have to restart the client each time the list of root folders is updated, so we introduced a new "onWorkspaceRootChanged" event. Extensions that need to know when the list of root folders is modified can react to this event, e.g. to update their widgets. It's still necessary to reload the Theia frontend when switching workspace in a given tab or when closing a workspace.
- the root folder list comprised of 1 to many folders can be displayed from the file navigator widget.
- the root folders will be scanned for git repositories that the user can select, stage and commit files into.

**What's not included:**
- users should have the choice of naming the workspace and choosing where to store the config file
- preference extension should be able to handle the settings from multiple project
- search-in-workspace and file-search extension should be able to perform the search across all folders in the workspace, and / or provide filtering mechanism to reduce the amount of information being displayed
- output and problems widgets should display data from all root folders, and / or provide filtering mechanism to reduce the amount of information being displayed
- task extension should be able to run tasks defined under all root folders
- users should be able to open the terminal from any root folder in the workspace


Signed-off-by: elaihau <liang.huang@ericsson.com>