### PR TITLE
[plug-in] Fix RegExp for starting hosted instance

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
@@ -64,7 +64,7 @@ export interface HostedPluginManager {
 }
 
 const HOSTED_INSTANCE_START_TIMEOUT_MS = 30000;
-const THEIA_INSTANCE_REGEX = /.*Theia app listening on (.*)\. \[\].*/;
+const THEIA_INSTANCE_REGEX = /.*Theia app listening on (.*).*\./;
 const PROCESS_OPTIONS = {
     cwd: process.cwd(),
     env: { ...process.env }


### PR DESCRIPTION
Invalid regexp
with invalid regexp, it doesn't check server is started so it goes into timeout and then hosted instance is aborted

Change-Id: I010a83c47491da0f52c1d03c6e4df478a6e22a1c
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>