### PR TITLE
propagate args to ext scripts

### DIFF
--- a/dev-packages/ext-scripts/theiaext
+++ b/dev-packages/ext-scripts/theiaext
@@ -21,7 +21,7 @@ function getExtScript() {
     if (!(script in extScriptsPck.scripts)) {
         throw new Error('The ext script does not exist: ' + script);
     }
-    return extScriptsPck.scripts[script];
+    return [extScriptsPck.scripts[script], ...args.slice(1, args.length)].join(' ');
 }
 
 function run(script) {


### PR DESCRIPTION
It allows to pass args to ext scripts via npx, for example to filter out tests to run:

    npx run test @theia/core -- --grep foo