### PR TITLE
GH-2155: Fixed the missing `Search` menu item issue.

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -73,6 +73,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
     }
 
     registerMenus(menus: MenuModelRegistry): void {
+        super.registerMenus(menus);
         menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '6_find'], {
             commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id
         });


### PR DESCRIPTION
Closes #2155.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

Before:
<img width="285" alt="screen shot 2018-06-21 at 18 26 29" src="https://user-images.githubusercontent.com/1405703/41732326-061c3d56-7581-11e8-843a-659694597b53.png">


After:
<img width="286" alt="screen shot 2018-06-21 at 18 27 09" src="https://user-images.githubusercontent.com/1405703/41732312-0172f150-7581-11e8-9dfb-9fe1c0649050.png">
