### PR TITLE
Added workspaceContains language client activation

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -42,6 +42,10 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         return ['**/*.java', '**/pom.xml', '**/*.gradle'];
     }
 
+    protected get workspaceContains() {
+        return ['pom.xml', 'build.gradle'];
+    }
+
     protected onReady(languageClient: ILanguageClient): void {
         languageClient.onNotification(ActionableNotification.type, this.showActionableMessage.bind(this));
         super.onReady(languageClient);

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.12",
     "@theia/output": "^0.3.12",
     "@theia/process": "^0.3.12",
+    "@theia/workspace": "^0.3.12",
     "vscode-base-languageclient": "^0.0.1-alpha.5",
     "vscode-languageserver-protocol": "^3.6.0"
   },
@@ -49,3 +50,4 @@
     "extends": "../../configs/nyc.json"
   }
 }
+

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -179,6 +179,25 @@ export class WorkspaceService implements FrontendApplicationContribution {
         return options !== undefined && !!options.preserveWindow;
     }
 
+    /**
+     * Return true if one of the paths in paths array is present in the workspace
+     * NOTE: You should always explicitly use `/` as the separator between the path segments.
+     */
+    async containsSome(paths: string[]): Promise<boolean> {
+        const workspaceRoot = await this.root;
+        if (workspaceRoot) {
+            const uri = new URI(workspaceRoot.uri);
+            for (const path of paths) {
+                const fileUri = uri.resolve(path).toString();
+                const exists = await this.fileSystem.exists(fileUri);
+                if (exists) {
+                    return exists;
+                }
+            }
+        }
+        return false;
+    }
+
 }
 
 export interface WorkspaceInput {


### PR DESCRIPTION
The workspaceContains language server activation starts a language client if the workspace contains certain file(s). If none of the files are found the language client defaults back to the glob patterns.

Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>