### PR TITLE
Stopped activate from starting another language client if already set

### DIFF
--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -70,6 +70,9 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
     }
 
     activate(): Disposable {
+        if (this._languageClient) {
+            return Disposable.create(() => { });
+        }
         const languageClient = this.createLanguageClient();
         this.onWillStart(languageClient);
         return languageClient.start();


### PR DESCRIPTION
I've stopped activate from starting another language client if languageClient is already set. The reason for doing this is if you manually call activate (i.e. this.javaClientContribution.activate()) and then open a file that is associated with same language client (such as any .java file in my case) you will create duplicate language servers.


Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>