### PR TITLE
Fix clangd installation instruction

### DIFF
--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -6,7 +6,7 @@ provide LSP features.
 To install Clangd on Ubuntu 16.04:
 
     $ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    $ sudo echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >  /etc/apt/sources.list.d/llvm.list
+    $ echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" | sudo tee /etc/apt/sources.list.d/llvm.list
     $ sudo apt-get update && sudo apt-get install -y clang-tools-7
     $ sudo ln -s /usr/bin/clangd-7 /usr/bin/clangd
 


### PR DESCRIPTION
Doing "sudo foo > /blah" doesn't work for writing in root-owned file
/blah.  The usual trick is to use "| sudo tee".

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>