### PR TITLE
[quick open] Added support for toggle

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -68,6 +68,14 @@ export class CommandQuickOpenItem extends QuickOpenItem {
         return this.hidden;
     }
 
+    getIconClass() {
+        const toggleHandler = this.commands.getToggledHandler(this.command.id);
+        if (toggleHandler && toggleHandler.isToggled && toggleHandler.isToggled()) {
+            return `fa fa-check`;
+        }
+        return super.getIconClass();
+    }
+
     getKeybinding(): Keybinding | undefined {
         const bindings = this.keybindings.getKeybindingsForCommand(this.command.id);
         return bindings ? bindings[0] : undefined;

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -30,12 +30,24 @@
     z-index: 0;
 }
 
+/*
+ * we need to disable the background image when using font awesome icons
+ */
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon,
-.vs-dark .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon {
-    background-image: none;
-    margin-bottom: 4px;
+.vs-dark .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.fa {
+    background-image: none;    
     margin-right: 0px;
 }
+
+/*
+ * we need to disable the background image when using file-icons
+ */
+.monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon,
+.vs-dark .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
+    background-image: none;    
+    margin-right: 0px;
+}
+
 
 .monaco-tree-row  {
     padding-right: 11px;


### PR DESCRIPTION
Also fixed a regression, where icons weren't shown
for local and workspace symbols.

Signed-off-by: svenefftinge <sven.efftinge@typefox.io>