### PR TITLE
[git/blame] Fix keybinding context for Escape

### DIFF
--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -26,9 +26,9 @@ import { EDITOR_CONTEXT_MENU_GIT } from '../git-view-contribution';
 import debounce = require('lodash.debounce');
 
 export namespace BlameCommands {
-    export const SHOW_GIT_ANNOTATIONS: Command = {
-        id: 'git.editor.show.annotations',
-        label: 'Git: Show Blame Annotations'
+    export const TOGGLE_GIT_ANNOTATIONS: Command = {
+        id: 'git.editor.toggle.annotations',
+        label: 'Git: Toggle Blame Annotations'
     };
     export const CLEAR_GIT_ANNOTATIONS: Command = {
         id: 'git.editor.clear.annotations'
@@ -48,11 +48,15 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
     protected readonly blameManager: BlameManager;
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(BlameCommands.SHOW_GIT_ANNOTATIONS, {
+        commands.registerCommand(BlameCommands.TOGGLE_GIT_ANNOTATIONS, {
             execute: () => {
                 const editorWidget = this.currentFileEditorWidget;
                 if (editorWidget) {
-                    this.showBlame(editorWidget);
+                    if (this.showsBlameAnnotations(editorWidget.editor.uri)) {
+                        this.clearBlame(editorWidget.editor.uri);
+                    } else {
+                        this.showBlame(editorWidget);
+                    }
                 }
             },
             isVisible: () =>
@@ -132,14 +136,14 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EDITOR_CONTEXT_MENU_GIT, {
-            commandId: BlameCommands.SHOW_GIT_ANNOTATIONS.id,
-            label: BlameCommands.SHOW_GIT_ANNOTATIONS.label!.slice('Git: '.length)
+            commandId: BlameCommands.TOGGLE_GIT_ANNOTATIONS.id,
+            label: BlameCommands.TOGGLE_GIT_ANNOTATIONS.label!.slice('Git: '.length)
         });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
-            command: BlameCommands.SHOW_GIT_ANNOTATIONS.id,
+            command: BlameCommands.TOGGLE_GIT_ANNOTATIONS.id,
             context: EditorKeybindingContexts.editorTextFocus,
             keybinding: 'alt+b'
         });

--- a/packages/git/src/browser/blame/blame-module.ts
+++ b/packages/git/src/browser/blame/blame-module.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { interfaces } from 'inversify';
-import { FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
+import { KeybindingContribution, KeybindingContext } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { BlameContribution } from './blame-contribution';
+import { BlameContribution, BlameAnnotationsKeybindingContext } from './blame-contribution';
 import { BlameDecorator } from './blame-decorator';
 import { BlameManager } from './blame-manager';
 
@@ -25,7 +25,9 @@ export function bindBlame(bind: interfaces.Bind) {
     bind(BlameContribution).toSelf().inSingletonScope();
     bind(BlameManager).toSelf().inSingletonScope();
     bind(BlameDecorator).toSelf().inSingletonScope();
-    for (const serviceIdentifier of [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution]) {
+    for (const serviceIdentifier of [CommandContribution, KeybindingContribution, MenuContribution]) {
         bind(serviceIdentifier).toService(BlameContribution);
     }
+    bind(BlameAnnotationsKeybindingContext).toSelf().inSingletonScope();
+    bind(KeybindingContext).toService(BlameAnnotationsKeybindingContext);
 }


### PR DESCRIPTION
This PR introduces new keybinding context `showsBlameAnnotations` to make sure that the `Escape` keybinding is not preventing the delivery of key events to monaco, which causes #2376, #2334.

Additionally, this converts the "Show" command to a "Toggle" command.

Fixes #2376, #2334, #1951