### PR TITLE
[textmate] Check wasm support

### DIFF
--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -30,7 +30,10 @@ export const isWebKit = (userAgent.indexOf('AppleWebKit') >= 0);
 export const isChrome = (userAgent.indexOf('Chrome') >= 0);
 export const isSafari = (userAgent.indexOf('Chrome') === -1) && (userAgent.indexOf('Safari') >= 0);
 export const isIPad = (userAgent.indexOf('iPad') >= 0);
+// tslint:disable-next-line:no-any
 export const isNative = typeof (window as any).process !== 'undefined';
+// tslint:disable-next-line:no-any
+export const isBasicWasmSupported = typeof (window as any).WebAssembly !== 'undefined';
 
 /**
  * Parse a magnitude value (e.g. width, height, left, top) from a CSS attribute value.

--- a/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-frontend-bindings.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { interfaces } from 'inversify';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, isBasicWasmSupported } from '@theia/core/lib/browser';
 import { bindContributionProvider } from '@theia/core';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { BuiltinTextmateThemeProvider } from './monaco-textmate-builtin-theme-provider';
@@ -26,7 +26,7 @@ import { MonacoTextmateService, OnigasmPromise } from './monaco-textmate-service
 import { loadWASM } from 'onigasm';
 
 export default (bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
-    const onigasmPromise = loadWASM(require('onigasm/lib/onigasm.wasm'));
+    const onigasmPromise = isBasicWasmSupported ? loadWASM(require('onigasm/lib/onigasm.wasm')) : Promise.reject(new Error('wasm not supported'));
     bind(OnigasmPromise).toConstantValue(onigasmPromise);
 
     bind(MonacoTextmateService).toSelf().inSingletonScope();

--- a/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, named } from "inversify";
 import { Registry } from 'monaco-textmate';
 import { ILogger, DisposableCollection, ContributionProvider } from "@theia/core";
-import { FrontendApplicationContribution } from "@theia/core/lib/browser";
+import { FrontendApplicationContribution, isBasicWasmSupported } from "@theia/core/lib/browser";
 import { MonacoTextModelService } from "../monaco-text-model-service";
 import { LanguageGrammarDefinitionContribution } from "./textmate-contribution";
 import { createTextmateTokenizer } from "./textmate-tokenizer";
@@ -50,6 +50,11 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
     protected readonly onigasmPromise: OnigasmPromise;
 
     initialize() {
+        if (!isBasicWasmSupported) {
+            console.log('Textmate support deactivated because WebAssembly is not detected.');
+            return;
+        }
+
         for (const grammarProvider of this.grammarProviders.getContributions()) {
             grammarProvider.registerTextmateLanguage(this.textmateRegistry);
         }


### PR DESCRIPTION
Because Textmate uses WebAssembly binaries to run its tokenizers, we need some kind of fallback in case this is not supported. This commit adds this fallbacks for typescript and ecmascript.