### PR TITLE
fix #1284: switch to vscode-nsfw

### DIFF
--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -21,7 +21,7 @@ import cp = require('child_process');
 export function rebuild(target: 'electron' | 'browser', modules: string[]) {
     const nodeModulesPath = path.join(process.cwd(), 'node_modules');
     const browserModulesPath = path.join(process.cwd(), '.browser_modules');
-    const modulesToProcess = modules || ['node-pty', 'nsfw', 'find-git-repositories'];
+    const modulesToProcess = modules || ['node-pty', 'vscode-nsfw', 'find-git-repositories'];
 
     if (target === 'electron' && !fs.existsSync(browserModulesPath)) {
         const dependencies: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "inversify": "^4.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
-    "nsfw": "^1.0.16",
+    "vscode-nsfw": "^1.0.17",
     "perfect-scrollbar": "^1.3.0",
     "reconnecting-websocket": "^3.0.7",
     "reflect-metadata": "^0.1.10",

--- a/packages/core/src/node/logger-cli-contribution.ts
+++ b/packages/core/src/node/logger-cli-contribution.ts
@@ -19,7 +19,7 @@ import { injectable } from 'inversify';
 import { LogLevel } from '../common/logger';
 import { CliContribution } from './cli';
 import * as fs from 'fs-extra';
-import * as nsfw from 'nsfw';
+import * as nsfw from 'vscode-nsfw';
 import { Event, Emitter } from '../common/event';
 import * as path from 'path';
 

--- a/packages/core/src/typings/nsfw/index.d.ts
+++ b/packages/core/src/typings/nsfw/index.d.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-declare module 'nsfw' {
+declare module 'vscode-nsfw' {
     function nsfw(dir: string, eventHandler: (events: nsfw.ChangeEvent[]) => void, options?: nsfw.Options): Promise<nsfw.NSFW>;
 
     namespace nsfw {

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as fs from "fs";
-import * as nsfw from "nsfw";
+import * as nsfw from "vscode-nsfw";
 import * as paths from "path";
 import { IMinimatch, Minimatch } from "minimatch";
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6651,16 +6651,6 @@ npm-run-path@^2.0.0:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nsfw@^1.0.16:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/nsfw/-/nsfw-1.0.16.tgz#78ba3e7f513b53d160c221b9018e0baf108614cc"
-  dependencies:
-    fs-extra "^0.26.5"
-    lodash.isinteger "^4.0.4"
-    lodash.isundefined "^3.0.1"
-    nan "^2.0.0"
-    promisify-node "^0.3.0"
-
 nugget@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
@@ -9854,6 +9844,16 @@ vscode-languageserver@^3.4.3:
   dependencies:
     vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
+
+vscode-nsfw@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/vscode-nsfw/-/vscode-nsfw-1.0.17.tgz#da3820f26aea3a7e95cadc54bd9e5dae3d47e474"
+  dependencies:
+    fs-extra "^0.26.5"
+    lodash.isinteger "^4.0.4"
+    lodash.isundefined "^3.0.1"
+    nan "^2.0.0"
+    promisify-node "^0.3.0"
 
 vscode-ripgrep@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
in order to avoid memory leaks because of circular symlinks