### PR TITLE
[tsx] use unsafe lodash.debounce import to overcome bogus d.ts files

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -30,9 +30,10 @@ import { notEmpty } from '../../common/objects';
 import { isOSX } from '../../common/os';
 import { ReactWidget } from "../widgets/react-widget";
 import * as React from 'react';
-import { debounce } from "lodash";
 import { List, ListRowRenderer } from 'react-virtualized';
 import { TopDownTreeIterator } from "./tree-iterator";
+
+const debounce = require("lodash.debounce");
 
 export const TREE_CLASS = 'theia-Tree';
 export const TREE_CONTAINER_CLASS = 'theia-TreeContainer';


### PR DESCRIPTION
It is a temporary fix to overcome: https://github.com/Microsoft/TypeScript/issues/24599#issuecomment-403419270