### PR TITLE
[dirty-diff] handle CR at the end of lines

### DIFF
--- a/packages/git/src/browser/dirty-diff/content-lines.spec.ts
+++ b/packages/git/src/browser/dirty-diff/content-lines.spec.ts
@@ -21,8 +21,17 @@ chai.use(require('chai-string'));
 
 describe("content-lines", () => {
 
-    it("array like access of lines without splitting", () => {
+    it("array-like access of lines without splitting", () => {
         const raw = "abc\ndef\n123\n456";
+        const linesArray = ContentLines.arrayLike(ContentLines.fromString(raw));
+        expect(linesArray[0]).to.be.equal('abc');
+        expect(linesArray[1]).to.be.equal('def');
+        expect(linesArray[2]).to.be.equal('123');
+        expect(linesArray[3]).to.be.equal('456');
+    });
+
+    it("works with CRLF", () => {
+        const raw = "abc\ndef\r\n123\r456";
         const linesArray = ContentLines.arrayLike(ContentLines.fromString(raw));
         expect(linesArray[0]).to.be.equal('abc');
         expect(linesArray[1]).to.be.equal('def');

--- a/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
@@ -222,7 +222,7 @@ export class DirtyDiffModel implements Disposable {
         };
         if (isModified || isNewAndStaged) {
             this.staged = isNewAndStaged || modifiedChange!.staged || false;
-            readPreviousRevisionContent();
+            await readPreviousRevisionContent();
         }
         if (isNewAndUnstaged && !isNewAndStaged) {
             this.previousContent = undefined;
@@ -230,7 +230,7 @@ export class DirtyDiffModel implements Disposable {
         if (noRelevantChanges) {
             const inGitRepository = await this.isInGitRepository(repository);
             if (inGitRepository) {
-                readPreviousRevisionContent();
+                await readPreviousRevisionContent();
             }
         }
         this.update();


### PR DESCRIPTION
CR was not handled at all and this PR should fix this.

Can reproduced/verified with the example from #2373.

Additionally, this fixes a race between loading contents of a git resource and performing the update check.


Fixes #2373, #2177