### PR TITLE
cpp: Change "C++" to "C/C++" in command label

### DIFF
--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -30,7 +30,7 @@ import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
  */
 export const SWITCH_SOURCE_HEADER: Command = {
     id: 'switch_source_header',
-    label: 'C++: Switch between source/header file'
+    label: 'C/C++: Switch between source/header file',
 };
 
 export const FILE_OPEN_PATH = (path: string): Command => <Command>{


### PR DESCRIPTION
So we standardize how we refer to the languages supported by the cpp
extension.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>