### PR TITLE
[ts] one ls for all js related languages

### DIFF
--- a/packages/typescript/src/browser/typescript-client-contribution.ts
+++ b/packages/typescript/src/browser/typescript-client-contribution.ts
@@ -16,8 +16,7 @@
 
 import { injectable, inject } from "inversify";
 import { BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory } from '@theia/languages/lib/browser';
-import { TYPESCRIPT_LANGUAGE_ID, TYPESCRIPT_LANGUAGE_NAME } from '../common';
-import { JAVASCRIPT_LANGUAGE_ID, JAVASCRIPT_LANGUAGE_NAME } from '../common/index';
+import { TYPESCRIPT_LANGUAGE_ID, TYPESCRIPT_LANGUAGE_NAME, TYPESCRIPT_REACT_LANGUAGE_ID, JAVASCRIPT_LANGUAGE_ID, JAVASCRIPT_REACT_LANGUAGE_ID } from '../common';
 
 @injectable()
 export class TypeScriptClientContribution extends BaseLanguageClientContribution {
@@ -33,32 +32,35 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
         super(workspace, languages, languageClientFactory);
     }
 
-    protected get globPatterns() {
+    protected get globPatterns(): string[] {
         return [
             '**/*.ts',
-            '**/*.tsx'
+            '**/*.tsx',
+            '**/*.js',
+            '**/*.jsx'
         ];
     }
 
-}
-@injectable()
-export class JavaScriptClientContribution extends BaseLanguageClientContribution {
-
-    readonly id = JAVASCRIPT_LANGUAGE_ID;
-    readonly name = JAVASCRIPT_LANGUAGE_NAME;
-
-    constructor(
-        @inject(Workspace) protected readonly workspace: Workspace,
-        @inject(Languages) protected readonly languages: Languages,
-        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
-    ) {
-        super(workspace, languages, languageClientFactory);
+    protected get documentSelector(): string[] {
+        return [
+            TYPESCRIPT_LANGUAGE_ID,
+            TYPESCRIPT_REACT_LANGUAGE_ID,
+            JAVASCRIPT_LANGUAGE_ID,
+            JAVASCRIPT_REACT_LANGUAGE_ID
+        ];
     }
 
-    protected get globPatterns() {
+    protected get workspaceContains() {
+        // FIXME requires https://github.com/theia-ide/theia/issues/2359
+        // return [
+        //     "**/tsconfig.json",
+        //     "**/jsconfig.json",
+        //     "**/tsconfig.*.json",
+        //     "**/jsconfig.*.json"
+        // ];
         return [
-            '**/*.js',
-            '**/*.jsx',
+            "tsconfig.json",
+            "jsconfig.json"
         ];
     }
 

--- a/packages/typescript/src/browser/typescript-frontend-module.ts
+++ b/packages/typescript/src/browser/typescript-frontend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from "inversify";
 import { LanguageGrammarDefinitionContribution } from "@theia/monaco/lib/browser/textmate";
 import { LanguageClientContribution } from "@theia/languages/lib/browser";
 import { CallHierarchyService } from "@theia/callhierarchy/lib/browser";
-import { TypeScriptClientContribution, JavaScriptClientContribution } from "./typescript-client-contribution";
+import { TypeScriptClientContribution } from "./typescript-client-contribution";
 import { TypeScriptCallHierarchyService } from "./typescript-callhierarchy-service";
 import { TypescriptGrammarContribution } from "./typescript-language-config";
 import { JavascriptGrammarContribution } from "./javascript-language-config";
@@ -26,9 +26,6 @@ import { JavascriptGrammarContribution } from "./javascript-language-config";
 export default new ContainerModule(bind => {
     bind(TypeScriptClientContribution).toSelf().inSingletonScope();
     bind(LanguageClientContribution).toService(TypeScriptClientContribution);
-
-    bind(JavaScriptClientContribution).toSelf().inSingletonScope();
-    bind(LanguageClientContribution).toService(JavaScriptClientContribution);
 
     bind(TypeScriptCallHierarchyService).toSelf().inSingletonScope();
     bind(CallHierarchyService).toService(TypeScriptCallHierarchyService);

--- a/packages/typescript/src/node/typescript-backend-module.ts
+++ b/packages/typescript/src/node/typescript-backend-module.ts
@@ -16,11 +16,8 @@
 
 import { ContainerModule } from "inversify";
 import { LanguageServerContribution } from "@theia/languages/lib/node";
-import { JavaScriptContribution, TypeScriptContribution, TypeScriptReactContribution, JavaScriptReactContribution } from './typescript-contribution';
+import { TypeScriptContribution } from './typescript-contribution';
 
 export default new ContainerModule(bind => {
     bind(LanguageServerContribution).to(TypeScriptContribution).inSingletonScope();
-    bind(LanguageServerContribution).to(TypeScriptReactContribution).inSingletonScope();
-    bind(LanguageServerContribution).to(JavaScriptContribution).inSingletonScope();
-    bind(LanguageServerContribution).to(JavaScriptReactContribution).inSingletonScope();
 });

--- a/packages/typescript/src/node/typescript-contribution.ts
+++ b/packages/typescript/src/node/typescript-contribution.ts
@@ -16,15 +16,13 @@
 
 import { injectable } from "inversify";
 import { BaseLanguageServerContribution, IConnection } from "@theia/languages/lib/node";
-import {
-    TYPESCRIPT_LANGUAGE_ID, TYPESCRIPT_LANGUAGE_NAME,
-    TYPESCRIPT_REACT_LANGUAGE_ID, TYPESCRIPT_REACT_LANGUAGE_NAME,
-    JAVASCRIPT_LANGUAGE_ID, JAVASCRIPT_LANGUAGE_NAME,
-    JAVASCRIPT_REACT_LANGUAGE_ID, JAVASCRIPT_REACT_LANGUAGE_NAME
-} from '../common';
+import { TYPESCRIPT_LANGUAGE_ID, TYPESCRIPT_LANGUAGE_NAME } from '../common';
 
 @injectable()
-export abstract class AbstractTypeScriptContribution extends BaseLanguageServerContribution {
+export class TypeScriptContribution extends BaseLanguageServerContribution {
+
+    readonly id = TYPESCRIPT_LANGUAGE_ID;
+    readonly name = TYPESCRIPT_LANGUAGE_NAME;
 
     start(clientConnection: IConnection): void {
         const command = "node";
@@ -35,36 +33,5 @@ export abstract class AbstractTypeScriptContribution extends BaseLanguageServerC
         const serverConnection = this.createProcessStreamConnection(command, args);
         this.forward(clientConnection, serverConnection);
     }
-}
-
-@injectable()
-export class TypeScriptContribution extends AbstractTypeScriptContribution {
-
-    readonly id = TYPESCRIPT_LANGUAGE_ID;
-    readonly name = TYPESCRIPT_LANGUAGE_NAME;
-
-}
-
-@injectable()
-export class JavaScriptContribution extends AbstractTypeScriptContribution {
-
-    readonly id = JAVASCRIPT_LANGUAGE_ID;
-    readonly name = JAVASCRIPT_LANGUAGE_NAME;
-
-}
-
-@injectable()
-export class TypeScriptReactContribution extends AbstractTypeScriptContribution {
-
-    readonly id = TYPESCRIPT_REACT_LANGUAGE_ID;
-    readonly name = TYPESCRIPT_REACT_LANGUAGE_NAME;
-
-}
-
-@injectable()
-export class JavaScriptReactContribution extends AbstractTypeScriptContribution {
-
-    readonly id = JAVASCRIPT_REACT_LANGUAGE_ID;
-    readonly name = JAVASCRIPT_REACT_LANGUAGE_NAME;
 
 }


### PR DESCRIPTION
Recent changes introduced 2 new languages for React which broke language support in jsx and tsx files. This PR fixes them by using one language server for all js/ts related languages. Also, running 4 separate language servers for js, jsx, ts and tsx does not make sense.