### PR TITLE
cpp: Add command to show references for CodeLens

### DIFF
--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -22,7 +22,7 @@ import { open, OpenerService } from '@theia/core/lib/browser';
 import { CppLanguageClientContribution } from "./cpp-language-client-contribution";
 import { SwitchSourceHeaderRequest } from "./cpp-protocol";
 import { TextDocumentIdentifier } from "@theia/languages/lib/common";
-import { EditorManager } from "@theia/editor/lib/browser";
+import { EditorCommands, EditorManager } from "@theia/editor/lib/browser";
 import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 
 /**
@@ -31,6 +31,13 @@ import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 export const SWITCH_SOURCE_HEADER: Command = {
     id: 'switch_source_header',
     label: 'C/C++: Switch between source/header file',
+};
+
+/**
+ * A command that is used to show the references from a CodeLens.
+ */
+export const SHOW_CLANGD_REFERENCES: Command = {
+    id: 'clangd.references'
 };
 
 export const FILE_OPEN_PATH = (path: string): Command => <Command>{
@@ -60,6 +67,10 @@ export class CppCommandContribution implements CommandContribution {
         commands.registerCommand(SWITCH_SOURCE_HEADER, {
             isEnabled: () => editorContainsCppFiles(this.editorService),
             execute: () => this.switchSourceHeader()
+        });
+        commands.registerCommand(SHOW_CLANGD_REFERENCES, {
+            execute: (doc: TextDocumentIdentifier, pos: Position, locs: Location[]) =>
+                commands.executeCommand(EditorCommands.SHOW_REFERENCES.id, doc.uri, pos, locs)
         });
     }
 


### PR DESCRIPTION
When clicking on a CodeLens, a command needs to be executed. Clangd tells
Theia to execute the "clangd.references" command when clicking on the CodeLens
so it needs to be handled. This is similar to "java.show.references".

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>