### PR TITLE
Fix leak in Merge Conflicts Provider

### DIFF
--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -96,6 +96,12 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
      * @param params: ReplaceTextParams
      */
     replaceText(params: ReplaceTextParams): Promise<boolean>;
+
+    /**
+     * Execute edits on the editor.
+     * @param edits: edits created with `lsp.TextEdit.replace`, `lsp.TextEdit.instert`, `lsp.TextEdit.del`
+     */
+    executeEdits(edits: lsp.TextEdit[]): boolean;
 }
 
 export interface Dimension {

--- a/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
@@ -30,7 +30,7 @@ export class MergeConflictsCodeLensProvider implements CodeLensProvider {
         const mergeConflicts = await this.mergeConflictsProvider.get(uri);
         const result: CodeLens[] = [];
         if (mergeConflicts) {
-            mergeConflicts.mergeConflicts.forEach(mergeConflict => result.push(...this.toCodeLense(uri, mergeConflict)));
+            mergeConflicts.forEach(mergeConflict => result.push(...this.toCodeLense(uri, mergeConflict)));
         }
         return Promise.resolve(result);
     }

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
@@ -285,6 +285,40 @@ bar on branch
         });
     });
 
+    it("merge conflict with empty incoming change", () => {
+        const conflicts = parse(
+            `<<<<<<<
+a
+|||||||
+b
+=======
+>>>>>>>
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        expect(conflict.incoming).to.not.be.undefined;
+        expect(conflict.incoming.content).to.be.undefined;
+    });
+
+    it("merge conflict with empty current change", () => {
+        const conflicts = parse(
+            `<<<<<<<
+|||||||
+b
+=======
+a
+>>>>>>>
+`
+        );
+        expect(conflicts).to.have.lengthOf(1);
+        const conflict = conflicts[0];
+
+        expect(conflict.current).to.not.be.undefined;
+        expect(conflict.current.content).to.be.undefined;
+    });
+
 });
 
 function substring(text: string, range: Range): string {

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
@@ -69,6 +69,7 @@ export class MergeConflictsParser {
         start.to(start, any);
         currentMarker.to(currentMarker, startsWithLt);
         currentMarker.to(separator, startsWithEq);
+        currentMarker.to(baseMarker, startsWithPp);
         currentMarker.to(currentContent, any);
         currentContent.to(currentMarker, startsWithLt);
         currentContent.to(separator, startsWithEq);
@@ -85,6 +86,7 @@ export class MergeConflictsParser {
         baseContent.to(baseContent, any);
         separator.to(currentMarker, startsWithLt);
         separator.to(start, startsWithEq);
+        separator.to(incomingMarker, startsWithGt);
         separator.to(incomingContent, any);
         incomingContent.to(start, startsWithEq);
         incomingContent.to(currentMarker, startsWithLt);

--- a/packages/merge-conflicts/src/browser/merge-conflicts-provider.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-provider.ts
@@ -17,11 +17,11 @@
 import { inject, injectable, postConstruct } from "inversify";
 import { MergeConflict } from "./merge-conflict";
 import { TextEditor, EditorManager, EditorWidget } from "@theia/editor/lib/browser";
-import { Emitter, Event, DisposableCollection } from "@theia/core";
+import { Emitter, Event } from "@theia/core";
 import { Deferred } from "@theia/core/lib/common/promise-util";
 import { MergeConflictsParser } from "./merge-conflicts-parser";
 
-import throttle = require('lodash.throttle');
+import debounce = require('lodash.debounce');
 
 @injectable()
 export class MergeConflictsProvider {
@@ -35,17 +35,16 @@ export class MergeConflictsProvider {
     protected readonly onDidUpdateEmitter = new Emitter<MergeConflictsUpdate>();
     readonly onDidUpdate: Event<MergeConflictsUpdate> = this.onDidUpdateEmitter.event;
 
-    deferredValues = new Map<string, Deferred<MergeConflictsUpdate>>();
-    timeouts = new Map<string, number>();
+    protected values = new Map<string, Promise<MergeConflict[]>>();
+    protected valueTimeouts = new Map<string, number>();
 
     @postConstruct()
     protected initialize() {
         this.editorManager.onCreated(w => this.handleNewEditor(w));
     }
 
-    get(uri: string): Promise<MergeConflictsUpdate | undefined> {
-        const deferred = this.deferredValues.get(uri);
-        return deferred ? deferred.promise : Promise.resolve(undefined);
+    get(uri: string): Promise<MergeConflict[] | undefined> {
+        return this.values.get(uri) || Promise.resolve(undefined);
     }
 
     protected handleNewEditor(editorWidget: EditorWidget): void {
@@ -54,33 +53,36 @@ export class MergeConflictsProvider {
         if (uri.scheme !== 'file') {
             return;
         }
-        const toDispose = new DisposableCollection();
-        toDispose.push(editor.onDocumentContentChanged(throttle(document => this.contentChanged(editor), 500)));
-        editorWidget.disposed.connect(() => {
-            toDispose.dispose();
-        });
-        this.contentChanged(editor);
+        const debouncedUpdate = debounce(() => this.updateMergeConflicts(editor), 200, { leading: true });
+        const disposable = editor.onDocumentContentChanged(() => debouncedUpdate());
+        editorWidget.disposed.connect(() => disposable.dispose());
+        debouncedUpdate();
     }
 
-    protected contentChanged(editor: TextEditor): void {
+    protected updateMergeConflicts(editor: TextEditor): void {
         const uri = editor.uri.toString();
-        const deferred = new Deferred<MergeConflictsUpdate>();
-        this.deferredValues.set(uri, deferred);
+        if (this.valueTimeouts.has(uri)) {
+            window.clearTimeout(this.valueTimeouts.get(uri));
+        }
+        const deferred = new Deferred<MergeConflict[]>();
+        this.values.set(uri, deferred.promise);
         window.setTimeout(() => {
             const mergeConflicts = this.computeMergeConflicts(editor);
-            this.onDidUpdateEmitter.fire(mergeConflicts);
+            this.onDidUpdateEmitter.fire({ editor, mergeConflicts });
             deferred.resolve(mergeConflicts);
-        }, 100);
+        }, 50);
+        this.valueTimeouts.set(uri, window.setTimeout(() => {
+            this.values.delete(uri);
+        }, 1000));
     }
 
-    protected computeMergeConflicts(editor: TextEditor): MergeConflictsUpdate {
+    protected computeMergeConflicts(editor: TextEditor): MergeConflict[] {
         const document = editor.document;
         const input = <MergeConflictsParser.Input>{
             lineCount: document.lineCount,
             getLine: number => document.getLineContent(number + 1),
         };
-        const mergeConflicts: MergeConflict[] = this.mergeConflictParser.parse(input);
-        return { editor, mergeConflicts };
+        return this.mergeConflictParser.parse(input);
     }
 
 }

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from "monaco-languageclient";
+import { MonacoToProtocolConverter, ProtocolToMonacoConverter, TextEdit } from "monaco-languageclient";
 import { ElementExt } from "@phosphor/domutils";
 import URI from "@theia/core/lib/common/uri";
 import { DisposableCollection, Disposable, Emitter, Event } from "@theia/core/lib/common";
@@ -379,6 +379,10 @@ export class MonacoEditor implements TextEditor, IEditorReference {
             };
         });
         return this.editor.executeEdits(params.source, edits);
+    }
+
+    executeEdits(edits: TextEdit[]): boolean {
+        return this.editor.executeEdits("MonacoEditor", this.p2m.asTextEdits(edits) as IIdentifiedSingleEditOperation[]);
     }
 
 }

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -348,26 +348,12 @@ export class MonacoEditor implements TextEditor, IEditorReference {
     }
 
     getVisibleColumn(position: Position): number {
-        return this.editor.getVisibleColumnFromPosition({
-            column: position.character + 1,
-            lineNumber: position.line + 1
-        });
+        return this.editor.getVisibleColumnFromPosition(this.p2m.asPosition(position));
     }
 
     async replaceText(params: ReplaceTextParams): Promise<boolean> {
         const edits: IIdentifiedSingleEditOperation[] = params.replaceOperations.map(param => {
-            const startPos = param.range.start;
-            const endPos = param.range.end;
-            const range = this.p2m.asRange({
-                start: {
-                    line: startPos.line - 1,
-                    character: startPos.character - 1
-                },
-                end: {
-                    line: endPos.line - 1,
-                    character: endPos.character - 1
-                }
-            });
+            const range = monaco.Range.fromPositions(this.p2m.asPosition(param.range.start), this.p2m.asPosition(param.range.end));
             return {
                 forceMoveMarkers: true,
                 identifier: {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -326,12 +326,12 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 text: this._replaceTerm,
                 range: {
                     start: {
-                        line: resultLineNode.line,
-                        character: resultLineNode.character
+                        line: resultLineNode.line - 1,
+                        character: resultLineNode.character - 1
                     },
                     end: {
-                        line: resultLineNode.line,
-                        character: resultLineNode.character + resultLineNode.length
+                        line: resultLineNode.line - 1,
+                        character: resultLineNode.character - 1 + resultLineNode.length
                     }
                 }
             } as ReplaceOperation));


### PR DESCRIPTION
This PR fixes leaking of `MonacoEditor` in merge conflicts provider. It also improves editing performance, as updates for editor change events are now debounced.

Besides that, merge conflicts resolutions use `TextEditor.executeEdits` API instead of `Workspace` API, which is more direct and symmetrical to the computation part.

Fixes #2281, #1756, #2293