### PR TITLE
Use file-icons with colors (fixes #2130)

### DIFF
--- a/packages/core/src/browser/file-icons-js.d.ts
+++ b/packages/core/src/browser/file-icons-js.d.ts
@@ -7,4 +7,5 @@
 
 declare module "file-icons-js" {
     function getClass(filePath: string): string;
+    function getClassWithColor(filePath: string): string;
 }

--- a/packages/core/src/browser/label-provider.spec.ts
+++ b/packages/core/src/browser/label-provider.spec.ts
@@ -29,7 +29,7 @@ describe("DefaultUriLabelProviderContribution", function () {
         const prov = new DefaultUriLabelProviderContribution();
         const icon = prov.getIcon(new URI('file:///tmp/hello/you.txt'));
 
-        expect(icon).eq('text-icon');
+        expect(icon).eq('text-icon medium-blue');
     });
 
     it("should return icon class for something that seems to be a directory", function () {

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -61,7 +61,7 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
     }
 
     protected getFileIcon(uri: URI): string | undefined {
-        return fileIcons.getClass(uri.displayName);
+        return fileIcons.getClassWithColor(uri.displayName);
     }
 
     getName(uri: URI): string {


### PR DESCRIPTION
Before:

<img width="1381" alt="screen shot 2018-06-19 at 20 04 54" src="https://user-images.githubusercontent.com/372735/41615991-0f0db9ba-73fd-11e8-9f61-677652a2512f.png">

After (including #2059 / #2118):

<img width="1381" alt="screen shot 2018-06-19 at 20 04 03" src="https://user-images.githubusercontent.com/372735/41616035-2912a8ca-73fd-11e8-960c-459d78ab28ac.png">

