### PR TITLE
THEIA-2091: Update vscode-ripgrep lib to use cached ripgrep search lib.

### DIFF
--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -7,7 +7,7 @@
     "@theia/filesystem": "^0.3.11",
     "@theia/workspace": "^0.3.11",
     "fuzzy": "^0.1.3",
-    "vscode-ripgrep": "^1.0.0"
+    "vscode-ripgrep": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@theia/core": "^0.3.11",
     "@theia/editor": "^0.3.11",
-    "vscode-ripgrep": "^1.0.0"
+    "vscode-ripgrep": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9764,9 +9764,9 @@ vscode-languageserver@^3.4.3:
     vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
 
-vscode-ripgrep@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.0.0.tgz#99d81e96cc2437a1bc20f28facbcca72516e9c73"
+vscode-ripgrep@^1.0.0, vscode-ripgrep@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.0.1.tgz#eff2f2b2a49921ac0acd3ff8dfecaaeebf0184cf"
 
 vscode-uri@^1.0.0, vscode-uri@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9764,7 +9764,7 @@ vscode-languageserver@^3.4.3:
     vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
 
-vscode-ripgrep@^1.0.0, vscode-ripgrep@^1.0.1:
+vscode-ripgrep@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.0.1.tgz#eff2f2b2a49921ac0acd3ff8dfecaaeebf0184cf"
 


### PR DESCRIPTION
Update vscode-ripgrep lib to use cached ripgrep search lib.

Related issue: https://github.com/theia-ide/theia/issues/2091

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>