### PR TITLE
Fix error with git 2.17.1

### DIFF
--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -774,6 +774,41 @@ describe('git', async function () {
 
 });
 
+describe('log', () => {
+
+    async function testLogFromRepoRoot(testLocalGit: string) {
+        const savedValue = process.env.USE_LOCAL_GIT;
+        try {
+            process.env.USE_LOCAL_GIT = testLocalGit;
+            const root = await createTestRepository(track.mkdirSync('log-test'));
+            const localUri = FileUri.create(root).toString();
+            const repository = { localUri };
+            const git = await createGit();
+            const result = await git.log(repository, { uri: localUri });
+            expect(result.length === 1).to.be.true;
+            expect(result[0].author.email === 'jon@doe.com').to.be.true;
+        } catch (err) {
+            throw err;
+        } finally {
+            process.env.USE_LOCAL_GIT = savedValue;
+        }
+    }
+
+    // See https://github.com/theia-ide/theia/issues/2143
+    it('should not fail with embedded git when executed from the repository root', async () => {
+        await testLogFromRepoRoot('false');
+    });
+
+    // See https://github.com/theia-ide/theia/issues/2143
+    it('should not fail with local git when executed from the repository root', async () => {
+        await testLogFromRepoRoot('true');
+    });
+
+    // THE ABOVE TEST SHOULD ALWAYS BE THE LAST GIT TEST RUN.
+    // It changes the underlying git to be the local git, which can't be
+    // undone. (See https://github.com/theia-ide/theia/issues/2246).
+});
+
 function toPathSegment(repository: Repository, uri: string): string {
     return upath.relative(FileUri.fsPath(repository.localUri), FileUri.fsPath(uri));
 }

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -550,7 +550,7 @@ export class DugiteGit implements Git {
                 [CommitPlaceholders.SHORT_HASH, ...CommitDetailsParser.DEFAULT_PLACEHOLDERS.slice(1)] : CommitDetailsParser.DEFAULT_PLACEHOLDERS;
         args.push(...['--name-status', '--date=unix', `--format=${this.commitDetailsParser.getFormat(...placeholders)}`, '-z', '--']);
         if (options && options.uri) {
-            const file = Path.relative(this.getFsPath(repository), this.getFsPath(options.uri));
+            const file = Path.relative(this.getFsPath(repository), this.getFsPath(options.uri)) || '.';
             args.push(...[file]);
         }
         const result = await this.exec(repository, args);


### PR DESCRIPTION
https://github.com/theia-ide/theia/blob/3241dd5f745a4c13ce661fa0fd374875a4c317db/packages/git/src/node/dugite-git.ts#L541

Seeing the following error when USE_LOCAL_GIT is set to true and the version of git is 2.17.1

```
[2018-06-20T17:29:07.255Z] ERROR: Theia/3622 on localhost: The command `git log HEAD -C -M -m -n 100 --name-status --date=unix --format=%x02%h%x01%aE%x01%aN%x01%ad%x01%ar%x01%x01%b%x01 -z -- ` exited with an unexpected code: 128. The caller should either handle this error, or expect that exit code. (logger=root)

[2018-06-20T17:29:07.256Z] ERROR: Theia/3622 on localhost: (logger=root)
    fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
     []
```

This happens when `file` is the empty string; git 2.17.x has started objecting to that, whereas earlier versions of git accepted it.

Signed-off-by: John Pitman <jspitman@ca.ibm.com>