### PR TITLE
cpp: Watch changes to compile_commands.json

### DIFF
--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -67,12 +67,17 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     }
 
     protected get documentSelector() {
+        // This is used (at least) to determine which files, when they are open,
+        // trigger the launch of the C/C++ language server.
         return HEADER_AND_SOURCE_FILE_EXTENSIONS;
     }
 
     protected get globPatterns() {
+        // This is used (at least) to determine which files we watch.  Change
+        // notifications are forwarded to the language server.
         return [
-            '**/*.{' + HEADER_AND_SOURCE_FILE_EXTENSIONS.join() + '}'
+            '**/*.{' + HEADER_AND_SOURCE_FILE_EXTENSIONS.join() + '}',
+            '**/compile_commands.json',
         ];
     }
 


### PR DESCRIPTION
This patch makes it so we watch any file called compile_commands.json
and we forward the change notifications to the language server.  clangd
will use this to see if the compilation flags of some cpp files have
changed, and therefore if re-parse/re-indexing is necessary.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>