### PR TITLE
Removed FrontendApplicationContribution from AbstractViewContribution

### DIFF
--- a/examples/browser/test/left-panel/left-panel.ts
+++ b/examples/browser/test/left-panel/left-panel.ts
@@ -42,11 +42,6 @@ export class LeftPanel {
             && this.isPanelVisible();
     }
 
-    isExtensionTabVisible(): boolean {
-        return (this.driver.element('#extensions').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1)
-            && this.isPanelVisible();
-    }
-
     protected isPanelVisible(): boolean {
         return (this.driver.element('#theia-left-side-panel').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1);
     }

--- a/examples/browser/test/left-panel/left-panel.ui-spec.ts
+++ b/examples/browser/test/left-panel/left-panel.ui-spec.ts
@@ -24,10 +24,9 @@ before(() => {
 });
 
 describe('theia left panel', () => {
-    it(`should show 'Files', 'Git' and 'Extensions`, () => {
+    it(`should show 'Files' and 'Git'`, () => {
         expect(leftPanel.doesTabExist('Files')).to.be.true;
         expect(leftPanel.doesTabExist('Git')).to.be.true;
-        expect(leftPanel.doesTabExist('Extensions')).to.be.true;
     });
 
     describe('files tab', () => {
@@ -51,18 +50,6 @@ describe('theia left panel', () => {
             leftPanel.openCloseTab('Git');
             expect(leftPanel.isGitContainerVisible()).to.be.false;
             expect(leftPanel.isTabActive('Git')).to.be.false;
-        });
-    });
-
-    describe('extensions tab', () => {
-        it(`should open/close the extensions tab`, () => {
-            leftPanel.openCloseTab('Extensions');
-            expect(leftPanel.isExtensionTabVisible()).to.be.true;
-            expect(leftPanel.isTabActive('Extensions')).to.be.true;
-
-            leftPanel.openCloseTab('Extensions');
-            expect(leftPanel.isExtensionTabVisible()).to.be.false;
-            expect(leftPanel.isTabActive('Extensions')).to.be.false;
         });
     });
 });

--- a/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
@@ -6,9 +6,9 @@
  */
 
 import { CallHierarchyContribution } from './callhierarchy-contribution';
-import { CommandContribution, MenuContribution, bindContributionProvider } from "@theia/core/lib/common";
+import { bindContributionProvider } from "@theia/core/lib/common";
 import { CallHierarchyService, CallHierarchyServiceProvider } from "./callhierarchy-service";
-import { WidgetFactory, KeybindingContribution } from '@theia/core/lib/browser';
+import { WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
 import { CALLHIERARCHY_ID } from './callhierarchy';
 import { createHierarchyTreeWidget } from './callhierarchy-tree';
 import { CurrentEditorAccess } from './current-editor-access';
@@ -23,10 +23,7 @@ export default new ContainerModule(bind => {
     bindContributionProvider(bind, CallHierarchyService);
     bind(CallHierarchyServiceProvider).to(CallHierarchyServiceProvider).inSingletonScope();
 
-    bind(CallHierarchyContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(ctx => ctx.container.get(CallHierarchyContribution));
-    bind(MenuContribution).toDynamicValue(ctx => ctx.container.get(CallHierarchyContribution));
-    bind(KeybindingContribution).toDynamicValue(ctx => ctx.container.get(CallHierarchyContribution));
+    bindViewContribution(bind, CallHierarchyContribution);
 
     bind(WidgetFactory).toDynamicValue(context => ({
         id: CALLHIERARCHY_ID,

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -13,7 +13,6 @@ import {
 } from '../../common';
 import { KeybindingContribution, KeybindingRegistry } from "../keybinding";
 import { WidgetManager } from '../widget-manager';
-import { FrontendApplicationContribution, FrontendApplication } from '../frontend-application';
 import { CommonMenus } from '../common-frontend-contribution';
 import { ApplicationShell } from './application-shell';
 
@@ -34,7 +33,6 @@ export interface ViewContributionOptions {
 // tslint:disable-next-line:no-any
 export function bindViewContribution<T extends AbstractViewContribution<any>>(bind: interfaces.Bind, identifier: interfaces.Newable<T>): interfaces.BindingWhenOnSyntax<T> {
     const syntax = bind<T>(identifier).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(identifier);
     bind(CommandContribution).toService(identifier);
     bind(KeybindingContribution).toService(identifier);
     bind(MenuContribution).toService(identifier);
@@ -45,7 +43,7 @@ export function bindViewContribution<T extends AbstractViewContribution<any>>(bi
  * An abstract superclass for frontend contributions that add a view to the application shell.
  */
 @injectable()
-export abstract class AbstractViewContribution<T extends Widget> implements CommandContribution, MenuContribution, KeybindingContribution, FrontendApplicationContribution {
+export abstract class AbstractViewContribution<T extends Widget> implements CommandContribution, MenuContribution, KeybindingContribution {
 
     @inject(WidgetManager) protected widgetManager: WidgetManager;
     @inject(ApplicationShell) protected shell: ApplicationShell;
@@ -93,10 +91,6 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
             shell.revealWidget(widget.id);
         }
         return widget;
-    }
-
-    async initializeLayout(app: FrontendApplication): Promise<void> {
-        await this.openView();
     }
 
     registerCommands(commands: CommandRegistry): void {

--- a/packages/extension-manager/src/browser/extension-frontend-module.ts
+++ b/packages/extension-manager/src/browser/extension-frontend-module.ts
@@ -7,8 +7,8 @@
 
 import { ContainerModule } from 'inversify';
 import {
-    FrontendApplicationContribution, WebSocketConnectionProvider, WidgetFactory,
-    OpenHandler, KeybindingContribution
+    WebSocketConnectionProvider, WidgetFactory,
+    OpenHandler, bindViewContribution
 } from '@theia/core/lib/browser';
 import { ExtensionServer, extensionPath } from '../common/extension-protocol';
 import { ExtensionManager } from '../common';
@@ -16,8 +16,6 @@ import { ExtensionContribution, EXTENSIONS_WIDGET_FACTORY_ID } from './extension
 import { ExtensionWidget } from './extension-widget';
 import { ExtensionWidgetFactory } from './extension-widget-factory';
 import { ExtensionOpenHandler } from './extension-open-handler';
-import { CommandContribution } from '@theia/core/lib/common/command';
-import { MenuContribution } from '@theia/core/lib/common/menu';
 
 import '../../src/browser/style/index.css';
 
@@ -28,11 +26,7 @@ export default new ContainerModule(bind => {
     }).inSingletonScope();
     bind(ExtensionManager).toSelf().inSingletonScope();
 
-    bind(ExtensionContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(ExtensionContribution));
-    bind(CommandContribution).toDynamicValue(c => c.container.get(ExtensionContribution));
-    bind(KeybindingContribution).toDynamicValue(c => c.container.get(ExtensionContribution));
-    bind(MenuContribution).toDynamicValue(c => c.container.get(ExtensionContribution));
+    bindViewContribution(bind, ExtensionContribution);
 
     bind(ExtensionWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({

--- a/packages/git/src/browser/diff/git-diff-frontend-module.ts
+++ b/packages/git/src/browser/diff/git-diff-frontend-module.ts
@@ -7,8 +7,7 @@
 
 import { interfaces } from "inversify";
 import { GitDiffContribution } from './git-diff-contribution';
-import { WidgetFactory } from "@theia/core/lib/browser";
-import { CommandContribution, MenuContribution } from '@theia/core';
+import { WidgetFactory, bindViewContribution } from "@theia/core/lib/browser";
 import { GitDiffWidget, GIT_DIFF } from "./git-diff-widget";
 
 import '../../../src/browser/style/diff.css';
@@ -21,11 +20,6 @@ export function bindGitDiffModule(bind: interfaces.Bind) {
         createWidget: () => ctx.container.get<GitDiffWidget>(GitDiffWidget)
     }));
 
-    bind(GitDiffContribution).toSelf().inSingletonScope();
-    for (const identifier of [CommandContribution, MenuContribution]) {
-        bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(GitDiffContribution)
-        ).inSingletonScope();
-    }
+    bindViewContribution(bind, GitDiffContribution);
 
 }

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -7,7 +7,7 @@
 
 import { ContainerModule } from 'inversify';
 import { ResourceResolver } from "@theia/core/lib/common";
-import { WebSocketConnectionProvider, WidgetFactory, bindViewContribution, LabelProviderContribution } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, WidgetFactory, bindViewContribution, LabelProviderContribution, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser';
 import { Git, GitPath, GitWatcher, GitWatcherPath, GitWatcherServer, GitWatcherServerProxy, ReconnectingGitWatcherServer } from '../common';
 import { GitViewContribution, GIT_WIDGET_FACTORY_ID } from './git-view-contribution';
@@ -41,6 +41,8 @@ export default new ContainerModule(bind => {
     bind(Git).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, GitPath)).inSingletonScope();
 
     bindViewContribution(bind, GitViewContribution);
+    bind(FrontendApplicationContribution).toService(GitViewContribution);
+
     bind(GitWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({
         id: GIT_WIDGET_FACTORY_ID,

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -7,7 +7,7 @@
 import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { DisposableCollection, CommandRegistry, MenuModelRegistry } from '@theia/core';
-import { AbstractViewContribution, StatusBar, StatusBarAlignment, DiffUris, StatusBarEntry } from '@theia/core/lib/browser';
+import { AbstractViewContribution, StatusBar, StatusBarAlignment, DiffUris, StatusBarEntry, FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
 import { EditorManager, EditorWidget, EditorOpenerOptions, EditorContextMenu, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { GitFileChange, GitFileStatus } from '../common';
 import { GitWidget } from './git-widget';
@@ -69,7 +69,7 @@ export namespace GIT_COMMANDS {
 }
 
 @injectable()
-export class GitViewContribution extends AbstractViewContribution<GitWidget> {
+export class GitViewContribution extends AbstractViewContribution<GitWidget> implements FrontendApplicationContribution {
 
     static GIT_SELECTED_REPOSITORY = 'git-selected-repository';
     static GIT_REPOSITORY_STATUS = 'git-repository-status';
@@ -94,6 +94,10 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> {
             toggleCommandId: 'gitView:toggle',
             toggleKeybinding: 'ctrlcmd+shift+g'
         });
+    }
+
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        await this.openView();
     }
 
     onStart(): void {

--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -85,23 +85,24 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
     }
 
     async showWidget(uri: string | undefined) {
-        this.refreshWidget(uri);
-        this.openView({
+        await this.openView({
             activate: true
         });
+        this.refreshWidget(uri);
     }
 
     protected async refreshWidget(uri: string | undefined) {
+        const widget = this.tryGetWidget();
+        if (!widget) {
+            // the widget doesn't exist, so don't wake it up
+            return;
+        }
         const options: Git.Options.Log = {
             uri,
             maxCount: GIT_HISTORY_MAX_COUNT,
             shortSha: true
         };
-        const widget = await this.widget;
         await widget.setContent(options);
-        this.openView({
-            activate: false
-        });
     }
 
     protected newUriAwareCommandHandler(handler: UriCommandHandler<URI>): UriAwareCommandHandler<URI> {

--- a/packages/git/src/browser/history/git-history-frontend-module.ts
+++ b/packages/git/src/browser/history/git-history-frontend-module.ts
@@ -7,9 +7,7 @@
 
 import { GitHistoryContribution, GIT_HISTORY } from "./git-history-contribution";
 import { interfaces, Container } from "inversify";
-import { CommandContribution, MenuContribution } from "@theia/core";
-import { KeybindingContribution } from "@theia/core/lib/browser/keybinding";
-import { WidgetFactory, OpenHandler } from "@theia/core/lib/browser";
+import { WidgetFactory, OpenHandler, bindViewContribution } from "@theia/core/lib/browser";
 import { GitHistoryWidget } from "./git-history-widget";
 import { GIT_COMMIT_DETAIL, GitCommitDetailWidget, GitCommitDetails, GitCommitDetailWidgetOptions } from "./git-commit-detail-widget";
 import { GitAvatarService } from "./git-avatar-service";
@@ -41,11 +39,6 @@ export function bindGitHistoryModule(bind: interfaces.Bind) {
     bind(GitCommitDetailOpenHandler).toSelf();
     bind(OpenHandler).toDynamicValue(ctx => ctx.container.get(GitCommitDetailOpenHandler));
 
-    bind(GitHistoryContribution).toSelf().inSingletonScope();
-    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution]) {
-        bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(GitHistoryContribution)
-        ).inSingletonScope();
-    }
+    bindViewContribution(bind, GitHistoryContribution);
 
 }

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -6,7 +6,7 @@
  */
 
 import { injectable, inject } from 'inversify';
-import { FrontendApplication } from '@theia/core/lib/browser';
+import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { PROBLEM_KIND } from '../../common/problem-marker';
@@ -14,7 +14,7 @@ import { ProblemManager, ProblemStat } from './problem-manager';
 import { ProblemWidget } from './problem-widget';
 
 @injectable()
-export class ProblemContribution extends AbstractViewContribution<ProblemWidget> {
+export class ProblemContribution extends AbstractViewContribution<ProblemWidget> implements FrontendApplicationContribution {
 
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
     @inject(StatusBar) protected readonly statusBar: StatusBar;
@@ -36,6 +36,10 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         this.problemManager.onDidChangeMarkers(() => {
             this.setStatusBarElement(this.problemManager.getProblemStat());
         });
+    }
+
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        await this.openView();
     }
 
     protected setStatusBarElement(problemStat: ProblemStat) {

--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -9,8 +9,7 @@ import { ContainerModule } from 'inversify';
 import { ProblemWidget } from './problem-widget';
 import { ProblemContribution } from './problem-contribution';
 import { createProblemWidget } from './problem-container';
-import { CommandContribution, MenuContribution } from "@theia/core/lib/common";
-import { FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
 import { ProblemManager } from './problem-manager';
 import { PROBLEM_KIND } from '../../common/problem-marker';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
@@ -30,12 +29,9 @@ export default new ContainerModule(bind => {
         createWidget: () => context.container.get<ProblemWidget>(ProblemWidget)
     }));
 
-    bind(ProblemContribution).toSelf().inSingletonScope();
-    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution, FrontendApplicationContribution]) {
-        bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(ProblemContribution)
-        ).inSingletonScope();
-    }
+    bindViewContribution(bind, ProblemContribution);
+    bind(FrontendApplicationContribution).toService(ProblemContribution);
+
     bind(ProblemDecorator).toSelf().inSingletonScope();
-    bind(NavigatorTreeDecorator).to(ProblemDecorator).inSingletonScope();
+    bind(NavigatorTreeDecorator).toService(ProblemDecorator);
 });

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -8,7 +8,8 @@
 import { injectable, inject, postConstruct } from "inversify";
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { CommandRegistry, MenuModelRegistry, MenuPath, isOSX } from "@theia/core/lib/common";
-import { Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands, OpenerService } from "@theia/core/lib/browser";
+import { Navigatable, SelectableTreeNode, Widget, KeybindingRegistry, CommonCommands,
+         OpenerService, FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser";
 import { SHELL_TABBAR_CONTEXT_MENU } from "@theia/core/lib/browser";
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
 import { FILE_NAVIGATOR_ID, FileNavigatorWidget } from './navigator-widget';
@@ -39,7 +40,7 @@ export namespace NavigatorContextMenu {
 }
 
 @injectable()
-export class FileNavigatorContribution extends AbstractViewContribution<FileNavigatorWidget>  {
+export class FileNavigatorContribution extends AbstractViewContribution<FileNavigatorWidget> implements FrontendApplicationContribution {
 
     constructor(
         @inject(FileNavigatorPreferences) protected readonly fileNavigatorPreferences: FileNavigatorPreferences,
@@ -62,6 +63,10 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
     protected async init() {
         await this.fileNavigatorPreferences.ready;
         this.shell.currentChanged.connect(() => this.onCurrentWidgetChangedHandler());
+    }
+
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        await this.openView();
     }
 
     registerCommands(registry: CommandRegistry): void {

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -6,7 +6,7 @@
  */
 
 import { ContainerModule } from 'inversify';
-import { KeybindingContext, bindViewContribution } from "@theia/core/lib/browser";
+import { KeybindingContext, bindViewContribution, FrontendApplicationContribution } from "@theia/core/lib/browser";
 import { FileNavigatorWidget, FILE_NAVIGATOR_ID } from "./navigator-widget";
 import { NavigatorActiveContext } from './navigator-keybinding-context';
 import { FileNavigatorContribution } from './navigator-contribution';
@@ -24,6 +24,7 @@ export default new ContainerModule(bind => {
     bind(FileNavigatorFilter).toSelf().inSingletonScope();
 
     bindViewContribution(bind, FileNavigatorContribution);
+    bind(FrontendApplicationContribution).toService(FileNavigatorContribution);
 
     bind(KeybindingContext).to(NavigatorActiveContext).inSingletonScope();
 

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -8,11 +8,12 @@
 import { injectable } from "inversify";
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { OutlineViewWidget } from './outline-view-widget';
+import { FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser/frontend-application";
 
 export const OUTLINE_WIDGET_FACTORY_ID = 'outline-view';
 
 @injectable()
-export class OutlineViewContribution extends AbstractViewContribution<OutlineViewWidget> {
+export class OutlineViewContribution extends AbstractViewContribution<OutlineViewWidget> implements FrontendApplicationContribution {
 
     constructor() {
         super({
@@ -25,5 +26,9 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
             toggleCommandId: 'outlineView:toggle',
             toggleKeybinding: 'ctrlcmd+shift+o'
         });
+    }
+
+    async initializeLayout(app: FrontendApplication): Promise<void> {
+        await this.openView();
     }
 }

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -9,11 +9,8 @@ import { ContainerModule, interfaces } from 'inversify';
 import { OutlineViewService } from './outline-view-service';
 import { OutlineViewContribution } from './outline-view-contribution';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
-import { FrontendApplicationContribution, createTreeContainer, TreeWidget } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, createTreeContainer, TreeWidget, bindViewContribution } from '@theia/core/lib/browser';
 import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widget';
-import { CommandContribution } from '@theia/core/lib/common/command';
-import { KeybindingContribution } from '@theia/core/lib/browser/keybinding';
-import { MenuContribution } from '@theia/core/lib/common/menu';
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>
@@ -23,11 +20,8 @@ export default new ContainerModule(bind => {
     bind(OutlineViewService).toSelf().inSingletonScope();
     bind(WidgetFactory).toDynamicValue(context => context.container.get(OutlineViewService));
 
-    bind(OutlineViewContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(OutlineViewContribution));
-    bind(CommandContribution).toDynamicValue(c => c.container.get(OutlineViewContribution));
-    bind(KeybindingContribution).toDynamicValue(c => c.container.get(OutlineViewContribution));
-    bind(MenuContribution).toDynamicValue(c => c.container.get(OutlineViewContribution));
+    bindViewContribution(bind, OutlineViewContribution);
+    bind(FrontendApplicationContribution).toService(OutlineViewContribution);
 });
 
 function createOutlineViewWidget(parent: interfaces.Container): OutlineViewWidget {

--- a/packages/output/src/browser/output-frontend-module.ts
+++ b/packages/output/src/browser/output-frontend-module.ts
@@ -7,9 +7,7 @@
 
 import { ContainerModule, interfaces } from "inversify";
 import { OutputWidget, OUTPUT_WIDGET_KIND } from "./output-widget";
-import { WidgetFactory } from "@theia/core/lib/browser";
-import { KeybindingContribution } from '@theia/core/lib/browser';
-import { MenuContribution, CommandContribution } from "@theia/core";
+import { WidgetFactory, bindViewContribution } from "@theia/core/lib/browser";
 import { OutputContribution } from "./output-contribution";
 import { OutputChannelManager } from "../common/output-channel";
 import { bindOutputPreferences } from "../common/output-preferences";
@@ -24,8 +22,5 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
         createWidget: () => context.container.get<OutputWidget>(OutputWidget)
     }));
 
-    bind(OutputContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(context => context.container.get(OutputContribution));
-    bind(KeybindingContribution).toDynamicValue(c => c.container.get(OutputContribution));
-    bind(MenuContribution).toDynamicValue(context => context.container.get(OutputContribution));
+    bindViewContribution(bind, OutputContribution);
 });

--- a/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
@@ -62,7 +62,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
                         }
                     });
 
-                    this.hostedPluginServer.isHostedTheiaRunning().then((running) => {
+                    this.hostedPluginServer.isHostedTheiaRunning().then(running => {
                         if (running) {
                             this.onHostedPluginRunning();
                         }
@@ -166,7 +166,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
         } else {
             // ask state of hosted plugin when switching to Online
             if (this.entry) {
-                this.hostedPluginServer.isHostedTheiaRunning().then((running) => {
+                this.hostedPluginServer.isHostedTheiaRunning().then(running => {
                     if (running) {
                         this.onHostedPluginRunning();
                     } else {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -8,8 +8,8 @@
 import '../../../src/main/style/status-bar.css';
 
 import { ContainerModule } from "inversify";
-import { FrontendApplicationContribution, FrontendApplication, WidgetFactory, KeybindingContribution } from "@theia/core/lib/browser";
-import { MaybePromise, CommandContribution, MenuContribution, ResourceResolver } from "@theia/core/lib/common";
+import { FrontendApplicationContribution, FrontendApplication, WidgetFactory, bindViewContribution } from "@theia/core/lib/browser";
+import { MaybePromise, CommandContribution, ResourceResolver } from "@theia/core/lib/common";
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { PluginWorker } from './plugin-worker';
 import { HostedPluginSupport } from "../../hosted/browser/hosted-plugin";
@@ -43,7 +43,6 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();
 
     bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));
     bind(CommandContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));
 
     bind(TextEditorService).to(TextEditorServiceImpl).inSingletonScope();
@@ -66,11 +65,7 @@ export default new ContainerModule(bind => {
         return connection.createProxy<HostedPluginServer>(hostedServicePath, hostedWatcher.getHostedPluginClient());
     }).inSingletonScope();
 
-    bind(PluginFrontendViewContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(PluginFrontendViewContribution));
-    bind(CommandContribution).toDynamicValue(c => c.container.get(PluginFrontendViewContribution));
-    bind(KeybindingContribution).toDynamicValue(c => c.container.get(PluginFrontendViewContribution));
-    bind(MenuContribution).toDynamicValue(c => c.container.get(PluginFrontendViewContribution));
+    bindViewContribution(bind, PluginFrontendViewContribution);
 
     bind(PluginWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -8,8 +8,8 @@
 import { ContainerModule, interfaces } from "inversify";
 import { SearchInWorkspaceService, SearchInWorkspaceClientImpl } from './search-in-workspace-service';
 import { SearchInWorkspaceServer } from '../common/search-in-workspace-interface';
-import { WebSocketConnectionProvider, KeybindingContribution, WidgetFactory, createTreeContainer, TreeWidget } from '@theia/core/lib/browser';
-import { CommandContribution, MenuContribution, ResourceResolver } from "@theia/core";
+import { WebSocketConnectionProvider, WidgetFactory, createTreeContainer, TreeWidget, bindViewContribution } from '@theia/core/lib/browser';
+import { ResourceResolver } from "@theia/core";
 import { SearchInWorkspaceWidget } from "./search-in-workspace-widget";
 import { SearchInWorkspaceResultTreeWidget } from "./search-in-workspace-result-tree-widget";
 import { SearchInWorkspaceFrontendContribution } from "./search-in-workspace-frontend-contribution";
@@ -25,10 +25,7 @@ export default new ContainerModule(bind => {
     }));
     bind(SearchInWorkspaceResultTreeWidget).toDynamicValue(ctx => createSearchTreeWidget(ctx.container));
 
-    bind(SearchInWorkspaceFrontendContribution).toSelf().inSingletonScope();
-    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution]) {
-        bind(identifier).toService(SearchInWorkspaceFrontendContribution);
-    }
+    bindViewContribution(bind, SearchInWorkspaceFrontendContribution);
 
     // The object that gets notified of search results.
     bind(SearchInWorkspaceClientImpl).toSelf().inSingletonScope();


### PR DESCRIPTION
The application contribution callbacks where only used to do
`initializedLayout` which is undesired in most cases. As a result the
`FrontendApplicationContribution`wasn't bound in many cases.

This also removes the plug-in as well as extension UI from being
initially opened. the GitHistory was eagerly started, too, due to
reacting to git log events. (fixes #2140)

Signed-off-by: svenefftinge <sven.efftinge@typefox.io>