### PR TITLE
Improved styles in search-in-workspace widget

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -265,6 +265,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         const input = <input
             id="search-input-field"
             type="text"
+            size={1}
             placeholder="Search"
             defaultValue={this.searchTerm}
             onFocus={e => {
@@ -306,6 +307,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             <input
                 id="replace-input-field"
                 type="text"
+                size={1}
                 placeholder="Replace"
                 defaultValue={this.replaceTerm}
                 onKeyUp={e => {
@@ -394,6 +396,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             <div className="label">{"files to " + kind}</div>
             <input
                 type="text"
+                size={1}
                 defaultValue={value}
                 id={kind + "-glob-field"}
                 onKeyUp={e => {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -307,6 +307,7 @@
     display: flex;
     align-items:  center;
     width: 15px;
+    min-width: 15px;
     justify-content: center;
     margin-right: 2px;
     box-sizing: border-box;


### PR DESCRIPTION
- Added min-width to replace-toggle
- Set minimal size for input fields

Fixes #2317 

Of course at some point the option buttons will be hidden. But now the input field will be scaled down to the smallest possible size (where it makes no sense to use the search extension anyway).