### PR TITLE
[git] Use common error handler

### DIFF
--- a/packages/git/src/browser/git-error-handler.ts
+++ b/packages/git/src/browser/git-error-handler.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from "inversify";
+import { MessageService } from "@theia/core";
+
+@injectable()
+export class GitErrorHandler {
+
+    @inject(MessageService) protected readonly messageService: MessageService;
+
+    // tslint:disable-next-line:no-any
+    public handleError(error: any): void {
+        const message = error instanceof Error ? error.message : error;
+        if (message) {
+            this.messageService.error(message, { timeout: 0 });
+        }
+    }
+
+}

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -34,6 +34,7 @@ import { bindBlame } from './blame/blame-module';
 import { GitRepositoryTracker } from './git-repository-tracker';
 import { GitCommitMessageValidator } from './git-commit-message-validator';
 import { GitSyncService } from './git-sync-service';
+import { GitErrorHandler } from './git-error-handler';
 
 import '../../src/browser/style/index.css';
 
@@ -70,4 +71,5 @@ export default new ContainerModule(bind => {
     bind(GitCommitMessageValidator).toSelf().inSingletonScope();
 
     bind(GitSyncService).toSelf().inSingletonScope();
+    bind(GitErrorHandler).toSelf().inSingletonScope();
 });


### PR DESCRIPTION
I'd like to introduce a common `GitErrorHandler` explicitly for git errors, and to use it in `GitQuickOpenService`, `GitSyncService`, and `GitWidget`. As before, it would handle catched errors from `Git` interface and create user notifications. 

This should make it easier to customize handling of errors in a more consistent way.

It also...
* Fixes error notifications for `GitQuickOpenService`
* Fixes potential NPEs if error is undefined

Fixes #2179