### PR TITLE
New `@theia/example-hybrid` application

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -59,12 +59,24 @@ export abstract class AbstractGenerator {
         return os.EOL + lines.join(os.EOL);
     }
 
+    get package(): ApplicationPackage {
+        return this.pck;
+    }
+
+    normalized(string: string): string {
+        return string.replace(/\W/, '');
+    }
+
     protected ifBrowser(value: string, defaultValue: string = '') {
         return this.pck.ifBrowser(value, defaultValue);
     }
 
     protected ifElectron(value: string, defaultValue: string = '') {
         return this.pck.ifElectron(value, defaultValue);
+    }
+
+    protected ifHybrid(value: string, defaultValue: string = '') {
+        return this.pck.ifHybrid(value, defaultValue);
     }
 
     protected async write(path: string, content: string): Promise<void> {

--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -14,11 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { ApplicationProps } from '@theia/application-package/lib/';
 import fs = require('fs-extra');
 import path = require('path');
 import cp = require('child_process');
 
-export function rebuild(target: 'electron' | 'browser', modules: string[]) {
+export function rebuild(target: ApplicationProps.Target, modules: string[]) {
     const nodeModulesPath = path.join(process.cwd(), 'node_modules');
     const browserModulesPath = path.join(process.cwd(), '.browser_modules');
     const modulesToProcess = modules || ['node-pty', 'vscode-nsfw', 'find-git-repositories'];
@@ -54,7 +55,8 @@ export function rebuild(target: 'electron' | 'browser', modules: string[]) {
                 fs.writeFile(packFile, packageText);
             }, 100);
         }
-    } else if (target === 'browser' && fs.existsSync(browserModulesPath)) {
+
+    } else if (/^(browser|hybrid)$/.test(target) && fs.existsSync(browserModulesPath)) {
         for (const moduleName of fs.readdirSync(browserModulesPath)) {
             console.log('Reverting ' + moduleName);
             const src = path.join(browserModulesPath, moduleName);
@@ -63,6 +65,7 @@ export function rebuild(target: 'electron' | 'browser', modules: string[]) {
             fs.copySync(src, dest);
         }
         fs.removeSync(browserModulesPath);
+
     } else {
         console.log('native node modules are already rebuilt for ' + target);
     }

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -17,11 +17,14 @@
 import * as fs from 'fs-extra';
 import * as paths from 'path';
 import { readJsonFile, writeJsonFile } from './json-file';
-import { NpmRegistry, NodePackage, PublishedNodePackage, sortByKey } from './npm-registry';
+import { NpmRegistry, NpmRegistryOptions, NodePackage, PublishedNodePackage, sortByKey } from './npm-registry';
 import { Extension, ExtensionPackage, RawExtensionPackage } from './extension-package';
 import { ExtensionPackageCollector } from './extension-package-collector';
 import { ApplicationProps } from './application-props';
 
+export class ApplicationPackageConfig extends NpmRegistryOptions {
+    readonly target: ApplicationProps.Target;
+}
 // tslint:disable-next-line:no-any
 export type ApplicationLog = (message?: any, ...optionalParams: any[]) => void;
 export class ApplicationPackageOptions {
@@ -198,6 +201,10 @@ export class ApplicationPackage {
         return this.target === 'electron';
     }
 
+    isHybrid(): boolean {
+        return this.target === 'hybrid';
+    }
+
     ifBrowser<T>(value: T): T | undefined;
     ifBrowser<T>(value: T, defaultValue: T): T;
     ifBrowser<T>(value: T, defaultValue?: T): T | undefined {
@@ -208,6 +215,12 @@ export class ApplicationPackage {
     ifElectron<T>(value: T, defaultValue: T): T;
     ifElectron<T>(value: T, defaultValue?: T): T | undefined {
         return this.isElectron() ? value : defaultValue;
+    }
+
+    ifHybrid<T>(value: T): T | undefined;
+    ifHybrid<T>(value: T, defaultValue: T): T;
+    ifHybrid<T>(value: T, defaultValue?: T): T | undefined {
+        return this.isHybrid() ? value : defaultValue;
     }
 
     get targetBackendModules(): Map<string, string> {

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -60,7 +60,7 @@ export interface ApplicationProps extends NpmRegistryProps {
 }
 export namespace ApplicationProps {
 
-    export type Target = 'browser' | 'electron';
+    export type Target = 'browser' | 'electron' | 'hybrid';
 
     export const DEFAULT: ApplicationProps = {
         ...NpmRegistryProps.DEFAULT,

--- a/examples/hybrid/compile.tsconfig.json
+++ b/examples/hybrid/compile.tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../configs/base.tsconfig"
+}

--- a/examples/hybrid/package.json
+++ b/examples/hybrid/package.json
@@ -1,0 +1,59 @@
+{
+  "private": true,
+  "name": "@theia/example-hybrid",
+  "version": "0.3.11",
+  "theia": {
+    "target": "hybrid"
+  },
+  "dependencies": {
+    "@theia/callhierarchy": "^0.3.11",
+    "@theia/core": "^0.3.11",
+    "@theia/cpp": "^0.3.11",
+    "@theia/editor": "^0.3.11",
+    "@theia/editorconfig": "^0.3.11",
+    "@theia/extension-manager": "^0.3.11",
+    "@theia/file-search": "^0.3.11",
+    "@theia/filesystem": "^0.3.11",
+    "@theia/git": "^0.3.11",
+    "@theia/java": "^0.3.11",
+    "@theia/keymaps": "^0.3.11",
+    "@theia/languages": "^0.3.11",
+    "@theia/markers": "^0.3.11",
+    "@theia/merge-conflicts": "^0.3.11",
+    "@theia/messages": "^0.3.11",
+    "@theia/metrics": "^0.3.11",
+    "@theia/mini-browser": "^0.3.11",
+    "@theia/monaco": "^0.3.11",
+    "@theia/navigator": "^0.3.11",
+    "@theia/outline-view": "^0.3.11",
+    "@theia/output": "^0.3.11",
+    "@theia/plugin-ext": "^0.3.11",
+    "@theia/plugin-ext-vscode": "^0.3.11",
+    "@theia/preferences": "^0.3.11",
+    "@theia/preview": "^0.3.11",
+    "@theia/process": "^0.3.11",
+    "@theia/python": "^0.3.11",
+    "@theia/search-in-workspace": "^0.3.11",
+    "@theia/task": "^0.3.11",
+    "@theia/terminal": "^0.3.11",
+    "@theia/typescript": "^0.3.11",
+    "@theia/userstorage": "^0.3.11",
+    "@theia/variable-resolver": "^0.3.11",
+    "@theia/workspace": "^0.3.11"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn build",
+    "clean": "theia clean",
+    "build": "theia build --mode development",
+    "watch": "yarn build --watch --mode development",
+    "start": "theia start",
+    "start:debug": "yarn start --log-level=debug",
+    "test": "electron-mocha --timeout 60000 --require ts-node/register \"./test/**/*.espec.ts\"",
+    "test:ui": "wdio wdio.conf.js"
+  },
+  "devDependencies": {
+    "@theia/cli": "^0.3.11",
+    "webpack": "^4.13.0",
+    "webpack-cli": "^3.0.8"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "@types/ws": "^3.0.2",
     "@types/yargs": "^8.0.2",
     "ajv": "^5.2.2",
+    "axios": "^0.18.0",
     "body-parser": "^1.17.2",
     "electron": "1.8.2-beta.5",
     "es6-promise": "^4.2.4",
@@ -45,14 +46,17 @@
   "publishConfig": {
     "access": "public"
   },
-  "theiaExtensions": [
-    {
+  "theiaExtensions": [{
       "frontend": "lib/browser/menu/browser-menu-module",
       "frontendElectron": "lib/electron-browser/menu/electron-menu-module"
     },
     {
       "frontend": "lib/browser/window/browser-window-module",
       "frontendElectron": "lib/electron-browser/window/electron-window-module"
+    },
+    {
+      "frontendElectron": "lib/electron-browser/remote/electron-remote-module",
+      "backendElectron": "lib/electron-node/remote/electron-remote-module"
     }
   ],
   "keywords": [

--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -35,6 +35,11 @@ export const isNative = typeof (window as any).process !== 'undefined';
 // tslint:disable-next-line:no-any
 export const isBasicWasmSupported = typeof (window as any).WebAssembly !== 'undefined';
 
+// Current protocol in use to display the application
+export const isHttps = /^https:/.test(self.location.href);
+export const isHttp = /^http:/.test(self.location.href);
+export const isFile = /^file:/.test(self.location.href);
+
 /**
  * Parse a magnitude value (e.g. width, height, left, top) from a CSS attribute value.
  * Returns the given default value (or undefined) if the value cannot be determined,

--- a/packages/core/src/browser/quick-open/quick-open-model.ts
+++ b/packages/core/src/browser/quick-open/quick-open-model.ts
@@ -75,7 +75,7 @@ export class QuickOpenItem<T extends QuickOpenItemOptions = QuickOpenItemOptions
         return this.options.detailHighlights;
     }
     isHidden(): boolean {
-        return this.options.hidden || false;
+        return !!this.options.hidden;
     }
     getUri(): URI | undefined {
         return this.options.uri;

--- a/packages/core/src/common/remote/electron-remote-protocol.ts
+++ b/packages/core/src/common/remote/electron-remote-protocol.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,26 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/**
- * Simple implementation of the deferred pattern.
- * An object that exposes a promise and functions to resolve and reject it.
- */
-export class Deferred<T> {
-    resolve: (value?: T) => void;
-    reject: (err?: any) => void; // tslint:disable-line
+export const ElectronRemoteQuestionPath = Symbol('ElectronRemoteQuestionPath');
+export const ElectronRemoteAnswer = Symbol('ElectronRemoteAnswer');
 
-    promise = new Promise<T>((resolve, reject) => {
-        this.resolve = resolve;
-        this.reject = reject;
-    });
-}
-
-/**
- * Simple timeout-as-promise implementation.
- *
- * @param time delay to wait for
- * @param value value to resolve to after the timeout
- */
-export function timeout<T = void>(time: Number, value?: T): Promise<T> {
-    return new Promise(resolve => setTimeout(resolve, time, value));
-}
+export const defaultElectronRemoteQuestionPath = '/are-you-theia';
+export const defaultElectronRemoteAnswer = {
+    answer: 'yes-I-am-Theia',
+};

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -20,9 +20,10 @@ import {
     Command, CommandContribution, CommandRegistry,
     isOSX, MenuModelRegistry, MenuContribution
 } from '../../common';
-import { KeybindingContribution, KeybindingRegistry } from '../../browser';
+import { KeybindingContribution, KeybindingRegistry, QuickOpenService } from '../../browser';
 import { FrontendApplication, FrontendApplicationContribution, CommonMenus } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
+import { WindowService } from '../../browser/window/window-service';
 
 export namespace ElectronCommands {
     export const TOGGLE_DEVELOPER_TOOLS: Command = {
@@ -58,6 +59,12 @@ export namespace ElectronMenus {
 
 @injectable()
 export class ElectronMenuContribution implements FrontendApplicationContribution, CommandContribution, MenuContribution, KeybindingContribution {
+
+    @inject(QuickOpenService)
+    protected readonly quickOpenService: QuickOpenService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
 
     constructor(
         @inject(ElectronMainMenuFactory) protected readonly factory: ElectronMainMenuFactory

--- a/packages/core/src/electron-browser/remote/electron-backend-location.ts
+++ b/packages/core/src/electron-browser/remote/electron-backend-location.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,26 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/**
- * Simple implementation of the deferred pattern.
- * An object that exposes a promise and functions to resolve and reject it.
- */
-export class Deferred<T> {
-    resolve: (value?: T) => void;
-    reject: (err?: any) => void; // tslint:disable-line
+import { isFile } from '../../browser';
 
-    promise = new Promise<T>((resolve, reject) => {
-        this.resolve = resolve;
-        this.reject = reject;
-    });
-}
+export type ElectronBackendLocation = 'local' | 'remote';
+export namespace ElectronBackendLocation {
 
-/**
- * Simple timeout-as-promise implementation.
- *
- * @param time delay to wait for
- * @param value value to resolve to after the timeout
- */
-export function timeout<T = void>(time: Number, value?: T): Promise<T> {
-    return new Promise(resolve => setTimeout(resolve, time, value));
+    export const location: ElectronBackendLocation = isFile ? 'local' : 'remote';
+
+    export function getLocation(): ElectronBackendLocation {
+        return location;
+    }
+
+    export function isLocal(): boolean {
+        return location === 'local';
+    }
+
+    export function isRemote(): boolean {
+        return location === 'remote';
+    }
 }

--- a/packages/core/src/electron-browser/remote/electron-remote-contribution.ts
+++ b/packages/core/src/electron-browser/remote/electron-remote-contribution.ts
@@ -1,0 +1,357 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// tslint:disable:no-any
+
+import { join } from 'path';
+import { inject, injectable } from 'inversify';
+import Axios, { AxiosResponse } from 'axios';
+import URI from '../../common/uri';
+import {
+    Command, CommandContribution, CommandRegistry,
+    MenuModelRegistry, MenuContribution, ILogger
+} from '../../common';
+import {
+    StorageService, KeybindingContribution, KeybindingRegistry,
+    QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickOpenGroupItem, QuickOpenGroupItemOptions
+} from '../../browser';
+import { CommonMenus } from '../../browser';
+import { WindowService } from '../../browser/window/window-service';
+import { timeout as delay } from '../../common/promise-util';
+import { ElectronBackendLocation } from './electron-backend-location';
+import { ElectronRemoteQuestionPath, ElectronRemoteAnswer } from '../../common/remote/electron-remote-protocol';
+
+export type RemoteEntryGroup = 'Input' | 'Autocomplete' | 'History';
+export type Response<T = any> = AxiosResponse<T>;
+export interface RemoteEntryOptions {
+    errorMessage?: string;
+    questionPath?: string;
+    expectedAnswer?: any;
+}
+export class RemoteEntry {
+
+    protected _ok?: boolean;
+    protected _response?: Response;
+    protected _error?: Error;
+
+    constructor(
+        public url: string,
+        protected options: RemoteEntryOptions = {},
+        public group?: string,
+    ) { }
+
+    protected get errorMessage(): string | undefined {
+        return this.options.errorMessage;
+    }
+    protected get questionPath(): string | undefined {
+        return this.options.questionPath;
+    }
+    protected get expectedAnswer(): object | undefined {
+        return this.options.expectedAnswer;
+    }
+
+    protected createError(response: Response): Error {
+        return new Error(this.errorMessage || response.statusText);
+    }
+
+    protected compareAnswer(answer: any, expected: any): boolean {
+        return Object.keys(answer)
+            .filter(key => answer.hasOwnProperty(key))
+            .every(key => answer[key] === expected[key])
+            ;
+    }
+
+    protected coerce(response: Response): Response {
+        if (/^2/.test(response.status.toString())) {
+            if (this.expectedAnswer) {
+                if (!(this._ok = this.compareAnswer(response.data, this.expectedAnswer))) {
+                    throw this.createError(response);
+                }
+            }
+            return response;
+        }
+        throw this.createError(response);
+    }
+
+    async poll(timeout?: number): Promise<Response> {
+        if (this._error) {
+            throw this._error;
+        }
+        if (this._response) {
+            return this._response;
+        }
+        const url = this.questionPath ? join(this.url, this.questionPath) : this.url;
+        try {
+            return this.coerce(this._response = await Axios.get(url, { timeout, responseType: 'json' }));
+        } catch (error) {
+            if (error.response && /^4/.test(error.response.status.toString())) {
+                error = this.createError(error.response);
+            }
+            throw this._error = error;
+        }
+    }
+
+    get response(): RemoteEntry['_response'] {
+        if (this._error) {
+            throw this._error;
+        }
+        return this._response;
+    }
+
+    hasError(): boolean {
+        return typeof this._error !== 'undefined';
+    }
+
+    hasResponse(): boolean {
+        return typeof this.response !== 'undefined';
+    }
+
+    isOk(): boolean {
+        return !!this._ok;
+    }
+
+    getStatusText(): string {
+        try {
+            const response = this.response;
+            if (response) {
+                return 'Online';
+            }
+        } catch (error) {
+            return error.message;
+        }
+        return 'Unresolved';
+    }
+
+    clear(): void {
+        this._response = undefined;
+        this._error = undefined;
+        this._ok = undefined;
+    }
+}
+
+@injectable()
+export class ElectronRemoteContribution implements QuickOpenModel, CommandContribution, MenuContribution, KeybindingContribution {
+
+    @inject(StorageService) protected readonly localStorageService: StorageService;
+    @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService;
+    @inject(WindowService) protected readonly windowService: WindowService;
+    @inject(ILogger) protected readonly logger: ILogger;
+
+    protected historyEntries: Promise<RemoteEntry[]>;
+    protected timeout: number = 500; // ms
+
+    constructor(
+        @inject(ElectronRemoteQuestionPath) protected readonly questionPath?: string,
+        @inject(ElectronRemoteAnswer) protected readonly expectedAnswer?: object,
+    ) { }
+
+    protected remoteEntryOptions: RemoteEntryOptions = {
+        errorMessage: 'Not a Theia Application',
+        expectedAnswer: this.expectedAnswer,
+        questionPath: this.questionPath,
+    };
+
+    protected get history(): Promise<string[]> {
+        return this.localStorageService.getData<string[]>(ElectronRemoteHistory.KEY, [])
+            .then(history => history.map(entry => decodeURI(entry)));
+    }
+
+    protected async remember(url: string): Promise<void> {
+        const history = await this.localStorageService.getData<string[]>(ElectronRemoteHistory.KEY, []);
+        const encoded = encodeURI(url);
+        if (encoded) {
+            const index = history.indexOf(encoded);
+            if (index >= 0) {
+                history.splice(index);
+            }
+            history.unshift(encoded);
+            this.localStorageService.setData(ElectronRemoteHistory.KEY, history);
+        }
+    }
+
+    protected async clearHistory(): Promise<void> {
+        return this.localStorageService.setData(ElectronRemoteHistory.KEY, undefined);
+    }
+
+    protected async computeHistoryCache(): Promise<RemoteEntry[]> {
+        return this.accumulateResponses(
+            (await this.history).map(
+                url => new RemoteEntry(url, this.remoteEntryOptions, 'History')
+            ), this.timeout);
+    }
+
+    protected async accumulateResponses(input: RemoteEntry[], timeout: number): Promise<RemoteEntry[]> {
+        const output: RemoteEntry[] = [];
+        input.forEach(async entry => {
+            await entry.poll(timeout).catch(e => void 0);
+            output.push(entry);
+        });
+        await delay(timeout);
+        return output.slice(0);
+    }
+
+    protected urlOpener = (url: string) => (mode: QuickOpenMode): boolean => {
+        if (mode === QuickOpenMode.OPEN) {
+            this.windowService.openNewWindow(url);
+            this.remember(url);
+        }
+        return true;
+    }
+
+    protected convertEntryToQuickOpenItem(entry: RemoteEntry, override: QuickOpenGroupItemOptions = {}): QuickOpenItem {
+        const opener = this.urlOpener(entry.url);
+        return new QuickOpenGroupItem({
+            label: entry.url,
+            groupLabel: entry.group,
+            description: entry.getStatusText(),
+            run: mode => entry.isOk() ? opener(mode) : false,
+            ...override,
+        });
+    }
+
+    async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
+        const defaultSchemes = ['http', 'https'];
+        const items: QuickOpenItem[] = [];
+        const inputResponses = [];
+        const inputEntries = [];
+
+        // Add a way to open a local electron window
+        if (ElectronBackendLocation.isRemote()) {
+            items.push(new QuickOpenGroupItem({
+                label: 'Localhost Application',
+                groupLabel: 'Electron',
+                description: 'Electron',
+                run: this.urlOpener('localhost'),
+            }));
+        }
+
+        if (lookFor) {
+            let url = new URI(lookFor);
+
+            // Autocompletion (http/https) if not using http(s) filescheme
+            if (!/^https?$/.test(url.scheme)) {
+                const reformated = new URI(`//${lookFor}`);
+                for (const scheme of defaultSchemes) {
+                    url = reformated.withScheme(scheme);
+                    inputEntries.push(
+                        new RemoteEntry(url.toString(), this.remoteEntryOptions, 'Autocomplete')
+                    );
+                }
+            } else {
+                inputEntries.push(
+                    new RemoteEntry(url.toString(), this.remoteEntryOptions, 'Input')
+                );
+            }
+
+            // Host polling
+            inputResponses.push(...await this.accumulateResponses(inputEntries, this.timeout));
+        }
+
+        // Sorting the autocompletion and history based on the status of the responses
+        const sortedEntries = [...inputResponses, ...await this.historyEntries]
+            // make unique
+            .filter((entry, index, array) => array.findIndex(e => e.url === entry.url) === index)
+            // place OK responses first
+            .sort((a, b) => {
+                if (a.isOk() === b.isOk()) {
+                    return 0;
+                } else if (a.isOk()) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            })
+            // place a separator between OK and Error responses
+            .map((entry, index, array) => {
+                const previous = array[index - 1];
+                const options: QuickOpenGroupItemOptions = {};
+                if (previous && previous.isOk() && !entry.isOk()) {
+                    options.showBorder = true;
+                }
+                return this.convertEntryToQuickOpenItem(entry, options);
+            });
+
+        items.push(...sortedEntries);
+        acceptor(items);
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(ElectronRemoteCommands.CONNECT_TO_REMOTE, {
+            execute: () => {
+                this.historyEntries = this.computeHistoryCache();
+                this.quickOpenService.open(this, {
+                    placeholder: 'Type the URL to connect to...',
+                    fuzzyMatchLabel: true,
+                });
+            }
+        });
+
+        registry.registerCommand(ElectronRemoteCommands.DISCONNECT_FROM_REMOTE, {
+            isEnabled: () => ElectronBackendLocation.isRemote(),
+            isVisible: () => ElectronBackendLocation.isRemote(),
+            execute: () => {
+                this.windowService.openNewWindow('localhost');
+                close();
+            },
+        });
+        registry.registerCommand(ElectronRemoteCommands.CLEAR_REMOTE_HISTORY, {
+            execute: () => this.clearHistory()
+        });
+    }
+
+    registerKeybindings(registry: KeybindingRegistry): void {
+        registry.registerKeybindings({
+            command: ElectronRemoteCommands.CONNECT_TO_REMOTE.id,
+            keybinding: 'ctrl+alt+r'
+        });
+    }
+
+    registerMenus(registry: MenuModelRegistry) {
+        registry.registerMenuAction(ElectronMenus.ELECTRON_REMOTE, {
+            commandId: ElectronRemoteCommands.CONNECT_TO_REMOTE.id,
+            order: 'z4',
+        });
+        // Do not load the disconnect button if we are not on a remote server
+        if (ElectronBackendLocation.isRemote()) {
+            registry.registerMenuAction(ElectronMenus.ELECTRON_REMOTE, {
+                commandId: ElectronRemoteCommands.DISCONNECT_FROM_REMOTE.id,
+                order: 'z5',
+            });
+        }
+    }
+}
+
+export namespace ElectronRemoteCommands {
+    export const CONNECT_TO_REMOTE: Command = {
+        id: 'electron.remote.connect',
+        label: 'Remote: Connect to a Server'
+    };
+    export const CLEAR_REMOTE_HISTORY: Command = {
+        id: 'electron.remote.history.clear',
+        label: 'Remote: Clear host history'
+    };
+    export const DISCONNECT_FROM_REMOTE: Command = {
+        id: 'electron.remote.disconnect',
+        label: 'Remote: Disconnect',
+    };
+}
+
+export namespace ElectronMenus {
+    export const ELECTRON_REMOTE = [...CommonMenus.FILE_OPEN, 'z_connect'];
+}
+
+export namespace ElectronRemoteHistory {
+    export const KEY = 'theia.remote.history';
+}

--- a/packages/core/src/electron-browser/remote/electron-remote-module.ts
+++ b/packages/core/src/electron-browser/remote/electron-remote-module.ts
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { CommandContribution, MenuContribution } from '../../common';
+import {
+    ElectronRemoteQuestionPath, ElectronRemoteAnswer,
+    defaultElectronRemoteQuestionPath, defaultElectronRemoteAnswer
+} from '../../common/remote/electron-remote-protocol';
+import { KeybindingContribution } from '../../browser';
+import { ElectronRemoteContribution } from './electron-remote-contribution';
+
+export default new ContainerModule(bind => {
+    bind(ElectronRemoteContribution).toSelf().inSingletonScope();
+    for (const serviceIdentifier of [KeybindingContribution, CommandContribution, MenuContribution]) {
+        bind(serviceIdentifier).toService(ElectronRemoteContribution);
+    }
+    bind(ElectronRemoteQuestionPath).toConstantValue(defaultElectronRemoteQuestionPath);
+    bind(ElectronRemoteAnswer).toConstantValue(defaultElectronRemoteAnswer);
+});

--- a/packages/core/src/electron-node/remote/electron-remote-backend-contribution.ts
+++ b/packages/core/src/electron-node/remote/electron-remote-backend-contribution.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,26 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/**
- * Simple implementation of the deferred pattern.
- * An object that exposes a promise and functions to resolve and reject it.
- */
-export class Deferred<T> {
-    resolve: (value?: T) => void;
-    reject: (err?: any) => void; // tslint:disable-line
+import * as express from 'express';
+import { injectable, inject } from 'inversify';
+import { BackendApplicationContribution } from '../../node';
+import { ElectronRemoteQuestionPath, ElectronRemoteAnswer } from '../../common/remote/electron-remote-protocol';
 
-    promise = new Promise<T>((resolve, reject) => {
-        this.resolve = resolve;
-        this.reject = reject;
-    });
-}
+@injectable()
+export class ElectronRemoteBackendContribution implements BackendApplicationContribution {
 
-/**
- * Simple timeout-as-promise implementation.
- *
- * @param time delay to wait for
- * @param value value to resolve to after the timeout
- */
-export function timeout<T = void>(time: Number, value?: T): Promise<T> {
-    return new Promise(resolve => setTimeout(resolve, time, value));
+    @inject(ElectronRemoteQuestionPath) protected readonly path: string;
+    @inject(ElectronRemoteAnswer) protected readonly answer: object;
+
+    configure(app: express.Application): void {
+        app.get(this.path, (request, response) => {
+            response.send(this.answer);
+        });
+    }
 }

--- a/packages/core/src/electron-node/remote/electron-remote-module.ts
+++ b/packages/core/src/electron-node/remote/electron-remote-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,26 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/**
- * Simple implementation of the deferred pattern.
- * An object that exposes a promise and functions to resolve and reject it.
- */
-export class Deferred<T> {
-    resolve: (value?: T) => void;
-    reject: (err?: any) => void; // tslint:disable-line
+import { ContainerModule } from 'inversify';
+import { BackendApplicationContribution } from '../../node';
+import { ElectronRemoteBackendContribution } from './electron-remote-backend-contribution';
+import {
+    ElectronRemoteQuestionPath, ElectronRemoteAnswer,
+    defaultElectronRemoteQuestionPath, defaultElectronRemoteAnswer
+} from '../../common/remote/electron-remote-protocol';
 
-    promise = new Promise<T>((resolve, reject) => {
-        this.resolve = resolve;
-        this.reject = reject;
-    });
-}
-
-/**
- * Simple timeout-as-promise implementation.
- *
- * @param time delay to wait for
- * @param value value to resolve to after the timeout
- */
-export function timeout<T = void>(time: Number, value?: T): Promise<T> {
-    return new Promise(resolve => setTimeout(resolve, time, value));
-}
+export default new ContainerModule(bind => {
+    bind(BackendApplicationContribution).to(ElectronRemoteBackendContribution).inSingletonScope();
+    bind(ElectronRemoteQuestionPath).toConstantValue(defaultElectronRemoteQuestionPath);
+    bind(ElectronRemoteAnswer).toConstantValue(defaultElectronRemoteAnswer);
+});

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -34,7 +34,7 @@ export function loadVsRequire(context: any): Promise<any> {
                     context.require = originalRequire;
                 }
                 resolve(amdRequire);
-            });
+            }, { once: true });
             document.body.appendChild(vsLoader);
         }, { once: true })
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,6 +952,13 @@ aws4@^1.2.1, aws4@^1.6.0, aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -2044,6 +2051,10 @@ changes-stream@^2.2.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+chardet@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.5.0.tgz#fe3ac73c00c3d865ffcc02a0682e2c20b6a06029"
 
 "charenc@>= 0.0.1":
   version "0.0.2"
@@ -3486,6 +3497,13 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-scope@^3.7.1:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.3.tgz#bb507200d3d17f60247636160b4826284b108535"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -3688,6 +3706,14 @@ external-editor@^2.0.4, external-editor@^2.1.0:
   dependencies:
     chardet "^0.4.0"
     iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
+external-editor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.0.tgz#dc35c48c6f98a30ca27a20e9687d7f3c77704bb6"
+  dependencies:
+    chardet "^0.5.0"
+    iconv-lite "^0.4.22"
     tmp "^0.0.33"
 
 extglob@^0.3.1:
@@ -3937,6 +3963,12 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
+
+follow-redirects@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.1.tgz#67a8f14f5a1f67f962c2c46469c79eaec0a90291"
+  dependencies:
+    debug "^3.1.0"
 
 font-awesome-webpack@0.0.5-beta.2:
   version "0.0.5-beta.2"
@@ -4290,6 +4322,10 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, gl
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-modules-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/global-modules-path/-/global-modules-path-2.1.0.tgz#923ec524e8726bb0c1a4ed4b8e21e1ff80c88bbb"
 
 global-modules@^1.0.0:
   version "1.0.0"
@@ -4752,7 +4788,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.22, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -4797,6 +4833,13 @@ ignore@^3.3.5:
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -4876,7 +4919,25 @@ inquirer@^5.1.0, inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-interpret@^1.0.0, interpret@^1.0.4:
+inquirer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.0.0.tgz#e8c20303ddc15bbfc2c12a6213710ccd9e1413d8"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+interpret@^1.0.0, interpret@^1.0.4, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
@@ -8272,6 +8333,12 @@ rxjs@^5.1.1, rxjs@^5.4.2, rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
+rxjs@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -9620,6 +9687,10 @@ v8-compile-cache@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"
 
+v8-compile-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz#526492e35fc616864284700b7043e01baee09f0a"
+
 valid-filename@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/valid-filename/-/valid-filename-2.0.1.tgz#0768d6f364b1ed3bdf68f0d15abffb0d9d6cecaf"
@@ -9910,6 +9981,22 @@ webpack-cli@2.0.12:
     yeoman-environment "^2.0.0"
     yeoman-generator "^2.0.3"
 
+webpack-cli@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.0.8.tgz#90eddcf04a4bfc31aa8c0edc4c76785bc4f1ccd9"
+  dependencies:
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    enhanced-resolve "^4.0.0"
+    global-modules-path "^2.1.0"
+    import-local "^1.0.0"
+    inquirer "^6.0.0"
+    interpret "^1.1.0"
+    loader-utils "^1.1.0"
+    supports-color "^5.4.0"
+    v8-compile-cache "^2.0.0"
+    yargs "^11.1.0"
+
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
@@ -9933,6 +10020,36 @@ webpack@^4.0.0:
     chrome-trace-event "^1.0.0"
     enhanced-resolve "^4.1.0"
     eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.4"
+    tapable "^1.0.0"
+    uglifyjs-webpack-plugin "^1.2.4"
+    watchpack "^1.5.0"
+    webpack-sources "^1.0.1"
+
+webpack@^4.13.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.15.0.tgz#c9704e98f045499b84bdb194d23ade18dfaf4441"
+  dependencies:
+    "@webassemblyjs/ast" "1.5.13"
+    "@webassemblyjs/helper-module-context" "1.5.13"
+    "@webassemblyjs/wasm-edit" "1.5.13"
+    "@webassemblyjs/wasm-opt" "1.5.13"
+    "@webassemblyjs/wasm-parser" "1.5.13"
+    acorn "^5.6.2"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^3.7.1"
     json-parse-better-errors "^1.0.2"
     loader-runner "^2.3.0"
     loader-utils "^1.1.0"
@@ -10192,7 +10309,7 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
-yargs@11.1.0, yargs@^11.0.0:
+yargs@11.1.0, yargs@^11.0.0, yargs@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:


### PR DESCRIPTION
This PR adds support for an electron client to connect to an hybrid backend.

Currently done:
- [x] New `@theia/example-hybrid` package that can serve both web browsers and electron apps.
- [x] Modified the generators to autogen `@theia/example-hybrid`.
- [x] New Electron-specific commands to choose a remote host to connect to.
  - [x] Basic host connection history.
  - [x] Host polling to see status (online/offline).
- [x] Some issues when actually loading remote content in Electron.
  -  It seems to come from the AMD loader importing the monaco editor.
- [ ] Security options are not yet set to accommodate for remote content loading
  - Such as disabling node integration and such...

---

How to test this PR:

- Use `node v8.2.1`, it should be the same as the one used by Electron, so that you don't have to rebuild native modules when starting `@theia/example-electron` and `@theia/example-hybrid`
```sh
nvm install 8.2.1
nvm alias electron 8.2.1
nvm alias default electron
nvm use electron
```
- Start both `@theia/example-electron` and `@theia/example-hybrid` so that you have a server to connect to.
- Open the command palette (<kbd>F1</kbd>) and use `Remote: Connect to a server`.