### PR TITLE
[plug-in] Add PATH to plugin's forked instance

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -100,9 +100,14 @@ export class HostedPluginSupport {
     }
 
     private fork(options: IPCConnectionOptions): cp.ChildProcess {
+
+        // create env and add PATH to it so any executable from root process is available
+        const env = createIpcEnv();
+        env.PATH = process.env.PATH;
+
         const forkOptions: cp.ForkOptions = {
             silent: true,
-            env: createIpcEnv(),
+            env: env,
             execArgv: [],
             stdio: ['pipe', 'pipe', 'pipe', 'ipc']
         };


### PR DESCRIPTION
For example it allows to call yeoman from a plug-in if it's a custom PATH
Without fix we have for example ENOENT error as executables are not found

Change-Id: I9e62f1bec20425e54fe139761e60fd12717f4e6f
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>