### PR TITLE
[tree] don't render collapsed nodes

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -490,7 +490,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected renderNodeChildren(node: TreeNode, props: NodeProps): React.ReactNode {
-        if (CompositeTreeNode.is(node)) {
+        if (CompositeTreeNode.is(node) && !ExpandableTreeNode.isCollapsed(node)) {
             return this.renderCompositeChildren(node, props);
         }
         // tslint:disable-next-line:no-null-keyword


### PR DESCRIPTION
It improves perf if a folder with a lot of nodes is closed, like `node_modules`. In the case, if it is opened it still feels choppy, we should try to break down the tree to smaller react components to allow more fine-grained virtual DOM updates.