### PR TITLE
[plugin-ext] Fix plugin api in electron packaging

### DIFF
--- a/packages/plugin-ext/src/api/rpc-protocol.ts
+++ b/packages/plugin-ext/src/api/rpc-protocol.ts
@@ -236,7 +236,11 @@ class RPCMultiplexer {
 
     public send(msg: string): void {
         if (this.messagesToSend.length === 0) {
-            setImmediate(this.sendAccumulatedBound);
+            if (typeof setImmediate !== 'undefined') {
+                setImmediate(this.sendAccumulatedBound);
+            } else {
+                setTimeout(this.sendAccumulatedBound, 0);
+            }
         }
         this.messagesToSend.push(msg);
     }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -42,6 +42,7 @@ export interface PluginPackage {
     displayName: string;
     description: string;
     contributes: {};
+    packagePath: string;
 }
 
 export const PluginScanner = Symbol('PluginScanner');

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -43,7 +43,12 @@ rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, new HostedPluginManagerExtIm
         ctx.importScripts('/context/' + contextPath);
     },
     loadPlugin(contextPath: string, plugin: Plugin): void {
-        ctx.importScripts('/hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+        if (isElectron()) {
+            ctx.importScripts(plugin.pluginPath);
+        } else {
+            ctx.importScripts('/hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+        }
+
         if (plugin.lifecycle.frontendModuleName) {
             if (!ctx[plugin.lifecycle.frontendModuleName]) {
                 console.error(`WebWorker: Cannot start plugin "${plugin.model.name}". Frontend plugin not found: "${plugin.lifecycle.frontendModuleName}"`);
@@ -62,3 +67,11 @@ rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, new HostedPluginManagerExtIm
         });
     }
 }));
+
+function isElectron() {
+    if (typeof navigator === 'object' && typeof navigator.userAgent === 'string' && navigator.userAgent.indexOf('Electron') >= 0) {
+        return true;
+    }
+
+    return false;
+}

--- a/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/scanner-theia-electron.ts
@@ -14,14 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { HostedPluginManager, ElectronNodeHostedPluginRunner } from '../node/hosted-plugin-manager';
-import { interfaces } from 'inversify';
-import { bindCommonHostedBackend } from '../node/plugin-ext-hosted-backend-module';
-import { PluginScanner } from '../../common/plugin-protocol';
-import { TheiaPluginScannerElectron } from './scanner-theia-electron';
-
-export function bindElectronBackend(bind: interfaces.Bind): void {
-    bind(HostedPluginManager).to(ElectronNodeHostedPluginRunner);
-    bind(PluginScanner).to(TheiaPluginScannerElectron).inSingletonScope();
-    bindCommonHostedBackend(bind);
+import { TheiaPluginScanner } from "../node/scanners/scanner-theia";
+import { injectable } from "inversify";
+import { PluginPackage, PluginModel } from "../../common/plugin-protocol";
+@injectable()
+export class TheiaPluginScannerElectron extends TheiaPluginScanner {
+    getModel(plugin: PluginPackage): PluginModel {
+        const result = super.getModel(plugin);
+        if (result.entryPoint.frontend) {
+            result.entryPoint.frontend = plugin.packagePath + result.entryPoint.frontend;
+        }
+        return result;
+    }
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -31,7 +31,6 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginReader).toSelf().inSingletonScope();
     bind(HostedPluginServer).to(HostedPluginServerImpl).inSingletonScope();
     bind(HostedPluginSupport).toSelf().inSingletonScope();
-    bind(PluginScanner).to(TheiaPluginScanner).inSingletonScope();
     bind(MetadataScanner).toSelf().inSingletonScope();
 
     bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(HostedPluginReader)).inSingletonScope();
@@ -50,6 +49,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
 
 export function bindHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginManager).to(NodeHostedPluginRunner).inSingletonScope();
+    bind(PluginScanner).to(TheiaPluginScanner).inSingletonScope();
     bindContributionProvider(bind, Symbol.for(HostedPluginUriPostProcessorSymbolName));
     bindCommonHostedBackend(bind);
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -73,6 +73,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
         }
 
         const plugin: PluginPackage = require(packageJsonPath);
+        plugin.packagePath = path;
         const pluginMetadata = this.scanner.getPluginMetadata(plugin);
         if (pluginMetadata.model.entryPoint.backend) {
             pluginMetadata.model.entryPoint.backend = resolve(path, pluginMetadata.model.entryPoint.backend);

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -278,7 +278,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
 // tslint:disable-next-line:no-any
 export function startPlugin(plugin: Plugin, pluginMain: any, plugins: Map<string, () => void>): void {
     if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
-        pluginMain[plugin.lifecycle.startMethod].apply(global, []);
+        pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), []);
     } else {
         console.log('there is no doStart method on plugin');
     }
@@ -287,4 +287,10 @@ export function startPlugin(plugin: Plugin, pluginMain: any, plugins: Map<string
         const pluginId = getPluginId(plugin.model);
         plugins.set(pluginId, pluginMain[plugin.lifecycle.stopMethod]);
     }
+}
+
+// for electron
+function getGlobal() {
+    // tslint:disable-next-line:no-null-keyword
+    return typeof self === "undefined" ? typeof global === "undefined" ? null : global : self;
 }


### PR DESCRIPTION
Should fix eclipse/che/issues/9767 and #2201 

Pull request do next:
Use `setTimeout` when `setImmediate` is not available.
Use absolute path for plugin script for WebWorker `importScripts` function 

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>