### PR TITLE
[generator] split frontend code in dev mode

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -16,7 +16,20 @@
 
 import * as os from 'os';
 import * as fs from 'fs-extra';
+import * as yargs from 'yargs';
 import { ApplicationPackage } from '@theia/application-package';
+
+const argv = yargs.option('mode', {
+    description: 'Mode to use',
+    choices: ['development', 'production'],
+    default: 'production'
+}).option('split-frontend', {
+    description: 'Split frontend modules into separate chunks. By default enabled in the dev mode and disabled in the prod mode.',
+    type: 'boolean',
+    default: undefined
+}).argv;
+const mode: 'development' | 'production' = argv.mode;
+const splitFrontend: boolean = argv['split-frontend'] === undefined ? mode === 'development' : argv['split-frontend'];
 
 export abstract class AbstractGenerator {
 
@@ -25,7 +38,7 @@ export abstract class AbstractGenerator {
     ) { }
 
     protected compileFrontendModuleImports(modules: Map<string, string>): string {
-        return this.compileModuleImports(modules, 'require');
+        return this.compileModuleImports(modules, splitFrontend ? 'import' : 'require');
     }
 
     protected compileBackendModuleImports(modules: Map<string, string>): string {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -43,7 +43,7 @@
     "prepare": "yarn run clean && yarn build",
     "clean": "theia clean && rimraf errorShots",
     "build": "theia build --mode development",
-    "watch": "yarn build --watch --mode development",
+    "watch": "yarn build --watch",
     "start": "theia start",
     "start:debug": "yarn start --log-level=debug",
     "test": "wdio",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -46,7 +46,7 @@
     "prepare": "yarn run clean && yarn build",
     "clean": "theia clean",
     "build": "theia build --mode development",
-    "watch": "yarn build --watch --mode development",
+    "watch": "yarn build --watch",
     "start": "theia start",
     "start:debug": "yarn start --log-level=debug",
     "test": "electron-mocha --timeout 60000 --require ts-node/register \"./test/**/*.espec.ts\"",


### PR DESCRIPTION
Webpack 4 is able to perform code splitting based on dynamic imports:
- we enable it in the dev mode to speed up incremental builds and reloading changed chunks. One can disable it in the dev mode via `theia watch --mode development --no-split-frontend`.
- we disable it in the prod by default, since it can be slow to load all chunks with high latency. The better alternative is to obfuscate, minify and cache few chunks. One can enable it in the prod mode via `theia watch --split-frontend`.

Time to rebuild changes:
- in `@theia/core` - a package with a lot of dependent packages : 4198ms (before) -> 2318ms (after) - about 2x faster
- in `@theia/variable-resovler` - a typical extension package: 4265ms -> 296ms - about 14x faster

As you can see, developing Theia extensions should get much faster.