### PR TITLE
tslint: Enable trailing-comma

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -52,7 +52,10 @@
       "ignore-interfaces"
     ],
     "trailing-comma": [
-      false
+      true,
+      {
+        "multiline": "always"
+      }
     ],
     "triple-equals": [
       true,

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -86,8 +86,8 @@ export class ApplicationPackageManager {
             stdio: [0, 1, 2, 'ipc'],
             env: {
                 ...process.env,
-                THEIA_PARENT_PID: String(process.pid)
-            }
+                THEIA_PARENT_PID: String(process.pid),
+            },
         };
         const mainArgs = [...args];
         const inspectIndex = mainArgs.findIndex(v => v.startsWith('--inspect'));

--- a/dev-packages/application-manager/src/application-process.ts
+++ b/dev-packages/application-manager/src/application-process.ts
@@ -23,12 +23,12 @@ export class ApplicationProcess {
 
     protected readonly defaultOptions = {
         cwd: this.pck.projectPath,
-        env: process.env
+        env: process.env,
     };
 
     constructor(
         protected readonly pck: ApplicationPackage,
-        protected readonly binProjectPath: string
+        protected readonly binProjectPath: string,
     ) { }
 
     spawn(command: string, args?: string[], options?: cp.SpawnOptions): cp.ChildProcess {

--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -22,11 +22,11 @@ import { ApplicationPackage } from '@theia/application-package';
 const argv = yargs.option('mode', {
     description: 'Mode to use',
     choices: ['development', 'production'],
-    default: 'production'
+    default: 'production',
 }).option('split-frontend', {
     description: 'Split frontend modules into separate chunks. By default enabled in the dev mode and disabled in the prod mode.',
     type: 'boolean',
-    default: undefined
+    default: undefined,
 }).argv;
 const mode: 'development' | 'production' = argv.mode;
 const splitFrontend: boolean = argv['split-frontend'] === undefined ? mode === 'development' : argv['split-frontend'];
@@ -34,7 +34,7 @@ const splitFrontend: boolean = argv['split-frontend'] === undefined ? mode === '
 export abstract class AbstractGenerator {
 
     constructor(
-        protected readonly pck: ApplicationPackage
+        protected readonly pck: ApplicationPackage,
     ) { }
 
     protected compileFrontendModuleImports(modules: Map<string, string>): string {

--- a/dev-packages/application-manager/src/rebuild.ts
+++ b/dev-packages/application-manager/src/rebuild.ts
@@ -25,7 +25,7 @@ export function rebuild(target: 'electron' | 'browser', modules: string[]) {
 
     if (target === 'electron' && !fs.existsSync(browserModulesPath)) {
         const dependencies: {
-            [dependency: string]: string
+            [dependency: string]: string,
         } = {};
         for (const module of modulesToProcess) {
             console.log("Processing " + module);

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -40,7 +40,7 @@ export class ApplicationPackage {
 
     static defaultConfig: ApplicationPackageConfig = {
         ...NpmRegistry.defaultConfig,
-        target: 'browser'
+        target: 'browser',
     };
 
     readonly projectPath: string;
@@ -48,7 +48,7 @@ export class ApplicationPackage {
     readonly error: ApplicationLog;
 
     constructor(
-        protected readonly options: ApplicationPackageOptions
+        protected readonly options: ApplicationPackageOptions,
     ) {
         this.projectPath = options.projectPath;
         this.log = options.log || console.log.bind(console);
@@ -99,7 +99,7 @@ export class ApplicationPackage {
         if (!this._extensionPackages) {
             const collector = new ExtensionPackageCollector(
                 raw => this.newExtensionPackage(raw),
-                this.resolveModule
+                this.resolveModule,
             );
             this._extensionPackages = collector.collect(this.pck);
         }
@@ -243,7 +243,7 @@ export class ApplicationPackage {
 
     save(): Promise<void> {
         return writeJsonFile(this.packagePath, this.pck, {
-            detectIndent: true
+            detectIndent: true,
         });
     }
 

--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -25,7 +25,7 @@ export class ExtensionPackageCollector {
 
     constructor(
         protected readonly extensionPackageFactory: (raw: PublishedNodePackage) => ExtensionPackage,
-        protected readonly resolveModule: (modulePath: string) => string
+        protected readonly resolveModule: (modulePath: string) => string,
     ) { }
 
     protected root: NodePackage;

--- a/dev-packages/application-package/src/extension-package.ts
+++ b/dev-packages/application-package/src/extension-package.ts
@@ -29,7 +29,7 @@ export interface Extension {
 export class ExtensionPackage {
     constructor(
         readonly raw: PublishedNodePackage & Partial<RawExtensionPackage>,
-        protected readonly registry: NpmRegistry
+        protected readonly registry: NpmRegistry,
     ) { }
 
     get name(): string {
@@ -188,10 +188,10 @@ export namespace RawExtensionPackage {
     export class ViewState {
         readme?: string;
         tags?: {
-            [tag: string]: string
+            [tag: string]: string,
         };
         constructor(
-            protected readonly registry: NpmRegistry
+            protected readonly registry: NpmRegistry,
         ) { }
         get latestVersion(): string | undefined {
             if (this.tags) {

--- a/dev-packages/application-package/src/npm-registry.ts
+++ b/dev-packages/application-package/src/npm-registry.ts
@@ -61,10 +61,10 @@ export namespace PublishedNodePackage {
 
 export interface ViewResult {
     'dist-tags': {
-        [tag: string]: string
+        [tag: string]: string,
     }
     'versions': {
-        [version: string]: NodePackage
+        [version: string]: NodePackage,
     },
     'readme': string;
     [key: string]: any
@@ -99,7 +99,7 @@ export class NpmRegistry {
 
     static defaultConfig: NpmRegistryConfig = {
         next: false,
-        registry: 'https://registry.npmjs.org/'
+        registry: 'https://registry.npmjs.org/',
     };
 
     readonly config: NpmRegistryConfig = { ...NpmRegistry.defaultConfig };
@@ -111,7 +111,7 @@ export class NpmRegistry {
     constructor(options?: Partial<NpmRegistryOptions>) {
         this.options = {
             watchChanges: false,
-            ...options
+            ...options,
         };
         this.resetIndex();
     }
@@ -162,11 +162,11 @@ export class NpmRegistry {
             url += encodeURIComponent(name);
         }
         const headers: {
-            [header: string]: string
+            [header: string]: string,
         } = {};
         return new Promise((resolve, reject) => {
             request({
-                url, headers
+                url, headers,
             }, (err, response, body) => {
                 if (err) {
                     reject(err);

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -47,7 +47,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                 console.error(err);
                 process.exit(1);
             }
-        }
+        },
     };
 }
 
@@ -67,7 +67,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                     console.error(err);
                     process.exit(1);
                 }
-            }
+            },
         })
         .command({
             command: 'clean',
@@ -79,7 +79,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                     console.error(err);
                     process.exit(1);
                 }
-            }
+            },
         })
         .command({
             command: 'copy',
@@ -90,7 +90,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                     console.error(err);
                     process.exit(1);
                 }
-            }
+            },
         })
         .command({
             command: 'generate',
@@ -101,7 +101,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                     console.error(err);
                     process.exit(1);
                 }
-            }
+            },
         })
         .command({
             command: 'build',
@@ -113,7 +113,7 @@ function rebuildCommand(command: string, target: ApplicationPackageTarget): yarg
                     console.error(err);
                     process.exit(1);
                 }
-            }
+            },
         })
         .command(rebuildCommand('rebuild', target))
         .command(rebuildCommand('rebuild:browser', 'browser'))

--- a/packages/bunyan/src/node/bunyan-logger-server.ts
+++ b/packages/bunyan/src/node/bunyan-logger-server.ts
@@ -136,7 +136,7 @@ export class BunyanLoggerServer implements ILoggerServer {
         }
 
         return Promise.resolve(
-            this.toTheiaLevel(logger.level())
+            this.toTheiaLevel(logger.level()),
         );
     }
 

--- a/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-contribution.ts
@@ -29,7 +29,7 @@ export const CALL_HIERARCHY_LABEL = 'Call Hierarchy';
 export namespace CallHierarchyCommands {
     export const OPEN: Command = {
         id: 'callhierarchy:open',
-        label: 'Open Call Hierarchy'
+        label: 'Open Call Hierarchy',
     };
 }
 
@@ -43,10 +43,10 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
             widgetId: CALLHIERARCHY_ID,
             widgetName: CALL_HIERARCHY_LABEL,
             defaultWidgetOptions: {
-                area: 'bottom'
+                area: 'bottom',
             },
             toggleCommandId: CALL_HIERARCHY_TOGGLE_COMMAND_ID,
-            toggleKeybinding: 'ctrlcmd+shift+f1'
+            toggleKeybinding: 'ctrlcmd+shift+f1',
         });
     }
 
@@ -68,9 +68,9 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         commands.registerCommand(CallHierarchyCommands.OPEN, {
             execute: () => this.openView({
                 toggle: false,
-                activate: true
+                activate: true,
             }),
-            isEnabled: this.isCallHierarchyAvailable.bind(this)
+            isEnabled: this.isCallHierarchyAvailable.bind(this),
         });
         super.registerCommands(commands);
     }
@@ -79,7 +79,7 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         const menuPath = [...EDITOR_CONTEXT_MENU, 'navigation'];
         menus.registerMenuAction(menuPath, {
             commandId: CallHierarchyCommands.OPEN.id,
-            label: CALL_HIERARCHY_LABEL
+            label: CALL_HIERARCHY_LABEL,
         });
         super.registerMenus(menus);
     }
@@ -88,7 +88,7 @@ export class CallHierarchyContribution extends AbstractViewContribution<CallHier
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: CallHierarchyCommands.OPEN.id,
-            keybinding: 'ctrlcmd+f1'
+            keybinding: 'ctrlcmd+f1',
         });
     }
 }

--- a/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-frontend-module.ts
@@ -36,6 +36,6 @@ export default new ContainerModule(bind => {
 
     bind(WidgetFactory).toDynamicValue(context => ({
         id: CALLHIERARCHY_ID,
-        createWidget: () => createHierarchyTreeWidget(context.container)
+        createWidget: () => createHierarchyTreeWidget(context.container),
     }));
 });

--- a/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts
@@ -41,7 +41,7 @@ export class CallHierarchyContext {
             return cachedSymbols;
         }
         const symbols = await this.languageClient.sendRequest(DocumentSymbolRequest.type, <DocumentSymbolParams>{
-            textDocument: TextDocumentIdentifier.create(uri)
+            textDocument: TextDocumentIdentifier.create(uri),
         });
         this.symbolCache.set(uri, symbols);
         return symbols;
@@ -60,7 +60,7 @@ export class CallHierarchyContext {
         try {
             locations = await this.languageClient.sendRequest(DefinitionRequest.type, <TextDocumentPositionParams>{
                 position: Position.create(line, character),
-                textDocument: { uri }
+                textDocument: { uri },
             });
         } catch (error) {
             this.logger.error(`Error from definitions request: ${uri}#${line}/${character}`, error);
@@ -75,15 +75,15 @@ export class CallHierarchyContext {
         try {
             const references = await this.languageClient.sendRequest(ReferencesRequest.type, <ReferenceParams>{
                 context: {
-                    includeDeclaration: false // TODO find out, why definitions are still contained
+                    includeDeclaration: false, // TODO find out, why definitions are still contained
                 },
                 position: {
                     line: definition.range.start.line,
-                    character: definition.range.start.character
+                    character: definition.range.start.character,
                 },
                 textDocument: {
-                    uri: definition.uri
-                }
+                    uri: definition.uri,
+                },
             });
             const uniqueReferences = utils.filterUnique(references);
             const filteredReferences = utils.filterSame(uniqueReferences, definition);
@@ -263,11 +263,11 @@ export abstract class AbstractDefaultCallHierarchyService implements CallHierarc
         const model = await context.getEditorModelReference(symbol.location.uri);
         let position = new monaco.Position(
             symbol.location.range.start.line + 1,
-            symbol.location.range.start.character + 1
+            symbol.location.range.start.character + 1,
         );
         const endPosition = new monaco.Position(
             symbol.location.range.end.line + 1,
-            symbol.location.range.end.character + 1
+            symbol.location.range.end.character + 1,
         );
         do {
             const word = model.object.textEditorModel.getWordAtPosition(position);

--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -17,7 +17,7 @@
 import { injectable, inject } from "inversify";
 import {
     ContextMenuRenderer, TreeWidget, NodeProps, TreeProps, TreeNode,
-    TreeModel, DockPanel
+    TreeModel, DockPanel,
 } from "@theia/core/lib/browser";
 import { LabelProvider } from "@theia/core/lib/browser/label-provider";
 import { DefinitionNode, CallerNode } from "./callhierarchy-tree";
@@ -40,7 +40,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         @inject(CallHierarchyTreeModel) readonly model: CallHierarchyTreeModel,
         @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
-        @inject(EditorManager) readonly editorManager: EditorManager
+        @inject(EditorManager) readonly editorManager: EditorManager,
     ) {
         super(props, model, contextMenuRenderer);
 
@@ -167,8 +167,8 @@ export class CallHierarchyTreeWidget extends TreeWidget {
             this.editorManager.open(
                 new URI(location.uri), {
                     mode: keepFocus ? 'reveal' : 'activate',
-                    selection: Range.create(location.range.start, location.range.end)
-                }
+                    selection: Range.create(location.range.start, location.range.end),
+                },
             ).then(editorWidget => {
                 if (editorWidget.parent instanceof DockPanel) {
                     editorWidget.parent.selectWidget(editorWidget);

--- a/packages/callhierarchy/src/browser/utils.ts
+++ b/packages/callhierarchy/src/browser/utils.ts
@@ -44,7 +44,7 @@ function sameStart(a: Range, b: Range): boolean {
 
 export function filterSame(locations: Location[], definition: Location): Location[] {
     return locations.filter(candidate => candidate.uri !== definition.uri
-        || !sameStart(candidate.range, definition.range)
+        || !sameStart(candidate.range, definition.range),
     );
 }
 

--- a/packages/core/src/browser/about-dialog.ts
+++ b/packages/core/src/browser/about-dialog.ts
@@ -34,10 +34,10 @@ export class AboutDialog extends AbstractDialog<void> {
     protected readonly appServer: ApplicationServer;
 
     constructor(
-        @inject(AboutDialogProps) protected readonly props: AboutDialogProps
+        @inject(AboutDialogProps) protected readonly props: AboutDialogProps,
     ) {
         super({
-            title: props.title
+            title: props.title,
         });
     }
 

--- a/packages/core/src/browser/browser.ts
+++ b/packages/core/src/browser/browser.ts
@@ -98,7 +98,7 @@ function getMonacoEditorScroll(elem: HTMLElement): ElementScroll | undefined {
         left: -parseCssMagnitude(linesContentStyle.left, 0),
         top: -parseCssMagnitude(linesContentStyle.top, 0),
         maxLeft: parseCssMagnitude(viewLinesStyle.width, 0) - parseCssMagnitude(elemStyle.width, 0),
-        maxTop: parseCssMagnitude(viewLinesStyle.height, 0) - parseCssMagnitude(elemStyle.height, 0)
+        maxTop: parseCssMagnitude(viewLinesStyle.height, 0) - parseCssMagnitude(elemStyle.height, 0),
     };
 }
 
@@ -120,7 +120,7 @@ export function preventNavigation(event: WheelEvent): void {
                 left: elem.scrollLeft,
                 top: elem.scrollTop,
                 maxLeft: elem.scrollWidth - elem.clientWidth,
-                maxTop: elem.scrollHeight - elem.clientHeight
+                maxTop: elem.scrollHeight - elem.clientHeight,
             };
         }
         if (scroll) {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -54,99 +54,99 @@ export namespace CommonCommands {
 
     export const OPEN: Command = {
         id: 'core.open',
-        label: 'Open'
+        label: 'Open',
     };
 
     export const CUT: Command = {
         id: 'core.cut',
-        label: 'Cut'
+        label: 'Cut',
     };
     export const COPY: Command = {
         id: 'core.copy',
-        label: 'Copy'
+        label: 'Copy',
     };
     export const PASTE: Command = {
         id: 'core.paste',
-        label: 'Paste'
+        label: 'Paste',
     };
 
     export const UNDO: Command = {
         id: 'core.undo',
-        label: 'Undo'
+        label: 'Undo',
     };
     export const REDO: Command = {
         id: 'core.redo',
-        label: 'Redo'
+        label: 'Redo',
     };
 
     export const FIND: Command = {
         id: 'core.find',
-        label: 'Find'
+        label: 'Find',
     };
     export const REPLACE: Command = {
         id: 'core.replace',
-        label: 'Replace'
+        label: 'Replace',
     };
 
     export const NEXT_TAB: Command = {
         id: 'core.nextTab',
-        label: 'Switch to Next Tab'
+        label: 'Switch to Next Tab',
     };
     export const PREVIOUS_TAB: Command = {
         id: 'core.previousTab',
-        label: 'Switch to Previous Tab'
+        label: 'Switch to Previous Tab',
     };
     export const CLOSE_TAB: Command = {
         id: 'core.close.tab',
-        label: 'Close Tab'
+        label: 'Close Tab',
     };
     export const CLOSE_OTHER_TABS: Command = {
         id: 'core.close.other.tabs',
-        label: 'Close Other Tabs'
+        label: 'Close Other Tabs',
     };
     export const CLOSE_RIGHT_TABS: Command = {
         id: 'core.close.right.tabs',
-        label: 'Close Tabs to the Right'
+        label: 'Close Tabs to the Right',
     };
     export const CLOSE_ALL_TABS: Command = {
         id: 'core.close.all.tabs',
-        label: 'Close All Tabs'
+        label: 'Close All Tabs',
     };
     export const COLLAPSE_PANEL: Command = {
         id: 'core.collapse.tab',
-        label: 'Collapse Side Panel'
+        label: 'Collapse Side Panel',
     };
     export const COLLAPSE_ALL_PANELS: Command = {
         id: 'core.collapse.all.tabs',
-        label: 'Collapse All Side Panels'
+        label: 'Collapse All Side Panels',
     };
     export const TOGGLE_BOTTOM_PANEL: Command = {
         id: 'core.toggle.bottom.panel',
-        label: 'Toggle Bottom Panel'
+        label: 'Toggle Bottom Panel',
     };
 
     export const SAVE: Command = {
         id: 'core.save',
-        label: 'Save'
+        label: 'Save',
     };
     export const SAVE_ALL: Command = {
         id: 'core.saveAll',
-        label: 'Save All'
+        label: 'Save All',
     };
 
     export const AUTO_SAVE: Command = {
         id: 'textEditor.commands.autosave',
-        label: 'Auto Save'
+        label: 'Auto Save',
     };
 
     export const QUIT: Command = {
         id: 'core.quit',
-        label: 'Quit'
+        label: 'Quit',
     };
 
     export const ABOUT_COMMAND: Command = {
         id: 'core.about',
-        label: 'About'
+        label: 'About',
     };
 
 }
@@ -166,7 +166,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         @inject(SelectionService) protected readonly selectionService: SelectionService,
         @inject(MessageService) protected readonly messageService: MessageService,
         @inject(OpenerService) protected readonly openerService: OpenerService,
-        @inject(AboutDialog) protected readonly aboutDialog: AboutDialog
+        @inject(AboutDialog) protected readonly aboutDialog: AboutDialog,
     ) { }
 
     registerMenus(registry: MenuModelRegistry): void {
@@ -176,91 +176,91 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         registry.registerSubmenu(CommonMenus.HELP, 'Help');
 
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
-            commandId: CommonCommands.SAVE.id
+            commandId: CommonCommands.SAVE.id,
         });
         registry.registerMenuAction(CommonMenus.FILE_SAVE, {
-            commandId: CommonCommands.SAVE_ALL.id
+            commandId: CommonCommands.SAVE_ALL.id,
         });
 
         registry.registerMenuAction(CommonMenus.FILE_AUTOSAVE, {
-            commandId: CommonCommands.AUTO_SAVE.id
+            commandId: CommonCommands.AUTO_SAVE.id,
         });
 
         registry.registerMenuAction(CommonMenus.EDIT_UNDO, {
             commandId: CommonCommands.UNDO.id,
-            order: '0'
+            order: '0',
         });
         registry.registerMenuAction(CommonMenus.EDIT_UNDO, {
             commandId: CommonCommands.REDO.id,
-            order: '1'
+            order: '1',
         });
 
         registry.registerMenuAction(CommonMenus.EDIT_FIND, {
             commandId: CommonCommands.FIND.id,
-            order: '0'
+            order: '0',
         });
         registry.registerMenuAction(CommonMenus.EDIT_FIND, {
             commandId: CommonCommands.REPLACE.id,
-            order: '1'
+            order: '1',
         });
 
         registry.registerMenuAction(CommonMenus.EDIT_CLIPBOARD, {
             commandId: CommonCommands.CUT.id,
-            order: '0'
+            order: '0',
         });
         registry.registerMenuAction(CommonMenus.EDIT_CLIPBOARD, {
             commandId: CommonCommands.COPY.id,
-            order: '1'
+            order: '1',
         });
         registry.registerMenuAction(CommonMenus.EDIT_CLIPBOARD, {
             commandId: CommonCommands.PASTE.id,
-            order: '2'
+            order: '2',
         });
 
         registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
             commandId: CommonCommands.TOGGLE_BOTTOM_PANEL.id,
-            order: '0'
+            order: '0',
         });
         registry.registerMenuAction(CommonMenus.VIEW_LAYOUT, {
             commandId: CommonCommands.COLLAPSE_ALL_PANELS.id,
-            order: '1'
+            order: '1',
         });
 
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_TAB.id,
             label: 'Close',
-            order: '0'
+            order: '0',
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_OTHER_TABS.id,
             label: 'Close Others',
-            order: '1'
+            order: '1',
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_RIGHT_TABS.id,
             label: 'Close to the Right',
-            order: '2'
+            order: '2',
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.CLOSE_ALL_TABS.id,
             label: 'Close All',
-            order: '3'
+            order: '3',
         });
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: CommonCommands.COLLAPSE_PANEL.id,
             label: 'Collapse',
-            order: '4'
+            order: '4',
         });
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
             label: 'About',
-            order: '9'
+            order: '9',
         });
     }
 
     registerCommands(commandRegistry: CommandRegistry): void {
         commandRegistry.registerCommand(CommonCommands.OPEN, new UriAwareCommandHandler<URI>(this.selectionService, {
-            execute: uri => open(this.openerService, uri)
+            execute: uri => open(this.openerService, uri),
         }));
         commandRegistry.registerCommand(CommonCommands.CUT, {
             execute: () => {
@@ -269,7 +269,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 } else {
                     this.messageService.warn("Please use the browser's cut command or shortcut.");
                 }
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.COPY, {
             execute: () => {
@@ -278,7 +278,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 } else {
                     this.messageService.warn("Please use the browser's copy command or shortcut.");
                 }
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.PASTE, {
             execute: () => {
@@ -287,7 +287,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 } else {
                     this.messageService.warn("Please use the browser's paste command or shortcut.");
                 }
-            }
+            },
         });
 
         commandRegistry.registerCommand(CommonCommands.UNDO);
@@ -298,11 +298,11 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
 
         commandRegistry.registerCommand(CommonCommands.NEXT_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activateNextTab()
+            execute: () => this.shell.activateNextTab(),
         });
         commandRegistry.registerCommand(CommonCommands.PREVIOUS_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.activatePreviousTab()
+            execute: () => this.shell.activatePreviousTab(),
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_TAB, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
@@ -310,7 +310,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 const tabBar = this.shell.currentTabBar!;
                 const currentTitle = tabBar.currentTitle;
                 this.shell.closeTabs(tabBar, (title, index) => title === currentTitle);
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_OTHER_TABS, {
             isEnabled: () => {
@@ -324,7 +324,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 const tabBar = this.shell.currentTabBar!;
                 const currentTitle = tabBar.currentTitle;
                 this.shell.closeTabs(this.shell.currentTabArea!, (title, index) => title !== currentTitle);
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_RIGHT_TABS, {
             isEnabled: () => {
@@ -342,11 +342,11 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 const tabBar = this.shell.currentTabBar!;
                 const currentIndex = tabBar.currentIndex;
                 this.shell.closeTabs(tabBar, (title, index) => index > currentIndex);
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_ALL_TABS, {
             isEnabled: () => this.shell.currentTabBar !== undefined,
-            execute: () => this.shell.closeTabs(this.shell.currentTabArea!)
+            execute: () => this.shell.closeTabs(this.shell.currentTabArea!),
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_PANEL, {
             isEnabled: () => ApplicationShell.isSideArea(this.shell.currentTabArea),
@@ -356,14 +356,14 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 if (ApplicationShell.isSideArea(currentArea)) {
                     this.shell.collapsePanel(currentArea);
                 }
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_ALL_PANELS, {
             execute: () => {
                 this.shell.collapsePanel('left');
                 this.shell.collapsePanel('right');
                 this.shell.collapsePanel('bottom');
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_BOTTOM_PANEL, {
             isEnabled: () => this.shell.getWidgets('bottom').length > 0,
@@ -373,23 +373,23 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 } else {
                     this.shell.expandPanel('bottom');
                 }
-            }
+            },
         });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
-            execute: () => this.shell.save()
+            execute: () => this.shell.save(),
         });
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
-            execute: () => this.shell.saveAll()
+            execute: () => this.shell.saveAll(),
         });
 
         commandRegistry.registerCommand(CommonCommands.QUIT, {
             execute: () => {
                 /* FIXME implement QUIT of innermost command.  */
-            }
+            },
         });
         commandRegistry.registerCommand(CommonCommands.ABOUT_COMMAND, {
-            execute: () => this.openAbout()
+            execute: () => this.openAbout(),
         });
     }
 
@@ -397,61 +397,61 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         if (supportCut) {
             registry.registerKeybinding({
                 command: CommonCommands.CUT.id,
-                keybinding: "ctrlcmd+x"
+                keybinding: "ctrlcmd+x",
             });
         }
         if (supportCopy) {
             registry.registerKeybinding({
                 command: CommonCommands.COPY.id,
-                keybinding: "ctrlcmd+c"
+                keybinding: "ctrlcmd+c",
             });
         }
         if (supportPaste) {
             registry.registerKeybinding({
                 command: CommonCommands.PASTE.id,
-                keybinding: "ctrlcmd+v"
+                keybinding: "ctrlcmd+v",
             });
         }
         registry.registerKeybindings(
             {
                 command: CommonCommands.UNDO.id,
-                keybinding: "ctrlcmd+z"
+                keybinding: "ctrlcmd+z",
             },
             {
                 command: CommonCommands.REDO.id,
-                keybinding: "ctrlcmd+shift+z"
+                keybinding: "ctrlcmd+shift+z",
             },
             {
                 command: CommonCommands.FIND.id,
-                keybinding: "ctrlcmd+f"
+                keybinding: "ctrlcmd+f",
             },
             {
                 command: CommonCommands.REPLACE.id,
-                keybinding: "ctrlcmd+alt+f"
+                keybinding: "ctrlcmd+alt+f",
             },
             {
                 command: CommonCommands.NEXT_TAB.id,
-                keybinding: "ctrlcmd+tab"
+                keybinding: "ctrlcmd+tab",
             },
             {
                 command: CommonCommands.PREVIOUS_TAB.id,
-                keybinding: "ctrlcmd+shift+tab"
+                keybinding: "ctrlcmd+shift+tab",
             },
             {
                 command: CommonCommands.CLOSE_TAB.id,
-                keybinding: "alt+w"
+                keybinding: "alt+w",
             },
             {
                 command: CommonCommands.CLOSE_OTHER_TABS.id,
-                keybinding: "ctrlcmd+alt+t"
+                keybinding: "ctrlcmd+alt+t",
             },
             {
                 command: CommonCommands.CLOSE_ALL_TABS.id,
-                keybinding: "alt+shift+w"
+                keybinding: "alt+shift+w",
             },
             {
                 command: CommonCommands.COLLAPSE_PANEL.id,
-                keybinding: "alt+c"
+                keybinding: "alt+c",
             },
             {
                 command: CommonCommands.TOGGLE_BOTTOM_PANEL.id,
@@ -463,16 +463,16 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
             },
             {
                 command: CommonCommands.SAVE.id,
-                keybinding: "ctrlcmd+s"
+                keybinding: "ctrlcmd+s",
             },
             {
                 command: CommonCommands.SAVE_ALL.id,
-                keybinding: "ctrlcmd+alt+s"
+                keybinding: "ctrlcmd+alt+s",
             },
             {
                 command: CommonCommands.QUIT.id,
-                keybinding: "ctrlcmd+q"
-            }
+                keybinding: "ctrlcmd+q",
+            },
         );
     }
 

--- a/packages/core/src/browser/connection-status-service.ts
+++ b/packages/core/src/browser/connection-status-service.ts
@@ -53,7 +53,7 @@ export enum ConnectionStatus {
     /**
      * The connection is lost between frontend and backend.
      */
-    OFFLINE
+    OFFLINE,
 }
 
 @injectable()
@@ -85,7 +85,7 @@ export abstract class AbstractConnectionStatusService implements ConnectionStatu
 
     constructor(
         @inject(ConnectionStatusOptions) @optional() protected readonly options: ConnectionStatusOptions = ConnectionStatusOptions.DEFAULT,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) {
     }
 
@@ -147,7 +147,7 @@ export class FrontendConnectionStatusService extends AbstractConnectionStatusSer
         @inject(WebSocketConnectionProvider) protected readonly wsConnectionProvider: WebSocketConnectionProvider,
         @inject(PingService) protected readonly pingService: PingService,
         @inject(ConnectionStatusOptions) @optional() protected readonly options: ConnectionStatusOptions = ConnectionStatusOptions.DEFAULT,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) {
         super(options, logger);
         this.schedulePing();
@@ -180,7 +180,7 @@ export class ApplicationConnectionStatusContribution extends DefaultFrontendAppl
     constructor(
         @inject(ConnectionStatusService) protected readonly connectionStatusService: ConnectionStatusService,
         @inject(StatusBar) protected readonly statusBar: StatusBar,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) {
         super();
         this.connectionStatusService.onStatusChange(state => this.onStateChange(state));
@@ -212,7 +212,7 @@ export class ApplicationConnectionStatusContribution extends DefaultFrontendAppl
             alignment: StatusBarAlignment.LEFT,
             text: 'Offline',
             tooltip: 'Cannot connect to backend.',
-            priority: 5000
+            priority: 5000,
         });
     }
 }

--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -40,7 +40,7 @@ export abstract class AbstractDialog<T> extends BaseWidget {
     protected acceptButton: HTMLButtonElement | undefined;
 
     constructor(
-        @inject(DialogProps) protected readonly props: DialogProps
+        @inject(DialogProps) protected readonly props: DialogProps,
     ) {
         super();
         this.addClass('dialogOverlay');
@@ -205,7 +205,7 @@ export class ConfirmDialogProps extends DialogProps {
 export class ConfirmDialog extends AbstractDialog<boolean> {
 
     constructor(
-        @inject(ConfirmDialogProps) protected readonly props: ConfirmDialogProps
+        @inject(ConfirmDialogProps) protected readonly props: ConfirmDialogProps,
     ) {
         super(props);
 
@@ -248,7 +248,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
     protected readonly inputField: HTMLInputElement;
 
     constructor(
-        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps
+        @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps,
     ) {
         super(props);
 

--- a/packages/core/src/browser/diff-uris.ts
+++ b/packages/core/src/browser/diff-uris.ts
@@ -25,7 +25,7 @@ export namespace DiffUris {
     export function encode(left: URI, right: URI, name?: string): URI {
         const diffUris = [
             left.toString(),
-            right.toString()
+            right.toString(),
         ];
 
         const diffUriStr = JSON.stringify(diffUris);

--- a/packages/core/src/browser/endpoint.spec.ts
+++ b/packages/core/src/browser/endpoint.spec.ts
@@ -27,13 +27,13 @@ describe("Endpoint", () => {
             expectWsUri(
                 {
                     httpScheme: "ws",
-                    path: "/miau/"
+                    path: "/miau/",
                 },
                 {
                     host: "example.org",
                     pathname: "/",
                     search: "",
-                    protocol: ""
+                    protocol: "",
                 }, "ws://example.org/miau/");
         });
 
@@ -41,13 +41,13 @@ describe("Endpoint", () => {
             expectWsUri(
                 {
                     httpScheme: "ws",
-                    path: "/miau/"
+                    path: "/miau/",
                 },
                 {
                     host: "example.org",
                     pathname: "/mainresource",
                     search: "",
-                    protocol: ""
+                    protocol: "",
                 }, "ws://example.org/mainresource/miau/");
         });
 
@@ -55,13 +55,13 @@ describe("Endpoint", () => {
             expectWsUri(
                 {
                     httpScheme: "ws",
-                    path: "/miau/"
+                    path: "/miau/",
                 },
                 {
                     host: "example.org",
                     pathname: "/mainresource/",
                     search: "",
-                    protocol: ""
+                    protocol: "",
                 }, "ws://example.org/mainresource/miau/");
         });
 
@@ -69,13 +69,13 @@ describe("Endpoint", () => {
             expectWsUri(
                 {
                     httpScheme: "ws",
-                    path: "/miau"
+                    path: "/miau",
                 },
                 {
                     host: "example.org",
                     pathname: "/mainresource",
                     search: "",
-                    protocol: ""
+                    protocol: "",
                 }, "ws://example.org/mainresource/miau");
         });
     });
@@ -85,13 +85,13 @@ describe("Endpoint", () => {
         it("Should choose https:// if location protocol is https://", () => {
             expectRestUri(
                 {
-                    path: "/"
+                    path: "/",
                 },
                 {
                     host: "example.org",
                     pathname: "/",
                     search: "",
-                    protocol: "https:"
+                    protocol: "https:",
                 }, "https://example.org/");
         });
     });

--- a/packages/core/src/browser/endpoint.ts
+++ b/packages/core/src/browser/endpoint.ts
@@ -28,7 +28,7 @@ export class Endpoint {
 
     constructor(
         protected readonly options: Endpoint.Options = {},
-        protected readonly location: Endpoint.Location = window.location
+        protected readonly location: Endpoint.Location = window.location,
     ) { }
 
     getWebSocketUrl(): URI {

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -26,7 +26,7 @@ import {
     CommandContribution, CommandRegistry, CommandService,
     MenuModelRegistry, MenuContribution,
     MessageService,
-    MessageClient
+    MessageClient,
 } from "../common";
 import { KeybindingRegistry, KeybindingContext, KeybindingContribution } from "./keybinding";
 import { FrontendApplication, FrontendApplicationContribution, DefaultFrontendApplicationContribution } from './frontend-application';
@@ -38,14 +38,14 @@ import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import {
     ApplicationShell, ApplicationShellOptions, DockPanelRenderer, TabBarRenderer,
-    TabBarRendererFactory, ShellLayoutRestorer, SidePanelHandler, SidePanelHandlerFactory, SplitPositionHandler, DockPanelRendererFactory
+    TabBarRendererFactory, ShellLayoutRestorer, SidePanelHandler, SidePanelHandlerFactory, SplitPositionHandler, DockPanelRendererFactory,
 } from './shell';
 import { StatusBar, StatusBarImpl } from "./status-bar/status-bar";
 import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from "./label-provider";
 import {
     PreferenceProviders, PreferenceProvider,
-    PreferenceScope, PreferenceService, PreferenceServiceImpl
+    PreferenceScope, PreferenceService, PreferenceServiceImpl,
 } from './preferences';
 import { ContextMenuRenderer } from './context-menu-renderer';
 import { ThemingCommandContribution, ThemeService, BuiltinThemeProvider } from './theming';
@@ -93,7 +93,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(DefaultResourceProvider).toSelf().inSingletonScope();
     bind(ResourceProvider).toProvider(context =>
-        uri => context.container.get(DefaultResourceProvider).get(uri)
+        uri => context.container.get(DefaultResourceProvider).get(uri),
     );
     bindContributionProvider(bind, ResourceResolver);
 
@@ -114,14 +114,14 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(CommonFrontendContribution).toSelf().inSingletonScope();
     [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(CommonFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(CommonFrontendContribution)).inSingletonScope(),
     );
 
     bind(QuickOpenService).toSelf().inSingletonScope();
     bind(QuickCommandService).toSelf().inSingletonScope();
     bind(QuickCommandFrontendContribution).toSelf().inSingletonScope();
     [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(QuickCommandFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(QuickCommandFrontendContribution)).inSingletonScope(),
     );
 
     bind(LocalStorageService).toSelf().inSingletonScope();
@@ -150,7 +150,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
         return {
             ping() {
                 return envServer.getValue('does_not_matter');
-            }
+            },
         };
     });
     bind(FrontendConnectionStatusService).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -81,7 +81,7 @@ export class FrontendApplication {
         @inject(ContributionProvider) @named(FrontendApplicationContribution)
         protected readonly contributions: ContributionProvider<FrontendApplicationContribution>,
         @inject(ApplicationShell) protected readonly _shell: ApplicationShell,
-        @inject(FrontendApplicationStateService) protected readonly stateService: FrontendApplicationStateService
+        @inject(FrontendApplicationStateService) protected readonly stateService: FrontendApplicationStateService,
     ) { }
 
     get shell(): ApplicationShell {
@@ -122,7 +122,7 @@ export class FrontendApplication {
             return Promise.resolve(document.body);
         }
         return new Promise<HTMLElement>(resolve =>
-            window.addEventListener('load', () => resolve(document.body), { once: true })
+            window.addEventListener('load', () => resolve(document.body), { once: true }),
         );
     }
 

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -58,14 +58,14 @@ before(async () => {
 
         bind(TestContribution).toSelf().inSingletonScope();
         [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
-            bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(TestContribution)).inSingletonScope()
+            bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(TestContribution)).inSingletonScope(),
         );
 
         bind(KeybindingContext).toConstantValue({
             id: 'testContext',
             isEnabled(arg?: Keybinding): boolean {
                 return true;
-            }
+            },
         });
 
         bind(StatusBarImpl).toSelf().inSingletonScope();
@@ -115,7 +115,7 @@ describe('keybindings', () => {
     it("should set a keymap", () => {
         const keybindings: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrl+c"
+            keybinding: "ctrl+c",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
@@ -132,7 +132,7 @@ describe('keybindings', () => {
     it("should reset to default in case of invalid keybinding", () => {
         const keybindings: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrl+invalid"
+            keybinding: "ctrl+invalid",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
@@ -148,7 +148,7 @@ describe('keybindings', () => {
     it("should remove all keybindings from a command that has multiple keybindings", () => {
         const keybindings: Keybinding[] = [{
             command: TEST_COMMAND2.id,
-            keybinding: "F3"
+            keybinding: "F3",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
@@ -165,7 +165,7 @@ describe('keybindings', () => {
     it("should register a correct keybinding, then default back to the original for a wrong one after", () => {
         let keybindings: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrl+c"
+            keybinding: "ctrl+c",
         }];
 
         // Get default binding
@@ -183,7 +183,7 @@ describe('keybindings', () => {
         // Set invalid binding
         keybindings = [{
             command: TEST_COMMAND.id,
-            keybinding: "ControlLeft+Invalid"
+            keybinding: "ControlLeft+Invalid",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
@@ -201,14 +201,14 @@ describe('keybindings', () => {
     it("should only return the more specific keybindings when a keystroke is entered", () => {
         const keybindingsUser: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrl+b"
+            keybinding: "ctrl+b",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindingsUser);
 
         const keybindingsSpecific: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrl+c"
+            keybinding: "ctrl+c",
         }];
 
         const validKeyCode = KeyCode.createKeyCode({ first: Key.KEY_C, modifiers: [KeyModifier.CtrlCmd] });
@@ -229,7 +229,7 @@ describe('keybindings', () => {
     it("should return partial keybinding matches", () => {
         const keybindingsUser: Keybinding[] = [{
             command: TEST_COMMAND.id,
-            keybinding: "ctrlcmd+x t"
+            keybinding: "ctrlcmd+x t",
         }];
 
         keybindingRegistry.setKeymap(KeybindingScope.USER, keybindingsUser);
@@ -248,12 +248,12 @@ describe('keybindings', () => {
         const keybindingShadowing: Keybinding[] = [
             {
                 command,
-                keybinding: validKeyBinding
+                keybinding: validKeyBinding,
             },
             {
                 command,
-                keybinding: "ctrlcmd+b"
-            }
+                keybinding: "ctrlcmd+b",
+            },
         ];
 
         keybindingRegistry.registerKeybindings(...keybindingShadowing);
@@ -269,22 +269,22 @@ describe('keybindings', () => {
 
         const ignoredDefaultBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: "test.ignored-command"
+            command: "test.ignored-command",
         };
 
         const defaultBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: "test.workspace-command"
+            command: "test.workspace-command",
         };
 
         const userBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: "test.workspace-command"
+            command: "test.workspace-command",
         };
 
         const workspaceBinding: Keybinding = {
             keybinding: keyCode.toString(),
-            command: "test.workspace-command"
+            command: "test.workspace-command",
         };
 
         keybindingRegistry.setKeymap(KeybindingScope.DEFAULT, [defaultBinding, ignoredDefaultBinding]);
@@ -512,15 +512,15 @@ describe("keys api", () => {
 });
 
 const TEST_COMMAND: Command = {
-    id: 'test.command'
+    id: 'test.command',
 };
 
 const TEST_COMMAND2: Command = {
-    id: 'test.command2'
+    id: 'test.command2',
 };
 
 const TEST_COMMAND_SHADOW: Command = {
-    id: 'test.command-shadow'
+    id: 'test.command-shadow',
 };
 
 @injectable()
@@ -536,17 +536,17 @@ export class TestContribution implements CommandContribution, KeybindingContribu
         [{
             command: TEST_COMMAND.id,
             context: 'testContext',
-            keybinding: 'ctrl+a'
+            keybinding: 'ctrl+a',
         },
         {
             command: TEST_COMMAND2.id,
             context: 'testContext',
-            keybinding: 'ctrl+f1'
+            keybinding: 'ctrl+f1',
         },
         {
             command: TEST_COMMAND2.id,
             context: 'testContext',
-            keybinding: 'ctrl+f2'
+            keybinding: 'ctrl+f2',
         },
         ].forEach(binding => {
             keybindings.registerKeybinding(binding);

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -26,7 +26,7 @@ export enum KeybindingScope {
     DEFAULT,
     USER,
     WORKSPACE,
-    END
+    END,
 }
 export namespace KeybindingScope {
     export const length = KeybindingScope.END - KeybindingScope.DEFAULT;
@@ -45,7 +45,7 @@ export namespace Keybinding {
         const copy: Keybinding = {
             command: binding.command,
             keybinding: binding.keybinding,
-            context: binding.context
+            context: binding.context,
         };
         return JSON.stringify(copy);
     }
@@ -88,12 +88,12 @@ export namespace KeybindingContexts {
 
     export const NOOP_CONTEXT: KeybindingContext = {
         id: 'noop.keybinding.context',
-        isEnabled: () => true
+        isEnabled: () => true,
     };
 
     export const DEFAULT_CONTEXT: KeybindingContext = {
         id: 'default.keybinding.context',
-        isEnabled: () => false
+        isEnabled: () => false,
     };
 }
 
@@ -190,7 +190,7 @@ export class KeybindingRegistry {
      */
     containsKeybinding(bindings: Keybinding[], binding: Keybinding): boolean {
         const collisions = this.getKeySequenceCollisions(bindings, KeySequence.parse(
-            this.getCurrentPlatformKeybinding(binding.keybinding))
+            this.getCurrentPlatformKeybinding(binding.keybinding)),
         ).filter(b => b.context === binding.context);
 
         if (collisions.full.length > 0) {
@@ -469,7 +469,7 @@ export class KeybindingRegistry {
             this.statusBar.setElement('keybinding-status', {
                 text: `(${KeySequence.acceleratorFor(this.keySequence, "+")}) was pressed, waiting for more keys`,
                 alignment: StatusBarAlignment.LEFT,
-                priority: 2
+                priority: 2,
             });
 
         } else {

--- a/packages/core/src/browser/keys.ts
+++ b/packages/core/src/browser/keys.ts
@@ -47,7 +47,7 @@ export namespace KeySequence {
         NONE = 0,
         PARTIAL,
         SHADOW,
-        FULL
+        FULL,
     }
 
     /* Compares two KeySequences, returns:
@@ -480,7 +480,7 @@ export enum KeyModifier {
     /**
      * M4 is the CTRL key on MacOS X, and is undefined on other platforms.
      */
-    MacCtrl = "M4"
+    MacCtrl = "M4",
 }
 
 export namespace KeyModifier {

--- a/packages/core/src/browser/label-parser.spec.ts
+++ b/packages/core/src/browser/label-parser.spec.ts
@@ -26,7 +26,7 @@ before(() => {
     testContainer.bind(CommandService).toDynamicValue(ctx => ({
         executeCommand<T>(): Promise<T | undefined> {
             return Promise.resolve(undefined);
-        }
+        },
     })).inSingletonScope();
 
     statusBarEntryUtility = testContainer.get(LabelParser);

--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -87,7 +87,7 @@ export class LabelProvider {
 
     constructor(
         @inject(ContributionProvider) @named(LabelProviderContribution)
-        protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>
+        protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>,
     ) { }
 
     async getIcon(element: object): Promise<string> {
@@ -119,7 +119,7 @@ export class LabelProvider {
 
     protected findContribution(element: object): LabelProviderContribution[] {
         const prioritized = Prioritizeable.prioritizeAllSync(this.contributionProvider.getContributions(), contrib =>
-            contrib.canHandle(element)
+            contrib.canHandle(element),
         );
         return prioritized.map(c => c.value);
     }

--- a/packages/core/src/browser/logger-frontend-module.ts
+++ b/packages/core/src/browser/logger-frontend-module.ts
@@ -25,7 +25,7 @@ export const loggerFrontendModule = new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
         initialize() {
             setRootLogger(ctx.container.get<ILogger>(ILogger));
-        }
+        },
     }));
 
     bind(LoggerName).toConstantValue(rootLoggerName);
@@ -43,6 +43,6 @@ export const loggerFrontendModule = new ContainerModule(bind => {
             child.bind(ILogger).to(Logger).inTransientScope();
             child.bind(LoggerName).toConstantValue(name);
             return child.get(ILogger);
-        }
+        },
     );
 });

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -19,7 +19,7 @@ import { MenuBar as MenuBarWidget, Menu as MenuWidget, Widget } from "@phosphor/
 import { CommandRegistry as PhosphorCommandRegistry } from "@phosphor/commands";
 import {
     CommandRegistry, ActionMenuNode, CompositeMenuNode,
-    MenuModelRegistry, MAIN_MENU_BAR, MenuPath
+    MenuModelRegistry, MAIN_MENU_BAR, MenuPath,
 } from "../../common";
 import { KeybindingRegistry, Keybinding } from "../keybinding";
 import { FrontendApplicationContribution, FrontendApplication } from "../frontend-application";
@@ -30,7 +30,7 @@ export class BrowserMainMenuFactory {
     constructor(
         @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
         @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry,
-        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry
+        @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
     ) { }
 
     createMenuBar(): MenuBarWidget {
@@ -85,7 +85,7 @@ export class BrowserMainMenuFactory {
             icon: command.iconClass,
             isEnabled: () => this.commandRegistry.isEnabled(command.id),
             isVisible: () => this.commandRegistry.isVisible(command.id),
-            isToggled: () => this.commandRegistry.isToggled(command.id)
+            isToggled: () => this.commandRegistry.isToggled(command.id),
         });
 
         const bindings = this.keybindingRegistry.getKeybindingsForCommand(command.id);
@@ -97,7 +97,7 @@ export class BrowserMainMenuFactory {
             commands.addKeyBinding({
                 command: command.id,
                 keys,
-                selector: '.p-Widget' // We have the Phosphor.JS dependency anyway.
+                selector: '.p-Widget', // We have the Phosphor.JS dependency anyway.
             });
         }
     }
@@ -152,13 +152,13 @@ class DynamicMenuWidget extends MenuWidget {
                 if (item.label) {
                     parent.addItem({
                         type: 'submenu',
-                        submenu: new DynamicMenuWidget(item, this.options)
+                        submenu: new DynamicMenuWidget(item, this.options),
                     });
                 } else {
                     if (item.children.length > 0) {
                         if (parent.items.length > 0) {
                             parent.addItem({
-                                type: 'separator'
+                                type: 'separator',
                             });
                         }
                         this.updateSubMenus(parent, item, commands);
@@ -167,7 +167,7 @@ class DynamicMenuWidget extends MenuWidget {
             } else if (item instanceof ActionMenuNode) {
                 parent.addItem({
                     command: item.action.commandId,
-                    type: 'command'
+                    type: 'command',
                 });
             }
         }
@@ -178,7 +178,7 @@ class DynamicMenuWidget extends MenuWidget {
 export class BrowserMenuBarContribution implements FrontendApplicationContribution {
 
     constructor(
-        @inject(BrowserMainMenuFactory) protected readonly factory: BrowserMainMenuFactory
+        @inject(BrowserMainMenuFactory) protected readonly factory: BrowserMainMenuFactory,
     ) { }
 
     onStart(app: FrontendApplication): void {

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -76,7 +76,7 @@ export class WebSocketConnectionProvider {
         const factory = new JsonRpcProxyFactory<T>(target);
         this.listen({
             path,
-            onConnection: c => factory.listen(c)
+            onConnection: c => factory.listen(c),
         });
         return factory.createProxy();
     }
@@ -145,7 +145,7 @@ export class WebSocketConnectionProvider {
             reconnectionDelayGrowFactor: 1.3,
             connectionTimeout: 10000,
             maxRetries: Infinity,
-            debug: false
+            debug: false,
         });
     }
 

--- a/packages/core/src/browser/opener-service.spec.ts
+++ b/packages/core/src/browser/opener-service.spec.ts
@@ -26,10 +26,10 @@ const openHandler: OpenHandler = {
     },
     open() {
         return Promise.resolve(undefined);
-    }
+    },
 };
 const openerService = new DefaultOpenerService({
-    getContributions: () => [openHandler]
+    getContributions: () => [openHandler],
 });
 
 describe("opener-service", () => {

--- a/packages/core/src/browser/opener-service.ts
+++ b/packages/core/src/browser/opener-service.ts
@@ -87,7 +87,7 @@ export class DefaultOpenerService implements OpenerService {
 
     constructor(
         @inject(ContributionProvider) @named(OpenHandler)
-        protected readonly handlersProvider: ContributionProvider<OpenHandler>
+        protected readonly handlersProvider: ContributionProvider<OpenHandler>,
     ) { }
 
     async getOpener(uri: URI, options?: OpenerOptions): Promise<OpenHandler> {

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -27,7 +27,7 @@ export const PreferenceSchema = Symbol("PreferenceSchema");
 export interface PreferenceSchema {
     [name: string]: Object,
     properties: {
-        [name: string]: PreferenceProperty
+        [name: string]: PreferenceProperty,
     }
 }
 
@@ -52,7 +52,7 @@ export class PreferenceSchemaProvider {
     constructor(
         @inject(ILogger) protected readonly logger: ILogger,
         @inject(ContributionProvider) @named(PreferenceContribution)
-        protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>
+        protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>,
     ) {
         this.preferenceContributions.getContributions().forEach(contrib => {
             for (const property in contrib.schema) {

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -23,7 +23,7 @@ describe('preference proxy', function() {
     it('.ready should return a promise', function() {
 
         const proxy = createPreferenceProxy(new MockPreferenceService(), {
-            properties: {}
+            properties: {},
         });
         const proto = Object.getPrototypeOf(proxy.ready);
         expect(proto).to.equal(Promise.prototype);

--- a/packages/core/src/browser/preferences/preference-proxy.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.ts
@@ -51,14 +51,14 @@ export function createPreferenceProxy<T extends Configuration>(preferences: Pref
                 } else {
                     onPreferenceChangedEmitter.fire({
                         preferenceName: e.preferenceName,
-                        newValue: configuration[e.preferenceName]
+                        newValue: configuration[e.preferenceName],
                     });
                 }
             } else {
                 onPreferenceChangedEmitter.fire({
                     preferenceName: e.preferenceName,
                     newValue: configuration[e.preferenceName],
-                    oldValue: e.oldValue
+                    oldValue: e.oldValue,
                 });
             }
         }
@@ -89,7 +89,7 @@ export function createPreferenceProxy<T extends Configuration>(preferences: Pref
         },
         set: unsupportedOperation,
         deleteProperty: unsupportedOperation,
-        defineProperty: unsupportedOperation
+        defineProperty: unsupportedOperation,
     });
 }
 

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -22,7 +22,7 @@ import { PreferenceProvider } from './preference-provider';
 
 export enum PreferenceScope {
     User,
-    Workspace
+    Workspace,
 }
 
 export interface PreferenceChangedEvent {
@@ -69,7 +69,7 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
         if (!this._preferenceProviders) {
             this._preferenceProviders = [
                 this.getPreferenceProvider(PreferenceScope.User),
-                this.getPreferenceProvider(PreferenceScope.Workspace)
+                this.getPreferenceProvider(PreferenceScope.Workspace),
             ];
         }
         return this._preferenceProviders;

--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -21,7 +21,7 @@ import { KeybindingRegistry, KeybindingContribution } from "../keybinding";
 
 export const quickCommand: Command = {
     id: 'quickCommand',
-    label: 'Open Quick Command'
+    label: 'Open Quick Command',
 };
 
 @injectable()
@@ -32,18 +32,18 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickCommand, {
-            execute: () => this.quickCommandService.open()
+            execute: () => this.quickCommandService.open(),
         });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: quickCommand.id,
-            keybinding: "f1"
+            keybinding: "f1",
         });
         keybindings.registerKeybinding({
             command: quickCommand.id,
-            keybinding: "ctrlcmd+shift+p"
+            keybinding: "ctrlcmd+shift+p",
         });
     }
 

--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -28,7 +28,7 @@ export class QuickCommandService implements QuickOpenModel {
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
         @inject(KeybindingRegistry) protected readonly keybindings: KeybindingRegistry,
-        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService
+        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
     ) { }
 
     open(): void {
@@ -44,7 +44,7 @@ export class QuickCommandService implements QuickOpenModel {
         this.quickOpenService.open(this, {
             placeholder: 'Type the name of a command you want to execute',
             fuzzyMatchLabel: true,
-            fuzzySort: false
+            fuzzySort: false,
         });
     }
 
@@ -62,7 +62,7 @@ export class CommandQuickOpenItem extends QuickOpenItem {
     constructor(
         protected readonly command: Command,
         protected readonly commands: CommandRegistry,
-        protected readonly keybindings: KeybindingRegistry
+        protected readonly keybindings: KeybindingRegistry,
     ) {
         super();
         this.activeElement = window.document.activeElement as HTMLElement;

--- a/packages/core/src/browser/quick-open/quick-open-model.ts
+++ b/packages/core/src/browser/quick-open/quick-open-model.ts
@@ -25,7 +25,7 @@ export interface Highlight {
 export enum QuickOpenMode {
     PREVIEW,
     OPEN,
-    OPEN_IN_BACKGROUND
+    OPEN_IN_BACKGROUND,
 }
 
 export interface QuickOpenItemOptions {

--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -50,7 +50,7 @@ export namespace QuickOpenOptions {
 
         onClose: () => { /* no-op*/ },
 
-        selectIndex: () => -1
+        selectIndex: () => -1,
     });
     export function resolve(options: QuickOpenOptions = {}, source: Resolved = defaultOptions): Resolved {
         return Object.assign({}, source, options);

--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -121,7 +121,7 @@ export class ShouldSaveDialog extends AbstractDialog<boolean> {
 
     constructor(widget: Widget) {
         super({
-            title: `Do you want to save the changes you made to ${widget.title.label || widget.title.caption}?`
+            title: `Do you want to save the changes you made to ${widget.title.label || widget.title.caption}?`,
         });
 
         const messageNode = document.createElement("div");

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -19,7 +19,7 @@ import { ArrayExt, find, toArray } from '@phosphor/algorithm';
 import { Signal } from '@phosphor/signaling';
 import {
     BoxLayout, BoxPanel, DockLayout, DockPanel, FocusTracker, Layout, Panel, SplitLayout,
-    SplitPanel, TabBar, Widget, Title
+    SplitPanel, TabBar, Widget, Title,
 } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
 import { IDragEvent } from '@phosphor/dragdrop';
@@ -56,7 +56,7 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
     readonly tabBarClasses: string[] = [];
 
     constructor(
-        @inject(TabBarRendererFactory) protected readonly tabBarRendererFactory: () => TabBarRenderer
+        @inject(TabBarRendererFactory) protected readonly tabBarRendererFactory: () => TabBarRenderer,
     ) { }
 
     createTabBar(): TabBar<Widget> {
@@ -67,7 +67,7 @@ export class DockPanelRenderer implements DockLayout.IRenderer {
             handlers: ['drag-thumb', 'keyboard', 'wheel', 'touch'],
             useBothWheelAxes: true,
             scrollXMarginOffset: 4,
-            suppressScrollY: true
+            suppressScrollY: true,
         });
         this.tabBarClasses.forEach(c => tabBar.addClass(c));
         renderer.tabBar = tabBar;
@@ -145,7 +145,7 @@ export class ApplicationShell extends Widget {
     protected readonly bottomPanelState: SidePanel.State = {
         empty: true,
         expansion: SidePanel.ExpansionState.collapsed,
-        pendingUpdate: Promise.resolve()
+        pendingUpdate: Promise.resolve(),
     };
 
     private readonly tracker = new FocusTracker<Widget>();
@@ -160,7 +160,7 @@ export class ApplicationShell extends Widget {
         @inject(SidePanelHandlerFactory) sidePanelHandlerFactory: () => SidePanelHandler,
         @inject(SplitPositionHandler) protected splitPositionHandler: SplitPositionHandler,
         @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService,
-        @inject(ApplicationShellOptions) @optional() options: RecursivePartial<ApplicationShell.Options> = {}
+        @inject(ApplicationShellOptions) @optional() options: RecursivePartial<ApplicationShell.Options> = {},
     ) {
         super(options as Widget.IOptions);
         this.addClass(APPLICATION_SHELL_CLASS);
@@ -170,16 +170,16 @@ export class ApplicationShell extends Widget {
         this.options = {
             bottomPanel: {
                 ...ApplicationShell.DEFAULT_OPTIONS.bottomPanel,
-                ...options.bottomPanel || {}
+                ...options.bottomPanel || {},
             },
             leftPanel: {
                 ...ApplicationShell.DEFAULT_OPTIONS.leftPanel,
-                ...options.leftPanel || {}
+                ...options.leftPanel || {},
             },
             rightPanel: {
                 ...ApplicationShell.DEFAULT_OPTIONS.rightPanel,
-                ...options.rightPanel || {}
-            }
+                ...options.rightPanel || {},
+            },
         };
 
         this.mainPanel = this.createMainPanel();
@@ -234,7 +234,7 @@ export class ApplicationShell extends Widget {
                     startTime: performance.now(),
                     leftExpanded: false,
                     rightExpanded: false,
-                    bottomExpanded: false
+                    bottomExpanded: false,
                 };
             }
         }
@@ -361,7 +361,7 @@ export class ApplicationShell extends Widget {
         const dockPanel = new TheiaDockPanel({
             mode: 'multiple-document',
             renderer,
-            spacing: 0
+            spacing: 0,
         });
         dockPanel.id = 'theia-main-content-panel';
         return dockPanel;
@@ -377,7 +377,7 @@ export class ApplicationShell extends Widget {
         const dockPanel = new TheiaDockPanel({
             mode: 'multiple-document',
             renderer,
-            spacing: 0
+            spacing: 0,
         });
         dockPanel.id = 'theia-bottom-content-panel';
         dockPanel.widgetAdded.connect((sender, widget) => {
@@ -446,7 +446,7 @@ export class ApplicationShell extends Widget {
         const bottomSplitLayout = this.createSplitLayout(
             [this.mainPanel, this.bottomPanel],
             [1, 0],
-            { orientation: 'vertical', spacing: 0 }
+            { orientation: 'vertical', spacing: 0 },
         );
         const panelForBottomArea = new SplitPanel({ layout: bottomSplitLayout });
         panelForBottomArea.id = 'theia-bottom-split-panel';
@@ -454,7 +454,7 @@ export class ApplicationShell extends Widget {
         const leftRightSplitLayout = this.createSplitLayout(
             [this.leftPanelHandler.container, panelForBottomArea, this.rightPanelHandler.container],
             [0, 1, 0],
-            { orientation: 'horizontal', spacing: 0 }
+            { orientation: 'horizontal', spacing: 0 },
         );
         const panelForSideAreas = new SplitPanel({ layout: leftRightSplitLayout });
         panelForSideAreas.id = 'theia-left-right-split-panel';
@@ -462,7 +462,7 @@ export class ApplicationShell extends Widget {
         return this.createBoxLayout(
             [this.topPanel, panelForSideAreas, this.statusBar],
             [0, 1, 0],
-            { direction: 'top-to-bottom', spacing: 0 }
+            { direction: 'top-to-bottom', spacing: 0 },
         );
     }
 
@@ -477,11 +477,11 @@ export class ApplicationShell extends Widget {
             bottomPanel: {
                 config: this.bottomPanel.saveLayout(),
                 size: this.bottomPanel.isVisible ? this.getBottomPanelSize() : this.bottomPanelState.lastPanelSize,
-                expanded: this.isExpanded('bottom')
+                expanded: this.isExpanded('bottom'),
             },
             leftPanel: this.leftPanelHandler.getLayoutData(),
             rightPanel: this.rightPanelHandler.getLayoutData(),
-            activeWidgetId: this.activeWidget ? this.activeWidget.id : undefined
+            activeWidgetId: this.activeWidget ? this.activeWidget.id : undefined,
         };
     }
 
@@ -570,7 +570,7 @@ export class ApplicationShell extends Widget {
         const options: SplitPositionOptions = {
             side: 'bottom',
             duration: enableAnimation ? this.options.bottomPanel.expandDuration : 0,
-            referenceWidget: this.bottomPanel
+            referenceWidget: this.bottomPanel,
         };
         const promise = this.splitPositionHandler.setSidePanelSize(this.bottomPanel, size, options);
         const result = new Promise<void>(resolve => {
@@ -588,7 +588,7 @@ export class ApplicationShell extends Widget {
         return Promise.all([
             this.bottomPanelState.pendingUpdate,
             this.leftPanelHandler.state.pendingUpdate,
-            this.rightPanelHandler.state.pendingUpdate
+            this.rightPanelHandler.state.pendingUpdate,
             // tslint:disable-next-line:no-any
         ]) as Promise<any>;
     }
@@ -977,7 +977,7 @@ export class ApplicationShell extends Widget {
                 alignment: StatusBarAlignment.RIGHT,
                 tooltip: 'Toggle Bottom Panel',
                 command: 'core.toggle.bottom.panel',
-                priority: 0
+                priority: 0,
             };
             this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
         }
@@ -1285,20 +1285,20 @@ export namespace ApplicationShell {
             emptySize: 140,
             expandThreshold: 160,
             expandDuration: 150,
-            initialSizeRatio: 0.382
+            initialSizeRatio: 0.382,
         }),
         leftPanel: Object.freeze(<SidePanel.Options>{
             emptySize: 140,
             expandThreshold: 140,
             expandDuration: 150,
-            initialSizeRatio: 0.191
+            initialSizeRatio: 0.191,
         }),
         rightPanel: Object.freeze(<SidePanel.Options>{
             emptySize: 140,
             expandThreshold: 140,
             expandDuration: 150,
-            initialSizeRatio: 0.191
-        })
+            initialSizeRatio: 0.191,
+        }),
     });
 
     /**

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -64,13 +64,13 @@ export class ShellLayoutRestorer implements CommandContribution {
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand({
             id: 'reset.layout',
-            label: 'Reset Workbench Layout'
+            label: 'Reset Workbench Layout',
         }, {
                 execute: () => {
                     this.shouldStoreLayout = false;
                     this.storageService.setData(this.storageKey, undefined)
                         .then(() => window.location.reload(true));
-                }
+                },
             });
     }
 
@@ -138,7 +138,7 @@ export class ShellLayoutRestorer implements CommandContribution {
             }
             return {
                 constructionOptions: desc,
-                innerWidgetState: innerState
+                innerWidgetState: innerState,
             };
         }
     }

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -46,7 +46,7 @@ export class SidePanelHandler {
      */
     protected static readonly rankProperty = new AttachedProperty<Widget, number | undefined>({
         name: 'sidePanelRank',
-        create: () => undefined
+        create: () => undefined,
     });
 
     /**
@@ -72,7 +72,7 @@ export class SidePanelHandler {
     readonly state: SidePanel.State = {
         empty: true,
         expansion: SidePanel.ExpansionState.collapsed,
-        pendingUpdate: Promise.resolve()
+        pendingUpdate: Promise.resolve(),
     };
 
     /**
@@ -117,7 +117,7 @@ export class SidePanelHandler {
             handlers: ['drag-thumb', 'keyboard', 'wheel', 'touch'],
             useBothWheelAxes: true,
             scrollYMarginOffset: 8,
-            suppressScrollX: true
+            suppressScrollX: true,
         });
         tabBarRenderer.tabBar = sideBar;
         tabBarRenderer.contextMenuPath = SHELL_TABBAR_CONTEXT_MENU;
@@ -140,7 +140,7 @@ export class SidePanelHandler {
 
     protected createSidePanel(): TheiaDockPanel {
         const sidePanel = new TheiaDockPanel({
-            mode: 'single-document'
+            mode: 'single-document',
         });
         sidePanel.id = 'theia-' + this.side + '-side-panel';
 
@@ -184,7 +184,7 @@ export class SidePanelHandler {
         const items = toArray(map(this.tabBar.titles, title => <SidePanel.WidgetItem>{
             widget: title.owner,
             rank: SidePanelHandler.rankProperty.get(title.owner),
-            expanded: title === currentTitle
+            expanded: title === currentTitle,
         }));
         const size = currentTitle !== null ? this.getPanelSize() : this.state.lastPanelSize;
         return { type: 'sidepanel', items, size };
@@ -430,7 +430,7 @@ export class SidePanelHandler {
         const options: SplitPositionOptions = {
             side: this.side,
             duration: enableAnimation ? this.options.expandDuration : 0,
-            referenceWidget: this.dockPanel
+            referenceWidget: this.dockPanel,
         };
         const promise = this.splitPositionHandler.setSidePanelSize(this.container, size, options);
         const result = new Promise<void>(resolve => {
@@ -605,7 +605,7 @@ export namespace SidePanel {
         collapsed = 'collapsed',
         expanding = 'expanding',
         expanded = 'expanded',
-        collapsing = 'collapsing'
+        collapsing = 'collapsing',
     }
 }
 

--- a/packages/core/src/browser/shell/split-panels.ts
+++ b/packages/core/src/browser/shell/split-panels.ts
@@ -66,7 +66,7 @@ export class SplitPositionHandler {
             ...options,
             parent, targetSize, index,
             started: false,
-            ended: false
+            ended: false,
         };
         return this.moveSplitPos(move);
     }

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -86,11 +86,11 @@ export class TabBarRenderer extends TabBar.Renderer {
         return h.li(
             {
                 key, className, title: title.caption, style, dataset,
-                oncontextmenu: event => this.handleContextMenuEvent(event, title)
+                oncontextmenu: event => this.handleContextMenuEvent(event, title),
             },
             this.renderIcon(data),
             this.renderLabel(data),
-            this.renderCloseIcon(data)
+            this.renderCloseIcon(data),
         );
     }
 
@@ -293,7 +293,7 @@ export class SideTabBar extends ScrollableTabBar {
     private mouseData?: {
         pressX: number,
         pressY: number,
-        mouseDownTabIndex: number
+        mouseDownTabIndex: number,
     };
 
     constructor(options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
@@ -356,7 +356,7 @@ export class SideTabBar extends ScrollableTabBar {
                     const tabStyle = window.getComputedStyle(hiddenTab);
                     const rd: Partial<SideBarRenderData> = {
                         paddingTop: parseFloat(tabStyle.paddingTop!),
-                        paddingBottom: parseFloat(tabStyle.paddingBottom!)
+                        paddingBottom: parseFloat(tabStyle.paddingBottom!),
                     };
                     // Extract label size from the DOM
                     const labelElements = hiddenTab.getElementsByClassName('p-TabBar-tabLabel');
@@ -452,7 +452,7 @@ export class SideTabBar extends ScrollableTabBar {
         this.mouseData = {
             pressX: event.clientX,
             pressY: event.clientY,
-            mouseDownTabIndex: index
+            mouseDownTabIndex: index,
         };
     }
 

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -18,7 +18,7 @@ import { injectable, inject, interfaces } from "inversify";
 import { Widget } from '@phosphor/widgets';
 import {
     MenuModelRegistry, Command, CommandContribution,
-    MenuContribution, CommandRegistry
+    MenuContribution, CommandRegistry,
 } from '../../common';
 import { KeybindingContribution, KeybindingRegistry } from "../keybinding";
 import { WidgetManager } from '../widget-manager';
@@ -60,12 +60,12 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
     readonly toggleCommand?: Command;
 
     constructor(
-        protected readonly options: ViewContributionOptions
+        protected readonly options: ViewContributionOptions,
     ) {
         if (options.toggleCommandId) {
             this.toggleCommand = {
                 id: options.toggleCommandId,
-                label: 'Toggle ' + options.widgetName + ' View'
+                label: 'Toggle ' + options.widgetName + ' View',
             };
         }
     }
@@ -87,7 +87,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
             // The widget is not attached yet, so add it to the shell
             const widgetArgs: OpenViewArguments = {
                 ...this.options.defaultWidgetOptions,
-                ...args
+                ...args,
             };
             shell.addWidget(widget, widgetArgs);
         } else if (args.toggle && area && shell.isExpanded(area) && tabBar.currentTitle === widget.title) {
@@ -107,8 +107,8 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
             commands.registerCommand(this.toggleCommand, {
                 execute: () => this.openView({
                     toggle: true,
-                    activate: true
-                })
+                    activate: true,
+                }),
             });
         }
     }
@@ -117,7 +117,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         if (this.toggleCommand) {
             menus.registerMenuAction(CommonMenus.VIEW_VIEWS, {
                 commandId: this.toggleCommand.id,
-                label: this.options.widgetName
+                label: this.options.widgetName,
             });
         }
     }
@@ -126,7 +126,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         if (this.toggleCommand && this.options.toggleKeybinding) {
             keybindings.registerKeybinding({
                 command: this.toggleCommand.id,
-                keybinding: this.options.toggleKeybinding
+                keybinding: this.options.toggleKeybinding,
             });
         }
     }

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -46,7 +46,7 @@ export interface StatusBarEntry {
 }
 
 export enum StatusBarAlignment {
-    LEFT, RIGHT
+    LEFT, RIGHT,
 }
 
 export interface StatusBarEntryAttributes {
@@ -75,7 +75,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     constructor(
         @inject(CommandService) protected readonly commands: CommandService,
         @inject(LabelParser) protected readonly entryService: LabelParser,
-        @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService
+        @inject(FrontendApplicationStateService) protected readonly applicationStateService: FrontendApplicationStateService,
     ) {
         super();
         delete this.scrollOptions;
@@ -163,7 +163,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
 
         if (entry.color) {
             attrs.style = {
-                color: entry.color
+                color: entry.color,
             };
         }
 

--- a/packages/core/src/browser/storage-service.spec.ts
+++ b/packages/core/src/browser/storage-service.spec.ts
@@ -44,25 +44,25 @@ describe("storage-service", () => {
 
     it("stores data", async () => {
         storageService.setData('foo', {
-            test: 'foo'
+            test: 'foo',
         });
         expect(await storageService.getData('bar', 'bar')).equals('bar');
         expect((await storageService.getData('foo', {
-            test: 'bar'
+            test: 'bar',
         })).test).equals('foo');
     });
 
     it("removes data", async () => {
         storageService.setData('foo', {
-            test: 'foo'
+            test: 'foo',
         });
         expect((await storageService.getData('foo', {
-            test: 'bar'
+            test: 'bar',
         })).test).equals('foo');
 
         storageService.setData('foo', undefined);
         expect((await storageService.getData('foo', {
-            test: 'bar'
+            test: 'bar',
         })).test).equals('bar');
     });
 

--- a/packages/core/src/browser/storage-service.ts
+++ b/packages/core/src/browser/storage-service.ts
@@ -45,7 +45,7 @@ export class LocalStorageService implements StorageService {
     private storage: LocalStorage;
 
     constructor(
-        @inject(ILogger) protected logger: ILogger
+        @inject(ILogger) protected logger: ILogger,
     ) {
         if (typeof window !== 'undefined' && window.localStorage) {
             this.storage = window.localStorage;

--- a/packages/core/src/browser/test/mock-connection-status-service.ts
+++ b/packages/core/src/browser/test/mock-connection-status-service.ts
@@ -21,7 +21,7 @@ export class MockConnectionStatusService extends AbstractConnectionStatusService
 
     constructor() {
         super({
-            offlineTimeout: 10
+            offlineTimeout: 10,
         }, new MockLogger());
     }
 

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -50,7 +50,7 @@ export class ThemeService {
     }
 
     protected constructor(
-        public defaultTheme: string = 'dark'
+        public defaultTheme: string = 'dark',
     ) {
         const global = window as any; // tslint:disable-line
         global[ThemeServiceSymbol] = this;
@@ -96,7 +96,7 @@ export class ThemeService {
         this.activeTheme = newTheme;
         window.localStorage.setItem('theme', themeId);
         this.themeChange.fire({
-            newTheme, oldTheme
+            newTheme, oldTheme,
         });
     }
 
@@ -134,7 +134,7 @@ export class ThemingCommandContribution implements CommandContribution, CommandH
                 if (this.resetTo) {
                     this.themeService.setCurrentTheme(this.resetTo);
                 }
-            }
+            },
         });
     }
 
@@ -155,7 +155,7 @@ export class ThemingCommandContribution implements CommandContribution, CommandH
                     }
                     this.themeService.setCurrentTheme(t.id);
                     return true;
-                }
+                },
             }));
         acceptor(items);
     }
@@ -177,7 +177,7 @@ export class BuiltinThemeProvider {
         },
         deactivate() {
             BuiltinThemeProvider.darkCss.unuse();
-        }
+        },
     };
 
     static readonly lightTheme = {
@@ -190,7 +190,7 @@ export class BuiltinThemeProvider {
         },
         deactivate() {
             BuiltinThemeProvider.lightCss.unuse();
-        }
+        },
     };
 
     static readonly themes = [

--- a/packages/core/src/browser/tree/test/mock-tree-model.ts
+++ b/packages/core/src/browser/tree/test/mock-tree-model.ts
@@ -38,7 +38,7 @@ export namespace MockTreeModel {
                 selected,
                 focus,
                 parent: parent,
-                children: []
+                children: [],
             };
             const children = (root.children || []).map(child => Node.toTreeNode(child, node));
             if (children.length === 0) {
@@ -59,12 +59,12 @@ export namespace MockTreeModel {
                 "id": "1.1",
                 "children": [
                     {
-                        "id": "1.1.1"
+                        "id": "1.1.1",
                     },
                     {
-                        "id": "1.1.2"
-                    }
-                ]
+                        "id": "1.1.2",
+                    },
+                ],
             },
             {
                 "id": "1.2",
@@ -73,64 +73,64 @@ export namespace MockTreeModel {
                         "id": "1.2.1",
                         "children": [
                             {
-                                "id": "1.2.1.1"
+                                "id": "1.2.1.1",
                             },
                             {
-                                "id": "1.2.1.2"
-                            }
-                        ]
+                                "id": "1.2.1.2",
+                            },
+                        ],
                     },
                     {
-                        "id": "1.2.2"
+                        "id": "1.2.2",
                     },
                     {
-                        "id": "1.2.3"
-                    }
-                ]
+                        "id": "1.2.3",
+                    },
+                ],
             },
             {
-                "id": "1.3"
-            }
-        ]
+                "id": "1.3",
+            },
+        ],
     });
 
     export const FLAT_MOCK_ROOT = () => Node.toTreeNode({
         "id": 'ROOT',
         "children": [
             {
-                "id": "1"
+                "id": "1",
             },
             {
-                "id": "2"
+                "id": "2",
             },
             {
-                "id": "3"
+                "id": "3",
             },
             {
-                "id": "4"
+                "id": "4",
             },
             {
-                "id": "5"
+                "id": "5",
             },
             {
-                "id": "6"
+                "id": "6",
             },
             {
-                "id": "7"
+                "id": "7",
             },
             {
-                "id": "8"
+                "id": "8",
             },
             {
-                "id": "9"
+                "id": "9",
             },
             {
-                "id": "10"
+                "id": "10",
             },
             {
-                "id": "11"
-            }
-        ]
+                "id": "11",
+            },
+        ],
     });
 
 }

--- a/packages/core/src/browser/tree/tree-decorator.spec.ts
+++ b/packages/core/src/browser/tree/tree-decorator.spec.ts
@@ -41,43 +41,43 @@ describe('tree-decorator', () => {
             const expected = new Map<string, TreeDecoration.Data[]>();
             expected.set('id_1', [
                 {
-                    tooltip: 'tooltip'
+                    tooltip: 'tooltip',
                 },
                 {
                     fontData: {
-                        color: 'blue'
-                    }
-                }
+                        color: 'blue',
+                    },
+                },
             ]);
             expected.set('id_2', [
                 {
-                    backgroundColor: 'yellow'
+                    backgroundColor: 'yellow',
                 },
                 {
-                    priority: 100
-                }
+                    priority: 100,
+                },
             ]);
             expect(decoratorService.inflateDecorators(
                 {
                     "id_1": [
                         {
-                            "tooltip": "tooltip"
+                            "tooltip": "tooltip",
                         },
                         {
                             "fontData": {
-                                "color": "blue"
-                            }
-                        }
+                                "color": "blue",
+                            },
+                        },
                     ],
                     "id_2": [
                         {
-                            "backgroundColor": "yellow"
+                            "backgroundColor": "yellow",
                         },
                         {
-                            "priority": 100
-                        }
-                    ]
-                }
+                            "priority": 100,
+                        },
+                    ],
+                },
             )).to.be.deep.equal(expected);
         });
 
@@ -89,41 +89,41 @@ describe('tree-decorator', () => {
             const decorations = new Map<string, TreeDecoration.Data[]>();
             decorations.set('id_1', [
                 {
-                    tooltip: 'tooltip'
+                    tooltip: 'tooltip',
                 },
                 {
                     fontData: {
-                        color: 'blue'
-                    }
-                }
+                        color: 'blue',
+                    },
+                },
             ]);
             decorations.set('id_2', [
                 {
-                    backgroundColor: 'yellow'
+                    backgroundColor: 'yellow',
                 },
                 {
-                    priority: 100
-                }
+                    priority: 100,
+                },
             ]);
             expect(decoratorService.deflateDecorators(decorations)).to.be.deep.equal({
                 "id_1": [
                     {
-                        "tooltip": "tooltip"
+                        "tooltip": "tooltip",
                     },
                     {
                         "fontData": {
-                            "color": "blue"
-                        }
-                    }
+                            "color": "blue",
+                        },
+                    },
                 ],
                 "id_2": [
                     {
-                        "backgroundColor": "yellow"
+                        "backgroundColor": "yellow",
                     },
                     {
-                        "priority": 100
-                    }
-                ]
+                        "priority": 100,
+                    },
+                ],
             });
         });
 
@@ -150,7 +150,7 @@ describe('tree-decorator', () => {
 
         it('split', () => {
             const actual = TreeDecoration.CaptionHighlight.split('alma', {
-                ranges: [{ offset: 0, length: 1 }]
+                ranges: [{ offset: 0, length: 1 }],
             });
             expect(actual).has.lengthOf(2);
             expect(actual[0].highligh).to.be.true;

--- a/packages/core/src/browser/tree/tree-decorator.ts
+++ b/packages/core/src/browser/tree/tree-decorator.ts
@@ -117,8 +117,8 @@ export abstract class AbstractTreeDecoratorService implements TreeDecoratorServi
         this.toDispose.push(this.onDidChangeDecorationsEmitter);
         this.toDispose.pushAll(this.decorators.map(decorator =>
             decorator.onDidChangeDecorations(data =>
-                this.onDidChangeDecorationsEmitter.fire(undefined)
-            ))
+                this.onDidChangeDecorationsEmitter.fire(undefined),
+            )),
         );
     }
 
@@ -268,7 +268,7 @@ export namespace TreeDecoration {
         /**
          * Occupies the top left quarter of the original icon.
          */
-        TOP_LEFT
+        TOP_LEFT,
 
     }
 

--- a/packages/core/src/browser/tree/tree-iterator.ts
+++ b/packages/core/src/browser/tree/tree-iterator.ts
@@ -29,7 +29,7 @@ export namespace TreeIterator {
 
     export const DEFAULT_OPTIONS: Options = {
         pruneCollapsed: false,
-        pruneSiblings: false
+        pruneSiblings: false,
     };
 
 }
@@ -42,7 +42,7 @@ export abstract class AbstractTreeIterator implements TreeIterator, Iterable<Tre
     constructor(protected readonly root: TreeNode, options?: Partial<TreeIterator.Options>) {
         this.options = {
             ...TreeIterator.DEFAULT_OPTIONS,
-            ...options
+            ...options,
         };
         this.delegate = this.iterator(this.root);
     }

--- a/packages/core/src/browser/tree/tree-selection-impl.ts
+++ b/packages/core/src/browser/tree/tree-selection-impl.ts
@@ -56,13 +56,13 @@ export class TreeSelectionServiceImpl implements TreeSelectionService {
             if (TreeSelection.is(arg)) {
                 return {
                     type,
-                    ...arg
+                    ...arg,
                 };
             }
             const node = arg;
             return {
                 type,
-                node
+                node,
             };
         })(selectionOrTreeNode);
 

--- a/packages/core/src/browser/tree/tree-selection-state.spec.ts
+++ b/packages/core/src/browser/tree/tree-selection-state.spec.ts
@@ -54,11 +54,11 @@ describe('tree-selection-state', () => {
         newState()
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: ['1']
+                selection: ['1'],
             })
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: []
+                selection: [],
             });
     });
 
@@ -67,7 +67,7 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '1')
             .nextState('range', '3', {
                 focus: '1',
-                selection: ['1', '2', '3']
+                selection: ['1', '2', '3'],
             });
     });
 
@@ -77,11 +77,11 @@ describe('tree-selection-state', () => {
             .nextState('range', '3')
             .nextState('toggle', '2', {
                 focus: '1',
-                selection: ['1', '3']
+                selection: ['1', '3'],
             })
             .nextState('toggle', '2', {
                 focus: '1',
-                selection: ['1', '2', '3']
+                selection: ['1', '2', '3'],
             });
     });
 
@@ -90,15 +90,15 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '5')
             .nextState('range', '2', {
                 focus: '5',
-                selection: ['2', '3', '4', '5']
+                selection: ['2', '3', '4', '5'],
             })
             .nextState('toggle', '3', {
                 focus: '5',
-                selection: ['2', '4', '5']
+                selection: ['2', '4', '5'],
             })
             .nextState('range', '7', {
                 focus: '5',
-                selection: ['2', '4', '5', '6', '7']
+                selection: ['2', '4', '5', '6', '7'],
             });
     });
 
@@ -108,7 +108,7 @@ describe('tree-selection-state', () => {
             .nextState('range', '1')
             .nextState('range', '6', {
                 focus: '4',
-                selection: ['4', '5', '6']
+                selection: ['4', '5', '6'],
             });
     });
 
@@ -118,7 +118,7 @@ describe('tree-selection-state', () => {
             .nextState('range', '6')
             .nextState('range', '8', {
                 focus: '4',
-                selection: ['4', '5', '6', '7', '8']
+                selection: ['4', '5', '6', '7', '8'],
             });
     });
 
@@ -127,7 +127,7 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '4')
             .nextState('toggle', '5', {
                 focus: '5',
-                selection: ['4', '5']
+                selection: ['4', '5'],
             });
     });
 
@@ -136,7 +136,7 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '4')
             .nextState('range', '2', {
                 focus: '4',
-                selection: ['4', '3', '2']
+                selection: ['4', '3', '2'],
             });
     });
 
@@ -145,11 +145,11 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '3')
             .nextState('range', '5', {
                 focus: '3',
-                selection: ['3', '4', '5']
+                selection: ['3', '4', '5'],
             })
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: ['3', '4', '5', '1']
+                selection: ['3', '4', '5', '1'],
             });
     });
 
@@ -158,15 +158,15 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '3')
             .nextState('range', '5', {
                 focus: '3',
-                selection: ['5', '4', '3']
+                selection: ['5', '4', '3'],
             })
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: ['1', '5', '4', '3']
+                selection: ['1', '5', '4', '3'],
             })
             .nextState('toggle', '4', {
                 focus: '1',
-                selection: ['1', '5', '3']
+                selection: ['1', '5', '3'],
             });
     });
 
@@ -176,15 +176,15 @@ describe('tree-selection-state', () => {
             .nextState('range', '2')
             .nextState('toggle', '3', {
                 focus: '5',
-                selection: ['5', '4', '2']
+                selection: ['5', '4', '2'],
             })
             .nextState('range', '1', {
                 focus: '5',
-                selection: ['5', '4', '3', '2', '1']
+                selection: ['5', '4', '3', '2', '1'],
             })
             .nextState('range', '7', {
                 focus: '5',
-                selection: ['5', '6', '7']
+                selection: ['5', '6', '7'],
             });
     });
 
@@ -195,15 +195,15 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '3')
             .nextState('range', '2', {
                 focus: '3',
-                selection: ['2', '3', '4', '5']
+                selection: ['2', '3', '4', '5'],
             })
             .nextState('range', '5', {
                 focus: '3',
-                selection: ['5', '4', '3']
+                selection: ['5', '4', '3'],
             })
             .nextState('toggle', '4', {
                 focus: '3',
-                selection: ['5', '3']
+                selection: ['5', '3'],
             });
     });
 
@@ -212,11 +212,11 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '2')
             .nextState('range', '3', {
                 focus: '2', // In VSCode this is 3.
-                selection: ['2', '3']
+                selection: ['2', '3'],
             })
             .nextState('range', '4', {
                 focus: '2', // In VSCode this is 4. They distinguish between `Shift + Up Arrow` and `Shift + Click`.
-                selection: ['2', '3', '4']
+                selection: ['2', '3', '4'],
             });
     });
 
@@ -225,19 +225,19 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '2')
             .nextState('range', '3', {
                 focus: '2',
-                selection: ['2', '3']
+                selection: ['2', '3'],
             })
             .nextState('toggle', '5', {
                 focus: '5',
-                selection: ['2', '3', '5']
+                selection: ['2', '3', '5'],
             })
             .nextState('range', '6', {
                 focus: '5',
-                selection: ['2', '3', '5', '6']
+                selection: ['2', '3', '5', '6'],
             })
             .nextState('toggle', '3', {
                 focus: '5',
-                selection: ['2', '5', '6']
+                selection: ['2', '5', '6'],
             });
     });
 
@@ -249,7 +249,7 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '2')
             .nextState('range', '7', {
                 focus: '2',
-                selection: ['1', '2', '3', '4', '5', '6', '7']
+                selection: ['1', '2', '3', '4', '5', '6', '7'],
             });
     });
 
@@ -258,35 +258,35 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '9')
             .nextState('range', '6', {
                 focus: '9',
-                selection: ['9', '8', '7', '6']
+                selection: ['9', '8', '7', '6'],
             })
             .nextState('range', '10', {
                 focus: '9',
-                selection: ['9', '10']
+                selection: ['9', '10'],
             })
             .nextState('range', '2', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '5', '4', '3', '2']
+                selection: ['9', '8', '7', '6', '5', '4', '3', '2'],
             })
             .nextState('toggle', '4', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '5', '3', '2']
+                selection: ['9', '8', '7', '6', '5', '3', '2'],
             })
             .nextState('toggle', '5', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '3', '2']
+                selection: ['9', '8', '7', '6', '3', '2'],
             })
             .nextState('toggle', '6', {
                 focus: '9',
-                selection: ['9', '8', '7', '3', '2']
+                selection: ['9', '8', '7', '3', '2'],
             })
             .nextState('toggle', '7', {
                 focus: '9',
-                selection: ['9', '8', '3', '2']
+                selection: ['9', '8', '3', '2'],
             })
             .nextState('range', '5', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '5', '3', '2']
+                selection: ['9', '8', '7', '6', '5', '3', '2'],
             });
     });
 
@@ -295,15 +295,15 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '9')
             .nextState('range', '3', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '5', '4', '3']
+                selection: ['9', '8', '7', '6', '5', '4', '3'],
             })
             .nextState('toggle', '4', {
                 focus: '9',
-                selection: ['9', '8', '7', '6', '5', '3']
+                selection: ['9', '8', '7', '6', '5', '3'],
             })
             .nextState('range', '10', {
                 focus: '9',
-                selection: ['10', '9', '8', '7', '6', '5', '3']
+                selection: ['10', '9', '8', '7', '6', '5', '3'],
             });
     });
 
@@ -312,19 +312,19 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '1')
             .nextState('toggle', '2', {
                 focus: '2',
-                selection: ['1', '2']
+                selection: ['1', '2'],
             })
             .nextState('default', '2', {
                 focus: '2',
-                selection: ['2']
+                selection: ['2'],
             })
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: ['1', '2']
+                selection: ['1', '2'],
             })
             .nextState('default', '2', {
                 focus: '2',
-                selection: ['2']
+                selection: ['2'],
             });
     });
 
@@ -332,11 +332,11 @@ describe('tree-selection-state', () => {
         newState()
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: ['1']
+                selection: ['1'],
             })
             .nextState('toggle', '1', {
                 focus: '1',
-                selection: []
+                selection: [],
             });
     });
 
@@ -345,23 +345,23 @@ describe('tree-selection-state', () => {
             .nextState('toggle', '2')
             .nextState('range', '1', {
                 focus: '2',
-                selection: ['1', '2']
+                selection: ['1', '2'],
             })
             .nextState('range', '2', {
                 focus: '2',
-                selection: ['2']
+                selection: ['2'],
             })
             .nextState('range', '3', {
                 focus: '2',
-                selection: ['2', '3']
+                selection: ['2', '3'],
             })
             .nextState('range', '2', {
                 focus: '2',
-                selection: ['2']
+                selection: ['2'],
             })
             .nextState('range', '1', {
                 focus: '2',
-                selection: ['1', '2']
+                selection: ['1', '2'],
             });
     });
 
@@ -369,31 +369,31 @@ describe('tree-selection-state', () => {
         newState()
             .nextState('toggle', '10', {
                 focus: '10',
-                selection: ['10']
+                selection: ['10'],
             })
             .nextState('range', '3', {
                 focus: '10',
-                selection: ['3', '4', '5', '6', '7', '8', '9', '10']
+                selection: ['3', '4', '5', '6', '7', '8', '9', '10'],
             })
             .nextState('toggle', '7', {
                 focus: '10',
-                selection: ['3', '4', '5', '6', '8', '9', '10']
+                selection: ['3', '4', '5', '6', '8', '9', '10'],
             })
             .nextState('toggle', '8', {
                 focus: '10',
-                selection: ['3', '4', '5', '6', '9', '10']
+                selection: ['3', '4', '5', '6', '9', '10'],
             })
             .nextState('toggle', '6', {
                 focus: '10',
-                selection: ['3', '4', '5', '9', '10']
+                selection: ['3', '4', '5', '9', '10'],
             })
             .nextState('toggle', '5', {
                 focus: '10',
-                selection: ['3', '4', '9', '10']
+                selection: ['3', '4', '9', '10'],
             })
             .nextState('range', '2', {
                 focus: '10',
-                selection: ['2', '3', '4', '5', '6', '7', '8', '9', '10']
+                selection: ['2', '3', '4', '5', '6', '7', '8', '9', '10'],
             });
     });
 
@@ -430,7 +430,7 @@ describe('tree-selection-state', () => {
                     }
                 }
                 return nextState(next);
-            }
+            },
         };
     }
 

--- a/packages/core/src/browser/tree/tree-selection-state.ts
+++ b/packages/core/src/browser/tree/tree-selection-state.ts
@@ -62,7 +62,7 @@ export class TreeSelectionState {
     nextState(selection: FocusableTreeSelection): TreeSelectionState {
         const { node, type } = {
             type: TreeSelection.SelectionType.DEFAULT,
-            ...selection
+            ...selection,
         };
         switch (type) {
             case TreeSelection.SelectionType.DEFAULT: return this.handleDefault(this, node);
@@ -101,7 +101,7 @@ export class TreeSelectionState {
         return new TreeSelectionState(tree, [{
             node,
             type: TreeSelection.SelectionType.TOGGLE,
-            focus: node
+            focus: node,
         }]);
     }
 
@@ -127,7 +127,7 @@ export class TreeSelectionState {
         return new TreeSelectionState(tree, [...copy, {
             node,
             type: TreeSelection.SelectionType.TOGGLE,
-            focus
+            focus,
         }]);
     }
 
@@ -152,7 +152,7 @@ export class TreeSelectionState {
         return new TreeSelectionState(tree, [...copy, {
             node,
             type: TreeSelection.SelectionType.RANGE,
-            focus
+            focus,
         }]);
     }
 

--- a/packages/core/src/browser/tree/tree-selection.ts
+++ b/packages/core/src/browser/tree/tree-selection.ts
@@ -68,7 +68,7 @@ export namespace TreeSelection {
     export enum SelectionType {
         DEFAULT,
         TOGGLE,
-        RANGE
+        RANGE,
     }
 
     export function is(arg: Object | undefined): arg is TreeSelection {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -78,7 +78,7 @@ export interface NodeProps {
 }
 
 export const defaultTreeProps: TreeProps = {
-    leftPadding: 16
+    leftPadding: 16,
 };
 
 export namespace TreeWidget {
@@ -109,7 +109,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     ) {
         super();
         this.scrollOptions = {
-            suppressScrollX: true
+            suppressScrollX: true,
         };
         this.addClass(TREE_CLASS);
         this.node.tabIndex = 0;
@@ -124,7 +124,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             this.model.onNodeRefreshed(() => this.updateDecorations()),
             this.model.onExpansionChanged(() => this.updateDecorations()),
             this.decoratorService,
-            this.decoratorService.onDidChangeDecorations(() => this.updateDecorations())
+            this.decoratorService.onDidChangeDecorations(() => this.updateDecorations()),
         ]);
         setTimeout(() => {
             this.updateRows();
@@ -140,7 +140,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             const depths = new Map<CompositeTreeNode | undefined, number>();
             const rows = Array.from(new TopDownTreeIterator(root, {
                 pruneCollapsed: true,
-                pruneSiblings: true
+                pruneSiblings: true,
             }), (node, index) => {
                 const parentDepth = depths.get(node.parent);
                 const depth = parentDepth === undefined ? 0 : TreeNode.isVisible(node.parent) ? parentDepth + 1 : parentDepth;
@@ -150,7 +150,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 return [node.id, {
                     index,
                     node,
-                    depth
+                    depth,
                 }] as [string, TreeWidget.NodeRow];
             });
             this.rows = new Map(rows);
@@ -221,7 +221,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected createContainerAttributes(): React.HTMLAttributes<HTMLElement> {
         return {
             className: TREE_CONTAINER_CLASS,
-            onContextMenu: event => this.handleContextMenuEvent(this.model.root, event)
+            onContextMenu: event => this.handleContextMenuEvent(this.model.root, event),
         };
     }
 
@@ -284,7 +284,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 {
                     paddingLeft: '4px',
                     paddingRight: '6px',
-                    minWidth: '8px'
+                    minWidth: '8px',
                 }
             }
             onClick={this.toggle}>
@@ -299,12 +299,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         }
         const className = classes.join(' ');
         let attrs = this.decorateCaption(node, {
-            className
+            className,
         });
         if (tooltip.length > 0) {
             attrs = {
                 ...attrs,
-                title: tooltip
+                title: tooltip,
             };
         }
         const highlight = this.getDecorationData(node, 'highlight')[0];
@@ -315,13 +315,13 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             if (highlight.color) {
                 style = {
                     ...style,
-                    color: highlight.color
+                    color: highlight.color,
                 };
             }
             if (highlight.backgroundColor) {
                 style = {
                     ...style,
-                    backgroundColor: highlight.backgroundColor
+                    backgroundColor: highlight.backgroundColor,
                 };
             }
             const createChildren = (fragment: TreeDecoration.CaptionHighlight.Fragment) => {
@@ -343,12 +343,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         const style = this.getDecorationData(node, 'fontData').filter(notEmpty).reverse().map(fontData => this.applyFontStyles({}, fontData)).reduce((acc, current) =>
             ({
                 ...acc,
-                ...current
+                ...current,
             })
             , {});
         return {
             ...attrs,
-            style
+            style,
         };
     }
 
@@ -365,7 +365,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         if (color) {
             modified = {
                 ...modified,
-                color
+                color,
             };
         }
         if (style) {
@@ -374,7 +374,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                     case 'bold':
                         modified = {
                             ...modified,
-                            fontWeight: style
+                            fontWeight: style,
                         };
                         break;
                     case 'normal': // Fall through.
@@ -382,14 +382,14 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                     case 'italic':
                         modified = {
                             ...modified,
-                            fontStyle: style
+                            fontStyle: style,
                         };
                         break;
                     case 'underline': // Fall through.
                     case 'line-through':
                         modified = {
                             ...modified,
-                            textDecoration: style
+                            textDecoration: style,
                         };
                         break;
                     default:
@@ -415,7 +415,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             const className = classes.join(' ');
             const attrs = {
                 className,
-                style
+                style,
             };
             children.push(React.createElement('div', attrs, affix.data));
         }
@@ -485,7 +485,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             style,
             onClick: event => this.handleClickEvent(node, event),
             onDoubleClick: event => this.handleDblClickEvent(node, event),
-            onContextMenu: event => this.handleContextMenuEvent(node, event)
+            onContextMenu: event => this.handleContextMenuEvent(node, event),
         };
     }
 
@@ -510,7 +510,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         // If the node is a composite, a toggle will be rendered. Otherwise we need to add the width and the left, right padding => 18px
         const paddingLeft = `${props.depth * this.props.leftPadding + (this.isExpandable(node) ? 0 : 18)}px`;
         return {
-            paddingLeft
+            paddingLeft,
         };
     }
 
@@ -523,7 +523,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         if (backgroundColor) {
             style = {
                 ...(style || {}),
-                backgroundColor
+                backgroundColor,
             };
         }
         return style;
@@ -548,11 +548,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected onAfterAttach(msg: Message): void {
         const up = [
             Key.ARROW_UP,
-            KeyCode.createKeyCode({ first: Key.ARROW_UP, modifiers: [KeyModifier.Shift] })
+            KeyCode.createKeyCode({ first: Key.ARROW_UP, modifiers: [KeyModifier.Shift] }),
         ];
         const down = [
             Key.ARROW_DOWN,
-            KeyCode.createKeyCode({ first: Key.ARROW_DOWN, modifiers: [KeyModifier.Shift] })
+            KeyCode.createKeyCode({ first: Key.ARROW_DOWN, modifiers: [KeyModifier.Shift] }),
         ];
         super.onAfterAttach(msg);
         this.addKeyListener(this.node, Key.ARROW_LEFT, event => this.handleLeft(event));
@@ -646,8 +646,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 const { x, y } = event.nativeEvent;
                 this.onRender.push(Disposable.create(() =>
                     setTimeout(() =>
-                        this.contextMenuRenderer.render(contextMenuPath, { x, y })
-                    )
+                        this.contextMenuRenderer.render(contextMenuPath, { x, y }),
+                    ),
                 ));
             }
             this.update();
@@ -709,12 +709,12 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     storeState(): object {
         const decorations = this.decoratorService.deflateDecorators(this.decorations);
         let state: object = {
-            decorations
+            decorations,
         };
         if (this.model.root) {
             state = {
                 ...state,
-                root: this.deflateForStorage(this.model.root)
+                root: this.deflateForStorage(this.model.root),
             };
         }
         return state;

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -158,7 +158,7 @@ export class TreeImpl implements Tree {
     protected readonly toDispose = new DisposableCollection();
 
     protected nodes: {
-        [id: string]: TreeNode | undefined
+        [id: string]: TreeNode | undefined,
     } = {};
 
     constructor() {

--- a/packages/core/src/browser/widget-manager.ts
+++ b/packages/core/src/browser/widget-manager.ts
@@ -134,7 +134,7 @@ export class WidgetManager {
             this.widgetPromises.delete(key);
         });
         this.onDidCreateWidgetEmitter.fire({
-            factoryId, widget
+            factoryId, widget,
         });
         return widget as T;
     }

--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -87,7 +87,7 @@ export abstract class WidgetOpenHandler<W extends BaseWidget> implements OpenHan
     protected async doOpen(widget: W, options?: WidgetOpenerOptions): Promise<void> {
         const op: WidgetOpenerOptions = {
             mode: 'activate',
-            ...options
+            ...options,
         };
         if (!widget.isAttached) {
             this.shell.addWidget(widget, op.widgetOptions || { area: 'main' });

--- a/packages/core/src/browser/widgets/react-renderer.tsx
+++ b/packages/core/src/browser/widgets/react-renderer.tsx
@@ -21,7 +21,7 @@ import { Disposable } from '../../common';
 export class ReactRenderer implements Disposable {
     readonly host: HTMLElement;
     constructor(
-        host?: HTMLElement
+        host?: HTMLElement,
     ) {
         this.host = host || document.createElement('div');
     }

--- a/packages/core/src/browser/widgets/react-widget.tsx
+++ b/packages/core/src/browser/widgets/react-widget.tsx
@@ -25,7 +25,7 @@ export abstract class ReactWidget extends BaseWidget {
 
     protected readonly onRender = new DisposableCollection();
     protected scrollOptions = {
-        suppressScrollX: true
+        suppressScrollX: true,
     };
 
     constructor() {

--- a/packages/core/src/browser/widgets/virtual-renderer.ts
+++ b/packages/core/src/browser/widgets/virtual-renderer.ts
@@ -22,7 +22,7 @@ import { h, VirtualNode, VirtualText, VirtualDOM } from "@phosphor/virtualdom";
 export class VirtualRenderer {
     readonly host: HTMLElement;
     constructor(
-        host?: HTMLElement
+        host?: HTMLElement,
     ) {
         this.host = host || document.createElement('div');
     }

--- a/packages/core/src/browser/widgets/virtual-widget.ts
+++ b/packages/core/src/browser/widgets/virtual-widget.ts
@@ -29,7 +29,7 @@ export class VirtualWidget extends BaseWidget {
     protected readonly onRender = new DisposableCollection();
     protected childContainer?: HTMLElement;
     protected scrollOptions = {
-        suppressScrollX: true
+        suppressScrollX: true,
     };
 
     protected onUpdateRequest(msg: Message): void {

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -80,7 +80,7 @@ export class BaseWidget extends Widget {
                 const container = await this.getScrollContainer();
                 container.style.overflow = 'hidden';
                 this.scrollBar = new PerfectScrollbar(container, {
-                    suppressScrollX: true
+                    suppressScrollX: true,
                 });
 
                 this.toDispose.push(Disposable.create(async () => {
@@ -156,11 +156,11 @@ export namespace EventListenerObject {
 }
 export type EventListenerOrEventListenerObject<K extends keyof HTMLElementEventMap> = EventListener<K> | EventListenerObject<K>;
 export function addEventListener<K extends keyof HTMLElementEventMap>(
-    element: HTMLElement, type: K, listener: EventListenerOrEventListenerObject<K>, useCapture?: boolean
+    element: HTMLElement, type: K, listener: EventListenerOrEventListenerObject<K>, useCapture?: boolean,
 ): Disposable {
     element.addEventListener(type, listener, useCapture);
     return Disposable.create(() =>
-        element.removeEventListener(type, listener)
+        element.removeEventListener(type, listener),
     );
 }
 
@@ -214,6 +214,6 @@ export function addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element
     };
     document.addEventListener(type, documentListener);
     return Disposable.create(() =>
-        document.removeEventListener(type, documentListener)
+        document.removeEventListener(type, documentListener),
     );
 }

--- a/packages/core/src/common/cancellation.ts
+++ b/packages/core/src/common/cancellation.ts
@@ -38,12 +38,12 @@ export namespace CancellationToken {
 
     export const None: CancellationToken = Object.freeze({
         isCancellationRequested: false,
-        onCancellationRequested: Event.None
+        onCancellationRequested: Event.None,
     });
 
     export const Cancelled: CancellationToken = Object.freeze({
         isCancellationRequested: true,
-        onCancellationRequested: shortcutEvent
+        onCancellationRequested: shortcutEvent,
     });
 }
 

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -98,7 +98,7 @@ export class CommandRegistry implements CommandService {
 
     constructor(
         @inject(ContributionProvider) @named(CommandContribution)
-        protected readonly contributionProvider: ContributionProvider<CommandContribution>
+        protected readonly contributionProvider: ContributionProvider<CommandContribution>,
     ) { }
 
     onStart(): void {
@@ -132,7 +132,7 @@ export class CommandRegistry implements CommandService {
         return {
             dispose: () => {
                 delete this._commands[command.id];
-            }
+            },
         };
     }
 
@@ -151,7 +151,7 @@ export class CommandRegistry implements CommandService {
                 if (idx >= 0) {
                     handlers.splice(idx, 1);
                 }
-            }
+            },
         };
     }
 

--- a/packages/core/src/common/contribution-provider.ts
+++ b/packages/core/src/common/contribution-provider.ts
@@ -32,7 +32,7 @@ class ContainerBasedContributionProvider<T extends object> implements Contributi
 
     constructor(
         protected readonly serviceIdentifier: interfaces.ServiceIdentifier<T>,
-        protected readonly container: interfaces.Container
+        protected readonly container: interfaces.Container,
     ) { }
 
     getContributions(recursive?: boolean): T[] {

--- a/packages/core/src/common/disposable.ts
+++ b/packages/core/src/common/disposable.ts
@@ -25,7 +25,7 @@ export interface Disposable {
 export namespace Disposable {
     export function create(func: () => void): Disposable {
         return {
-            dispose: func
+            dispose: func,
         };
     }
     export const NULL = create(() => { });
@@ -86,7 +86,7 @@ export class DisposableCollection implements Disposable {
 
     pushAll(disposables: Disposable[]): Disposable[] {
         return disposables.map(disposable =>
-            this.push(disposable)
+            this.push(disposable),
         );
     }
 

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -43,7 +43,7 @@ export namespace Event {
     const _disposable = { dispose() { } };
     export const None: Event<any> = Object.assign(function () { return _disposable; }, {
         get maxListeners(): number { return 0; },
-        set maxListeners(maxListeners: number) { }
+        set maxListeners(maxListeners: number) { },
     });
 }
 
@@ -165,7 +165,7 @@ export class Emitter<T> {
                                 this._options.onLastListenerRemove(this);
                             }
                         }
-                    }
+                    },
                 };
                 if (Array.isArray(disposables)) {
                     disposables.push(result);
@@ -173,8 +173,8 @@ export class Emitter<T> {
 
                 return result;
             }, {
-                    maxListeners: 30
-                }
+                    maxListeners: 30,
+                },
             );
         }
         return this._event;

--- a/packages/core/src/common/logger-watcher.ts
+++ b/packages/core/src/common/logger-watcher.ts
@@ -26,7 +26,7 @@ export class LoggerWatcher {
         return {
             onLogLevelChanged(event: ILogLevelChangedEvent) {
                 emitter.fire(event);
-            }
+            },
         };
     }
 

--- a/packages/core/src/common/logger.spec.ts
+++ b/packages/core/src/common/logger.spec.ts
@@ -41,7 +41,7 @@ describe('logger', () => {
             } finally {
                 unsetRootLogger();
             }
-        }
+        },
         ).to.not.throw(ReferenceError);
     });
 

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -26,7 +26,7 @@ export enum LogLevel {
     WARN = 40,
     INFO = 30,
     DEBUG = 20,
-    TRACE = 10
+    TRACE = 10,
 }
 
 export namespace LogLevel {
@@ -36,7 +36,7 @@ export namespace LogLevel {
         [LogLevel.WARN, 'warn'],
         [LogLevel.INFO, 'info'],
         [LogLevel.DEBUG, 'debug'],
-        [LogLevel.TRACE, 'trace']
+        [LogLevel.TRACE, 'trace'],
     ]);
 
     export function toString(level: LogLevel): string | undefined {
@@ -347,7 +347,7 @@ export class Logger implements ILogger {
 
     isEnabled(logLevel: number): Promise<boolean> {
         return this._logLevel.then(level =>
-            logLevel >= level
+            logLevel >= level,
         );
     }
     ifEnabled(logLevel: number): Promise<void> {
@@ -356,7 +356,7 @@ export class Logger implements ILogger {
                 if (enabled) {
                     resolve();
                 }
-            })
+            }),
         );
     }
     log(logLevel: number, arg2: any | Loggable, ...params: any[]): Promise<void> {
@@ -373,8 +373,8 @@ export class Logger implements ILogger {
         return this.ifEnabled(logLevel).then(() =>
             this.created.then(() =>
                 (message: any, ...params: any[]) =>
-                    this.server.log(this.name, logLevel, this.format(message), params.map(p => this.format(p)))
-            )
+                    this.server.log(this.name, logLevel, this.format(message), params.map(p => this.format(p))),
+            ),
         );
     }
     protected format(value: any): any {

--- a/packages/core/src/common/menu.spec.ts
+++ b/packages/core/src/common/menu.spec.ts
@@ -30,23 +30,23 @@ describe('menu-model-registry', () => {
                 registerMenus(menuRegistry: MenuModelRegistry): void {
                     menuRegistry.registerSubmenu(fileMenu, "File");
                     menuRegistry.registerMenuAction(fileOpenMenu, {
-                        commandId: 'open'
+                        commandId: 'open',
                     });
                     menuRegistry.registerMenuAction(fileOpenMenu, {
-                        commandId: 'open.with'
+                        commandId: 'open.with',
                     });
-                }
+                },
             }, {
                     registerCommands(reg: CommandRegistry) {
                         reg.registerCommand({
                             id: 'open',
-                            label: "A"
+                            label: "A",
                         });
                         reg.registerCommand({
                             id: 'open.with',
-                            label: "B"
+                            label: "B",
                         });
-                    }
+                    },
                 });
             const all = service.getMenu();
             const main = all.children[0] as CompositeMenuNode;

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -42,7 +42,7 @@ export class MenuModelRegistry {
     constructor(
         @inject(ContributionProvider) @named(MenuContribution)
         protected readonly contributions: ContributionProvider<MenuContribution>,
-        @inject(CommandRegistry) protected readonly commands: CommandRegistry
+        @inject(CommandRegistry) protected readonly commands: CommandRegistry,
     ) { }
 
     onStart(): void {
@@ -119,7 +119,7 @@ export class CompositeMenuNode implements MenuNode {
     protected readonly _children: MenuNode[] = [];
     constructor(
         public readonly id: string,
-        public label?: string
+        public label?: string,
     ) { }
 
     get children(): ReadonlyArray<MenuNode> {
@@ -143,7 +143,7 @@ export class CompositeMenuNode implements MenuNode {
                 if (idx >= 0) {
                     this._children.splice(idx, 1);
                 }
-            }
+            },
         };
     }
 
@@ -159,7 +159,7 @@ export class CompositeMenuNode implements MenuNode {
 export class ActionMenuNode implements MenuNode {
     constructor(
         public readonly action: MenuAction,
-        protected readonly commands: CommandRegistry
+        protected readonly commands: CommandRegistry,
     ) { }
 
     get id(): string {

--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -23,7 +23,7 @@ export enum MessageType {
     Error = 1,
     Warning = 2,
     Info = 3,
-    Log = 4
+    Log = 4,
 }
 
 export interface Message {
@@ -62,7 +62,7 @@ export class DispatchingMessageClient extends MessageClient {
 
     showMessage(message: Message): Promise<string | undefined> {
         return Promise.race([...this.clients].map(client =>
-            client.showMessage(message)
+            client.showMessage(message),
         ));
     }
 

--- a/packages/core/src/common/message-service.ts
+++ b/packages/core/src/common/message-service.ts
@@ -21,7 +21,7 @@ import { MessageClient, MessageType, MessageOptions } from "./message-service-pr
 export class MessageService {
 
     constructor(
-        @inject(MessageClient) protected readonly client: MessageClient
+        @inject(MessageClient) protected readonly client: MessageClient,
     ) { }
 
     log(message: string, ...actions: string[]): Promise<string | undefined>;

--- a/packages/core/src/common/messaging/connection-error-handler.ts
+++ b/packages/core/src/common/messaging/connection-error-handler.ts
@@ -36,7 +36,7 @@ export interface ResolvedConnectionErrorHandlerOptions {
 
 export type ConnectionErrorHandlerOptions = Partial<ResolvedConnectionErrorHandlerOptions> & {
     readonly serverName: string
-    readonly logger: ILogger
+    readonly logger: ILogger,
 };
 
 export class ConnectionErrorHandler {
@@ -47,7 +47,7 @@ export class ConnectionErrorHandler {
             maxErrors: 3,
             maxRestarts: 5,
             restartInterval: 3,
-            ...options
+            ...options,
         };
     }
 

--- a/packages/core/src/common/messaging/proxy-factory.spec.ts
+++ b/packages/core/src/common/messaging/proxy-factory.spec.ts
@@ -111,6 +111,6 @@ function getSetup() {
         client,
         clientProxy,
         server,
-        serverProxy
+        serverProxy,
     };
 }

--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -37,7 +37,7 @@ export type JsonRpcProxy<T> = T & JsonRpcConnectionEventEmitter;
 export class JsonRpcConnectionHandler<T extends object> implements ConnectionHandler {
     constructor(
         readonly path: string,
-        readonly targetFactory: (proxy: JsonRpcProxy<T>) => any
+        readonly targetFactory: (proxy: JsonRpcProxy<T>) => any,
     ) { }
 
     onConnection(connection: MessageConnection): void {
@@ -110,11 +110,11 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
 
     protected waitForConnection(): void {
         this.connectionPromise = new Promise(resolve =>
-            this.connectionPromiseResolve = resolve
+            this.connectionPromiseResolve = resolve,
         );
         this.connectionPromise.then(connection => {
             connection.onClose(() =>
-                this.onDidCloseConnectionEmitter.fire(undefined)
+                this.onDidCloseConnectionEmitter.fire(undefined),
             );
             this.onDidOpenConnectionEmitter.fire(undefined);
         });
@@ -239,7 +239,7 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
                     } catch (err) {
                         reject(err);
                     }
-                })
+                }),
             );
     }
 

--- a/packages/core/src/common/messaging/web-socket-channel.ts
+++ b/packages/core/src/common/messaging/web-socket-channel.ts
@@ -27,7 +27,7 @@ export class WebSocketChannel implements IWebSocket {
 
     constructor(
         readonly id: number,
-        protected readonly doSend: (content: string) => void
+        protected readonly doSend: (content: string) => void,
     ) {
         this.toDispose.push(Disposable.NULL);
     }
@@ -57,7 +57,7 @@ export class WebSocketChannel implements IWebSocket {
         this.doSend(JSON.stringify(<WebSocketChannel.OpenMessage>{
             kind: 'open',
             id: this.id,
-            path
+            path,
         }));
     }
 
@@ -65,7 +65,7 @@ export class WebSocketChannel implements IWebSocket {
         this.checkNotDisposed();
         this.doSend(JSON.stringify(<WebSocketChannel.ReadyMessage>{
             kind: 'ready',
-            id: this.id
+            id: this.id,
         }));
     }
 
@@ -74,7 +74,7 @@ export class WebSocketChannel implements IWebSocket {
         this.doSend(JSON.stringify(<WebSocketChannel.DataMessage>{
             kind: 'data',
             id: this.id,
-            content
+            content,
         }));
     }
 
@@ -82,7 +82,7 @@ export class WebSocketChannel implements IWebSocket {
         this.checkNotDisposed();
         this.doSend(JSON.stringify(<WebSocketChannel.CloseMessage>{
             kind: 'close',
-            id: this.id
+            id: this.id,
         }));
     }
 

--- a/packages/core/src/common/os.ts
+++ b/packages/core/src/common/os.ts
@@ -33,6 +33,6 @@ export type CMD = [string, string[]];
 export function cmd(command: string, ...args: string[]): CMD {
     return [
         isWindows ? 'cmd' : command,
-        isWindows ? ['/c', command, ...args] : args
+        isWindows ? ['/c', command, ...args] : args,
     ];
 }

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -51,7 +51,7 @@ export class Path {
      * The raw should be normalized, meaning that only '/' is allowed as a path separator.
      */
     constructor(
-        private raw: string
+        private raw: string,
     ) {
         const firstIndex = raw.indexOf(Path.separator);
         const lastIndex = raw.lastIndexOf(Path.separator);

--- a/packages/core/src/common/reference.spec.ts
+++ b/packages/core/src/common/reference.spec.ts
@@ -25,7 +25,7 @@ describe('reference', () => {
         const references = new ReferenceCollection<string, Disposable>(key => ({
             key, dispose: () => {
                 expectation.disposed = true;
-            }
+            },
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
@@ -47,7 +47,7 @@ describe('reference', () => {
         const references = new ReferenceCollection<string, Disposable>(key => ({
             key, dispose: () => {
                 expectation.disposed = true;
-            }
+            },
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
@@ -75,7 +75,7 @@ describe('reference', () => {
         const references = new ReferenceCollection<string, Disposable>(key => ({
             key, dispose: () => {
                 expectation.disposed = true;
-            }
+            },
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
@@ -97,7 +97,7 @@ describe('reference', () => {
         const expectation: { disposed: boolean } = { disposed: false };
         const references = new ReferenceCollection<string, Disposable>(key => ({
             key, dispose: () => {
-            }
+            },
         }));
         assert.ok(!references.has("a"));
         assert.ok(!expectation.disposed);
@@ -115,7 +115,7 @@ describe('reference', () => {
     it("the same object should be provided by an async factory for the same key", async () => {
         const references = new ReferenceCollection<string, Disposable>(async key => ({
             key, dispose: () => {
-            }
+            },
         }));
         const result = await Promise.all([...Array(10).keys()].map(() => references.acquire("a")));
         result.forEach(v => assert.ok(result[0].object === v.object));

--- a/packages/core/src/common/reference.ts
+++ b/packages/core/src/common/reference.ts
@@ -80,7 +80,7 @@ export class ReferenceCollection<K, V extends Disposable> implements Disposable 
         const references = this.references.get(key) || this.createReferences(key, object);
         const reference: Reference<V> = {
             object,
-            dispose: () => { }
+            dispose: () => { },
         };
         references.push(reference);
         return reference;

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -89,7 +89,7 @@ export class DefaultResourceProvider {
 
     constructor(
         @inject(ContributionProvider) @named(ResourceResolver)
-        protected readonly resolversProvider: ContributionProvider<ResourceResolver>
+        protected readonly resolversProvider: ContributionProvider<ResourceResolver>,
     ) { }
 
     /**

--- a/packages/core/src/common/selection-service.spec.ts
+++ b/packages/core/src/common/selection-service.spec.ts
@@ -26,7 +26,7 @@ describe('selection-service', () => {
             const service = createSelectionService();
             const events: any[] = [];
             const disposable = service.onSelectionChanged(
-                e => events.push(e)
+                e => events.push(e),
             );
             service.selection = "foo";
             disposable.dispose();

--- a/packages/core/src/common/test/mock-resource-provider.ts
+++ b/packages/core/src/common/test/mock-resource-provider.ts
@@ -27,7 +27,7 @@ export class MockResourceProvider {
         return await {
             uri: new URI(''),
             dispose() { },
-            readContents(options?: { encoding?: string }): Promise<string> { return Promise.resolve(""); }
+            readContents(options?: { encoding?: string }): Promise<string> { return Promise.resolve(""); },
         };
     }
 }

--- a/packages/core/src/common/types.spec.ts
+++ b/packages/core/src/common/types.spec.ts
@@ -27,19 +27,19 @@ describe('types', () => {
                     assert.deepStrictEqual([
                         {
                             priority: 4,
-                            value: -4
+                            value: -4,
                         },
                         {
                             priority: 3,
-                            value: -3
+                            value: -3,
                         }, {
                             priority: 2,
-                            value: -2
+                            value: -2,
                         }, {
                             priority: 1,
-                            value: -1
-                        }
-                    ], values)
+                            value: -1,
+                        },
+                    ], values),
                 );
         });
 
@@ -50,19 +50,19 @@ describe('types', () => {
                     assert.deepStrictEqual([
                         {
                             priority: 4,
-                            value: -4
+                            value: -4,
                         },
                         {
                             priority: 3,
-                            value: -3
+                            value: -3,
                         }, {
                             priority: 2,
-                            value: -2
+                            value: -2,
                         }, {
                             priority: 1,
-                            value: -1
-                        }
-                    ], values)
+                            value: -1,
+                        },
+                    ], values),
                 );
         });
     });

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -35,7 +35,7 @@ export namespace Prioritizeable {
     export async function toPrioritizeable<T>(rawValue: MaybeArray<MaybePromise<T>>, getPriority: GetPriority<T>): Promise<MaybeArray<Prioritizeable<T>>> {
         if (rawValue instanceof Array) {
             return Promise.all(
-                rawValue.map(v => toPrioritizeable(v, getPriority))
+                rawValue.map(v => toPrioritizeable(v, getPriority)),
             );
         }
         const value = await rawValue;
@@ -45,7 +45,7 @@ export namespace Prioritizeable {
     export function toPrioritizeableSync<T>(rawValue: T[], getPriority: GetPrioritySync<T>): Prioritizeable<T>[] {
         return rawValue.map(v => ({
             value: v,
-            priority: getPriority(v)
+            priority: getPriority(v),
         }));
     }
     export function prioritizeAllSync<T>(values: T[], getPriority: GetPrioritySync<T>): Prioritizeable<T>[] {

--- a/packages/core/src/common/uri-command-handler.ts
+++ b/packages/core/src/common/uri-command-handler.ts
@@ -67,7 +67,7 @@ export class UriAwareCommandHandler<T extends MaybeArray<URI>> implements Comman
     constructor(
         protected readonly selectionService: SelectionService,
         protected readonly handler: UriCommandHandler<T>,
-        protected readonly options?: UriAwareCommandHandler.Options
+        protected readonly options?: UriAwareCommandHandler.Options,
     ) { }
 
     // tslint:disable-next-line:no-any

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -74,7 +74,7 @@ export default class URI {
     withScheme(scheme: string): URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
-            scheme
+            scheme,
         });
         return new URI(newCodeUri);
     }
@@ -92,7 +92,7 @@ export default class URI {
     withAuthority(authority: string): URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
-            authority
+            authority,
         });
         return new URI(newCodeUri);
     }
@@ -110,7 +110,7 @@ export default class URI {
     withPath(path: string | Path): URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
-            path: path.toString()
+            path: path.toString(),
         });
         return new URI(newCodeUri);
     }
@@ -128,7 +128,7 @@ export default class URI {
     withQuery(query: string): URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
-            query
+            query,
         });
         return new URI(newCodeUri);
     }
@@ -146,7 +146,7 @@ export default class URI {
     withFragment(fragment: string): URI {
         const newCodeUri = Uri.from({
             ...this.codeUri.toJSON(),
-            fragment
+            fragment,
         });
         return new URI(newCodeUri);
     }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -18,7 +18,7 @@ import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
 import {
     CommandRegistry, isOSX, ActionMenuNode, CompositeMenuNode,
-    MAIN_MENU_BAR, MenuModelRegistry, MenuPath
+    MAIN_MENU_BAR, MenuModelRegistry, MenuPath,
 } from '../../common';
 import { PreferenceService, KeybindingRegistry, Keybinding, KeyCode, Key } from '../../browser';
 
@@ -31,7 +31,7 @@ export class ElectronMainMenuFactory {
         @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
         @inject(PreferenceService) protected readonly preferencesService: PreferenceService,
         @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
-        @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry
+        @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry,
     ) { }
 
     createMenuBar(): Electron.Menu {
@@ -60,12 +60,12 @@ export class ElectronMainMenuFactory {
                     // should we create a submenu?
                     items.push({
                         label: menu.label,
-                        submenu: this.fillMenuTemplate([], menu)
+                        submenu: this.fillMenuTemplate([], menu),
                     });
                 } else {
                     // or just a separator?
                     items.push({
-                        type: 'separator'
+                        type: 'separator',
                     });
                     // followed by the elements
                     this.fillMenuTemplate(items, menu);
@@ -96,7 +96,7 @@ export class ElectronMainMenuFactory {
                     enabled: true, // https://github.com/theia-ide/theia/issues/446
                     visible: true,
                     click: () => this.execute(commandId),
-                    accelerator
+                    accelerator,
                 });
                 if (this.commandRegistry.getToggledHandler(commandId)) {
                     toggledCommands.push(commandId);
@@ -182,34 +182,34 @@ export class ElectronMainMenuFactory {
             label: 'Theia',
             submenu: [
                 {
-                    role: 'about'
+                    role: 'about',
                 },
                 {
-                    type: 'separator'
+                    type: 'separator',
                 },
                 {
                     role: 'services',
-                    submenu: []
+                    submenu: [],
                 },
                 {
-                    type: 'separator'
+                    type: 'separator',
                 },
                 {
-                    role: 'hide'
+                    role: 'hide',
                 },
                 {
-                    role: 'hideothers'
+                    role: 'hideothers',
                 },
                 {
-                    role: 'unhide'
+                    role: 'unhide',
                 },
                 {
-                    type: 'separator'
+                    type: 'separator',
                 },
                 {
-                    role: 'quit'
-                }
-            ]
+                    role: 'quit',
+                },
+            ],
         };
     }
 

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -18,7 +18,7 @@ import * as electron from 'electron';
 import { inject, injectable } from 'inversify';
 import {
     Command, CommandContribution, CommandRegistry,
-    MenuModelRegistry, MenuContribution
+    MenuModelRegistry, MenuContribution,
 } from '../../common';
 import { KeybindingContribution, KeybindingRegistry } from '../../browser';
 import { FrontendApplication, FrontendApplicationContribution, CommonMenus } from '../../browser';
@@ -27,23 +27,23 @@ import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 export namespace ElectronCommands {
     export const TOGGLE_DEVELOPER_TOOLS: Command = {
         id: 'theia.toggleDevTools',
-        label: 'Toggle Developer Tools'
+        label: 'Toggle Developer Tools',
     };
     export const RELOAD: Command = {
         id: 'view.reload',
-        label: 'Reload Window'
+        label: 'Reload Window',
     };
     export const ZOOM_IN: Command = {
         id: 'view.zoomIn',
-        label: 'Zoom In'
+        label: 'Zoom In',
     };
     export const ZOOM_OUT: Command = {
         id: 'view.zoomOut',
-        label: 'Zoom Out'
+        label: 'Zoom Out',
     };
     export const RESET_ZOOM: Command = {
         id: 'view.resetZoom',
-        label: 'Reset Zoom'
+        label: 'Reset Zoom',
     };
 }
 
@@ -60,7 +60,7 @@ export namespace ElectronMenus {
 export class ElectronMenuContribution implements FrontendApplicationContribution, CommandContribution, MenuContribution, KeybindingContribution {
 
     constructor(
-        @inject(ElectronMainMenuFactory) protected readonly factory: ElectronMainMenuFactory
+        @inject(ElectronMainMenuFactory) protected readonly factory: ElectronMainMenuFactory,
     ) { }
 
     onStart(app: FrontendApplication): void {
@@ -88,7 +88,7 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
                 } else {
                     webContent.closeDevTools();
                 }
-            }
+            },
         });
 
         registry.registerCommand(ElectronCommands.RELOAD, {
@@ -97,7 +97,7 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
                 if (focusedWindow) {
                     focusedWindow.reload();
                 }
-            }
+            },
         });
         registry.registerCommand(ElectronCommands.ZOOM_IN, {
             execute: () => {
@@ -105,10 +105,10 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
                 if (focusedWindow) {
                     const webContents = focusedWindow.webContents;
                     webContents.getZoomLevel(zoomLevel =>
-                        webContents.setZoomLevel(zoomLevel + 0.5)
+                        webContents.setZoomLevel(zoomLevel + 0.5),
                     );
                 }
-            }
+            },
         });
         registry.registerCommand(ElectronCommands.ZOOM_OUT, {
             execute: () => {
@@ -116,10 +116,10 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
                 if (focusedWindow) {
                     const webContents = focusedWindow.webContents;
                     webContents.getZoomLevel(zoomLevel =>
-                        webContents.setZoomLevel(zoomLevel - 0.5)
+                        webContents.setZoomLevel(zoomLevel - 0.5),
                     );
                 }
-            }
+            },
         });
         registry.registerCommand(ElectronCommands.RESET_ZOOM, {
             execute: () => {
@@ -127,7 +127,7 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
                 if (focusedWindow) {
                     focusedWindow.webContents.setZoomLevel(0);
                 }
-            }
+            },
         });
     }
 
@@ -135,48 +135,48 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
         registry.registerKeybindings(
             {
                 command: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
-                keybinding: "ctrlcmd+shift+i"
+                keybinding: "ctrlcmd+shift+i",
             },
             {
                 command: ElectronCommands.RELOAD.id,
-                keybinding: "ctrlcmd+r"
+                keybinding: "ctrlcmd+r",
             },
             {
                 command: ElectronCommands.ZOOM_IN.id,
-                keybinding: "ctrlcmd+="
+                keybinding: "ctrlcmd+=",
             },
             {
                 command: ElectronCommands.ZOOM_OUT.id,
-                keybinding: "ctrlcmd+-"
+                keybinding: "ctrlcmd+-",
             },
             {
                 command: ElectronCommands.RESET_ZOOM.id,
-                keybinding: "ctrlcmd+0"
-            }
+                keybinding: "ctrlcmd+0",
+            },
         );
     }
 
     registerMenus(registry: MenuModelRegistry) {
         registry.registerMenuAction(ElectronMenus.HELP_TOGGLE, {
-            commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id
+            commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
         });
 
         registry.registerMenuAction(ElectronMenus.VIEW_WINDOW, {
             commandId: ElectronCommands.RELOAD.id,
-            order: 'z0'
+            order: 'z0',
         });
 
         registry.registerMenuAction(ElectronMenus.VIEW_ZOOM, {
             commandId: ElectronCommands.ZOOM_IN.id,
-            order: 'z1'
+            order: 'z1',
         });
         registry.registerMenuAction(ElectronMenus.VIEW_ZOOM, {
             commandId: ElectronCommands.ZOOM_OUT.id,
-            order: 'z2'
+            order: 'z2',
         });
         registry.registerMenuAction(ElectronMenus.VIEW_ZOOM, {
             commandId: ElectronCommands.RESET_ZOOM.id,
-            order: 'z3'
+            order: 'z3',
         });
     }
 

--- a/packages/core/src/electron-browser/menu/electron-menu-module.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-module.ts
@@ -26,7 +26,7 @@ export default new ContainerModule(bind => {
     bind(ContextMenuRenderer).to(ElectronContextMenuRenderer).inSingletonScope();
     bind(KeybindingContext).toConstantValue({
         id: "theia.context",
-        isEnabled: true
+        isEnabled: true,
     });
 
     bind(ElectronMenuContribution).toSelf().inSingletonScope();

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -52,8 +52,8 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bind(ApplicationServer).toService(ApplicationServerImpl);
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(applicationPath, () =>
-            ctx.container.get(ApplicationServer)
-        )
+            ctx.container.get(ApplicationServer),
+        ),
     ).inSingletonScope();
 
     bind(EnvVariablesServer).to(EnvVariablesServerImpl).inSingletonScope();
@@ -61,6 +61,6 @@ export const backendApplicationModule = new ContainerModule(bind => {
         new JsonRpcConnectionHandler(envVariablesPath, () => {
             const envVariablesServer = ctx.container.get<EnvVariablesServer>(EnvVariablesServer);
             return envVariablesServer;
-        })
+        }),
     ).inSingletonScope();
 });

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -80,7 +80,7 @@ export class BackendApplication {
         @inject(ContributionProvider) @named(BackendApplicationContribution)
         protected readonly contributionsProvider: ContributionProvider<BackendApplicationContribution>,
         @inject(BackendApplicationCliContribution) protected readonly cliParams: BackendApplicationCliContribution,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) {
         process.on('uncaughtException', error => {
             if (error) {

--- a/packages/core/src/node/cli.spec.ts
+++ b/packages/core/src/node/cli.spec.ts
@@ -25,7 +25,7 @@ class TestCliManager extends CliManager {
 
     constructor(...contribs: CliContribution[]) {
         super({
-            getContributions() { return contribs; }
+            getContributions() { return contribs; },
         });
     }
 
@@ -52,7 +52,7 @@ describe('CliManager', () => {
             },
             setArguments(args: yargs.Arguments) {
                 value.resolve(args['foo']);
-            }
+            },
         });
         mnr.setArgs('-f', "bla");
         await mnr.initializeCli();
@@ -68,7 +68,7 @@ describe('CliManager', () => {
             },
             setArguments(args: yargs.Arguments) {
                 value.resolve(args['bar']);
-            }
+            },
         });
         mnr.setArgs('--foo');
         await mnr.initializeCli();
@@ -80,7 +80,7 @@ describe('CliManager', () => {
             const mnr = new TestCliManager();
             mnr.setArgs('--help');
             await mnr.initializeCli();
-        })
+        }),
     );
 });
 

--- a/packages/core/src/node/cluster.spec.ts
+++ b/packages/core/src/node/cluster.spec.ts
@@ -29,7 +29,7 @@ describe('master-process', () => {
             exec: path.resolve(__dirname, '../../lib/node/test/cluster-test-worker.js'),
             execArgv: [],
             args: [job],
-            stdio: ['ipc', 1, 2]
+            stdio: ['ipc', 1, 2],
         };
         cluster.setupMaster(testSettings);
     }

--- a/packages/core/src/node/cluster/master-process.ts
+++ b/packages/core/src/node/cluster/master-process.ts
@@ -32,7 +32,7 @@ export class MasterProcess extends EventEmitter {
         const success = worker.initialized.then(() => true);
 
         const failure = Promise.race(
-            [worker.failed, worker.disconnect, worker.exit, this.timeout(5000)]
+            [worker.failed, worker.disconnect, worker.exit, this.timeout(5000)],
         ).then(() => false);
         const started = await Promise.race([success, failure]);
 

--- a/packages/core/src/node/cluster/server-process.ts
+++ b/packages/core/src/node/cluster/server-process.ts
@@ -34,7 +34,7 @@ export const stubRemoteMasterProcessFactory: RemoteMasterProcessFactory = server
             if (!ready) {
                 throw new Error('onDidInitialize has not been called yet');
             }
-        }
+        },
     };
 };
 export const clusterRemoteMasterProcessFactory: RemoteMasterProcessFactory = serverProcess =>
@@ -48,7 +48,7 @@ export class ServerProcess implements BackendApplicationContribution {
     protected readonly sockets = new Set<net.Socket>();
 
     constructor(
-        @inject(RemoteMasterProcessFactory) protected readonly masterFactory: RemoteMasterProcessFactory
+        @inject(RemoteMasterProcessFactory) protected readonly masterFactory: RemoteMasterProcessFactory,
     ) {
         this.master = this.masterFactory({});
         this.master.onDidInitialize();

--- a/packages/core/src/node/cluster/server-worker.ts
+++ b/packages/core/src/node/cluster/server-worker.ts
@@ -36,7 +36,7 @@ export class ServerWorker {
 
         console.log('Starting server worker...');
         this.worker = cluster.fork(createIpcEnv({
-            env: process.env
+            env: process.env,
         }));
         this.server = createRemoteServer(this.worker, { onDidInitialize, restart });
 

--- a/packages/core/src/node/cluster/worker-reader.ts
+++ b/packages/core/src/node/cluster/worker-reader.ts
@@ -21,7 +21,7 @@ import { MessageReader, AbstractMessageReader } from 'vscode-jsonrpc/lib/message
 export class WorkerMessageReader extends AbstractMessageReader implements MessageReader {
 
     constructor(
-        protected readonly worker: Worker
+        protected readonly worker: Worker,
     ) {
         super();
     }
@@ -31,14 +31,14 @@ export class WorkerMessageReader extends AbstractMessageReader implements Messag
             if (code !== 0) {
                 const error: Error = {
                     name: '' + code,
-                    message: `Worker exited with '${code}' error code and '${signal}' signal`
+                    message: `Worker exited with '${code}' error code and '${signal}' signal`,
                 };
                 this.fireError(error);
             }
             this.fireClose();
         });
         this.worker.on('error', e =>
-            this.fireError(e)
+            this.fireError(e),
         );
         this.worker.on('message', callback);
     }

--- a/packages/core/src/node/cluster/worker-writer.ts
+++ b/packages/core/src/node/cluster/worker-writer.ts
@@ -23,7 +23,7 @@ export class WorkerMessageWriter extends AbstractMessageWriter implements Messag
     protected errorCount = 0;
 
     constructor(
-        protected readonly worker: Worker
+        protected readonly worker: Worker,
     ) {
         super();
     }

--- a/packages/core/src/node/console-logger-server.ts
+++ b/packages/core/src/node/console-logger-server.ts
@@ -29,7 +29,7 @@ const Consoles = new Map<LogLevel, Console>([
     [LogLevel.WARN, console.warn],
     [LogLevel.INFO, console.info],
     [LogLevel.DEBUG, console.debug],
-    [LogLevel.TRACE, console.trace]
+    [LogLevel.TRACE, console.trace],
 ]);
 
 @injectable()
@@ -56,7 +56,7 @@ export class ConsoleLoggerServer implements ILoggerServer {
         this.loggers.set(name, newLogLevel);
         const event = {
             loggerName: name,
-            newLogLevel
+            newLogLevel,
         };
         if (this.client !== undefined) {
             this.client.onLogLevelChanged(event);

--- a/packages/core/src/node/debug.ts
+++ b/packages/core/src/node/debug.ts
@@ -21,7 +21,7 @@ function isInDebugMode(): boolean {
     }
     if (process && process.execArgv) {
         return process.execArgv.some(arg =>
-            /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg)
+            /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg),
         );
     }
     return false;

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -38,7 +38,7 @@ export function bindLogger(bind: interfaces.Bind): void {
             child.bind(ILogger).to(Logger).inTransientScope();
             child.bind(LoggerName).toConstantValue(name);
             return child.get(ILogger);
-        }
+        },
     );
 }
 
@@ -50,7 +50,7 @@ export const loggerBackendModule = new ContainerModule(bind => {
         ({
             initialize() {
                 setRootLogger(ctx.container.get<ILogger>(ILogger));
-            }
+            },
         }));
 
     bindLogger(bind);
@@ -60,6 +60,6 @@ export const loggerBackendModule = new ContainerModule(bind => {
             const loggerServer = ctx.container.get<ILoggerServer>(ILoggerServer);
             loggerServer.setClient(client);
             return loggerServer;
-        })
+        }),
     ).inSingletonScope();
 });

--- a/packages/core/src/node/logger-cli-contribution.spec.ts
+++ b/packages/core/src/node/logger-cli-contribution.spec.ts
@@ -68,7 +68,7 @@ describe('log-level-cli-contribution', function() {
             levels: {
                 'hello': 'debug',
                 'world': 'fatal',
-            }
+            },
         }));
         fs.fsyncSync(file.fd);
         fs.closeSync(file.fd);
@@ -98,7 +98,7 @@ describe('log-level-cli-contribution', function() {
             levels: {
                 'hello': 'debug',
                 'world': 'fatal',
-            }
+            },
         }));
 
         const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
@@ -113,7 +113,7 @@ describe('log-level-cli-contribution', function() {
             levels: {
                 'hello': 'potato',
                 'world': 'fatal',
-            }
+            },
         }));
 
         const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
@@ -134,7 +134,7 @@ describe('log-level-cli-contribution', function() {
             levels: {
                 'hello': 'potato',
                 'world': 'fatal',
-            }
+            },
         });
         fs.writeFileSync(file.fd, '{' + text);
 
@@ -158,7 +158,7 @@ describe('log-level-cli-contribution', function() {
                 levels: {
                     'hello': 'debug',
                     'world': 'fatal',
-                }
+                },
             }));
             fs.fsyncSync(file.fd);
             fs.closeSync(file.fd);
@@ -184,7 +184,7 @@ describe('log-level-cli-contribution', function() {
                 levels: {
                     'bonjour': 'debug',
                     'world': 'trace',
-                }
+                },
             }));
             fs.fsyncSync(fd);
             fs.closeSync(fd);
@@ -208,7 +208,7 @@ describe('log-level-cli-contribution', function() {
             levels: {
                 'hello': 'debug',
                 'world': 'fatal',
-            }
+            },
         }));
         fs.fsyncSync(file.fd);
 
@@ -228,7 +228,7 @@ describe('log-level-cli-contribution', function() {
                 levels: {
                     'bonjour': 'debug',
                     'world': 'trace',
-                }
+                },
             });
             fs.writeFileSync(file.fd, text);
             fs.fsyncSync(file.fd);

--- a/packages/core/src/node/messaging/ipc-bootstrap.ts
+++ b/packages/core/src/node/messaging/ipc-bootstrap.ts
@@ -26,7 +26,7 @@ const writer = new IPCMessageWriter(process);
 const logger = new ConsoleLogger();
 const connection = createMessageConnection(reader, writer, logger);
 connection.trace(Trace.Off, {
-    log: (message, data) => console.log(`${message} ${data}`)
+    log: (message, data) => console.log(`${message} ${data}`),
 });
 
 const entryPoint = require(ipcEntryPoint!).default as IPCEntryPoint;

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -30,7 +30,7 @@ export interface ResolvedIPCConnectionOptions {
 }
 export type IPCConnectionOptions = Partial<ResolvedIPCConnectionOptions> & {
     readonly serverName: string
-    readonly entryPoint: string
+    readonly entryPoint: string,
 };
 
 @injectable()
@@ -43,7 +43,7 @@ export class IPCConnectionProvider {
         return this.doListen({
             logger: this.logger,
             args: [],
-            ...options
+            ...options,
         }, acceptor);
     }
 
@@ -80,10 +80,10 @@ export class IPCConnectionProvider {
             error: (message: string) => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${message}`),
             warn: (message: string) => this.logger.warn(`[${options.serverName}: ${childProcess.pid}] ${message}`),
             info: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`),
-            log: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`)
+            log: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`),
         });
         connection.trace(Trace.Off, {
-            log: (message, data) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message} ${data}`)
+            log: (message, data) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message} ${data}`),
         });
         return connection;
     }
@@ -92,7 +92,7 @@ export class IPCConnectionProvider {
         const forkOptions: cp.ForkOptions = {
             silent: true,
             env: createIpcEnv(options),
-            execArgv: []
+            execArgv: [],
         };
         const inspectArgPrefix = `--${options.serverName}-inspect`;
         const inspectArg = process.argv.find(v => v.startsWith(inspectArgPrefix));

--- a/packages/core/src/node/messaging/ipc-protocol.ts
+++ b/packages/core/src/node/messaging/ipc-protocol.ts
@@ -47,7 +47,7 @@ export const ipcEntryPoint = process.env[THEIA_ENTRY_POINT];
 
 export function createIpcEnv(options?: {
     entryPoint?: string
-    env?: NodeJS.ProcessEnv
+    env?: NodeJS.ProcessEnv,
 }): NodeJS.ProcessEnv {
     const op = Object.assign({}, options);
     const childEnv = Object.assign({}, op.env);

--- a/packages/core/src/node/messaging/messaging-contribution.ts
+++ b/packages/core/src/node/messaging/messaging-contribution.ts
@@ -51,7 +51,7 @@ export class MessagingContribution implements BackendApplicationContribution, Me
         }
         for (const handler of this.handlers.getContributions()) {
             this.listen(handler.path, (params, connection) =>
-                handler.onConnection(connection)
+                handler.onConnection(connection),
             );
         }
     }
@@ -78,7 +78,7 @@ export class MessagingContribution implements BackendApplicationContribution, Me
     onStart(server: http.Server | https.Server): void {
         const wss = new ws.Server({
             server,
-            perMessageDeflate: false
+            perMessageDeflate: false,
         });
         interface CheckAliveWS extends ws {
             alive: boolean;

--- a/packages/core/src/node/messaging/test/test-web-socket-channel.ts
+++ b/packages/core/src/node/messaging/test/test-web-socket-channel.ts
@@ -24,21 +24,21 @@ export class TestWebSocketChannel extends WebSocketChannel {
 
     constructor({ server, path }: {
         server: http.Server | https.Server,
-        path: string
+        path: string,
     }) {
         super(0, content => socket.send(content));
         const socket = new ws(`ws://localhost:${server.address().port}${WebSocketChannel.wsPath}`);
         socket.on('error', error =>
-            this.fireError(error)
+            this.fireError(error),
         );
         socket.on('close', (code, reason) =>
-            this.fireClose(code, reason)
+            this.fireClose(code, reason),
         );
         socket.on('message', data =>
-            this.handleMessage(JSON.parse(data.toString()))
+            this.handleMessage(JSON.parse(data.toString())),
         );
         socket.on('open', () =>
-            this.open(path)
+            this.open(path),
         );
         this.toDispose.push(Disposable.create(() => socket.close()));
     }

--- a/packages/core/src/node/test/cluster-test-worker.ts
+++ b/packages/core/src/node/test/cluster-test-worker.ts
@@ -38,7 +38,7 @@ const jobs: { [id: string]: (() => Promise<void>) | undefined } = {
     restarted: async () => {
         const server = new ServerProcess(clusterRemoteMasterProcessFactory);
         await server.kill();
-    }
+    },
 };
 
 const id = process.argv[process.argv.length - 1];
@@ -49,6 +49,6 @@ if (job) {
         reason => {
             console.error(`Test worker: '${id}' failed`, reason);
             process.exit(1);
-        }
+        },
     );
 }

--- a/packages/cpp/src/browser/cpp-build-configurations.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.ts
@@ -164,7 +164,7 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
  */
 export const CPP_CHANGE_BUILD_CONFIGURATION: Command = {
     id: 'cpp.change-build-configuration',
-    label: 'C/C++: Change Build Configuration'
+    label: 'C/C++: Change Build Configuration',
 };
 
 @injectable()
@@ -175,7 +175,7 @@ export class CppBuildConfigurationsContributions implements CommandContribution 
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CPP_CHANGE_BUILD_CONFIGURATION, {
-            execute: () => this.cppChangeBuildConfiguration.open()
+            execute: () => this.cppChangeBuildConfiguration.open(),
         });
     }
 }

--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -37,11 +37,11 @@ export const SWITCH_SOURCE_HEADER: Command = {
  * A command that is used to show the references from a CodeLens.
  */
 export const SHOW_CLANGD_REFERENCES: Command = {
-    id: 'clangd.references'
+    id: 'clangd.references',
 };
 
 export const FILE_OPEN_PATH = (path: string): Command => <Command>{
-    id: `file:openPath`
+    id: `file:openPath`,
 };
 
 export function editorContainsCppFiles(editorManager: EditorManager | undefined): boolean {
@@ -59,18 +59,17 @@ export class CppCommandContribution implements CommandContribution {
         @inject(CppLanguageClientContribution) protected readonly clientContribution: CppLanguageClientContribution,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(EditorManager) private editorService: EditorManager,
-        protected readonly selectionService: SelectionService
-
+        protected readonly selectionService: SelectionService,
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(SWITCH_SOURCE_HEADER, {
             isEnabled: () => editorContainsCppFiles(this.editorService),
-            execute: () => this.switchSourceHeader()
+            execute: () => this.switchSourceHeader(),
         });
         commands.registerCommand(SHOW_CLANGD_REFERENCES, {
             execute: (doc: TextDocumentIdentifier, pos: Position, locs: Location[]) =>
-                commands.executeCommand(EditorCommands.SHOW_REFERENCES.id, doc.uri, pos, locs)
+                commands.executeCommand(EditorCommands.SHOW_REFERENCES.id, doc.uri, pos, locs),
         });
     }
 

--- a/packages/cpp/src/browser/cpp-grammar-contribution.ts
+++ b/packages/cpp/src/browser/cpp-grammar-contribution.ts
@@ -29,7 +29,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         brackets: [
             ['{', '}'],
             ['[', ']'],
-            ['(', ')']
+            ['(', ')'],
         ],
         autoClosingPairs: [
             { open: '[', close: ']' },
@@ -48,16 +48,16 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         folding: {
             markers: {
                 start: new RegExp("^\\s*#pragma\\s+region\\b"),
-                end: new RegExp("^\\s*#pragma\\s+endregion\\b")
-            }
-        }
+                end: new RegExp("^\\s*#pragma\\s+endregion\\b"),
+            },
+        },
     };
 
     registerTextmateLanguage(registry: TextmateRegistry) {
         monaco.languages.register({
             id: C_LANGUAGE_ID,
             extensions: ['.c'],
-            aliases: ['C', 'c']
+            aliases: ['C', 'c'],
         });
 
         monaco.languages.setLanguageConfiguration(C_LANGUAGE_ID, this.config);
@@ -67,9 +67,9 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: platformGrammar
+                    content: platformGrammar,
                 };
-            }
+            },
         });
 
         const cGrammar = require('../../data/c.tmLanguage.json');
@@ -77,9 +77,9 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: cGrammar
+                    content: cGrammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(C_LANGUAGE_ID, 'source.c');
 
@@ -97,9 +97,9 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: cppGrammar
+                    content: cppGrammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(CPP_LANGUAGE_ID, 'source.cpp');
     }

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from "inversify";
 import { EditorManager } from "@theia/editor/lib/browser";
 import {
-    KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry
+    KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry,
 } from "@theia/core/lib/browser";
 import { editorContainsCppFiles } from "./cpp-commands";
 
@@ -36,7 +36,7 @@ export class CppKeybindingContext implements KeybindingContext {
 export class CppKeybindingContribution implements KeybindingContribution {
 
     constructor(
-        @inject(CppKeybindingContext) protected readonly cppKeybindingContext: CppKeybindingContext
+        @inject(CppKeybindingContext) protected readonly cppKeybindingContext: CppKeybindingContext,
     ) { }
 
     registerKeybindings(registry: KeybindingRegistry): void {
@@ -44,8 +44,8 @@ export class CppKeybindingContribution implements KeybindingContribution {
             {
                 command: 'switch_source_header',
                 context: this.cppKeybindingContext.id,
-                keybinding: "alt+o"
-            }
+                keybinding: "alt+o",
+            },
         ].forEach(binding => {
             registry.registerKeybinding(binding);
         });

--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from "inversify";
 import {
     BaseLanguageClientContribution, LanguageClientFactory,
     LanguageClientOptions,
-    ILanguageClient
+    ILanguageClient,
 } from '@theia/languages/lib/browser';
 import { Languages, Workspace, DidChangeConfigurationParams, DidChangeConfigurationNotification } from "@theia/languages/lib/common";
 import { ILogger } from '@theia/core/lib/common/logger';
@@ -40,7 +40,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
         @inject(Languages) protected readonly languages: Languages,
         @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
         @inject(MessageService) protected readonly messageService: MessageService,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) {
         super(workspace, languages, languageClientFactory);
     }

--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -28,16 +28,16 @@ export const cppPreferencesSchema: PreferenceSchema = {
                 type: "object",
                 properties: {
                     "name": {
-                        type: "string"
+                        type: "string",
                     },
                     "directory": {
-                        type: "string"
-                    }
+                        type: "string",
+                    },
                 },
                 required: ["name", "directory"],
-            }
-        }
-    }
+            },
+        },
+    },
 };
 
 export class CppConfiguration {

--- a/packages/editor/src/browser/decorations/editor-decoration-style.ts
+++ b/packages/editor/src/browser/decorations/editor-decoration-style.ts
@@ -60,7 +60,7 @@ export namespace EditorDecorationStyle {
     const editorDecorationsStyleSheet: CSSStyleSheet | undefined = createStyleSheet();
 
     export function createRule(selector: string, styleProvider: (style: CSSStyleDeclaration) => void,
-        styleSheet: CSSStyleSheet | undefined = editorDecorationsStyleSheet
+        styleSheet: CSSStyleSheet | undefined = editorDecorationsStyleSheet,
     ): void {
         if (!styleSheet) {
             return;

--- a/packages/editor/src/browser/decorations/editor-decoration.ts
+++ b/packages/editor/src/browser/decorations/editor-decoration.ts
@@ -95,7 +95,7 @@ export enum OverviewRulerLane {
     Left = 1,
     Center = 2,
     Right = 4,
-    Full = 7
+    Full = 7,
 }
 
 export enum TrackedRangeStickiness {

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -14,9 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import {inject, injectable} from "inversify";
-import {CommandContribution, CommandRegistry, Command} from "@theia/core/lib/common";
-import {CommonCommands, PreferenceService} from "@theia/core/lib/browser";
+import { inject, injectable } from "inversify";
+import { CommandContribution, CommandRegistry, Command } from "@theia/core/lib/common";
+import { CommonCommands, PreferenceService } from "@theia/core/lib/browser";
 
 export namespace EditorCommands {
 
@@ -24,21 +24,21 @@ export namespace EditorCommands {
      * Show editor references
      */
     export const SHOW_REFERENCES: Command = {
-        id: 'textEditor.commands.showReferences'
+        id: 'textEditor.commands.showReferences',
     };
     /**
      * Change indentation configuration (i.e., indent using tabs / spaces, and how many spaces per tab)
      */
     export const CONFIG_INDENTATION: Command = {
-        id: 'textEditor.commands.configIndentation'
+        id: 'textEditor.commands.configIndentation',
     };
     export const INDENT_USING_SPACES: Command = {
         id: 'textEditor.commands.indentUsingSpaces',
-        label: 'Indent Using Spaces'
+        label: 'Indent Using Spaces',
     };
     export const INDENT_USING_TABS: Command = {
         id: 'textEditor.commands.indentUsingTabs',
-        label: 'Indent Using Tabs'
+        label: 'Indent Using Tabs',
     };
 
     /**
@@ -46,21 +46,21 @@ export namespace EditorCommands {
      */
     export const GO_BACK: Command = {
         id: 'textEditor.commands.go.back',
-        label: 'Go Back'
+        label: 'Go Back',
     };
     /**
      * Command for going to the forthcoming editor navigation location.
      */
     export const GO_FORWARD: Command = {
         id: 'textEditor.commands.go.forward',
-        label: 'Go Forward'
+        label: 'Go Forward',
     };
     /**
      * Command that reveals the last text edit location, if any.
      */
     export const GO_LAST_EDIT: Command = {
         id: 'textEditor.commands.go.lastEdit',
-        label: 'Go to Last Edit Location'
+        label: 'Go to Last Edit Location',
     };
 }
 
@@ -84,7 +84,7 @@ export class EditorCommandContribution implements CommandContribution {
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),
-            execute: () => this.toggleAutoSave()
+            execute: () => this.toggleAutoSave(),
         });
     }
 

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -48,14 +48,14 @@ export class EditorContribution implements FrontendApplicationContribution {
             this.statusBar.setElement('editor-status-language', {
                 text: languageName,
                 alignment: StatusBarAlignment.RIGHT,
-                priority: 1
+                priority: 1,
             });
 
             this.setCursorPositionStatus(widget.editor.cursor, widget.editor);
             this.toDisposeOnCurrentEditorChanged.push(
                 widget.editor.onCursorPositionChanged(position =>
-                    this.setCursorPositionStatus(position, widget.editor)
-                )
+                    this.setCursorPositionStatus(position, widget.editor),
+                ),
             );
         } else {
             this.statusBar.removeElement('editor-status-language');
@@ -67,7 +67,7 @@ export class EditorContribution implements FrontendApplicationContribution {
         this.statusBar.setElement('editor-status-cursor-position', {
             text: `Ln ${position.line + 1}, Col ${editor.getVisibleColumn(position)}`,
             alignment: StatusBarAlignment.RIGHT,
-            priority: 100
+            priority: 100,
         });
     }
 }

--- a/packages/editor/src/browser/editor-keybinding.ts
+++ b/packages/editor/src/browser/editor-keybinding.ts
@@ -26,16 +26,16 @@ export class EditorKeybindingContribution implements KeybindingContribution {
         registry.registerKeybindings(
             {
                 command: EditorCommands.GO_BACK.id,
-                keybinding: isOSX ? 'ctrl+-' : isWindows ? 'alt+left' : /*isLinux*/ 'ctrl+alt+-'
+                keybinding: isOSX ? 'ctrl+-' : isWindows ? 'alt+left' : /*isLinux*/ 'ctrl+alt+-',
             },
             {
                 command: EditorCommands.GO_FORWARD.id,
-                keybinding: isOSX ? 'ctrl+shift+-' : isWindows ? 'alt+right' : /*isLinux*/ 'ctrl+shift+-'
+                keybinding: isOSX ? 'ctrl+shift+-' : isWindows ? 'alt+right' : /*isLinux*/ 'ctrl+shift+-',
             },
             {
                 command: EditorCommands.GO_LAST_EDIT.id,
-                keybinding: 'ctrl+alt+q'
-            }
+                keybinding: 'ctrl+alt+q',
+            },
         );
     }
 

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -45,25 +45,25 @@ export class EditorMenuContribution implements MenuContribution {
 
     registerMenus(registry: MenuModelRegistry) {
         registry.registerMenuAction(EditorContextMenu.UNDO_REDO, {
-            commandId: CommonCommands.UNDO.id
+            commandId: CommonCommands.UNDO.id,
         });
         registry.registerMenuAction(EditorContextMenu.UNDO_REDO, {
-            commandId: CommonCommands.REDO.id
+            commandId: CommonCommands.REDO.id,
         });
 
         // Editor navigation. Go > Back and Go > Forward.
         registry.registerSubmenu(EditorMainMenu.GO, 'Go');
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_BACK.id,
-            label: 'Back'
+            label: 'Back',
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_FORWARD.id,
-            label: 'Forward'
+            label: 'Forward',
         });
         registry.registerMenuAction(EditorMainMenu.NAVIGATION_GROUP, {
             commandId: EditorCommands.GO_LAST_EDIT.id,
-            label: 'Last Edit Location'
+            label: 'Last Edit Location',
         });
     }
 

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -55,19 +55,19 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
         this.toDispose.pushAll([
             // TODO listen on file resource changes, if a file gets deleted, remove the corresponding navigation locations (if any).
             // This would require introducing the FS dependency in the editor extension.
-            this.editorManager.onCurrentEditorChanged(this.onCurrentEditorChanged.bind(this))
+            this.editorManager.onCurrentEditorChanged(this.onCurrentEditorChanged.bind(this)),
         ]);
         this.commandRegistry.registerHandler(EditorCommands.GO_BACK.id, {
             execute: () => this.locationStack.back(),
-            isEnabled: () => this.locationStack.canGoBack()
+            isEnabled: () => this.locationStack.canGoBack(),
         });
         this.commandRegistry.registerHandler(EditorCommands.GO_FORWARD.id, {
             execute: () => this.locationStack.forward(),
-            isEnabled: () => this.locationStack.canGoForward()
+            isEnabled: () => this.locationStack.canGoForward(),
         });
         this.commandRegistry.registerHandler(EditorCommands.GO_LAST_EDIT.id, {
             execute: () => this.locationStack.reveal(this.locationStack.lastEditLocation()),
-            isEnabled: () => !!this.locationStack.lastEditLocation()
+            isEnabled: () => !!this.locationStack.lastEditLocation(),
         });
     }
 
@@ -92,7 +92,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
                 // Instead of registering an `onCursorPositionChanged` listener, we treat the zero length selection as a cursor position change.
                 // Otherwise we would have two events for a single cursor change interaction.
                 editor.onSelectionChanged(selection => this.onSelectionChanged(editor, selection)),
-                editor.onDocumentContentChanged(event => this.onDocumentContentChanged(editor, event))
+                editor.onDocumentContentChanged(event => this.onDocumentContentChanged(editor, event)),
             ]);
         }
     }
@@ -125,7 +125,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
 
     protected async storeState(): Promise<void> {
         this.storageService.setData(EditorNavigationContribution.ID, {
-            locations: this.locationStack.locations().map(NavigationLocation.toObject)
+            locations: this.locationStack.locations().map(NavigationLocation.toObject),
         });
     }
 

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -21,7 +21,7 @@ import {
     PreferenceService,
     PreferenceContribution,
     PreferenceSchema,
-    PreferenceChangeEvent
+    PreferenceChangeEvent,
 } from '@theia/core/lib/browser/preferences';
 
 export const editorPreferenceSchema: PreferenceSchema = {
@@ -31,305 +31,305 @@ export const editorPreferenceSchema: PreferenceSchema = {
             "type": "number",
             "minimum": 1,
             "default": 4,
-            "description": "Configure the tab size in the editor"
+            "description": "Configure the tab size in the editor",
         },
         "editor.lineNumbers": {
             "enum": [
                 "on",
-                "off"
+                "off",
             ],
-            "description": "Control the rendering of line numbers"
+            "description": "Control the rendering of line numbers",
         },
         "editor.renderWhitespace": {
             "enum": [
                 "none",
                 "boundary",
-                "all"
+                "all",
             ],
-            "description": "Control the rendering of whitespaces in the editor"
+            "description": "Control the rendering of whitespaces in the editor",
         },
         "editor.autoSave": {
             "enum": [
                 "on",
-                "off"
+                "off",
             ],
             "default": "on",
-            "description": "Configure whether the editor should be auto saved"
+            "description": "Configure whether the editor should be auto saved",
         },
         "editor.autoSaveDelay": {
             "type": "number",
             "default": 500,
-            "description": "Configure the auto save delay in milliseconds"
+            "description": "Configure the auto save delay in milliseconds",
         },
         "editor.rulers": {
             "type": "array",
             "default": [],
-            "description": "Render vertical lines at the specified columns."
+            "description": "Render vertical lines at the specified columns.",
         },
         "editor.wordSeparators": {
             "type": "string",
             "default": "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/",
-            "description": "A string containing the word separators used when doing word navigation."
+            "description": "A string containing the word separators used when doing word navigation.",
         },
         "editor.glyphMargin": {
             "type": "boolean",
             "default": true,
-            "description": "Enable the rendering of the glyph margin."
+            "description": "Enable the rendering of the glyph margin.",
         },
         "editor.roundedSelection": {
             "type": "boolean",
             "default": true,
-            "description": "Render the editor selection with rounded borders."
+            "description": "Render the editor selection with rounded borders.",
         },
         "editor.minimap.enabled": {
             "type": "boolean",
             "default": false,
-            "description": "Enable or disable the minimap"
+            "description": "Enable or disable the minimap",
         },
         "editor.minimap.showSlider": {
             "type": "string",
             "default": "mouseover",
-            "description": "Controls whether the minimap slider is automatically hidden. Possible values are 'always' and 'mouseover'"
+            "description": "Controls whether the minimap slider is automatically hidden. Possible values are 'always' and 'mouseover'",
         },
         "editor.minimap.renderCharacters": {
             "type": "boolean",
             "default": true,
-            "description": "Render the actual characters on a line (as opposed to color blocks)"
+            "description": "Render the actual characters on a line (as opposed to color blocks)",
         },
         "editor.minimap.maxColumn": {
             "type": "number",
             "default": 120,
-            "description": "Limit the width of the minimap to render at most a certain number of columns"
+            "description": "Limit the width of the minimap to render at most a certain number of columns",
         },
         "editor.overviewRulerLanes": {
             "type": "number",
             "default": 2,
-            "description": "The number of vertical lanes the overview ruler should render."
+            "description": "The number of vertical lanes the overview ruler should render.",
         },
         "editor.overviewRulerBorder": {
             "type": "boolean",
             "default": true,
-            "description": "Controls if a border should be drawn around the overview ruler."
+            "description": "Controls if a border should be drawn around the overview ruler.",
         },
         "editor.cursorBlinking": {
             "type": "string",
             "default": "blink",
-            "description": "Control the cursor animation style, possible values are 'blink', 'smooth', 'phase', 'expand' and 'solid'."
+            "description": "Control the cursor animation style, possible values are 'blink', 'smooth', 'phase', 'expand' and 'solid'.",
         },
         "editor.mouseWheelZoom": {
             "type": "boolean",
             "default": false,
-            "description": "Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl."
+            "description": "Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl.",
         },
         "editor.cursorStyle": {
             "type": "string",
             "default": "line",
-            "description": "Control the cursor style, either 'block' or 'line'."
+            "description": "Control the cursor style, either 'block' or 'line'.",
         },
         "editor.fontLigatures": {
             "type": "boolean",
             "default": false,
-            "description": "Enable font ligatures."
+            "description": "Enable font ligatures.",
         },
         "editor.hideCursorInOverviewRuler": {
             "type": "boolean",
             "default": false,
-            "description": "Should the cursor be hidden in the overview ruler."
+            "description": "Should the cursor be hidden in the overview ruler.",
         },
         "editor.scrollBeyondLastLine": {
             "type": "boolean",
             "default": true,
-            "description": "Enable that scrolling can go one screen size after the last line."
+            "description": "Enable that scrolling can go one screen size after the last line.",
         },
         "editor.wordWrap": {
             "enum": ['off', 'on', 'wordWrapColumn', 'bounded'],
             "default": "off",
-            "description": "Control the wrapping of the editor."
+            "description": "Control the wrapping of the editor.",
         },
         "editor.wordWrapColumn": {
             "type": "number",
             "default": 80,
-            "description": "Control the wrapping of the editor."
+            "description": "Control the wrapping of the editor.",
         },
         "editor.wrappingIndent": {
             "enum": ['none', 'same', 'indent'],
             "default": "same",
-            "description": "Control indentation of wrapped lines. Can be: 'none', 'same' or 'indent'."
+            "description": "Control indentation of wrapped lines. Can be: 'none', 'same' or 'indent'.",
         },
         "editor.links": {
             "type": "boolean",
             "default": true,
-            "description": "Enable detecting links and making them clickable."
+            "description": "Enable detecting links and making them clickable.",
         },
         "editor.mouseWheelScrollSensitivity": {
             "type": "number",
             "default": 1,
-            "description": "A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events."
+            "description": "A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.",
         },
         "editor.multiCursorModifier": {
             "enum": ['ctrlCmd', 'alt'],
             "default": "alt",
-            "description": "The modifier to be used to add multiple cursors with the mouse."
+            "description": "The modifier to be used to add multiple cursors with the mouse.",
         },
         "editor.accessibilitySupport": {
             "enum": ['auto', 'off', 'on'],
             "default": "auto",
-            "description": "Configure the editor's accessibility support."
+            "description": "Configure the editor's accessibility support.",
         },
         "editor.quickSuggestions": {
             "type": "boolean",
             "default": true,
-            "description": "Enable quick suggestions (shadow suggestions)"
+            "description": "Enable quick suggestions (shadow suggestions)",
         },
         "editor.quickSuggestionsDelay": {
             "type": "number",
             "default": 500,
-            "description": "Quick suggestions show delay (in ms)"
+            "description": "Quick suggestions show delay (in ms)",
         },
         "editor.parameterHints": {
             "type": "boolean",
             "default": true,
-            "description": "Enables parameter hints"
+            "description": "Enables parameter hints",
         },
         "editor.autoClosingBrackets": {
             "type": "boolean",
             "default": true,
-            "description": "Enable auto closing brackets."
+            "description": "Enable auto closing brackets.",
         },
         "editor.autoIndent": {
             "type": "boolean",
             "default": false,
-            "description": "Enable auto indentation adjustment."
+            "description": "Enable auto indentation adjustment.",
         },
         "editor.formatOnType": {
             "type": "boolean",
             "default": false,
-            "description": "Enable format on type."
+            "description": "Enable format on type.",
         },
         "editor.formatOnPaste": {
             "type": "boolean",
             "default": false,
-            "description": "Enable format on paste."
+            "description": "Enable format on paste.",
         },
         "editor.dragAndDrop": {
             "type": "boolean",
             "default": false,
-            "description": "Controls if the editor should allow to move selections via drag and drop."
+            "description": "Controls if the editor should allow to move selections via drag and drop.",
         },
         "editor.suggestOnTriggerCharacters": {
             "type": "boolean",
             "default": true,
-            "description": "Enable the suggestion box to pop-up on trigger characters."
+            "description": "Enable the suggestion box to pop-up on trigger characters.",
         },
         "editor.acceptSuggestionOnEnter": {
             "enum": ['on', 'smart', 'off'],
             "default": "on",
-            "description": "Accept suggestions on ENTER."
+            "description": "Accept suggestions on ENTER.",
         },
         "editor.acceptSuggestionOnCommitCharacter": {
             "type": "boolean",
             "default": true,
-            "description": "Accept suggestions on provider defined characters."
+            "description": "Accept suggestions on provider defined characters.",
         },
         "editor.snippetSuggestions": {
             "enum": ['top', 'bottom', 'inline', 'none'],
             "default": "inline",
-            "description": "Enable snippet suggestions."
+            "description": "Enable snippet suggestions.",
         },
         "editor.emptySelectionClipboard": {
             "type": "boolean",
-            "description": "Copying without a selection copies the current line."
+            "description": "Copying without a selection copies the current line.",
         },
         "editor.wordBasedSuggestions": {
             "type": "boolean",
             "default": true,
-            "description": "Enable word based suggestions. Defaults to 'true'"
+            "description": "Enable word based suggestions. Defaults to 'true'",
         },
         "editor.selectionHighlight": {
             "type": "boolean",
             "default": true,
-            "description": "Enable selection highlight."
+            "description": "Enable selection highlight.",
         },
         "editor.occurrencesHighlight": {
             "type": "boolean",
             "default": true,
-            "description": "Enable semantic occurrences highlight."
+            "description": "Enable semantic occurrences highlight.",
         },
         "editor.codeLens": {
             "type": "boolean",
             "default": true,
-            "description": "Show code lens"
+            "description": "Show code lens",
         },
         "editor.folding": {
             "type": "boolean",
             "default": true,
-            "description": "Enable code folding"
+            "description": "Enable code folding",
         },
         "editor.showFoldingControls": {
             "enum": ['always', 'mouseover'],
             "default": "mouseover",
-            "description": "Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter."
+            "description": "Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter.",
         },
         "editor.matchBrackets": {
             "type": "boolean",
             "default": true,
-            "description": "Enable highlighting of matching brackets."
+            "description": "Enable highlighting of matching brackets.",
         },
         "editor.renderControlCharacters": {
             "type": "boolean",
             "default": false,
-            "description": "Enable rendering of control characters."
+            "description": "Enable rendering of control characters.",
         },
         "editor.renderIndentGuides": {
             "type": "boolean",
             "default": false,
-            "description": "Enable rendering of indent guides."
+            "description": "Enable rendering of indent guides.",
         },
         "editor.renderLineHighlight": {
             "enum": ['none', 'gutter', 'line', 'all'],
             "default": "all",
-            "description": "Enable rendering of current line highlight."
+            "description": "Enable rendering of current line highlight.",
         },
         "editor.useTabStops": {
             "type": "boolean",
-            "description": "Inserting and deleting whitespace follows tab stops."
+            "description": "Inserting and deleting whitespace follows tab stops.",
         },
         "editor.insertSpaces": {
             "type": "boolean",
             "default": true,
-            "description": "Using whitespaces to replace tabs when tabbing."
+            "description": "Using whitespaces to replace tabs when tabbing.",
         },
         "diffEditor.renderSideBySide": {
             "type": "boolean",
             "description": "Render the differences in two side-by-side editors.",
-            "default": true
+            "default": true,
         },
         "diffEditor.ignoreTrimWhitespace": {
             "type": "boolean",
             "description": "Compute the diff by ignoring leading/trailing whitespace.",
-            "default": true
+            "default": true,
         },
         "diffEditor.renderIndicators": {
             "type": "boolean",
             "description": "Render +/- indicators for added/deleted changes.",
-            "default": true
+            "default": true,
         },
         "diffEditor.followsCaret": {
             "type": "boolean",
             "description": "Resets the navigator state when the user selects something in the editor.",
-            "default": true
+            "default": true,
         },
         "diffEditor.ignoreCharChanges": {
             "type": "boolean",
             "description": "Jump from line to line.",
-            "default": true
+            "default": true,
         },
         "diffEditor.alwaysRevealFirst": {
             "type": "boolean",
             "description": "Reveal first change.",
-            "default": true
-        }
-    }
+            "default": true,
+        },
+    },
 };
 
 export interface EditorConfiguration {

--- a/packages/editor/src/browser/editor-variable-contribution.ts
+++ b/packages/editor/src/browser/editor-variable-contribution.ts
@@ -32,7 +32,7 @@ export class EditorVariableContribution implements VariableContribution {
             resolve: () => {
                 const editor = this.getCurrentEditor();
                 return editor ? `${editor.cursor.line + 1}` : undefined;
-            }
+            },
         });
     }
 

--- a/packages/editor/src/browser/editor-widget.ts
+++ b/packages/editor/src/browser/editor-widget.ts
@@ -23,7 +23,7 @@ export class EditorWidget extends BaseWidget implements SaveableSource, Navigata
 
     constructor(
         readonly editor: TextEditor,
-        protected readonly selectionService: SelectionService
+        protected readonly selectionService: SelectionService,
     ) {
         super(editor);
         this.toDispose.push(this.editor);

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -22,7 +22,7 @@ import { Saveable, Navigatable } from '@theia/core/lib/browser';
 import { EditorDecoration } from './decorations';
 
 export {
-    Position, Range
+    Position, Range,
 };
 
 export const TextEditorProvider = Symbol('TextEditorProvider');

--- a/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
@@ -61,7 +61,7 @@ describe('navigation-location-service', () => {
     it('should allow navigating back when the stack has more than one locations', () => {
         stack.register(
             createCursorLocation(),
-            createCursorLocation({ line: 100, character: 100 })
+            createCursorLocation({ line: 100, character: 100 }),
         );
         expect(stack.canGoBack()).to.be.true;
     });
@@ -73,7 +73,7 @@ describe('navigation-location-service', () => {
     it('should not allow navigating forward when the pointer points to the end last element of the stack', () => {
         stack.register(
             createCursorLocation(),
-            createCursorLocation({ line: 100, character: 100 })
+            createCursorLocation({ line: 100, character: 100 }),
         );
         expect(stack.canGoForward()).to.be.false;
     });
@@ -88,7 +88,7 @@ describe('navigation-location-service', () => {
         it('should return with undefined if the stack contains no modifications', () => {
             stack.register(
                 createCursorLocation(),
-                createCursorLocation({ line: 100, character: 100 })
+                createCursorLocation({ line: 100, character: 100 }),
             );
             expect(stack.lastEditLocation()).to.be.undefined;
         });
@@ -97,12 +97,12 @@ describe('navigation-location-service', () => {
             const expected = NavigationLocation.create('file://path/to/file', {
                 text: '',
                 range: { start: { line: 200, character: 0 }, end: { line: 500, character: 0 } },
-                rangeLength: 0
+                rangeLength: 0,
             });
             stack.register(
                 createCursorLocation(),
                 expected,
-                createCursorLocation({ line: 100, character: 100 })
+                createCursorLocation({ line: 100, character: 100 }),
             );
             expect(stack.lastEditLocation()).to.be.deep.equal(expected);
         });
@@ -111,18 +111,18 @@ describe('navigation-location-service', () => {
             const modificationLocation = NavigationLocation.create('file://path/to/file', {
                 text: '',
                 range: { start: { line: 300, character: 0 }, end: { line: 500, character: 0 } },
-                rangeLength: 0
+                rangeLength: 0,
             });
             const expected = NavigationLocation.create('file://path/to/file', {
                 text: '',
                 range: { start: { line: 700, character: 0 }, end: { line: 800, character: 0 } },
-                rangeLength: 0
+                rangeLength: 0,
             });
             stack.register(
                 createCursorLocation(),
                 modificationLocation,
                 createCursorLocation({ line: 100, character: 100 }),
-                expected
+                expected,
             );
             await stack.back();
             await stack.back();

--- a/packages/editor/src/browser/navigation/navigation-location-service.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.ts
@@ -209,7 +209,7 @@ export class NavigationLocationService {
             start = { ...start, character: start.character + location.context.text.length };
         }
         return {
-            selection: Range.create(start, start)
+            selection: Range.create(start, start),
         } as EditorOpenerOptions;
     }
 

--- a/packages/editor/src/browser/navigation/navigation-location-similarity.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-similarity.spec.ts
@@ -27,21 +27,21 @@ describe('navigation-location-similarity', () => {
     it('should never be similar if they belong to different resources', () => {
         expect(similarity.similar(
             NavigationLocation.create('file:///a', { line: 0, character: 0, }),
-            NavigationLocation.create('file:///b', { line: 0, character: 0, })
+            NavigationLocation.create('file:///b', { line: 0, character: 0, }),
         )).to.be.false;
     });
 
     it('should be true if the locations are withing the threshold', () => {
         expect(similarity.similar(
             NavigationLocation.create('file:///a', { start: { line: 0, character: 10 }, end: { line: 0, character: 15 } }),
-            NavigationLocation.create('file:///a', { start: { line: 10, character: 3 }, end: { line: 0, character: 5 } })
+            NavigationLocation.create('file:///a', { start: { line: 10, character: 3 }, end: { line: 0, character: 5 } }),
         )).to.be.true;
     });
 
     it('should be false if the locations are outside of the threshold', () => {
         expect(similarity.similar(
             NavigationLocation.create('file:///a', { start: { line: 0, character: 10 }, end: { line: 0, character: 15 } }),
-            NavigationLocation.create('file:///a', { start: { line: 11, character: 3 }, end: { line: 0, character: 5 } })
+            NavigationLocation.create('file:///a', { start: { line: 11, character: 3 }, end: { line: 0, character: 5 } }),
         )).to.be.true;
     });
 

--- a/packages/editor/src/browser/navigation/navigation-location-updater.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-updater.spec.ts
@@ -47,7 +47,7 @@ describe('navigation-location-updater', () => {
         it('should never affect a location if they belong to different resources', () => {
             const actual = updater.affects(
                 NavigationLocation.create('file:///a', { line: 0, character: 0, }),
-                NavigationLocation.create('file:///b', { line: 0, character: 0, })
+                NavigationLocation.create('file:///b', { line: 0, character: 0, }),
             );
             expect(actual).to.be.false;
         });
@@ -57,70 +57,70 @@ describe('navigation-location-updater', () => {
             {
                 candidate: { start: { line: 3, character: 3 }, end: { line: 3, character: 12 } },
                 other: { range: { start: { line: 1, character: 6 }, end: { line: 3, character: 2 } }, rangeLength: 78, text: 'x' },
-                expected: { start: { line: 1, character: 8 }, end: { line: 1, character: 17 } }
+                expected: { start: { line: 1, character: 8 }, end: { line: 1, character: 17 } },
             },
             {
                 candidate: { start: { line: 3, character: 3 }, end: { line: 4, character: 18 } },
                 other: { range: { start: { line: 1, character: 6 }, end: { line: 3, character: 2 } }, rangeLength: 78, text: 'x' },
-                expected: { start: { line: 1, character: 8 }, end: { line: 2, character: 18 } }
+                expected: { start: { line: 1, character: 8 }, end: { line: 2, character: 18 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 3, character: 26 } },
                 other: { range: { start: { line: 1, character: 3 }, end: { line: 1, character: 12 } }, rangeLength: 9, text: 'x' },
-                expected: false
+                expected: false,
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 3, character: 26 } },
                 other: { range: { start: { line: 1, character: 3 }, end: { line: 1, character: 12 } }, rangeLength: 9, text: 'a\n\b\nc' },
-                expected: { start: { line: 5, character: 17 }, end: { line: 5, character: 26 } }
+                expected: { start: { line: 5, character: 17 }, end: { line: 5, character: 26 } },
             },
             // Spec (3.)
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 3, character: 26 } },
                 other: { range: { start: { line: 3, character: 18 }, end: { line: 3, character: 24 } }, rangeLength: 6, text: 'x' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 21 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 21 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 3, character: 26 } },
                 other: { range: { start: { line: 3, character: 18 }, end: { line: 3, character: 23 } }, rangeLength: 5, text: 'a\n\b\nc' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 4 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 4 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 3, character: 19 }, end: { line: 4, character: 19 } }, rangeLength: 41, text: 'xxx' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 29 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 29 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 3, character: 19 }, end: { line: 3, character: 21 } }, rangeLength: 2, text: 'a\nb' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 26 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 26 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 3, character: 18 }, end: { line: 4, character: 24 } }, rangeLength: 47, text: 'a\nb\nc' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 3 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 5, character: 3 } },
             },
             // Spec (4.)
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 6, character: 13 }, end: { line: 6, character: 23 } }, rangeLength: 10, text: '' },
-                expected: false
+                expected: false,
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 6, character: 13 }, end: { line: 6, character: 23 } }, rangeLength: 10, text: 'a\nb\nc' },
-                expected: false
+                expected: false,
             },
             // Spec (5.)
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } }, rangeLength: 50, text: '' },
-                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 17 } }
+                expected: { start: { line: 3, character: 17 }, end: { line: 3, character: 17 } },
             },
             {
                 candidate: { start: { line: 3, character: 17 }, end: { line: 4, character: 26 } },
                 other: { range: { start: { line: 3, character: 17 }, end: { line: 4, character: 27 } }, rangeLength: 51, text: '' },
-                expected: undefined
+                expected: undefined,
             },
         ] as TestInput[]).forEach(test => {
             const { other, expected, candidate } = test;

--- a/packages/editor/src/browser/navigation/navigation-location-updater.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-updater.ts
@@ -85,7 +85,7 @@ export class NavigationLocationUpdater {
             return {
                 uri,
                 type,
-                context
+                context,
             };
         }
 
@@ -106,7 +106,7 @@ export class NavigationLocationUpdater {
             return {
                 uri,
                 type,
-                context
+                context,
             };
         }
 
@@ -134,8 +134,8 @@ export class NavigationLocationUpdater {
             start,
             end: {
                 line: endLine,
-                character: endCharacter
-            }
+                character: endCharacter,
+            },
         };
         if (SelectionLocation.is(candidate)) {
             return range;
@@ -145,7 +145,7 @@ export class NavigationLocationUpdater {
             return {
                 range,
                 rangeLength,
-                text
+                text,
             };
         }
         throw new Error(`Unexpected navigation location: ${candidate}.`);
@@ -157,12 +157,12 @@ export class NavigationLocationUpdater {
         range = {
             start: {
                 line: range.start.line,
-                character: startCharacter
+                character: startCharacter,
             },
             end: {
                 line: range.end.line,
-                character: endCharacter
-            }
+                character: endCharacter,
+            },
         };
         if (CursorLocation.is(candidate)) {
             return range.start;
@@ -175,7 +175,7 @@ export class NavigationLocationUpdater {
             return {
                 range,
                 rangeLength,
-                text
+                text,
             };
         }
         throw new Error(`Unexpected navigation location: ${candidate}.`);
@@ -188,13 +188,13 @@ export class NavigationLocationUpdater {
             const { line, character } = input;
             return {
                 line: line + diff,
-                character
+                character,
             };
         }
         const { start, end } = input;
         return {
             start: this.shiftLine(start, diff),
-            end: this.shiftLine(end, diff)
+            end: this.shiftLine(end, diff),
         };
     }
 

--- a/packages/editor/src/browser/navigation/navigation-location.ts
+++ b/packages/editor/src/browser/navigation/navigation-location.ts
@@ -38,7 +38,7 @@ export namespace NavigationLocation {
         /**
          * Content change type.
          */
-        CONTENT_CHANGE
+        CONTENT_CHANGE,
 
     }
 
@@ -112,7 +112,7 @@ export namespace NavigationLocation {
         return {
             uri: uri.toString(),
             type,
-            context
+            context,
         };
     }
 
@@ -133,7 +133,7 @@ export namespace NavigationLocation {
                 return {
                     uri: toUri(uri),
                     context,
-                    type
+                    type,
                 };
             }
         }
@@ -179,7 +179,7 @@ export namespace NavigationLocation {
         return {
             uri: toUri(uri),
             type,
-            context
+            context,
         };
     }
 
@@ -228,7 +228,7 @@ export namespace CursorLocation {
         const { line, character } = context;
         return {
             line,
-            character
+            character,
         };
     }
 
@@ -240,7 +240,7 @@ export namespace CursorLocation {
             const { line, character } = object;
             return {
                 line,
-                character
+                character,
             };
         }
         return undefined;
@@ -281,7 +281,7 @@ export namespace SelectionLocation {
         const { start, end } = context;
         return {
             start: CursorLocation.toObject(start),
-            end: CursorLocation.toObject(end)
+            end: CursorLocation.toObject(end),
         };
     }
 
@@ -295,7 +295,7 @@ export namespace SelectionLocation {
             if (start && end) {
                 return {
                     start,
-                    end
+                    end,
                 };
             }
         }
@@ -336,7 +336,7 @@ export namespace ContentChangeLocation {
         return {
             range: SelectionLocation.toObject(context.range),
             rangeLength: context.rangeLength,
-            text: context.text
+            text: context.text,
         };
     }
 
@@ -352,7 +352,7 @@ export namespace ContentChangeLocation {
                 return {
                     range,
                     rangeLength: rangeLength!,
-                    text: text!
+                    text: text!,
                 };
             }
         } else {

--- a/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
@@ -53,7 +53,7 @@ describe('Editorconfig document manager', function () {
             tab_width: 4,
             end_of_line: 'crlf',
             trim_trailing_whitespace: true,
-            insert_final_newline: true
+            insert_final_newline: true,
         } as KnownProps;
 
         documentManager.applyProperties(properties, {} as MonacoEditor);
@@ -73,7 +73,7 @@ describe('Editorconfig document manager', function () {
 
         const properties = {
             indent_size: 'tab',
-            tab_width: 4
+            tab_width: 4,
         } as KnownProps;
 
         documentManager.applyProperties(properties, {} as MonacoEditor);
@@ -89,7 +89,7 @@ describe('Editorconfig document manager', function () {
         const stubTabWidth = sinon.stub(documentManager, 'ensureTabWidth');
 
         const properties = {
-            indent_size: 'tab'
+            indent_size: 'tab',
         } as KnownProps;
 
         documentManager.applyProperties(properties, {} as MonacoEditor);

--- a/packages/editorconfig/src/browser/editorconfig-document-manager.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.ts
@@ -25,7 +25,7 @@ export class EditorconfigDocumentManager {
 
     public static readonly LINE_ENDING = {
         LF: '\n',
-        CRLF: '\r\n'
+        CRLF: '\r\n',
     };
 
     @inject(EditorManager)
@@ -147,11 +147,11 @@ export class EditorconfigDocumentManager {
     ensureIndentStyle(editor: MonacoEditor, properties: KnownProps): void {
         if ('space' === properties.indent_style) {
             editor.document.textEditorModel.updateOptions({
-                insertSpaces: true
+                insertSpaces: true,
             });
         } else if ('tab' === properties.indent_style) {
             editor.document.textEditorModel.updateOptions({
-                insertSpaces: false
+                insertSpaces: false,
             });
         }
     }
@@ -169,7 +169,7 @@ export class EditorconfigDocumentManager {
         } else if (typeof properties.indent_size === 'number') {
             const indentSize: number = properties.indent_size as number;
             editor.document.textEditorModel.updateOptions({
-                tabSize: indentSize
+                tabSize: indentSize,
             });
         }
     }
@@ -183,7 +183,7 @@ export class EditorconfigDocumentManager {
         if (typeof properties.tab_width === 'number') {
             const tabWidth = properties.tab_width as number;
             editor.document.textEditorModel.updateOptions({
-                tabSize: tabWidth
+                tabSize: tabWidth,
             });
         }
     }
@@ -229,7 +229,7 @@ export class EditorconfigDocumentManager {
                     edits.push({
                         forceMoveMarkers: false,
                         range: new monaco.Range(i, trimmedLine.length + 1, i, line.length + 1),
-                        text: ""
+                        text: "",
                     });
                 }
             }
@@ -278,7 +278,7 @@ export class EditorconfigDocumentManager {
                 return {
                     forceMoveMarkers: false,
                     range: new monaco.Range(lines, lineContent.length + 1, lines, lineContent.length + 1),
-                    text: lineEnding
+                    text: lineEnding,
                 };
             }
         }

--- a/packages/editorconfig/src/browser/editorconfig-frontend-module.ts
+++ b/packages/editorconfig/src/browser/editorconfig-frontend-module.ts
@@ -30,6 +30,6 @@ export default new ContainerModule((bind, unbind) => {
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
         onStart(app: FrontendApplication): MaybePromise<void> {
             ctx.container.get<EditorconfigDocumentManager>(EditorconfigDocumentManager);
-        }
+        },
     }));
 });

--- a/packages/editorconfig/src/node/editorconfig-backend-module.ts
+++ b/packages/editorconfig/src/node/editorconfig-backend-module.ts
@@ -23,7 +23,7 @@ export default new ContainerModule(bind => {
     bind(EditorconfigService).to(EditorconfigServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(editorconfigServicePath, () =>
-            ctx.container.get(EditorconfigService)
-        )
+            ctx.container.get(EditorconfigService),
+        ),
     ).inSingletonScope();
 });

--- a/packages/extension-manager/src/browser/extension-contribution.ts
+++ b/packages/extension-manager/src/browser/extension-contribution.ts
@@ -35,10 +35,10 @@ export class ExtensionContribution extends AbstractViewContribution<ExtensionWid
             widgetName: 'Extensions',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 300
+                rank: 300,
             },
             toggleCommandId: 'extensionsView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+x'
+            toggleKeybinding: 'ctrlcmd+shift+x',
         });
     }
 

--- a/packages/extension-manager/src/browser/extension-detail-widget.tsx
+++ b/packages/extension-manager/src/browser/extension-detail-widget.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 export class ExtensionDetailWidget extends ReactWidget {
 
     constructor(
-        protected readonly resolvedExtension: ResolvedExtension
+        protected readonly resolvedExtension: ResolvedExtension,
     ) {
         super();
         this.addClass('theia-extension-detail');

--- a/packages/extension-manager/src/browser/extension-frontend-module.ts
+++ b/packages/extension-manager/src/browser/extension-frontend-module.ts
@@ -17,7 +17,7 @@
 import { ContainerModule } from 'inversify';
 import {
     WebSocketConnectionProvider, WidgetFactory,
-    OpenHandler, bindViewContribution
+    OpenHandler, bindViewContribution,
 } from '@theia/core/lib/browser';
 import { ExtensionServer, extensionPath } from '../common/extension-protocol';
 import { ExtensionManager } from '../common';
@@ -40,7 +40,7 @@ export default new ContainerModule(bind => {
     bind(ExtensionWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: EXTENSIONS_WIDGET_FACTORY_ID,
-        createWidget: () => ctx.container.get(ExtensionWidget)
+        createWidget: () => ctx.container.get(ExtensionWidget),
     }));
 
     bind(ExtensionWidgetFactory).toSelf().inSingletonScope();

--- a/packages/extension-manager/src/browser/extension-open-handler.ts
+++ b/packages/extension-manager/src/browser/extension-open-handler.ts
@@ -37,7 +37,7 @@ export class ExtensionOpenHandler extends WidgetOpenHandler<ExtensionDetailWidge
 
     protected createWidgetOptions(uri: URI): ExtensionWidgetOptions {
         return {
-            name: ExtensionUri.toExtensionName(uri)
+            name: ExtensionUri.toExtensionName(uri),
         };
     }
 

--- a/packages/extension-manager/src/browser/extension-widget-factory.ts
+++ b/packages/extension-manager/src/browser/extension-widget-factory.ts
@@ -31,7 +31,7 @@ export class ExtensionWidgetFactory implements WidgetFactory {
 
     constructor(
         @inject(FrontendApplication) protected readonly app: FrontendApplication,
-        @inject(ExtensionManager) protected readonly extensionManager: ExtensionManager
+        @inject(ExtensionManager) protected readonly extensionManager: ExtensionManager,
     ) { }
 
     async createWidget(options: ExtensionWidgetOptions): Promise<ExtensionDetailWidget> {

--- a/packages/extension-manager/src/browser/extension-widget.tsx
+++ b/packages/extension-manager/src/browser/extension-widget.tsx
@@ -35,7 +35,7 @@ export class ExtensionWidget extends ReactWidget {
 
     constructor(
         @inject(ExtensionManager) protected readonly extensionManager: ExtensionManager,
-        @inject(OpenerService) protected readonly openerService: OpenerService
+        @inject(OpenerService) protected readonly openerService: OpenerService,
     ) {
         super();
         this.id = 'extensions';

--- a/packages/extension-manager/src/common/extension-manager.ts
+++ b/packages/extension-manager/src/common/extension-manager.ts
@@ -48,7 +48,7 @@ export class Extension extends protocol.Extension implements Disposable {
             }
         }));
         this.toDispose.push(Disposable.create(() =>
-            manager.onDidChange.maxListeners = manager.onDidChange.maxListeners - 1)
+            manager.onDidChange.maxListeners = manager.onDidChange.maxListeners - 1),
         );
     }
 
@@ -67,7 +67,7 @@ export class Extension extends protocol.Extension implements Disposable {
      */
     resolve(): Promise<ResolvedExtension> {
         return this.server.resolve(this.name).then(resolved =>
-            Object.assign(this, resolved)
+            Object.assign(this, resolved),
         );
     }
 
@@ -116,7 +116,7 @@ export class ExtensionManager implements Disposable {
     protected readonly toDispose = new DisposableCollection();
 
     constructor(
-        @inject(protocol.ExtensionServer) protected readonly server: protocol.ExtensionServer
+        @inject(protocol.ExtensionServer) protected readonly server: protocol.ExtensionServer,
     ) {
         this.toDispose.push(server);
         this.toDispose.push(this.onChangedEmitter);
@@ -150,8 +150,8 @@ export class ExtensionManager implements Disposable {
     list(param?: protocol.SearchParam): Promise<Extension[]> {
         return this.server.list(param).then(extensions =>
             extensions.map(extension =>
-                new Extension(extension, this.server, this)
-            )
+                new Extension(extension, this.server, this),
+            ),
         );
     }
 

--- a/packages/extension-manager/src/node/application-project-cli.ts
+++ b/packages/extension-manager/src/node/application-project-cli.ts
@@ -38,21 +38,21 @@ export class ApplicationProjectCliContribution implements CliContribution {
     configure(conf: yargs.Argv): void {
         conf.option(appProjectPath, {
             description: "Sets the application project directory",
-            default: process.cwd()
+            default: process.cwd(),
         });
         conf.option(appNpmClient, {
             description: "Sets the application npm client",
             choices: ["npm", "yarn"],
-            default: "yarn"
+            default: "yarn",
         });
         conf.option(appAutoInstall, {
             description: "Sets whether the application should be build on package.json changes",
             type: "boolean",
-            default: true
+            default: true,
         });
         conf.option(appWatchRegistry, {
             type: "boolean",
-            default: true
+            default: true,
         });
     }
 
@@ -61,7 +61,7 @@ export class ApplicationProjectCliContribution implements CliContribution {
             projectPath: args[appProjectPath],
             npmClient: args[appNpmClient],
             autoInstall: args[appAutoInstall],
-            watchRegistry: args[appWatchRegistry]
+            watchRegistry: args[appWatchRegistry],
         };
     }
 

--- a/packages/extension-manager/src/node/application-project.spec.ts
+++ b/packages/extension-manager/src/node/application-project.spec.ts
@@ -31,7 +31,7 @@ let appProject: ApplicationProject;
 
 export async function assertInstallation(expectation: {
     installed?: string[],
-    uninstalled?: string[]
+    uninstalled?: string[],
 }): Promise<void> {
     const waitForWillInstall = new Promise<InstallationParam>(resolve => appProject.onWillInstall(resolve));
     const waitForDidInstall = new Promise<InstallationResult>(resolve => appProject.onDidInstall(resolve));
@@ -65,7 +65,7 @@ describe("application-project", function () {
             projectPath: appProjectPath,
             npmClient: 'yarn',
             autoInstall: false,
-            watchRegistry: false
+            watchRegistry: false,
         }).get(ApplicationProject);
     });
 
@@ -82,24 +82,24 @@ describe("application-project", function () {
             "private": true,
             "dependencies": {
                 "@theia/core": "0.1.1",
-                "@theia/filesystem": "0.1.1"
-            }
+                "@theia/filesystem": "0.1.1",
+            },
         });
         appProject.scheduleInstall();
         await assertInstallation({
-            installed: ['@theia/core', '@theia/filesystem']
+            installed: ['@theia/core', '@theia/filesystem'],
         });
 
         await fs.writeJSON(path.resolve(appProjectPath, 'package.json'), {
             "private": true,
             "dependencies": {
-                "@theia/core": "0.1.1"
-            }
+                "@theia/core": "0.1.1",
+            },
         });
         appProject.scheduleInstall();
         await assertInstallation({
             installed: ['@theia/core'],
-            uninstalled: ['@theia/filesystem']
+            uninstalled: ['@theia/filesystem'],
         });
     });
 

--- a/packages/extension-manager/src/node/application-project.ts
+++ b/packages/extension-manager/src/node/application-project.ts
@@ -22,7 +22,7 @@ import { ApplicationPackageOptions, NpmRegistry } from '@theia/application-packa
 import { ApplicationPackageManager } from '@theia/application-manager';
 import {
     Disposable, DisposableCollection, Event, Emitter, ILogger,
-    CancellationTokenSource, CancellationToken, isCancelled, checkCancelled
+    CancellationTokenSource, CancellationToken, isCancelled, checkCancelled,
 } from "@theia/core";
 import { FileUri, ServerProcess } from "@theia/core/lib/node";
 import { FileSystemWatcherServer, DidFilesChangedParams } from "@theia/filesystem/lib/common/filesystem-watcher-protocol";
@@ -50,22 +50,22 @@ export class ApplicationProject implements Disposable {
         @inject(FileSystemWatcherServer) protected readonly fileSystemWatcher: FileSystemWatcherServer,
         @inject(ILogger) protected readonly logger: ILogger,
         @inject(NpmClient) protected readonly npmClient: NpmClient,
-        @inject(ServerProcess) protected readonly serverProcess: ServerProcess
+        @inject(ServerProcess) protected readonly serverProcess: ServerProcess,
     ) {
         logger.debug('AppProjectOptions', options);
         this.registry = new NpmRegistry({
-            watchChanges: this.options.watchRegistry
+            watchChanges: this.options.watchRegistry,
         });
         this.backup();
         this.packageUri = FileUri.create(this.packagePath).toString();
         this.toDispose.push(this.fileSystemWatcher);
         this.fileSystemWatcher.setClient({
-            onDidFilesChanged: changes => this.onDidFilesChanged(changes)
+            onDidFilesChanged: changes => this.onDidFilesChanged(changes),
         });
         this.fileSystemWatcher.watchFileChanges(this.packageUri).then(watcher =>
             this.toDispose.push(Disposable.create(() =>
-                this.fileSystemWatcher.unwatchFileChanges(watcher)
-            ))
+                this.fileSystemWatcher.unwatchFileChanges(watcher),
+            )),
         );
         this.toDispose.push(this.onWillInstallEmitter);
         this.toDispose.push(this.onDidInstallEmitter);
@@ -95,7 +95,7 @@ export class ApplicationProject implements Disposable {
         return new ApplicationPackageManager(Object.assign({
             log: this.logger.info.bind(this.logger),
             error: this.logger.error.bind(this.logger),
-            registry: this.registry
+            registry: this.registry,
         }, this.options));
     }
 
@@ -144,7 +144,7 @@ export class ApplicationProject implements Disposable {
             this.logger.info('The app installation is finished');
             this.fireDidInstall({
                 reverting,
-                failed: false
+                failed: false,
             });
 
             this.serverProcess.kill();
@@ -156,7 +156,7 @@ export class ApplicationProject implements Disposable {
             this.logger.error('The app installation is failed' + os.EOL, error);
             this.fireDidInstall({
                 reverting,
-                failed: true
+                failed: true,
             });
             await this.revert(token);
         }

--- a/packages/extension-manager/src/node/extension-backend-module.ts
+++ b/packages/extension-manager/src/node/extension-backend-module.ts
@@ -33,10 +33,10 @@ export function bindNodeExtensionServer(bind: interfaces.Bind, args?: Applicatio
         bind(ApplicationProjectCliContribution).toSelf().inSingletonScope();
         bind(CliContribution).toDynamicValue(ctx => ctx.container.get(ApplicationProjectCliContribution)).inSingletonScope();
         bind(NpmClientOptions).toDynamicValue(ctx =>
-            ctx.container.get(ApplicationProjectCliContribution).args
+            ctx.container.get(ApplicationProjectCliContribution).args,
         ).inSingletonScope();
         bind(ApplicationProjectOptions).toDynamicValue(ctx =>
-            ctx.container.get(ApplicationProjectCliContribution).args
+            ctx.container.get(ApplicationProjectCliContribution).args,
         ).inSingletonScope();
     }
     bind(NpmClient).toSelf().inSingletonScope();
@@ -45,7 +45,7 @@ export function bindNodeExtensionServer(bind: interfaces.Bind, args?: Applicatio
     bind(ExtensionKeywords).toConstantValue([extensionKeyword]);
     bind(NodeExtensionServer).toSelf().inSingletonScope();
     bind(ExtensionServer).toDynamicValue(ctx =>
-        ctx.container.get(NodeExtensionServer)
+        ctx.container.get(NodeExtensionServer),
     ).inSingletonScope();
 }
 
@@ -56,7 +56,7 @@ export default new ContainerModule(bind => {
     const dispatchingClient: ExtensionClient = {
         onDidChange: change => clients.forEach(client => client.onDidChange(change)),
         onDidStopInstallation: result => clients.forEach(client => client.onDidStopInstallation(result)),
-        onWillStartInstallation: param => clients.forEach(client => client.onWillStartInstallation(param))
+        onWillStartInstallation: param => clients.forEach(client => client.onWillStartInstallation(param)),
     };
     bind(ConnectionHandler).toDynamicValue(ctx => {
         const server = ctx.container.get<ExtensionServer>(ExtensionServer);

--- a/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
+++ b/packages/extension-manager/src/node/node-extension-server.slow-spec.ts
@@ -34,7 +34,7 @@ let server: ExtensionServer;
 export function waitForDidChange(): Promise<void> {
     return new Promise(resolve => {
         server.setClient(<ExtensionClient>{
-            onDidChange: change => resolve()
+            onDidChange: change => resolve(),
         });
     });
 }
@@ -50,15 +50,15 @@ describe("node-extension-server", function () {
         fs.writeJsonSync(path.resolve(appProjectPath, 'package.json'), {
             "dependencies": {
                 "@theia/core": "0.1.0",
-                "@theia/extension-manager": "0.1.0"
-            }
+                "@theia/extension-manager": "0.1.0",
+            },
         });
 
         const container = extensionNodeTestContainer({
             projectPath: appProjectPath,
             npmClient: 'yarn',
             autoInstall: false,
-            watchRegistry: false
+            watchRegistry: false,
         });
         server = container.get(ExtensionServer);
         appProject = container.get(ApplicationProject);
@@ -75,7 +75,7 @@ describe("node-extension-server", function () {
         this.timeout(30000);
 
         return server.search({
-            query: "filesystem scope:theia"
+            query: "filesystem scope:theia",
         }).then(extensions => {
             assert.equal(extensions.length, 1, JSON.stringify(extensions, undefined, 2));
             assert.equal(extensions[0].name, '@theia/filesystem');
@@ -158,21 +158,21 @@ describe("node-extension-server", function () {
                 name: '@theia/core',
                 installed: true,
                 outdated: true,
-                dependent: undefined
+                dependent: undefined,
             }, extensions);
 
             assertExtension({
                 name: '@theia/filesystem',
                 installed: true,
                 outdated: false,
-                dependent: '@theia/extension-manager'
+                dependent: '@theia/extension-manager',
             }, extensions);
 
             assertExtension({
                 name: '@theia/extension-manager',
                 installed: true,
                 outdated: true,
-                dependent: undefined
+                dependent: undefined,
             }, extensions);
         });
     });
@@ -181,7 +181,7 @@ describe("node-extension-server", function () {
         this.timeout(50000);
 
         return server.list({
-            query: "scope:theia file"
+            query: "scope:theia file",
         }).then(extensions => {
             const filtered = extensions.filter(e => ['@theia/filesystem', '@theia/file-search'].indexOf(e.name) !== -1);
 
@@ -189,14 +189,14 @@ describe("node-extension-server", function () {
                 name: '@theia/filesystem',
                 installed: true,
                 outdated: false,
-                dependent: "@theia/extension-manager"
+                dependent: "@theia/extension-manager",
             }, filtered);
 
             assertExtension({
                 name: '@theia/file-search',
                 installed: false,
                 outdated: false,
-                dependent: undefined
+                dependent: undefined,
             }, filtered);
         });
     });
@@ -207,7 +207,7 @@ function assertExtension(expectation: {
     name: string
     installed: boolean
     outdated: boolean
-    dependent?: string
+    dependent?: string,
 }, extensions: Extension[]): void {
     const extension = extensions.find(e => e.name === expectation.name)!;
     assert.ok(extension, JSON.stringify(extensions, undefined, 2));
@@ -215,6 +215,6 @@ function assertExtension(expectation: {
         name: extension!.name,
         installed: extension.installed,
         outdated: extension.outdated,
-        dependent: extension.dependent
+        dependent: extension.dependent,
     }), JSON.stringify(extensions, undefined, 2));
 }

--- a/packages/extension-manager/src/node/node-extension-server.ts
+++ b/packages/extension-manager/src/node/node-extension-server.ts
@@ -20,7 +20,7 @@ import { injectable, inject } from 'inversify';
 import { DisposableCollection } from '@theia/core';
 import { PublishedNodePackage, ExtensionPackage } from '@theia/application-package';
 import {
-    RawExtension, ResolvedRawExtension, ResolvedExtension, Extension, ExtensionServer, ExtensionClient, SearchParam, ExtensionChange
+    RawExtension, ResolvedRawExtension, ResolvedExtension, Extension, ExtensionServer, ExtensionClient, SearchParam, ExtensionChange,
 } from '../common/extension-protocol';
 import * as npms from './npms';
 import { ApplicationProject } from './application-project';
@@ -38,7 +38,7 @@ export class NodeExtensionServer implements ExtensionServer {
 
     constructor(
         @inject(ApplicationProject) protected readonly project: ApplicationProject,
-        @inject(ExtensionKeywords) protected readonly extensionKeywords: ExtensionKeywords
+        @inject(ExtensionKeywords) protected readonly extensionKeywords: ExtensionKeywords,
     ) {
         this.toDispose.push(project.onWillInstall(param => this.notification('onWillStartInstallation')(param)));
         this.toDispose.push(project.onDidInstall(result => this.notification('onDidStopInstallation')(result)));
@@ -106,7 +106,7 @@ export class NodeExtensionServer implements ExtensionServer {
             if (manager.pck.setDependency(extension, `^${latestVersion}`)) {
                 this.notifyDidChange({
                     name: extension,
-                    installed: true
+                    installed: true,
                 });
                 await manager.pck.save();
             }
@@ -123,7 +123,7 @@ export class NodeExtensionServer implements ExtensionServer {
                 this.notifyDidChange({
                     name: extension,
                     installed: false,
-                    outdated: false
+                    outdated: false,
                 });
                 await manager.pck.save();
             }
@@ -165,7 +165,7 @@ export class NodeExtensionServer implements ExtensionServer {
             if (manager.pck.setDependency(extension, `^${latestVersion}`)) {
                 this.notifyDidChange({
                     name: extension,
-                    outdated: false
+                    outdated: false,
                 });
                 await manager.pck.save();
             }
@@ -186,7 +186,7 @@ export class NodeExtensionServer implements ExtensionServer {
                 return Object.assign(raw, {
                     busy: this.isBusy(raw.name),
                     installed: false,
-                    outdated: false
+                    outdated: false,
                 });
             }));
         }
@@ -211,7 +211,7 @@ export class NodeExtensionServer implements ExtensionServer {
         const rawExtension = this.toRawExtension(extensionPackage);
         const documentation = await this.compileDocumentation(extensionPackage);
         return Object.assign(rawExtension, {
-            documentation
+            documentation,
         });
     }
 
@@ -219,12 +219,12 @@ export class NodeExtensionServer implements ExtensionServer {
         const markdownConverter = new showdown.Converter({
             noHeaderId: true,
             strikethrough: true,
-            headerLevelStart: 2
+            headerLevelStart: 2,
         });
         const readme = await extensionPackage.getReadme();
         const readmeHtml = markdownConverter.makeHtml(readme);
         return sanitize(readmeHtml, {
-            allowedTags: sanitize.defaults.allowedTags.concat(['h1', 'h2', 'img'])
+            allowedTags: sanitize.defaults.allowedTags.concat(['h1', 'h2', 'img']),
         });
     }
 
@@ -238,7 +238,7 @@ export class NodeExtensionServer implements ExtensionServer {
             installed: extensionPackage.installed,
             outdated: await extensionPackage.isOutdated(),
             busy: this.isBusy(extensionPackage.name),
-            dependent: extensionPackage.dependent
+            dependent: extensionPackage.dependent,
         });
     }
 
@@ -247,7 +247,7 @@ export class NodeExtensionServer implements ExtensionServer {
             name: extensionPackage.name,
             version: extensionPackage.version,
             description: extensionPackage.description,
-            author: extensionPackage.getAuthor()
+            author: extensionPackage.getAuthor(),
         };
     }
 
@@ -263,7 +263,7 @@ export class NodeExtensionServer implements ExtensionServer {
         }
         this.notifyDidChange({
             name: extension,
-            busy
+            busy,
         });
     }
 

--- a/packages/extension-manager/src/node/npm-client.ts
+++ b/packages/extension-manager/src/node/npm-client.ts
@@ -28,7 +28,7 @@ export class NpmClient {
 
     constructor(
         @inject(NpmClientOptions) protected readonly options: NpmClientOptions,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) { }
 
     execute(projectPath: string, command: string, args: string[], token?: CancellationToken): Promise<void> {
@@ -41,10 +41,10 @@ export class NpmClient {
             }) : Disposable.NULL;
 
             npmProcess.stdout.on('data', data =>
-                this.logger.info(data.toString())
+                this.logger.info(data.toString()),
             );
             npmProcess.stderr.on('data', data =>
-                this.logger.error(data.toString())
+                this.logger.error(data.toString()),
             );
 
             npmProcess.on('close', (code, signal) => {
@@ -84,7 +84,7 @@ export class NpmClient {
     protected doSpawn(projectPath: string, [command, args]: CMD): cp.ChildProcess {
         this.logger.info(projectPath, command, ...args);
         return cp.spawn(command, args, {
-            cwd: projectPath
+            cwd: projectPath,
         });
     }
 

--- a/packages/extension-manager/src/node/npms.ts
+++ b/packages/extension-manager/src/node/npms.ts
@@ -33,8 +33,8 @@ export function search(query: string, from?: number, size?: number): Promise<Nod
             } else if (response.statusCode === 200) {
                 const result = JSON.parse(body) as {
                     results: {
-                        package: NodePackage
-                    }[]
+                        package: NodePackage,
+                    }[],
                 };
                 resolve(result.results.map(v => v.package));
             } else {

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -27,14 +27,14 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {
             execute: () => this.quickFileOpenService.open(),
-            isEnabled: () => this.quickFileOpenService.isEnabled()
+            isEnabled: () => this.quickFileOpenService.isEnabled(),
         });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: quickFileOpen.id,
-            keybinding: "ctrlcmd+p"
+            keybinding: "ctrlcmd+p",
         });
     }
 

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -17,7 +17,7 @@
 import { inject, injectable } from "inversify";
 import {
     QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickOpenService,
-    OpenerService, KeybindingRegistry, Keybinding
+    OpenerService, KeybindingRegistry, Keybinding,
 } from '@theia/core/lib/browser';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common/filesystem';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
@@ -29,7 +29,7 @@ import { Command } from '@theia/core/lib/common';
 
 export const quickFileOpen: Command = {
     id: 'file-search.openFile',
-    label: 'Open File...'
+    label: 'Open File...',
 };
 
 @injectable()
@@ -44,7 +44,7 @@ export class QuickFileOpenService implements QuickOpenModel {
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
         @inject(FileSearchService) protected readonly fileSearchService: FileSearchService,
-        @inject(LabelProvider) protected readonly labelProvider: LabelProvider
+        @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
     ) {
         workspaceService.root.then(root => this.wsRoot = root);
     }
@@ -165,7 +165,7 @@ export class FileQuickOpenItem extends QuickOpenItem {
         protected readonly label: string,
         protected readonly icon: string,
         protected readonly parent: string,
-        protected readonly openerService: OpenerService
+        protected readonly openerService: OpenerService,
     ) {
         super();
     }

--- a/packages/file-search/src/node/file-search-backend-module.ts
+++ b/packages/file-search/src/node/file-search-backend-module.ts
@@ -24,7 +24,7 @@ export default new ContainerModule(bind => {
     bind(FileSearchService).to(FileSearchServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(fileSearchServicePath, () =>
-            ctx.container.get(FileSearchService)
-        )
+            ctx.container.get(FileSearchService),
+        ),
     ).inSingletonScope();
 });

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -37,9 +37,9 @@ export class FileSearchServiceImpl implements FileSearchService {
             limit: Number.MAX_SAFE_INTEGER,
             useGitIgnore: true,
             defaultIgnorePatterns: [
-                '^.git$'
+                '^.git$',
             ],
-            ...options
+            ...options,
         };
         const args: string[] = [
             '--files',
@@ -52,8 +52,8 @@ export class FileSearchServiceImpl implements FileSearchService {
             command: rgPath,
             args,
             options: {
-                cwd: FileUri.fsPath(opts.rootUri)
-            }
+                cwd: FileUri.fsPath(opts.rootUri),
+            },
         });
         const result: string[] = [];
         const fuzzyMatches: string[] = [];
@@ -72,7 +72,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         }
         const lineReader = readline.createInterface({
             input: process.output,
-            output: process.input
+            output: process.input,
         });
         lineReader.on('line', line => {
             if (result.length >= opts.limit) {

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -79,7 +79,7 @@ export class FileDownloadCommandContribution implements CommandContribution {
 export namespace FileDownloadCommands {
 
     export const DOWNLOAD: Command = {
-        id: 'file.download'
+        id: 'file.download',
     };
 
 }

--- a/packages/filesystem/src/browser/download/file-download-service.ts
+++ b/packages/filesystem/src/browser/download/file-download-service.ts
@@ -52,7 +52,7 @@ export class FileDownloadService {
                     alignment: StatusBarAlignment.RIGHT,
                     text: '$(spinner~spin) Preparing download...',
                     tooltip: 'Preparing download...',
-                    priority: 1
+                    priority: 1,
                 });
             }
             this.downloadQueue.push(downloadId);
@@ -127,7 +127,7 @@ export class FileDownloadService {
         if (uris.length === 1) {
             return {
                 body: undefined,
-                method: 'GET'
+                method: 'GET',
             };
         }
         return {
@@ -139,7 +139,7 @@ export class FileDownloadService {
 
     protected body(uris: URI[]): FileDownloadData {
         return {
-            uris: uris.map(u => u.toString(true))
+            uris: uris.map(u => u.toString(true)),
         };
     }
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-widget.ts
@@ -27,7 +27,7 @@ export class FileDialogWidget extends FileTreeWidget {
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
         @inject(FileDialogModel) readonly model: FileDialogModel,
-        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
         this.addClass(FILE_DIALOG_CLASS);

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -45,7 +45,7 @@ export class FileDialog extends AbstractDialog<Readonly<FileStatNode> | undefine
 
     constructor(
         @inject(FileDialogProps) props: FileDialogProps,
-        @inject(FileDialogWidget) readonly widget: FileDialogWidget
+        @inject(FileDialogWidget) readonly widget: FileDialogWidget,
     ) {
         super(props);
         this.toDispose.push(widget);

--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -33,7 +33,7 @@ export class FileResource implements Resource {
     constructor(
         readonly uri: URI,
         protected readonly fileSystem: FileSystem,
-        protected readonly fileSystemWatcher: FileSystemWatcher
+        protected readonly fileSystemWatcher: FileSystemWatcher,
     ) {
         this.uriString = this.uri.toString();
         this.toDispose.push(this.onDidChangeContentsEmitter);

--- a/packages/filesystem/src/browser/file-tree/file-tree-model.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-model.ts
@@ -77,7 +77,7 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
         const root = this.root;
         if (FileStatNode.is(root)) {
             return changes.some(change =>
-                change.type < FileChangeType.DELETED && change.uri.toString() === root.uri.toString()
+                change.type < FileChangeType.DELETED && change.uri.toString() === root.uri.toString(),
             );
         }
         return false;
@@ -143,7 +143,7 @@ export class FileTreeModel extends TreeModelImpl implements LocationService {
             title: 'Replace file',
             msg: `File '${fileName}' already exists in the destination folder. Do you want to replace it?`,
             ok: 'Yes',
-            cancel: 'No'
+            cancel: 'No',
         });
         return dialog.open();
     }

--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -34,7 +34,7 @@ export class FileTreeWidget extends TreeWidget {
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
         @inject(FileTreeModel) readonly model: FileTreeModel,
-        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
         this.addClass(FILE_TREE_CLASS);
@@ -67,7 +67,7 @@ export class FileTreeWidget extends TreeWidget {
             onDragEnter: event => this.handleDragEnterEvent(this.model.root, event),
             onDragOver: event => this.handleDragOverEvent(this.model.root, event),
             onDragLeave: event => this.handleDragLeaveEvent(this.model.root, event),
-            onDrop: event => this.handleDropEvent(this.model.root, event)
+            onDrop: event => this.handleDropEvent(this.model.root, event),
         };
     }
 
@@ -80,7 +80,7 @@ export class FileTreeWidget extends TreeWidget {
             onDragEnter: event => this.handleDragEnterEvent(node, event),
             onDragOver: event => this.handleDragOverEvent(node, event),
             onDragLeave: event => this.handleDragLeaveEvent(node, event),
-            onDrop: event => this.handleDropEvent(node, event)
+            onDrop: event => this.handleDropEvent(node, event),
         };
     }
 

--- a/packages/filesystem/src/browser/file-tree/file-tree.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree.ts
@@ -54,7 +54,7 @@ export class FileTree extends TreeImpl {
             return [];
         }
         const result = await Promise.all(fileStat.children.map(async child =>
-            await this.toNode(child, parent)
+            await this.toNode(child, parent),
         ));
         return result.sort(DirNode.compare);
     }
@@ -74,7 +74,7 @@ export class FileTree extends TreeImpl {
                 id, uri, fileStat, name, icon, parent,
                 expanded: false,
                 selected: false,
-                children: []
+                children: [],
             };
         }
         if (FileNode.is(node)) {
@@ -83,7 +83,7 @@ export class FileTree extends TreeImpl {
         }
         return <FileNode>{
             id, uri, fileStat, name, icon, parent,
-            selected: false
+            selected: false,
         };
     }
 
@@ -132,7 +132,7 @@ export namespace DirNode {
             parent: undefined,
             children: [],
             expanded: true,
-            selected: false
+            selected: false,
         };
     }
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -20,7 +20,7 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { FileSystem, fileSystemPath } from "../common";
 import {
     fileSystemWatcherPath, FileSystemWatcherServer,
-    FileSystemWatcherServerProxy, ReconnectingFileSystemWatcherServer
+    FileSystemWatcherServerProxy, ReconnectingFileSystemWatcherServer,
 } from '../common/filesystem-watcher-protocol';
 import { FileResourceResolver } from './file-resource';
 import { FileSystemListener } from './filesystem-listener';
@@ -33,7 +33,7 @@ export default new ContainerModule(bind => {
     bindFileSystemPreferences(bind);
 
     bind(FileSystemWatcherServerProxy).toDynamicValue(ctx =>
-        WebSocketConnectionProvider.createProxy(ctx.container, fileSystemWatcherPath)
+        WebSocketConnectionProvider.createProxy(ctx.container, fileSystemWatcherPath),
     );
     bind(FileSystemWatcherServer).to(ReconnectingFileSystemWatcherServer);
     bind(FileSystemWatcher).toSelf().inSingletonScope();

--- a/packages/filesystem/src/browser/filesystem-listener.ts
+++ b/packages/filesystem/src/browser/filesystem-listener.ts
@@ -32,7 +32,7 @@ export class FileSystemListener implements FileSystemClient {
             title: `The file '${file.uri}' has been changed on the file system.`,
             msg: 'Do you want to overwrite the changes made on the file system?',
             ok: 'Yes',
-            cancel: 'No'
+            cancel: 'No',
         });
         return dialog.open();
     }

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -20,7 +20,7 @@ import {
     PreferenceProxy,
     PreferenceService,
     PreferenceSchema,
-    PreferenceContribution
+    PreferenceContribution,
 } from '@theia/core/lib/browser/preferences';
 
 export const filesystemPreferenceSchema: PreferenceSchema = {
@@ -29,15 +29,15 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
         "files.watcherExclude": {
             "description": "List of paths to exclude from the filesystem watcher",
             "additionalProperties": {
-                "type": "boolean"
+                "type": "boolean",
             },
             "default": {
                 "**/.git/objects/**": true,
                 "**/.git/subtree-cache/**": true,
-                "**/node_modules/**": true
-            }
-        }
-    }
+                "**/node_modules/**": true,
+            },
+        },
+    },
 };
 
 export interface FileSystemConfiguration {

--- a/packages/filesystem/src/browser/filesystem-watcher.ts
+++ b/packages/filesystem/src/browser/filesystem-watcher.ts
@@ -21,7 +21,7 @@ import { DidFilesChangedParams, FileChangeType, FileSystemWatcherServer, WatchOp
 import { FileSystemPreferences } from "./filesystem-preferences";
 
 export {
-    FileChangeType
+    FileChangeType,
 };
 
 export interface FileChange {
@@ -48,7 +48,7 @@ export class FileSystemWatcher implements Disposable {
 
         this.toDispose.push(this.server);
         this.server.setClient({
-            onDidFilesChanged: e => this.onDidFilesChanged(e)
+            onDidFilesChanged: e => this.onDidFilesChanged(e),
         });
 
         this.toDispose.push(this.preferences.onPreferenceChanged(e => {
@@ -68,7 +68,7 @@ export class FileSystemWatcher implements Disposable {
     protected onDidFilesChanged(event: DidFilesChangedParams): void {
         const changes = event.changes.map(change => <FileChange>{
             uri: new URI(change.uri),
-            type: change.type
+            type: change.type,
         });
         this.onFileChangedEmitter.fire(changes);
     }
@@ -82,19 +82,19 @@ export class FileSystemWatcher implements Disposable {
     watchFileChanges(uri: URI): Promise<Disposable> {
         return this.createWatchOptions()
             .then(options =>
-                this.server.watchFileChanges(uri.toString(), options)
+                this.server.watchFileChanges(uri.toString(), options),
             )
             .then(watcher => {
                 const toDispose = new DisposableCollection();
                 const toStop = Disposable.create(() =>
-                    this.server.unwatchFileChanges(watcher)
+                    this.server.unwatchFileChanges(watcher),
                 );
                 const toRestart = toDispose.push(toStop);
                 this.toRestartAll.push(Disposable.create(() => {
                     toRestart.dispose();
                     toStop.dispose();
                     this.watchFileChanges(uri).then(disposable =>
-                        toDispose.push(disposable)
+                        toDispose.push(disposable),
                     );
                 }));
                 return toDispose;
@@ -110,7 +110,7 @@ export class FileSystemWatcher implements Disposable {
 
     protected createWatchOptions(): Promise<WatchOptions> {
         return this.getIgnored().then(ignored => ({
-            ignored
+            ignored,
         }));
     }
 

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -25,7 +25,7 @@ export class LocationListRenderer extends ReactRenderer {
 
     constructor(
         readonly service: LocationService,
-        host?: HTMLElement
+        host?: HTMLElement,
     ) {
         super(host);
     }

--- a/packages/filesystem/src/common/filesystem-watcher-protocol.ts
+++ b/packages/filesystem/src/common/filesystem-watcher-protocol.ts
@@ -58,7 +58,7 @@ export interface FileChange {
 export enum FileChangeType {
     UPDATED = 0,
     ADDED = 1,
-    DELETED = 2
+    DELETED = 2,
 }
 
 export const FileSystemWatcherServerProxy = Symbol('FileSystemWatcherServerProxy');
@@ -75,7 +75,7 @@ export class ReconnectingFileSystemWatcherServer implements FileSystemWatcherSer
     protected readonly localToRemoteWatcher = new Map<number, number>();
 
     constructor(
-        @inject(FileSystemWatcherServerProxy) protected readonly proxy: FileSystemWatcherServerProxy
+        @inject(FileSystemWatcherServerProxy) protected readonly proxy: FileSystemWatcherServerProxy,
     ) {
         const onInitialized = this.proxy.onDidOpenConnection(() => {
             // skip reconnection on the first connection

--- a/packages/filesystem/src/node/download/directory-archiver.spec.ts
+++ b/packages/filesystem/src/node/download/directory-archiver.spec.ts
@@ -59,28 +59,28 @@ describe('directory-archiver', () => {
             {
                 input: ['/A/B/C/D.txt', '/X/Y/Z.txt'],
                 expected: new Map([['/A/B/C', ['/A/B/C/D.txt']], ['/X/Y', ['/X/Y/Z.txt']]]),
-                folders: ['/A', '/A/B', '/A/B/C', '/X', '/X/Y']
+                folders: ['/A', '/A/B', '/A/B/C', '/X', '/X/Y'],
             },
             {
                 input: ['/A/B/C/D.txt', '/A/B/C/E.txt'],
                 expected: new Map([['/A/B/C', ['/A/B/C/D.txt', '/A/B/C/E.txt']]]),
-                folders: ['/A', '/A/B', '/A/B/C']
+                folders: ['/A', '/A/B', '/A/B/C'],
             },
             {
                 input: ['/A', '/A/B/C/D.txt', '/A/B/C/E.txt'],
                 expected: new Map([['/A', ['/A', '/A/B/C/D.txt', '/A/B/C/E.txt']]]),
-                folders: ['/A', '/A/B', '/A/B/C']
+                folders: ['/A', '/A/B', '/A/B/C'],
             },
             {
                 input: ['/A/B/C/D.txt', '/A/B/C/E.txt', '/A'],
                 expected: new Map([['/A', ['/A', '/A/B/C/D.txt', '/A/B/C/E.txt']]]),
-                folders: ['/A', '/A/B', '/A/B/C']
+                folders: ['/A', '/A/B', '/A/B/C'],
             },
             {
                 input: ['/A/B/C/D.txt', '/A/B/X/E.txt'],
                 expected: new Map([['/A/B', ['/A/B/C/D.txt', '/A/B/X/E.txt']]]),
-                folders: ['/A', '/A/B', '/A/B/C', '/A/B/X']
-            }
+                folders: ['/A', '/A/B', '/A/B/C', '/A/B/X'],
+            },
         ] as ({ input: string[], expected: Map<string, string[]>, folders?: string[] })[]).forEach(test => {
             const { input, expected, folders } = test;
             it(`should find the common parent URIs among [${input.join(', ')}] => [${Array.from(expected.keys()).join(', ')}]`, async () => {

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -34,13 +34,13 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
             const logger = ctx.container.get<ILogger>(ILogger);
             return new NsfwFileSystemWatcherServer({
                 info: (message, ...args) => logger.info(message, ...args),
-                error: (message, ...args) => logger.error(message, ...args)
+                error: (message, ...args) => logger.error(message, ...args),
             });
         });
     } else {
         bind(FileSystemWatcherServerClient).toSelf();
         bind(FileSystemWatcherServer).toDynamicValue(ctx =>
-            ctx.container.get(FileSystemWatcherServerClient)
+            ctx.container.get(FileSystemWatcherServerClient),
         );
     }
 }
@@ -53,7 +53,7 @@ export default new ContainerModule(bind => {
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
             return server;
-        })
+        }),
     ).inSingletonScope();
 
     bindFileSystemWatcherServer(bind);
@@ -63,6 +63,6 @@ export default new ContainerModule(bind => {
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
             return server;
-        })
+        }),
     ).inSingletonScope();
 });

--- a/packages/filesystem/src/node/filesystem-watcher-client.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-client.ts
@@ -32,14 +32,14 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
 
     constructor(
         @inject(ILogger) protected readonly logger: ILogger,
-        @inject(IPCConnectionProvider) protected readonly ipcConnectionProvider: IPCConnectionProvider
+        @inject(IPCConnectionProvider) protected readonly ipcConnectionProvider: IPCConnectionProvider,
     ) {
         this.remote.setClient({
             onDidFilesChanged: e => {
                 if (this.client) {
                     this.client.onDidFilesChanged(e);
                 }
-            }
+            },
         });
         this.toDispose.push(this.remote);
         this.toDispose.push(this.listen());
@@ -68,8 +68,8 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
             entryPoint: path.resolve(__dirname, NSFW_WATCHER),
             errorHandler: new ConnectionErrorHandler({
                 serverName: NSFW_WATCHER,
-                logger: this.logger
-            })
+                logger: this.logger,
+            }),
         }, connection => this.proxyFactory.listen(connection));
     }
 

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -162,7 +162,7 @@ describe("NodeFileSystem", function () {
             const stat = {
                 uri: uri.toString(),
                 lastModification: new Date().getTime(),
-                isDirectory: false
+                isDirectory: false,
             };
 
             await expectThrowsAsync(fileSystem.setContent(stat, "foo"), Error);

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -38,7 +38,7 @@ export class FileSystemNodeOptions {
         encoding: 'utf8',
         overwrite: false,
         recursive: true,
-        moveToTrash: true
+        moveToTrash: true,
     };
 
 }
@@ -47,7 +47,7 @@ export class FileSystemNodeOptions {
 export class FileSystemNode implements FileSystem {
 
     constructor(
-        @inject(FileSystemNodeOptions) @optional() protected readonly options: FileSystemNodeOptions = FileSystemNodeOptions.DEFAULT
+        @inject(FileSystemNodeOptions) @optional() protected readonly options: FileSystemNodeOptions = FileSystemNodeOptions.DEFAULT,
     ) { }
 
     protected client: FileSystemClient | undefined;
@@ -210,7 +210,7 @@ Actual: ${JSON.stringify(file)}.`);
             this.doGetStat(_sourceUri, 0),
             this.doGetStat(_targetUri, 0),
             this.doGetOverwrite(options),
-            this.doGetRecursive(options)
+            this.doGetRecursive(options),
         ]);
         if (!sourceStat) {
             throw new Error(`File does not exist under ${sourceUri}.`);
@@ -347,7 +347,7 @@ Actual: ${JSON.stringify(file)}.`);
             uri: uri.toString(),
             lastModification: stat.mtime.getTime(),
             isDirectory: false,
-            size: stat.size
+            size: stat.size,
         };
     }
 
@@ -357,7 +357,7 @@ Actual: ${JSON.stringify(file)}.`);
             uri: uri.toString(),
             lastModification: stat.mtime.getTime(),
             isDirectory: true,
-            children
+            children,
         };
     }
 

--- a/packages/filesystem/src/node/nsfw-watcher/index.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/index.ts
@@ -23,11 +23,11 @@ import { IPCEntryPoint } from '@theia/core/lib/node/messaging/ipc-protocol';
 // tslint:disable:no-any
 
 const options: {
-    verbose: boolean
+    verbose: boolean,
 } = yargs.option('verbose', {
     default: false,
     alias: 'v',
-    type: 'boolean'
+    type: 'boolean',
 }).argv as any;
 
 export default <IPCEntryPoint>(connection => {

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -56,14 +56,14 @@ describe("nsfw-filesystem-watcher", function () {
         const watcherClient = {
             onDidFilesChanged(event: DidFilesChangedParams) {
                 event.changes.forEach(c => actualUris.add(c.uri.toString()));
-            }
+            },
         };
         watcherServer.setClient(watcherClient);
 
         const expectedUris = [
             root.resolve("foo").toString(),
             root.withPath(root.path.join('foo', 'bar')).toString(),
-            root.withPath(root.path.join('foo', 'bar', 'baz.txt')).toString()
+            root.withPath(root.path.join('foo', 'bar', 'baz.txt')).toString(),
         ];
 
         fs.mkdirSync(FileUri.fsPath(root.resolve("foo")));
@@ -91,7 +91,7 @@ describe("nsfw-filesystem-watcher", function () {
         const watcherClient = {
             onDidFilesChanged(event: DidFilesChangedParams) {
                 event.changes.forEach(c => actualUris.add(c.uri.toString()));
-            }
+            },
         };
         watcherServer.setClient(watcherClient);
 
@@ -115,7 +115,7 @@ describe("nsfw-filesystem-watcher", function () {
 
     function createNsfwFileSystemWatcherServer() {
         return new NsfwFileSystemWatcherServer({
-            verbose: true
+            verbose: true,
         });
     }
 

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -25,7 +25,7 @@ import {
     FileChangeType,
     FileSystemWatcherClient,
     FileSystemWatcherServer,
-    WatchOptions
+    WatchOptions,
 } from '../../common/filesystem-watcher-protocol';
 import { setInterval, clearInterval } from "timers";
 
@@ -52,19 +52,19 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
     protected readonly options: {
         verbose: boolean
         info: (message: string, ...args: any[]) => void
-        error: (message: string, ...args: any[]) => void
+        error: (message: string, ...args: any[]) => void,
     };
 
     constructor(options?: {
         verbose?: boolean,
         info?: (message: string, ...args: any[]) => void
-        error?: (message: string, ...args: any[]) => void
+        error?: (message: string, ...args: any[]) => void,
     }) {
         this.options = {
             verbose: false,
             info: (message, ...args) => console.info(message, ...args),
             error: (message, ...args) => console.error(message, ...args),
-            ...options
+            ...options,
         };
     }
 
@@ -100,7 +100,7 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
     protected async start(watcherId: number, basePath: string, rawOptions?: WatchOptions): Promise<void> {
         const options: WatchOptions = {
             ignored: [],
-            ...rawOptions
+            ...rawOptions,
         };
         if (options.ignored.length > 0) {
             this.debug('Files ignored for watching', options.ignored);
@@ -133,7 +133,7 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
             this.options.info('Stopped watching.');
         });
         this.watcherOptions.set(watcherId, {
-            ignored: options.ignored.map(pattern => new Minimatch(pattern))
+            ignored: options.ignored.map(pattern => new Minimatch(pattern)),
         });
         this.watchers.set(watcherId, disposable);
         this.toDispose.push(disposable);

--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -28,10 +28,10 @@ import debounce = require('lodash.debounce');
 export namespace BlameCommands {
     export const SHOW_GIT_ANNOTATIONS: Command = {
         id: 'git.editor.show.annotations',
-        label: 'Git: Show Blame Annotations'
+        label: 'Git: Show Blame Annotations',
     };
     export const CLEAR_GIT_ANNOTATIONS: Command = {
-        id: 'git.editor.clear.annotations'
+        id: 'git.editor.clear.annotations',
     };
 }
 
@@ -63,7 +63,7 @@ export class BlameContribution implements FrontendApplicationContribution, Comma
             isEnabled: () => {
                 const editorWidget = this.currentFileEditorWidget;
                 return !!editorWidget && this.isBlameable(editorWidget.editor.uri);
-            }
+            },
         });
         commands.registerCommand(BlameCommands.CLEAR_GIT_ANNOTATIONS, {
             execute: () => {
@@ -78,7 +78,7 @@ export class BlameContribution implements FrontendApplicationContribution, Comma
                 const editorWidget = this.currentFileEditorWidget;
                 const enabled = !!editorWidget && this.appliedDecorations.has(editorWidget.editor.uri.toString());
                 return enabled;
-            }
+            },
         });
     }
 
@@ -132,7 +132,7 @@ export class BlameContribution implements FrontendApplicationContribution, Comma
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EDITOR_CONTEXT_MENU_GIT, {
             commandId: BlameCommands.SHOW_GIT_ANNOTATIONS.id,
-            label: BlameCommands.SHOW_GIT_ANNOTATIONS.label!.slice('Git: '.length)
+            label: BlameCommands.SHOW_GIT_ANNOTATIONS.label!.slice('Git: '.length),
         });
     }
 
@@ -140,12 +140,12 @@ export class BlameContribution implements FrontendApplicationContribution, Comma
         keybindings.registerKeybinding({
             command: BlameCommands.SHOW_GIT_ANNOTATIONS.id,
             context: EditorKeybindingContexts.editorTextFocus,
-            keybinding: 'alt+b'
+            keybinding: 'alt+b',
         });
         keybindings.registerKeybinding({
             command: BlameCommands.CLEAR_GIT_ANNOTATIONS.id,
             context: EditorKeybindingContexts.strictEditorTextFocus,
-            keybinding: 'esc'
+            keybinding: 'esc',
         });
     }
 

--- a/packages/git/src/browser/blame/blame-decorator.ts
+++ b/packages/git/src/browser/blame/blame-decorator.ts
@@ -67,7 +67,7 @@ export class BlameDecorator implements HoverProvider {
 
         const hover = {
             contents: [message],
-            range: Range.create(Position.create(line, 0), Position.create(line, 10 ^ 10))
+            range: Range.create(Position.create(line, 0), Position.create(line, 10 ^ 10)),
         };
         return hover;
     }

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -32,7 +32,7 @@ import { Git } from "../../common";
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
         id: 'git-diff:open-file-diff',
-        label: 'Diff: Compare With...'
+        label: 'Diff: Compare With...',
     };
 }
 
@@ -46,21 +46,21 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         @inject(GitQuickOpenService) protected readonly quickOpenService: GitQuickOpenService,
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
         @inject(OpenerService) protected openerService: OpenerService,
-        @inject(MessageService) protected readonly notifications: MessageService
+        @inject(MessageService) protected readonly notifications: MessageService,
     ) {
         super({
             widgetId: GIT_DIFF,
             widgetName: 'Git diff',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 400
-            }
+                rank: 400,
+            },
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '5_diff'], {
-            commandId: GitDiffCommands.OPEN_FILE_DIFF.id
+            commandId: GitDiffCommands.OPEN_FILE_DIFF.id,
         });
     }
 
@@ -74,8 +74,8 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
                         const options: Git.Options.Diff = {
                             uri,
                             range: {
-                                fromRevision
-                            }
+                                fromRevision,
+                            },
                         };
                         if (fileStat) {
                             if (fileStat.isDirectory) {
@@ -92,7 +92,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
                             }
                         }
                     });
-            }
+            },
         }));
     }
 
@@ -100,7 +100,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         const widget = await this.widget;
         await widget.setContent(options);
         return this.openView({
-            activate: true
+            activate: true,
         });
     }
 

--- a/packages/git/src/browser/diff/git-diff-frontend-module.ts
+++ b/packages/git/src/browser/diff/git-diff-frontend-module.ts
@@ -26,7 +26,7 @@ export function bindGitDiffModule(bind: interfaces.Bind) {
     bind(GitDiffWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: GIT_DIFF,
-        createWidget: () => ctx.container.get<GitDiffWidget>(GitDiffWidget)
+        createWidget: () => ctx.container.get<GitDiffWidget>(GitDiffWidget),
     }));
 
     bindViewContribution(bind, GitDiffContribution);

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -73,7 +73,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         if (repository) {
             const fileChanges: GitFileChange[] = await this.git.diff(repository, {
                 range: options.range,
-                uri: options.uri
+                uri: options.uri,
             });
             const fileChangeNodes: GitFileChangeNode[] = [];
             for (const fileChange of fileChanges) {
@@ -81,12 +81,12 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
                 const [icon, label, description] = await Promise.all([
                     this.labelProvider.getIcon(fileChangeUri),
                     this.labelProvider.getName(fileChangeUri),
-                    this.relativePath(fileChangeUri.parent)
+                    this.relativePath(fileChangeUri.parent),
                 ]);
 
                 const caption = this.computeCaption(fileChange);
                 fileChangeNodes.push({
-                    ...fileChange, icon, label, description, caption
+                    ...fileChange, icon, label, description, caption,
                 });
             }
             this.fileChangeNodes = fileChangeNodes;
@@ -98,7 +98,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         const { fileChangeNodes, options } = this;
         return {
             fileChangeNodes,
-            options
+            options,
         };
     }
 
@@ -120,7 +120,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         return this.doRenderDiffListHeader(
             this.renderPathHeader(),
             this.renderRevisionHeader(),
-            this.renderToolbar()
+            this.renderToolbar(),
         );
     }
 
@@ -142,7 +142,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
     protected renderPathHeader(): React.ReactNode {
         return this.renderHeaderRow({
             name: 'path',
-            value: this.renderPath()
+            value: this.renderPath(),
         });
     }
     protected renderPath(): React.ReactNode {
@@ -158,7 +158,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
     protected renderRevisionHeader(): React.ReactNode {
         return this.renderHeaderRow({
             name: 'revision: ',
-            value: this.renderRevision()
+            value: this.renderRevision(),
         });
     }
     protected renderRevision(): React.ReactNode {
@@ -174,14 +174,14 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
     protected renderToolbar(): React.ReactNode {
         return this.doRenderToolbar(
             this.renderNavigationLeft(),
-            this.renderNavigationRight()
+            this.renderNavigationRight(),
         );
     }
     protected doRenderToolbar(...children: React.ReactNode[]) {
         return this.renderHeaderRow({
             classNames: ['space-between'],
             name: 'Files changed',
-            value: <div className='lrBtns'>{...children}</div>
+            value: <div className='lrBtns'>{...children}</div>,
         });
     }
 

--- a/packages/git/src/browser/dirty-diff/content-lines.ts
+++ b/packages/git/src/browser/dirty-diff/content-lines.ts
@@ -61,7 +61,7 @@ export namespace ContentLines {
                 }
                 const lineContent = content.substring(start, end);
                 return lineContent;
-            }
+            },
         };
     }
 
@@ -105,7 +105,7 @@ export namespace ContentLines {
                     }
                 }
                 throw new Error(`get ${String(p)} not implemented`);
-            }
+            },
         };
     }
 }

--- a/packages/git/src/browser/dirty-diff/diff-computer.spec.ts
+++ b/packages/git/src/browser/dirty-diff/diff-computer.spec.ts
@@ -36,11 +36,11 @@ describe("dirty-diff-computer", () => {
             [
                 "FIRST",
                 "SECOND TO-BE-REMOVED",
-                "THIRD"
+                "THIRD",
             ],
             [
                 "FIRST",
-                "THIRD"
+                "THIRD",
             ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
@@ -68,7 +68,7 @@ describe("dirty-diff-computer", () => {
     it("remove all lines", () => {
         const dirtyDiff = computeDirtyDiff(
             sequenceOfN(10, () => "TO-BE-REMOVED"),
-            [""]
+            [""],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             added: [],
@@ -110,7 +110,7 @@ describe("dirty-diff-computer", () => {
             const dirtyDiff = computeDirtyDiff(
                 sequenceOfN(2),
                 sequenceOfN(lines, () => "ADDED LINE")
-                    .concat(sequenceOfN(2))
+                    .concat(sequenceOfN(2)),
             );
             expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
                 modified: [],
@@ -124,7 +124,7 @@ describe("dirty-diff-computer", () => {
         const numberOfLines = 3;
         const dirtyDiff = computeDirtyDiff(
             [""],
-            sequenceOfN(numberOfLines, () => "ADDED LINE")
+            sequenceOfN(numberOfLines, () => "ADDED LINE"),
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             modified: [],
@@ -137,14 +137,14 @@ describe("dirty-diff-computer", () => {
         const dirtyDiff = computeDirtyDiff(
             [
                 "1",
-                "2"
+                "2",
             ],
             [
                 "1",
                 "",
                 "",
-                "2"
-            ]
+                "2",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             modified: [],
@@ -156,12 +156,12 @@ describe("dirty-diff-computer", () => {
     it("add empty line after single line", () => {
         const dirtyDiff = computeDirtyDiff(
             [
-                "1"
+                "1",
             ],
             [
                 "1",
-                ""
-            ]
+                "",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             modified: [],
@@ -175,7 +175,7 @@ describe("dirty-diff-computer", () => {
             const dirtyDiff = computeDirtyDiff(
                 sequenceOfN(2),
                 sequenceOfN(2)
-                    .concat(new Array(lines).map(() => ""))
+                    .concat(new Array(lines).map(() => "")),
             );
             expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
                 modified: [],
@@ -189,7 +189,7 @@ describe("dirty-diff-computer", () => {
         const dirtyDiff = computeDirtyDiff(
             [
                 "FIRST",
-                "LAST"
+                "LAST",
             ],
             [
                 "FIRST",
@@ -198,8 +198,8 @@ describe("dirty-diff-computer", () => {
                 "3. ADDED",
                 "4. ADDED",
                 "5. ADDED",
-                "LAST"
-            ]
+                "LAST",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             modified: [],
@@ -212,7 +212,7 @@ describe("dirty-diff-computer", () => {
         it(`add ${formatLines(lines)} after single line`, () => {
             const dirtyDiff = computeDirtyDiff(
                 ["0"],
-                ["0"].concat(sequenceOfN(lines, () => "ADDED LINE"))
+                ["0"].concat(sequenceOfN(lines, () => "ADDED LINE")),
             );
             expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
                 modified: [],
@@ -227,13 +227,13 @@ describe("dirty-diff-computer", () => {
             [
                 "FIRST",
                 "TO-BE-MODIFIED",
-                "LAST"
+                "LAST",
             ],
             [
                 "FIRST",
                 "MODIFIED",
-                "LAST"
-            ]
+                "LAST",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             removed: [],
@@ -246,7 +246,7 @@ describe("dirty-diff-computer", () => {
         const numberOfLines = 10;
         const dirtyDiff = computeDirtyDiff(
             sequenceOfN(numberOfLines, () => "TO-BE-MODIFIED"),
-            sequenceOfN(numberOfLines, () => "MODIFIED")
+            sequenceOfN(numberOfLines, () => "MODIFIED"),
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             removed: [],
@@ -261,13 +261,13 @@ describe("dirty-diff-computer", () => {
                 "1",
                 "2",
                 "3",
-                "4"
+                "4",
             ],
             [
                 "1",
                 "2-changed",
-                "3-changed"
-            ]
+                "3-changed",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             removed: [],
@@ -289,7 +289,7 @@ describe("dirty-diff-computer", () => {
                 "6",
                 "7",
                 "8",
-                "9"
+                "9",
             ],
             [
                 "CHANGED",
@@ -303,8 +303,8 @@ describe("dirty-diff-computer", () => {
                 "8",
                 "9",
                 "ADDED",
-                ""
-            ]
+                "",
+            ],
         );
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             removed: [3],
@@ -325,7 +325,7 @@ describe("dirty-diff-computer", () => {
                 "",
                 "",
                 "",
-                "last line"
+                "last line",
             ],
             [
                 "first line",
@@ -339,7 +339,7 @@ describe("dirty-diff-computer", () => {
                 "",
                 "last line",
                 "",
-                ""
+                "",
             ]);
         expect(dirtyDiff).to.be.deep.equal(<DirtyDiff>{
             removed: [11],

--- a/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-decorator.ts
@@ -30,7 +30,7 @@ const AddedLineDecoration = <EditorDecorationOptions>{
     overviewRuler: {
         color: 'rgba(0, 255, 0, 0.8)',
         position: OverviewRulerLane.Left,
-    }
+    },
 };
 
 const RemovedLineDecoration = <EditorDecorationOptions>{
@@ -38,7 +38,7 @@ const RemovedLineDecoration = <EditorDecorationOptions>{
     overviewRuler: {
         color: 'rgba(230, 0, 0, 0.8)',
         position: OverviewRulerLane.Left,
-    }
+    },
 };
 
 const ModifiedLineDecoration = <EditorDecorationOptions>{
@@ -46,7 +46,7 @@ const ModifiedLineDecoration = <EditorDecorationOptions>{
     overviewRuler: {
         color: 'rgba(0, 100, 150, 0.8)',
         position: OverviewRulerLane.Left,
-    }
+    },
 };
 
 @injectable()

--- a/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
+++ b/packages/git/src/browser/dirty-diff/dirty-diff-manager.ts
@@ -108,7 +108,7 @@ export class DirtyDiffManager {
                     return this.git.lsFiles(repository, fileUri.toString(), { errorUnmatch: true });
                 }
                 return false;
-            }
+            },
         };
     }
 
@@ -143,7 +143,7 @@ export class DirtyDiffModel implements Disposable {
     constructor(
         readonly editor: TextEditor,
         readonly preferences: GitPreferences,
-        protected readonly previousRevision: DirtyDiffModel.PreviousFileRevision
+        protected readonly previousRevision: DirtyDiffModel.PreviousFileRevision,
     ) {
         this.toDispose.push(this.preferences.onPreferenceChanged(e => this.handlePreferenceChange(e)));
     }

--- a/packages/git/src/browser/git-commit-message-validator.ts
+++ b/packages/git/src/browser/git-commit-message-validator.ts
@@ -43,14 +43,14 @@ export class GitCommitMessageValidator {
         if (index === 1 && line.length !== 0) {
             return {
                 status: 'warning',
-                message: 'The second line should be empty to separate the commit message from the body'
+                message: 'The second line should be empty to separate the commit message from the body',
             };
         }
         const diff = line.length - this.maxCharsPerLine();
         if (diff > 0) {
             return {
                 status: 'warning',
-                message: `${diff} characters over ${this.maxCharsPerLine()} in current line`
+                message: `${diff} characters over ${this.maxCharsPerLine()} in current line`,
             };
         }
         return undefined;

--- a/packages/git/src/browser/git-decorator.ts
+++ b/packages/git/src/browser/git-decorator.ts
@@ -98,7 +98,7 @@ export class GitDecorator implements TreeDecorator {
                     result.set(parentUriString, {
                         uri: parentUriString,
                         status: change.status,
-                        staged: !!change.staged
+                        staged: !!change.staged,
                     });
                     parentUri = parentUri.parent;
                 } else {
@@ -118,18 +118,18 @@ export class GitDecorator implements TreeDecorator {
                 {
                     data,
                     fontData: {
-                        color
+                        color,
                     },
-                    tooltip
-                }
-            ]
+                    tooltip,
+                },
+            ],
         };
         if (this.showColors) {
             decorationData = {
                 ...decorationData,
                 fontData: {
-                    color
-                }
+                    color,
+                },
             };
         }
         return decorationData;

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -56,7 +56,7 @@ export default new ContainerModule(bind => {
     bind(GitWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({
         id: GIT_WIDGET_FACTORY_ID,
-        createWidget: () => context.container.get<GitWidget>(GitWidget)
+        createWidget: () => context.container.get<GitWidget>(GitWidget),
     })).inSingletonScope();
 
     bind(GitResourceResolver).toSelf().inSingletonScope();

--- a/packages/git/src/browser/git-preferences.ts
+++ b/packages/git/src/browser/git-preferences.ts
@@ -23,24 +23,24 @@ export const GitConfigSchema: PreferenceSchema = {
         'git.decorations.enabled': {
             'type': 'boolean',
             'description': 'Show Git file status in the navigator.',
-            'default': true
+            'default': true,
         },
         'git.decorations.colors': {
             'type': 'boolean',
             'description': 'Use color decoration in the navigator.',
-            'default': false
+            'default': false,
         },
         'git.editor.decorations.enabled': {
             'type': 'boolean',
             'description': 'Show git decorations in the editor.',
-            'default': true
+            'default': true,
         },
         'git.editor.dirtydiff.linesLimit': {
             'type': 'number',
             'description': 'Do not show dirty diff decorations, if editor\'s line count exceeds this limit.',
-            'default': 1000
-        }
-    }
+            'default': 1000,
+        },
+    },
 };
 
 export interface GitConfiguration {

--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -38,7 +38,7 @@ export class GitQuickOpenService {
         @inject(Git) protected readonly git: Git,
         @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
         @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
-        @inject(MessageService) protected readonly messageService: MessageService
+        @inject(MessageService) protected readonly messageService: MessageService,
     ) { }
 
     async fetch(): Promise<void> {
@@ -173,11 +173,11 @@ export class GitQuickOpenService {
                                     } catch (error) {
                                         __this.gitErrorHandler.handleError(error);
                                     }
-                                }
+                                },
                             ));
                         }
                         acceptor(dynamicItems);
-                    }
+                    },
                 };
                 this.quickOpenService.open(createBranchModel, this.getOptions('The name of the branch:', false));
             };
@@ -257,7 +257,7 @@ export class GitQuickOpenService {
             placeholder,
             fuzzyMatchLabel,
             fuzzySort: false,
-            onClose
+            onClose,
         });
     }
 
@@ -265,7 +265,7 @@ export class GitQuickOpenService {
         return {
             onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
                 acceptor(Array.isArray(items) ? items : [items]);
-            }
+            },
         };
     }
 
@@ -300,7 +300,7 @@ export class GitQuickOpenService {
         try {
             const [local, remote] = await Promise.all([
                 this.git.branch(repository, { type: 'local' }),
-                this.git.branch(repository, { type: 'remote' })
+                this.git.branch(repository, { type: 'remote' }),
             ]);
             return [...local, ...remote];
         } catch (error) {

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -32,7 +32,7 @@ export class GitRepositoryProvider {
 
     constructor(
         @inject(Git) protected readonly git: Git,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
     ) {
         this.initialize();
     }
@@ -79,7 +79,7 @@ export class GitRepositoryProvider {
             return;
         }
         const repositories = await this.git.repositories(root.uri, {
-            ...options
+            ...options,
         });
         this._allRepositories = repositories;
         const selectedRepository = this._selectedRepository;

--- a/packages/git/src/browser/git-resource.ts
+++ b/packages/git/src/browser/git-resource.ts
@@ -42,7 +42,7 @@ export class GitResourceResolver implements ResourceResolver {
 
     constructor(
         @inject(Git) protected readonly git: Git,
-        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider
+        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
     ) { }
 
     resolve(uri: URI): Resource | Promise<Resource> {

--- a/packages/git/src/browser/git-sync-service.ts
+++ b/packages/git/src/browser/git-sync-service.ts
@@ -80,13 +80,13 @@ export class GitSyncService {
             this.setSyncing(true);
             if (method === 'pull-push' || method === 'rebase-push') {
                 await this.git.pull(repository, {
-                    rebase: method === 'rebase-push'
+                    rebase: method === 'rebase-push',
                 });
                 status = await this.git.status(repository);
             }
             if (this.shouldPush(status)) {
                 await this.git.push(repository, {
-                    force: method === 'force-push'
+                    force: method === 'force-push',
                 });
             }
         } catch (error) {
@@ -107,19 +107,19 @@ export class GitSyncService {
         const methods: {
             label: string
             warning: string
-            value: GitSyncService.SyncMethod
+            value: GitSyncService.SyncMethod,
         }[] = [{
             label: `Pull and push commits from and to '${upstreamBranch}'`,
             warning: `This action will pull and push commits from and to '${upstreamBranch}'.`,
-            value: 'pull-push'
+            value: 'pull-push',
         }, {
             label: `Fetch, rebase and push commits from and to '${upstreamBranch}'`,
             warning: `This action will fetch, rebase and push commits from and to '${upstreamBranch}'.`,
-            value: 'rebase-push'
+            value: 'rebase-push',
         }, {
             label: `Force push commits to '${upstreamBranch}'`,
             warning: `This action will override commits in '${upstreamBranch}'.`,
-            value: 'force-push'
+            value: 'force-push',
         }];
         const method = await this.pick(`Pick how changes should be synchronized:`, methods);
         if (method && await this.confirm('Synchronize Changes', methods.find(({ value }) => value === method)!.warning)) {
@@ -148,7 +148,7 @@ export class GitSyncService {
         ) {
             try {
                 await this.git.push(repository, {
-                    remote, localBranch, setUpstream: true
+                    remote, localBranch, setUpstream: true,
                 });
             } catch (error) {
                 this.gitErrorHandler.handleError(error);
@@ -191,11 +191,11 @@ export class GitSyncService {
                         }
                         resolve(value);
                         return true;
-                    }
+                    },
                 });
             });
             this.quickOpenService.open({
-                onType: (lookFor, acceptor) => acceptor(items)
+                onType: (lookFor, acceptor) => acceptor(items),
             }, { placeholder, onClose: () => resolve(undefined) });
         });
     }

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -31,49 +31,49 @@ export const EDITOR_CONTEXT_MENU_GIT = [...EDITOR_CONTEXT_MENU, '3_git'];
 export namespace GIT_COMMANDS {
     export const FETCH = {
         id: 'git.fetch',
-        label: 'Git: Fetch...'
+        label: 'Git: Fetch...',
     };
     export const PULL = {
         id: 'git.pull',
-        label: 'Git: Pull...'
+        label: 'Git: Pull...',
     };
     export const PUSH = {
         id: 'git.push',
-        label: 'Git: Push...'
+        label: 'Git: Push...',
     };
     export const MERGE = {
         id: 'git.merge',
-        label: 'Git: Merge...'
+        label: 'Git: Merge...',
     };
     export const CHECKOUT = {
         id: 'git.checkout',
-        label: 'Git: Checkout'
+        label: 'Git: Checkout',
     };
     export const COMMIT_AMEND = {
-        id: 'git.commit.amend'
+        id: 'git.commit.amend',
     };
     export const COMMIT_SIGN_OFF = {
-        id: 'git.commit.signOff'
+        id: 'git.commit.signOff',
     };
     export const CHANGE_REPOSITORY = {
         id: 'git.change.repository',
-        label: 'Git: Change Repository...'
+        label: 'Git: Change Repository...',
     };
     export const OPEN_FILE = {
         id: 'git.open.file',
-        label: 'Git: Open File'
+        label: 'Git: Open File',
     };
     export const OPEN_CHANGES = {
         id: 'git.open.changes',
-        label: 'Git: Open Changes'
+        label: 'Git: Open Changes',
     };
     export const SYNC = {
         id: 'git.sync',
-        label: 'Git: Sync'
+        label: 'Git: Sync',
     };
     export const PUBLISH = {
         id: 'git.publish',
-        label: 'Git: Publish Branch'
+        label: 'Git: Publish Branch',
     };
 }
 
@@ -98,10 +98,10 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
             widgetName: 'Git',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 200
+                rank: 200,
             },
             toggleCommandId: 'gitView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+g'
+            toggleKeybinding: 'ctrlcmd+shift+g',
         });
     }
 
@@ -118,7 +118,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
                     alignment: StatusBarAlignment.LEFT,
                     priority: 102,
                     command: GIT_COMMANDS.CHANGE_REPOSITORY.id,
-                    tooltip: path.toString()
+                    tooltip: path.toString(),
                 });
             } else {
                 this.statusBar.removeElement(GitViewContribution.GIT_SELECTED_REPOSITORY);
@@ -145,7 +145,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
                 text: `$(code-fork) ${branch}${dirty}`,
                 alignment: StatusBarAlignment.LEFT,
                 priority: 101,
-                command: GIT_COMMANDS.CHECKOUT.id
+                command: GIT_COMMANDS.CHECKOUT.id,
             });
             this.updateSyncStatusBarEntry();
         });
@@ -157,22 +157,22 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
         [GIT_COMMANDS.FETCH, GIT_COMMANDS.PULL, GIT_COMMANDS.PUSH, GIT_COMMANDS.MERGE].forEach(command =>
             menus.registerMenuAction(GitWidget.ContextMenu.OTHER_GROUP, {
                 commandId: command.id,
-                label: command.label.slice('Git: '.length)
-            })
+                label: command.label.slice('Git: '.length),
+            }),
         );
         menus.registerMenuAction(GitWidget.ContextMenu.COMMIT_GROUP, {
             commandId: GIT_COMMANDS.COMMIT_AMEND.id,
-            label: 'Commit (Amend)'
+            label: 'Commit (Amend)',
         });
         menus.registerMenuAction(GitWidget.ContextMenu.COMMIT_GROUP, {
             commandId: GIT_COMMANDS.COMMIT_SIGN_OFF.id,
-            label: 'Commit (Signed Off)'
+            label: 'Commit (Signed Off)',
         });
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {
-            commandId: GIT_COMMANDS.OPEN_FILE.id
+            commandId: GIT_COMMANDS.OPEN_FILE.id,
         });
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {
-            commandId: GIT_COMMANDS.OPEN_CHANGES.id
+            commandId: GIT_COMMANDS.OPEN_CHANGES.id,
         });
     }
 
@@ -180,27 +180,27 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
         super.registerCommands(registry);
         registry.registerCommand(GIT_COMMANDS.FETCH, {
             execute: () => this.quickOpenService.fetch(),
-            isEnabled: () => !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.PULL, {
             execute: () => this.quickOpenService.pull(),
-            isEnabled: () => !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.PUSH, {
             execute: () => this.quickOpenService.push(),
-            isEnabled: () => !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.MERGE, {
             execute: () => this.quickOpenService.merge(),
-            isEnabled: () => !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.CHECKOUT, {
             execute: () => this.quickOpenService.checkout(),
-            isEnabled: () => !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.COMMIT_SIGN_OFF, {
             execute: () => this.tryGetWidget()!.doCommit(this.repositoryTracker.selectedRepository, 'sign-off'),
-            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.COMMIT_AMEND, {
             execute: async () => {
@@ -217,31 +217,31 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
                     }
                 }
             },
-            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository
+            isEnabled: () => !!this.tryGetWidget() && !!this.repositoryTracker.selectedRepository,
         });
         registry.registerCommand(GIT_COMMANDS.CHANGE_REPOSITORY, {
             execute: () => this.quickOpenService.changeRepository(),
-            isEnabled: () => this.hasMultipleRepositories()
+            isEnabled: () => this.hasMultipleRepositories(),
         });
         registry.registerCommand(GIT_COMMANDS.OPEN_FILE, {
             execute: () => this.openFile(),
             isEnabled: () => !!this.openFileOptions,
-            isVisible: () => !!this.openFileOptions
+            isVisible: () => !!this.openFileOptions,
         });
         registry.registerCommand(GIT_COMMANDS.OPEN_CHANGES, {
             execute: () => this.openChanges(),
             isEnabled: () => !!this.openChangesOptions,
-            isVisible: () => !!this.openChangesOptions
+            isVisible: () => !!this.openChangesOptions,
         });
         registry.registerCommand(GIT_COMMANDS.SYNC, {
             execute: () => this.syncService.sync(),
             isEnabled: () => this.syncService.canSync(),
-            isVisible: () => this.syncService.canSync()
+            isVisible: () => this.syncService.canSync(),
         });
         registry.registerCommand(GIT_COMMANDS.PUBLISH, {
             execute: () => this.syncService.publish(),
             isEnabled: () => this.syncService.canPublish(),
-            isVisible: () => this.syncService.canPublish()
+            isVisible: () => this.syncService.canPublish(),
         });
     }
 
@@ -305,7 +305,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
             this.statusBar.setElement(GitViewContribution.GIT_SYNC_STATUS, {
                 alignment: StatusBarAlignment.LEFT,
                 priority: 100,
-                ...entry
+                ...entry,
             });
         } else {
             this.statusBar.removeElement(GitViewContribution.GIT_SYNC_STATUS);
@@ -319,7 +319,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
         if (this.syncService.isSyncing()) {
             return {
                 text: '$(refresh~spin)',
-                tooltip: 'Synchronizing Changes...'
+                tooltip: 'Synchronizing Changes...',
             };
         }
         const { upstreamBranch, aheadBehind } = status;
@@ -327,13 +327,13 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget> imp
             return {
                 text: '$(refresh)' + (aheadBehind ? ` ${aheadBehind.behind}↓ ${aheadBehind.ahead}↑` : ''),
                 command: GIT_COMMANDS.SYNC.id,
-                tooltip: 'Synchronize Changes'
+                tooltip: 'Synchronize Changes',
             };
         }
         return {
             text: '$(cloud-upload)',
             command: GIT_COMMANDS.PUBLISH.id,
-            tooltip: 'Publish Changes'
+            tooltip: 'Publish Changes',
         };
     }
 }

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -89,7 +89,7 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
     @postConstruct()
     protected init() {
         this.toDispose.push(this.repositoryProvider.onDidChangeRepository(repository =>
-            this.initialize(repository)
+            this.initialize(repository),
         ));
         this.initialize(this.repositoryProvider.selectedRepository);
         this.update();
@@ -124,7 +124,7 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
         return {
             message: this.message,
             commitMessageValidationResult: this.commitMessageValidationResult,
-            messageBoxHeight
+            messageBoxHeight,
         };
     }
 
@@ -157,13 +157,13 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
             if (message.trim().length === 0) {
                 this.commitMessageValidationResult = {
                     status: 'error',
-                    message: 'Please provide a commit message'
+                    message: 'Please provide a commit message',
                 };
             }
             if (this.commitMessageValidationResult === undefined && !(await this.git.status(repository)).changes.some(c => c.staged === true)) {
                 this.commitMessageValidationResult = {
                     status: 'error',
-                    message: 'No changes added to commit'
+                    message: 'No changes added to commit',
                 };
             }
             if (this.commitMessageValidationResult === undefined) {
@@ -199,25 +199,25 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
                 const [icon, label, description] = await Promise.all([
                     this.labelProvider.getIcon(uri),
                     this.labelProvider.getName(uri),
-                    repository ? Repository.relativePath(repository, uri.parent).toString() : this.labelProvider.getLongName(uri.parent)
+                    repository ? Repository.relativePath(repository, uri.parent).toString() : this.labelProvider.getLongName(uri.parent),
                 ]);
                 if (GitFileStatus[GitFileStatus.Conflicted.valueOf()] !== GitFileStatus[change.status]) {
                     if (change.staged) {
                         stagedChanges.push({
                             icon, label, description,
-                            ...change
+                            ...change,
                         });
                     } else {
                         unstagedChanges.push({
                             icon, label, description,
-                            ...change
+                            ...change,
                         });
                     }
                 } else {
                     if (!change.staged) {
                         mergeChanges.push({
                             icon, label, description,
-                            ...change
+                            ...change,
                         });
                     }
                 }
@@ -250,7 +250,7 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
                 }
                 style={
                     {
-                        display: !!this.commitMessageValidationResult ? 'block' : 'none'
+                        display: !!this.commitMessageValidationResult ? 'block' : 'none',
                     }
                 }>{validationMessage}</div>
         </div>;
@@ -372,7 +372,7 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
         if (el) {
             this.contextMenuRenderer.render(GitWidget.ContextMenu.PATH, {
                 x: el.getBoundingClientRect().left,
-                y: el.getBoundingClientRect().top + el.offsetHeight
+                y: el.getBoundingClientRect().top + el.offsetHeight,
             });
         }
     }
@@ -431,7 +431,7 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
     protected async getUserConfig(repository: Repository): Promise<[string, string]> {
         const [username, email] = (await Promise.all([
             this.git.exec(repository, ['config', 'user.name']),
-            this.git.exec(repository, ['config', 'user.email'])
+            this.git.exec(repository, ['config', 'user.email']),
         ])).map(result => result.stdout.trim());
         return [username, email];
     }

--- a/packages/git/src/browser/history/git-commit-detail-open-handler.ts
+++ b/packages/git/src/browser/history/git-commit-detail-open-handler.ts
@@ -59,7 +59,7 @@ export class GitCommitDetailOpenHandler extends WidgetOpenHandler<GitCommitDetai
     getCommitDetailWidgetOptions(commit: GitCommitDetails): GitCommitDetailWidgetOptions {
         const range = {
             fromRevision: commit.commitSha + "~1",
-            toRevision: commit.commitSha
+            toRevision: commit.commitSha,
         };
         return {
             range,
@@ -71,7 +71,7 @@ export class GitCommitDetailOpenHandler extends WidgetOpenHandler<GitCommitDetai
             commitMessage: commit.commitMessage,
             fileChangeNodes: commit.fileChangeNodes,
             messageBody: commit.messageBody,
-            commitSha: commit.commitSha
+            commitSha: commit.commitSha,
         };
     }
 

--- a/packages/git/src/browser/history/git-commit-detail-widget.ts
+++ b/packages/git/src/browser/history/git-commit-detail-widget.ts
@@ -48,7 +48,7 @@ export class GitCommitDetailWidget extends GitDiffWidget {
     constructor(
         @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
-        @inject(GitCommitDetailWidgetOptions) protected readonly commitDetailOptions: GitCommitDetailWidgetOptions
+        @inject(GitCommitDetailWidgetOptions) protected readonly commitDetailOptions: GitCommitDetailWidgetOptions,
     ) {
         super();
         this.id = "commit" + commitDetailOptions.commitSha;
@@ -75,7 +75,7 @@ export class GitCommitDetailWidget extends GitDiffWidget {
             year: "numeric",
             hour12: true,
             hour: "numeric",
-            minute: "numeric"
+            minute: "numeric",
         });
         const date = h.div({ className: "date header-value noWrapInfo" }, dateStr);
         const dateRow = h.div({ className: "header-row noWrapInfo" }, h.div({ className: 'theia-header' }, 'date: '), date);
@@ -98,7 +98,7 @@ export class GitCommitDetailWidget extends GitDiffWidget {
             mode: 'reveal',
             widgetOptions: ref ?
                 { area: 'main', mode: 'tab-after', ref } :
-                { area: 'main', mode: 'split-right', ref: this }
+                { area: 'main', mode: 'split-right', ref: this },
         });
         this.ref = widget instanceof Widget ? widget : undefined;
         if (this.ref) {

--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -27,10 +27,10 @@ import { GitRepositoryTracker } from '../git-repository-tracker';
 export namespace GitHistoryCommands {
     export const OPEN_FILE_HISTORY: Command = {
         id: 'git-history:open-file-history',
-        label: 'Git History'
+        label: 'Git History',
     };
     export const OPEN_BRANCH_HISTORY: Command = {
-        id: 'git-history:open-branch-history'
+        id: 'git-history:open-branch-history',
     };
 }
 
@@ -50,17 +50,17 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
             widgetName: 'Git History',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 400
+                rank: 400,
             },
             toggleCommandId: GitHistoryCommands.OPEN_BRANCH_HISTORY.id,
-            toggleKeybinding: 'alt+h'
+            toggleKeybinding: 'alt+h',
         });
     }
 
     @postConstruct()
     protected init() {
         this.repositoryTracker.onDidChangeRepository(async repository =>
-            this.refreshWidget(repository ? repository.localUri : undefined)
+            this.refreshWidget(repository ? repository.localUri : undefined),
         );
         this.repositoryTracker.onGitEvent(event => {
             const { source, status, oldStatus } = event;
@@ -78,7 +78,7 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '5_history'], {
-            commandId: GitHistoryCommands.OPEN_FILE_HISTORY.id
+            commandId: GitHistoryCommands.OPEN_FILE_HISTORY.id,
         });
 
         super.registerMenus(menus);
@@ -86,16 +86,16 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(GitHistoryCommands.OPEN_FILE_HISTORY, this.newUriAwareCommandHandler({
-            execute: async uri => this.showWidget(uri.toString())
+            execute: async uri => this.showWidget(uri.toString()),
         }));
         commands.registerCommand(GitHistoryCommands.OPEN_BRANCH_HISTORY, {
-            execute: () => this.showWidget(undefined)
+            execute: () => this.showWidget(undefined),
         });
     }
 
     async showWidget(uri: string | undefined) {
         await this.openView({
-            activate: true
+            activate: true,
         });
         this.refreshWidget(uri);
     }
@@ -109,7 +109,7 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
         const options: Git.Options.Log = {
             uri,
             maxCount: GIT_HISTORY_MAX_COUNT,
-            shortSha: true
+            shortSha: true,
         };
         await widget.setContent(options);
     }

--- a/packages/git/src/browser/history/git-history-frontend-module.ts
+++ b/packages/git/src/browser/history/git-history-frontend-module.ts
@@ -31,7 +31,7 @@ export function bindGitHistoryModule(bind: interfaces.Bind) {
     bind(GitHistoryWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: GIT_HISTORY,
-        createWidget: () => ctx.container.get<GitHistoryWidget>(GitHistoryWidget)
+        createWidget: () => ctx.container.get<GitHistoryWidget>(GitHistoryWidget),
     }));
 
     bind(WidgetFactory).toDynamicValue(ctx => ({
@@ -42,7 +42,7 @@ export function bindGitHistoryModule(bind: interfaces.Bind) {
             child.bind(GitCommitDetailWidget).toSelf();
             child.bind(GitCommitDetailWidgetOptions).toConstantValue(options);
             return child.get(GitCommitDetailWidget);
-        }
+        },
     }));
 
     bind(GitCommitDetailOpenHandler).toSelf();

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -79,9 +79,9 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                     ll.className = "history-lazy-loading show";
                     this.addCommits({
                         range: {
-                            toRevision: this.commits[this.commits.length - 1].commitSha
+                            toRevision: this.commits[this.commits.length - 1].commitSha,
                         },
-                        maxCount: GIT_HISTORY_MAX_COUNT
+                        maxCount: GIT_HISTORY_MAX_COUNT,
                     });
                 }
             };
@@ -129,7 +129,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                             fileChangeNodes,
                             fileChanges: commit.fileChanges,
                             expanded: false,
-                            selected: false
+                            selected: false,
                         });
                     }
                     this.commits.push(...commits);
@@ -151,7 +151,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                 const description = this.relativePath(fileChangeUri.parent);
                 const caption = this.computeCaption(fileChange);
                 commit.fileChangeNodes.push({
-                    ...fileChange, icon, label, description, caption, commitSha: commit.commitSha
+                    ...fileChange, icon, label, description, caption, commitSha: commit.commitSha,
                 });
             }));
             delete commit.fileChanges;
@@ -164,7 +164,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         return {
             commits,
             options,
-            singleFileMode
+            singleFileMode,
         };
     }
 
@@ -297,7 +297,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
     protected async openDetailWidget(commit: GitCommitNode) {
         const commitDetails = this.detailOpenHandler.getCommitDetailWidgetOptions(commit);
         this.detailOpenHandler.open(GitCommitDetailUri.toUri(commit.commitSha), {
-            ...commitDetails
+            ...commitDetails,
         } as GitCommitDetailOpenerOptions);
     }
 

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -198,7 +198,7 @@ export enum BranchType {
     /**
      * The remote branch type.
      */
-    Remote = 1
+    Remote = 1,
 
 }
 
@@ -393,7 +393,7 @@ export declare enum GitError {
     InvalidRefLength = 33,
     ProtectedBranchRequiresReview = 34,
     ProtectedBranchForcePush = 35,
-    PushWithPrivateEmail = 36
+    PushWithPrivateEmail = 36,
 }
 
 export interface GitFileBlame {

--- a/packages/git/src/common/git-watcher.ts
+++ b/packages/git/src/common/git-watcher.ts
@@ -99,7 +99,7 @@ export class ReconnectingGitWatcherServer implements GitWatcherServer {
     private readonly localToRemoteWatcher = new Map<number, number>();
 
     constructor(
-        @inject(GitWatcherServerProxy) private readonly proxy: GitWatcherServerProxy
+        @inject(GitWatcherServerProxy) private readonly proxy: GitWatcherServerProxy,
     ) {
         this.proxy.onDidOpenConnection(() => this.reconnect());
     }
@@ -153,7 +153,7 @@ export class GitWatcher implements GitWatcherClient, Disposable {
     private readonly onGitEventEmitter: Emitter<GitStatusChangeEvent>;
 
     constructor(
-        @inject(GitWatcherServer) private readonly server: GitWatcherServer
+        @inject(GitWatcherServer) private readonly server: GitWatcherServer,
     ) {
         this.toDispose = new DisposableCollection();
         this.onGitEventEmitter = new Emitter<GitStatusChangeEvent>();

--- a/packages/git/src/node/dugite-git-watcher.slow-spec.ts
+++ b/packages/git/src/node/dugite-git-watcher.slow-spec.ts
@@ -78,7 +78,7 @@ describe('git-watcher-slow', () => {
                 } else {
                     events.push(event);
                 }
-            }
+            },
         };
         watcher!.setClient(client);
         watchers.push(await watcher!.watchGitChanges(repository!));

--- a/packages/git/src/node/dugite-git-watcher.ts
+++ b/packages/git/src/node/dugite-git-watcher.ts
@@ -30,7 +30,7 @@ export class DugiteGitWatcherServer implements GitWatcherServer {
     protected readonly subscriptions = new Map<string, DisposableCollection>();
 
     constructor(
-        @inject(GitRepositoryManager) protected readonly manager: GitRepositoryManager
+        @inject(GitRepositoryManager) protected readonly manager: GitRepositoryManager,
     ) { }
 
     dispose(): void {

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -532,7 +532,7 @@ describe('git', async function () {
             await addAndCommit('add 🍏\n* green\n* red');
 
             await expectBlame([
-                [0, 'add 🍏', '* green\n* red']
+                [0, 'add 🍏', '* green\n* red'],
             ]);
         });
     });
@@ -794,7 +794,7 @@ namespace ChangeDelta {
     export function map(repository: Repository, fileChange: GitFileChange): ChangeDelta {
         return {
             pathSegment: toPathSegment(repository, fileChange.uri),
-            status: fileChange.status
+            status: fileChange.status,
         };
     }
 }

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -38,7 +38,7 @@ import { ILogger } from '@theia/core';
 import * as strings from '@theia/core/lib/common/strings';
 import {
     Git, GitUtils, Repository, WorkingDirectoryStatus, GitFileChange, GitFileStatus, Branch, Commit,
-    CommitIdentity, GitResult, CommitWithChanges, GitFileBlame, CommitLine
+    CommitIdentity, GitResult, CommitWithChanges, GitFileBlame, CommitLine,
 } from '../common';
 import { GitRepositoryManager } from './git-repository-manager';
 import { GitLocator } from './git-locator/git-locator-protocol';
@@ -85,14 +85,14 @@ export class NameStatusParser extends OutputParser<GitFileChange> {
                 changes.push({
                     status,
                     uri,
-                    oldUri
+                    oldUri,
                 });
                 index = index + 3;
             } else {
                 const uri = this.toUri(repositoryUri, items[index + 1]);
                 changes.push({
                     status,
-                    uri
+                    uri,
                 });
                 index = index + 2;
             }
@@ -113,7 +113,7 @@ export enum CommitPlaceholders {
     AUTHOR_DATE = '%ad',
     AUTHOR_RELATIVE_DATE = '%ar',
     SUBJECT = '%s',
-    BODY = '%b'
+    BODY = '%b',
 }
 
 /**
@@ -146,12 +146,12 @@ export class CommitDetailsParser extends OutputParser<CommitWithChanges> {
             changes.push({
                 sha,
                 author: {
-                    timestamp, email, name
+                    timestamp, email, name,
                 },
                 authorDateRelative,
                 summary,
                 body,
-                fileChanges
+                fileChanges,
             });
         }
         return changes;
@@ -205,7 +205,7 @@ export class GitBlameParser {
                         tzOffset: entry.authorTz,
                     },
                     summary: entry.summary,
-                    body: await commitBody(sha)
+                    body: await commitBody(sha),
                 };
                 commits.set(sha, commit);
             }
@@ -213,7 +213,7 @@ export class GitBlameParser {
             for (let lineOffset = 0; lineOffset < lineCount; lineOffset++) {
                 const line = <CommitLine>{
                     sha,
-                    line: entry.line! + lineOffset
+                    line: entry.line! + lineOffset,
                 };
                 lines[line.line] = line;
             }
@@ -323,7 +323,7 @@ export class DugiteGit implements Git {
         const containingPath = await this.resolveContainingPath(workspaceRootPath);
         if (containingPath) {
             repositories.push({
-                localUri: this.getUri(containingPath)
+                localUri: this.getUri(containingPath),
             });
         }
         const maxCount = typeof options.maxCount === 'number' ? options.maxCount - repositories.length : undefined;
@@ -331,11 +331,11 @@ export class DugiteGit implements Git {
             return repositories;
         }
         for (const repositoryPath of await this.locator.locate(workspaceRootPath, {
-            maxCount
+            maxCount,
         })) {
             if (containingPath !== repositoryPath) {
                 repositories.push({
-                    localUri: this.getUri(repositoryPath)
+                    localUri: this.getUri(repositoryPath),
                 });
             }
         }
@@ -351,7 +351,7 @@ export class DugiteGit implements Git {
     async add(repository: Repository, uri: string | string[]): Promise<void> {
         const paths = (Array.isArray(uri) ? uri : [uri]).map(FileUri.fsPath);
         return this.manager.run(repository, () =>
-            stage(this.getFsPath(repository), paths)
+            stage(this.getFsPath(repository), paths),
         );
     }
 
@@ -360,7 +360,7 @@ export class DugiteGit implements Git {
         const treeish = options && options.treeish ? options.treeish : undefined;
         const where = options && options.reset ? options.reset : undefined;
         return this.manager.run(repository, () =>
-            unstage(this.getFsPath(repository), paths, treeish, where)
+            unstage(this.getFsPath(repository), paths, treeish, where),
         );
     }
 
@@ -410,7 +410,7 @@ export class DugiteGit implements Git {
         const signOff = options && options.signOff;
         const amend = options && options.amend;
         return this.manager.run(repository, () =>
-            createCommit(this.getFsPath(repository), message || '', signOff, amend)
+            createCommit(this.getFsPath(repository), message || '', signOff, amend),
         );
     }
 
@@ -421,7 +421,7 @@ export class DugiteGit implements Git {
             this.fail(repository, `No remote repository specified. Please, specify either a URL or a remote name from which new revisions should be fetched.`);
         }
         return this.manager.run(repository, () =>
-            fetch(repositoryPath, r!)
+            fetch(repositoryPath, r!),
         );
     }
 
@@ -448,7 +448,7 @@ export class DugiteGit implements Git {
             await this.exec(repository, args);
         } else {
             return this.manager.run(repository, () =>
-                push(repositoryPath, currentRemote!, branchName, remoteBranch)
+                push(repositoryPath, currentRemote!, branchName, remoteBranch),
             );
         }
     }
@@ -485,14 +485,14 @@ export class DugiteGit implements Git {
         const repositoryPath = this.getFsPath(repository);
         const mode = this.getResetMode(options.mode);
         return this.manager.run(repository, () =>
-            reset(repositoryPath, mode, options.mode ? options.mode : 'HEAD')
+            reset(repositoryPath, mode, options.mode ? options.mode : 'HEAD'),
         );
     }
 
     merge(repository: Repository, options: Git.Options.Merge): Promise<void> {
         const repositoryPath = this.getFsPath(repository);
         return this.manager.run(repository, () =>
-            merge(repositoryPath, options.branch)
+            merge(repositoryPath, options.branch),
         );
     }
 
@@ -674,7 +674,7 @@ export class DugiteGit implements Git {
             type: toMap.type,
             upstream: toMap.upstream,
             upstreamWithoutRemote: toMap.upstreamWithoutRemote,
-            tip
+            tip,
         };
     }
 
@@ -685,7 +685,7 @@ export class DugiteGit implements Git {
             body: toMap.body,
             parentSHAs: [...toMap.parentSHAs],
             sha: toMap.sha,
-            summary: toMap.summary
+            summary: toMap.summary,
         };
     }
 
@@ -694,7 +694,7 @@ export class DugiteGit implements Git {
             timestamp: toMap.date.getTime(),
             email: toMap.email,
             name: toMap.name,
-            tzOffset: toMap.tzOffset
+            tzOffset: toMap.tzOffset,
         };
     }
 
@@ -710,7 +710,7 @@ export class DugiteGit implements Git {
             upstreamBranch: toMap.currentUpstreamBranch,
             aheadBehind,
             changes,
-            currentHead: toMap.currentTip
+            currentHead: toMap.currentTip,
         };
     }
 
@@ -733,7 +733,7 @@ export class DugiteGit implements Git {
             uri,
             status,
             oldUri,
-            staged: toMap.staged
+            staged: toMap.staged,
         };
     }
 

--- a/packages/git/src/node/git-backend-module.ts
+++ b/packages/git/src/node/git-backend-module.ts
@@ -35,7 +35,7 @@ export namespace GitBindingOptions {
     export const Default: GitBindingOptions = {
         bindManager(binding: interfaces.BindingToSyntax<{}>): interfaces.BindingWhenOnSyntax<{}> {
             return binding.to(GitRepositoryManager).inSingletonScope();
-        }
+        },
     };
 }
 
@@ -53,7 +53,7 @@ export function bindGit(bind: interfaces.Bind, bindingOptions: GitBindingOptions
             const logger = ctx.container.get<ILogger>(ILogger);
             return new GitLocatorImpl({
                 info: (message, ...args) => logger.info(message, ...args),
-                error: (message, ...args) => logger.error(message, ...args)
+                error: (message, ...args) => logger.error(message, ...args),
             });
         });
     } else {
@@ -79,7 +79,7 @@ export default new ContainerModule(bind => {
             const server = context.container.get<Git>(Git);
             client.onDidCloseConnection(() => server.dispose());
             return server;
-        })
+        }),
     ).inSingletonScope();
 
     bindRepositoryWatcher(bind);
@@ -89,6 +89,6 @@ export default new ContainerModule(bind => {
             server.setClient(client);
             client.onDidCloseConnection(() => server.dispose());
             return server;
-        })
+        }),
     ).inSingletonScope();
 });

--- a/packages/git/src/node/git-locator/git-locator-client.ts
+++ b/packages/git/src/node/git-locator/git-locator-client.ts
@@ -36,7 +36,7 @@ export class GitLocatorClient implements GitLocator {
         return new Promise((resolve, reject) => {
             const toStop = this.ipcConnectionProvider.listen({
                 serverName: 'git-locator',
-                entryPoint: paths.resolve(__dirname, 'git-locator-host')
+                entryPoint: paths.resolve(__dirname, 'git-locator-host'),
             }, async connection => {
                 const proxyFactory = new JsonRpcProxyFactory<GitLocator>();
                 const remote = proxyFactory.createProxy();

--- a/packages/git/src/node/git-locator/git-locator-impl.ts
+++ b/packages/git/src/node/git-locator/git-locator-impl.ts
@@ -30,17 +30,17 @@ export class GitLocatorImpl implements GitLocator {
 
     protected readonly options: {
         info: (message: string, ...args: any[]) => void
-        error: (message: string, ...args: any[]) => void
+        error: (message: string, ...args: any[]) => void,
     };
 
     constructor(options?: {
         info?: (message: string, ...args: any[]) => void
-        error?: (message: string, ...args: any[]) => void
+        error?: (message: string, ...args: any[]) => void,
     }) {
         this.options = {
             info: (message, ...args) => console.info(message, ...args),
             error: (message, ...args) => console.error(message, ...args),
-            ...options
+            ...options,
         };
     }
 
@@ -50,7 +50,7 @@ export class GitLocatorImpl implements GitLocator {
     async locate(basePath: string, options: GitLocateOptions): Promise<string[]> {
         return await this.doLocate(basePath, {
             maxCount: typeof options.maxCount === 'number' ? options.maxCount : -1,
-            visited: new Map<string, boolean>()
+            visited: new Map<string, boolean>(),
         });
     }
 
@@ -78,7 +78,7 @@ export class GitLocatorImpl implements GitLocator {
                     resolve(this.locateFrom(
                         newContext => this.generateNested(repositoryPaths, newContext),
                         context,
-                        repositoryPaths
+                        repositoryPaths,
                     ));
                 }
             }, () => []);
@@ -99,7 +99,7 @@ export class GitLocatorImpl implements GitLocator {
                 } else {
                     resolve(this.locateFrom(
                         newContext => this.generateRepositories(repositoryPath, files, newContext),
-                        context
+                        context,
                     ));
                 }
             });
@@ -110,14 +110,14 @@ export class GitLocatorImpl implements GitLocator {
         for (const file of files) {
             if (file !== '.git') {
                 yield this.doLocate(path.join(repositoryPath, file), {
-                    ...context
+                    ...context,
                 });
             }
         }
     }
 
     protected async locateFrom(
-        generator: (context: GitLocateContext) => IterableIterator<Promise<string[]>>, parentContext: GitLocateContext, initial?: string[]
+        generator: (context: GitLocateContext) => IterableIterator<Promise<string[]>>, parentContext: GitLocateContext, initial?: string[],
     ): Promise<string[]> {
         const result: string[] = [];
         if (initial) {
@@ -125,7 +125,7 @@ export class GitLocatorImpl implements GitLocator {
         }
         const context = {
             ...parentContext,
-            maxCount: parentContext.maxCount - result.length
+            maxCount: parentContext.maxCount - result.length,
         };
         for (const locateRepositories of generator(context)) {
             const repositories = await locateRepositories;

--- a/packages/git/src/node/git-repository-manager.ts
+++ b/packages/git/src/node/git-repository-manager.ts
@@ -25,7 +25,7 @@ export class GitRepositoryManager {
     @inject(GitRepositoryWatcherFactory)
     protected readonly watcherFactory: GitRepositoryWatcherFactory;
     protected readonly watchers = new ReferenceCollection<Repository, GitRepositoryWatcher>(
-        repository => this.watcherFactory({ repository })
+        repository => this.watcherFactory({ repository }),
     );
 
     run<T>(repository: Repository, op: () => Promise<T>): Promise<T> {

--- a/packages/git/src/node/test/binding-helper.ts
+++ b/packages/git/src/node/test/binding-helper.ts
@@ -34,7 +34,7 @@ export async function createGit(bindingOptions: GitBindingOptions = GitBindingOp
     bindGit(bind, {
         bindManager(binding: interfaces.BindingToSyntax<{}>): interfaces.BindingWhenOnSyntax<{}> {
             return binding.to(NoSyncRepositoryManager).inSingletonScope();
-        }
+        },
     });
     return container.get(DugiteGit);
 }

--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from "inversify";
 import { CommandService } from "@theia/core/lib/common";
 import {
-    Window, ILanguageClient, BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory, LanguageClientOptions
+    Window, ILanguageClient, BaseLanguageClientContribution, Workspace, Languages, LanguageClientFactory, LanguageClientOptions,
 } from '@theia/languages/lib/browser';
 import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME } from '../common';
 import { ActionableNotification, ActionableMessage, StatusReport, StatusNotification } from "./java-protocol";
@@ -37,7 +37,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
         @inject(Window) protected readonly window: Window,
         @inject(CommandService) protected readonly commandService: CommandService,
-        @inject(StatusBar) protected readonly statusBar: StatusBar
+        @inject(StatusBar) protected readonly statusBar: StatusBar,
     ) {
         super(workspace, languages, languageClientFactory);
     }
@@ -64,7 +64,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         const statusEntry = {
             alignment: StatusBarAlignment.LEFT,
             priority: 1,
-            text: "$(refresh~spin) " + message.message
+            text: "$(refresh~spin) " + message.message,
         } as StatusBarEntry;
         this.statusBar.setElement(this.statusNotificationName, statusEntry);
         this.statusBarTimeout = window.setTimeout(() => {
@@ -87,8 +87,8 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         const options = super.createOptions();
         options.initializationOptions = {
             extendedClientCapabilities: {
-                classFileContentsSupport: true
-            }
+                classFileContentsSupport: true,
+            },
         };
         return options;
     }

--- a/packages/java/src/browser/java-commands.ts
+++ b/packages/java/src/browser/java-commands.ts
@@ -27,14 +27,14 @@ import { JavaKeybindingContexts } from "./java-keybinding-contexts";
  * Show Java references
  */
 export const SHOW_JAVA_REFERENCES: Command = {
-    id: 'java.show.references'
+    id: 'java.show.references',
 };
 
 /**
  * Apply Workspace Edit
  */
 export const APPLY_WORKSPACE_EDIT: Command = {
-    id: 'java.apply.workspaceEdit'
+    id: 'java.apply.workspaceEdit',
 };
 
 /**
@@ -42,7 +42,7 @@ export const APPLY_WORKSPACE_EDIT: Command = {
  */
 export const JAVA_ORGANIZE_IMPORTS: Command = {
     label: 'Java: Organize Imports',
-    id: 'java.edit.organizeImports'
+    id: 'java.edit.organizeImports',
 };
 
 @injectable()
@@ -60,11 +60,11 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(SHOW_JAVA_REFERENCES, {
             execute: (uri: string, position: Position, locations: Location[]) =>
-                commands.executeCommand(EditorCommands.SHOW_REFERENCES.id, uri, position, locations)
+                commands.executeCommand(EditorCommands.SHOW_REFERENCES.id, uri, position, locations),
         });
         commands.registerCommand(APPLY_WORKSPACE_EDIT, {
             execute: (changes: WorkspaceEdit) =>
-                !!this.workspace.applyEdit && this.workspace.applyEdit(changes)
+                !!this.workspace.applyEdit && this.workspace.applyEdit(changes),
         });
         commands.registerCommand(JAVA_ORGANIZE_IMPORTS, {
             execute: async (changes: WorkspaceEdit) => {
@@ -77,8 +77,8 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
                 const result = await client.sendRequest(ExecuteCommandRequest.type, {
                     command: JAVA_ORGANIZE_IMPORTS.id,
                     arguments: [
-                        uri
-                    ]
+                        uri,
+                    ],
                 });
                 if (isWorkspaceEdit(result) && this.workspace.applyEdit) {
                     return await this.workspace.applyEdit(result);
@@ -87,14 +87,14 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
                 }
             },
             isVisible: () => !!this.editorManager.currentEditor,
-            isEnabled: () => !!this.editorManager.currentEditor
+            isEnabled: () => !!this.editorManager.currentEditor,
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...EDITOR_CONTEXT_MENU, '1_modification'], {
             commandId: JAVA_ORGANIZE_IMPORTS.id,
-            label: 'Organize Imports'
+            label: 'Organize Imports',
         });
     }
 
@@ -102,7 +102,7 @@ export class JavaCommandContribution implements CommandContribution, MenuContrib
         keybindings.registerKeybinding({
             command: JAVA_ORGANIZE_IMPORTS.id,
             context: JavaKeybindingContexts.javaEditorTextFocus,
-            keybinding: 'ctrlcmd+shift+o'
+            keybinding: 'ctrlcmd+shift+o',
         });
     }
 }

--- a/packages/java/src/browser/java-resource.ts
+++ b/packages/java/src/browser/java-resource.ts
@@ -25,7 +25,7 @@ export class JavaResource implements Resource {
 
     constructor(
         public uri: URI,
-        protected readonly clientContribution: JavaClientContribution
+        protected readonly clientContribution: JavaClientContribution,
     ) { }
 
     dispose(): void {
@@ -35,8 +35,8 @@ export class JavaResource implements Resource {
         const uri = this.uri.toString();
         return this.clientContribution.languageClient.then(languageClient =>
             languageClient.sendRequest(ClassFileContentsRequest.type, { uri }).then(content =>
-                content || ''
-            )
+                content || '',
+            ),
         );
     }
 
@@ -47,7 +47,7 @@ export class JavaResourceResolver implements ResourceResolver {
 
     constructor(
         @inject(JavaClientContribution)
-        protected readonly clientContribution: JavaClientContribution
+        protected readonly clientContribution: JavaClientContribution,
     ) { }
 
     resolve(uri: URI): JavaResource {

--- a/packages/java/src/browser/monaco-contribution/java-monaco-language.ts
+++ b/packages/java/src/browser/monaco-contribution/java-monaco-language.ts
@@ -29,5 +29,5 @@ export const configuration: monaco.languages.LanguageConfiguration = {
         { open: '[', close: ']', notIn: ['string', 'comment'] },
         { open: '(', close: ')', notIn: ['string', 'comment'] },
         { open: '<', close: '>', notIn: ['string', 'comment'] },
-    ]
+    ],
 };

--- a/packages/java/src/browser/monaco-contribution/java-textmate-contribution.ts
+++ b/packages/java/src/browser/monaco-contribution/java-textmate-contribution.ts
@@ -27,9 +27,9 @@ export class JavaTextmateContribution implements LanguageGrammarDefinitionContri
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: javaDocGrammar
+                    content: javaDocGrammar,
                 };
-            }
+            },
         });
         const scope = 'source.java';
         const javaGrammar = require('../../../data/java.tmlanguage.json');
@@ -37,9 +37,9 @@ export class JavaTextmateContribution implements LanguageGrammarDefinitionContri
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: javaGrammar
+                    content: javaGrammar,
                 };
-            }
+            },
         });
 
         registry.mapLanguageIdToTextmateGrammar(JAVA_LANGUAGE_ID, scope);

--- a/packages/java/src/node/java-contribution.ts
+++ b/packages/java/src/node/java-contribution.ts
@@ -52,20 +52,20 @@ export class JavaContribution extends BaseLanguageServerContribution {
         const args = [
             '-Declipse.application=org.eclipse.jdt.ls.core.id1',
             '-Dosgi.bundles.defaultStartLevel=4',
-            '-Declipse.product=org.eclipse.jdt.ls.core.product'
+            '-Declipse.product=org.eclipse.jdt.ls.core.product',
         ];
 
         if (DEBUG_MODE) {
             args.push(
                 '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044',
-                '-Dlog.level=ALL'
+                '-Dlog.level=ALL',
             );
         }
 
         args.push(
             '-jar', jarPath,
             '-configuration', configurationPath,
-            '-data', workspacePath
+            '-data', workspacePath,
         );
 
         this.startSocketServer().then(server => {

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -20,7 +20,7 @@ import {
     Command,
     CommandRegistry,
     MenuContribution,
-    MenuModelRegistry
+    MenuModelRegistry,
 } from '@theia/core/lib/common';
 import { open, OpenerService } from '@theia/core/lib/browser';
 import { FrontendApplication } from '@theia/core/lib/browser';
@@ -30,7 +30,7 @@ import { keymapsUri } from './keymaps-service';
 export namespace KeymapsCommands {
     export const OPEN_KEYMAPS: Command = {
         id: 'keymaps:open',
-        label: 'Open Keyboard Shortcuts'
+        label: 'Open Keyboard Shortcuts',
     };
 }
 
@@ -46,13 +46,13 @@ export class KeymapsFrontendContribution implements CommandContribution, MenuCon
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(KeymapsCommands.OPEN_KEYMAPS, {
             isEnabled: () => true,
-            execute: () => this.openKeymapsFile()
+            execute: () => this.openKeymapsFile(),
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: KeymapsCommands.OPEN_KEYMAPS.id
+            commandId: KeymapsCommands.OPEN_KEYMAPS.id,
         });
     }
 

--- a/packages/keymaps/src/browser/keymaps-frontend-module.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-module.ts
@@ -25,7 +25,7 @@ export default new ContainerModule(bind => {
     bind(KeymapsFrontendContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, MenuContribution]) {
         bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(KeymapsFrontendContribution)
+            ctx.container.get(KeymapsFrontendContribution),
         ).inSingletonScope();
     }
 

--- a/packages/keymaps/src/common/keymaps-validation.ts
+++ b/packages/keymaps/src/common/keymaps-validation.ts
@@ -27,23 +27,23 @@ export const keymapsSchema = {
         type: "object",
         properties: {
             keybinding: {
-                type: "string"
+                type: "string",
             },
             command: {
-                type: "string"
+                type: "string",
             },
             context: {
-                type: "string"
+                type: "string",
             },
         },
         required: ["command", "keybinding"],
         optional: ["context"],
         additionalProperties: false,
-    }
+    },
 };
 
 export const keymapsValidator = new ajv({ // https://github.com/epoberezkin/ajv#options
-    jsonPointers: true
+    jsonPointers: true,
 }).compile(keymapsSchema);
 
 /**

--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -21,7 +21,7 @@ import { FrontendApplication } from '@theia/core/lib/browser';
 import {
     LanguageContribution, ILanguageClient, LanguageClientOptions,
     DocumentSelector, TextDocument, FileSystemWatcher,
-    Workspace, Languages, Commands
+    Workspace, Languages, Commands,
 } from '../common';
 import { LanguageClientFactory } from "./language-client-factory";
 import { WorkspaceService } from "@theia/workspace/lib/browser";
@@ -51,7 +51,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
-        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
+        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
     ) {
         this.waitForReady();
     }
@@ -80,7 +80,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                     } catch (e) {
                         console.error(e);
                     }
-                })))
+                }))),
             ]);
         }
         return this.workspace.ready;
@@ -104,7 +104,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
 
     protected waitForReady(): void {
         this.ready = new Promise<ILanguageClient>(resolve =>
-            this.resolveReady = resolve
+            this.resolveReady = resolve,
         );
     }
 
@@ -169,7 +169,7 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
     // FIXME move it to the workspace
     protected waitForOpenTextDocument(selector: DocumentSelector): Promise<TextDocument> {
         const document = this.workspace.textDocuments.filter(doc =>
-            this.languages.match(selector, doc)
+            this.languages.match(selector, doc),
         )[0];
         if (document !== undefined) {
             return Promise.resolve(document);

--- a/packages/languages/src/browser/language-client-factory.ts
+++ b/packages/languages/src/browser/language-client-factory.ts
@@ -20,7 +20,7 @@ import { ErrorAction } from "vscode-base-languageclient/lib/base";
 import {
     Workspace, Languages, Window,
     ILanguageClient, LanguageClientOptions, BaseLanguageClient,
-    createConnection, ConnectionErrorHandler, ConnectionCloseHandler, LanguageContribution
+    createConnection, ConnectionErrorHandler, ConnectionCloseHandler, LanguageContribution,
 } from '../common';
 
 @injectable()
@@ -30,7 +30,7 @@ export class LanguageClientFactory {
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
         @inject(Window) protected readonly window: Window,
-        @inject(WebSocketConnectionProvider) protected readonly connectionProvider: WebSocketConnectionProvider
+        @inject(WebSocketConnectionProvider) protected readonly connectionProvider: WebSocketConnectionProvider,
     ) { }
 
     get(contribution: LanguageContribution, clientOptions: LanguageClientOptions): ILanguageClient {
@@ -41,7 +41,7 @@ export class LanguageClientFactory {
             clientOptions.errorHandler = {
                 // ignore connection errors
                 error: () => ErrorAction.Continue,
-                closed: () => defaultErrorHandler.closed()
+                closed: () => defaultErrorHandler.closed(),
             };
         }
         const client = new BaseLanguageClient({
@@ -58,10 +58,10 @@ export class LanguageClientFactory {
                                 resolve(connection);
                             },
                         },
-                            { reconnecting: false }
+                            { reconnecting: false },
                         );
-                    })
-            }
+                    }),
+            },
         });
         const defaultErrorHandler = client.createDefaultErrorHandler();
         return client;

--- a/packages/languages/src/browser/languages-frontend-contribution.ts
+++ b/packages/languages/src/browser/languages-frontend-contribution.ts
@@ -24,13 +24,13 @@ export class LanguagesFrontendContribution implements FrontendApplicationContrib
 
     constructor(
         @inject(ContributionProvider) @named(LanguageClientContribution)
-        protected readonly contributions: ContributionProvider<LanguageClientContribution>
+        protected readonly contributions: ContributionProvider<LanguageClientContribution>,
     ) { }
 
     onStart(app: FrontendApplication): void {
         for (const contribution of this.contributions.getContributions()) {
             contribution.waitForActivation(app).then(() =>
-                contribution.activate(app)
+                contribution.activate(app),
             );
         }
     }

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from 'inversify';
 import { Languages } from '../common';
 import {
     QuickOpenService, QuickOpenModel, QuickOpenItem, OpenerService,
-    QuickOpenMode, KeybindingContribution, KeybindingRegistry
+    QuickOpenMode, KeybindingContribution, KeybindingRegistry,
 } from '@theia/core/lib/browser';
 import { WorkspaceSymbolParams, SymbolInformation } from 'vscode-base-languageclient/lib/base';
 import { CancellationTokenSource, CommandRegistry, CommandHandler, Command, SelectionService } from '@theia/core';
@@ -31,7 +31,7 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
 
     private command: Command = {
         id: 'languages.workspace.symbol',
-        label: 'Open Workspace Symbol...'
+        label: 'Open Workspace Symbol...',
     };
 
     constructor(@inject(Languages) protected languages: Languages,
@@ -71,7 +71,7 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
             this.cancellationSource = newCancellationSource;
 
             const param: WorkspaceSymbolParams = {
-                query: lookFor
+                query: lookFor,
             };
 
             const items: QuickOpenItem[] = [];
@@ -99,7 +99,7 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         parent = (parent || '') + uri.displayName;
         return new SimpleOpenItem(sym.name, icon, parent, uri.toString(), () => {
             this.openerService.getOpener(uri).then(opener => opener.open(uri, {
-                selection: Range.create(sym.location.range.start, sym.location.range.start)
+                selection: Range.create(sym.location.range.start, sym.location.range.start),
             }));
         });
     }
@@ -113,7 +113,7 @@ class SimpleOpenItem extends QuickOpenItem {
         protected readonly parent: string,
         protected readonly toolTip: string,
         protected readonly onOpen: () => void,
-        protected readonly onSelect?: () => void
+        protected readonly onSelect?: () => void,
     ) {
         super();
     }
@@ -169,5 +169,5 @@ enum SymbolKind {
     String = 15,
     Number = 16,
     Boolean = 17,
-    Array = 18
+    Array = 18,
 }

--- a/packages/languages/src/common/window-impl.ts
+++ b/packages/languages/src/common/window-impl.ts
@@ -58,7 +58,7 @@ export class WindowImpl implements Window {
             appendLine: outputChannel.appendLine.bind(outputChannel),
             show: function (preserveFocus?: boolean): void {
                 // no-op
-            }
+            },
         };
     }
 }

--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -23,7 +23,7 @@ import {
     createProcessSocketConnection,
     createStreamConnection,
     forward,
-    IConnection
+    IConnection,
 } from 'vscode-ws-jsonrpc/lib/server';
 import { MaybePromise, ILogger } from "@theia/core/lib/common";
 import { LanguageContribution } from "../common";
@@ -31,7 +31,7 @@ import { RawProcess, RawProcessFactory } from '@theia/process/lib/node/raw-proce
 import { ProcessManager } from '@theia/process/lib/node/process-manager';
 
 export {
-    LanguageContribution, IConnection, Message
+    LanguageContribution, IConnection, Message,
 };
 
 export const LanguageServerContribution = Symbol('LanguageServerContribution');
@@ -112,7 +112,7 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
         return new Promise(resolve => {
             const server = net.createServer();
             server.addListener('listening', () =>
-                resolve(server)
+                resolve(server),
             );
             // allocate ports dynamically
             server.listen(0, '127.0.0.1');

--- a/packages/markers/src/browser/marker-manager.ts
+++ b/packages/markers/src/browser/marker-manager.ts
@@ -35,7 +35,7 @@ export class MarkerCollection<T> {
 
     constructor(
         public readonly uri: URI,
-        public readonly kind: string
+        public readonly kind: string,
     ) { }
 
     getOwners(): string[] {
@@ -61,7 +61,7 @@ export class MarkerCollection<T> {
             uri: this.uri.toString(),
             kind: this.kind,
             owner: owner,
-            data
+            data,
         });
     }
 

--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -33,7 +33,7 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
     constructor(
         protected readonly markerManager: MarkerManager<T>,
         protected readonly markerOptions: MarkerOptions,
-        protected readonly labelProvider: LabelProvider
+        protected readonly labelProvider: LabelProvider,
     ) {
         super();
 
@@ -45,7 +45,7 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
             name: 'MarkerTree',
             kind: markerOptions.kind,
             children: [],
-            parent: undefined
+            parent: undefined,
         };
     }
 
@@ -99,13 +99,13 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
             description,
             parent: this.root as MarkerRootNode,
             selected: false,
-            numberOfMarkers: 0
+            numberOfMarkers: 0,
         };
     }
 
     protected getMarkerNodes(parent: MarkerInfoNode, markers: Marker<T>[]): MarkerNode[] {
         return markers.map((marker, index) =>
-            this.createMarkerNode(marker, index, parent)
+            this.createMarkerNode(marker, index, parent),
         );
     }
     protected createMarkerNode(marker: Marker<T>, index: number, parent: MarkerInfoNode): MarkerNode {
@@ -121,7 +121,7 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
             parent,
             selected: false,
             uri: parent.uri,
-            marker
+            marker,
         };
     }
 }

--- a/packages/markers/src/browser/problem/problem-container.ts
+++ b/packages/markers/src/browser/problem/problem-container.ts
@@ -23,11 +23,11 @@ import { PROBLEM_KIND } from '../../common/problem-marker';
 
 export const PROBLEM_TREE_PROPS = <TreeProps>{
     ...defaultTreeProps,
-    contextMenuPath: [PROBLEM_KIND]
+    contextMenuPath: [PROBLEM_KIND],
 };
 
 export const PROBLEM_OPTIONS = <MarkerOptions>{
-    kind: 'problem'
+    kind: 'problem',
 };
 
 export function createProblemTreeContainer(parent: interfaces.Container): Container {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -33,10 +33,10 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             widgetId: PROBLEM_KIND,
             widgetName: 'Problems',
             defaultWidgetOptions: {
-                area: 'bottom'
+                area: 'bottom',
             },
             toggleCommandId: 'problemsView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+m'
+            toggleKeybinding: 'ctrlcmd+shift+m',
         });
     }
 
@@ -56,7 +56,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             text: `$(times-circle) ${problemStat.errors} $(exclamation-triangle) ${problemStat.warnings}`,
             alignment: StatusBarAlignment.LEFT,
             priority: 10,
-            command: this.toggleCommand ? this.toggleCommand.id : undefined
+            command: this.toggleCommand ? this.toggleCommand.id : undefined,
         });
     }
 }

--- a/packages/markers/src/browser/problem/problem-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-decorator.ts
@@ -82,7 +82,7 @@ export class ProblemDecorator implements TreeDecorator {
                         data: marker.data,
                         uri: parentUriString,
                         owner: marker.owner,
-                        kind: marker.kind
+                        kind: marker.kind,
                     });
                     parentUri = parentUri.parent;
                 } else {
@@ -113,9 +113,9 @@ export class ProblemDecorator implements TreeDecorator {
                 color,
                 background: {
                     shape: 'circle',
-                    color: 'var(--theia-layout-color0)'
-                }
-            }
+                    color: 'var(--theia-layout-color0)',
+                },
+            },
         };
     }
 

--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -31,11 +31,11 @@ export default new ContainerModule(bind => {
     bind(ProblemManager).toSelf().inSingletonScope();
 
     bind(ProblemWidget).toDynamicValue(ctx =>
-        createProblemWidget(ctx.container)
+        createProblemWidget(ctx.container),
     );
     bind(WidgetFactory).toDynamicValue(context => ({
         id: PROBLEM_KIND,
-        createWidget: () => context.container.get<ProblemWidget>(ProblemWidget)
+        createWidget: () => context.container.get<ProblemWidget>(ProblemWidget),
     }));
 
     bindViewContribution(bind, ProblemContribution);

--- a/packages/markers/src/browser/problem/problem-manager.spec.ts
+++ b/packages/markers/src/browser/problem/problem-manager.spec.ts
@@ -35,7 +35,7 @@ before(() => {
     testContainer.bind(LocalStorageService).toSelf().inSingletonScope();
     // tslint:disable-next-line:no-any
     testContainer.bind(FileSystemWatcher).toConstantValue({
-        onFilesChanged: Event.None
+        onFilesChanged: Event.None,
     } as FileSystemWatcher);
     testContainer.bind(ProblemManager).toSelf();
 
@@ -45,28 +45,28 @@ before(() => {
             range: {
                 start: {
                     line: 1,
-                    character: 1
+                    character: 1,
                 },
                 end: {
                     line: 1,
-                    character: 1
-                }
+                    character: 1,
+                },
             },
-            message: "Foo"
+            message: "Foo",
         },
         {
             range: {
                 start: {
                     line: 1,
-                    character: 1
+                    character: 1,
                 },
                 end: {
                     line: 1,
-                    character: 1
-                }
+                    character: 1,
+                },
             },
-            message: "Bar"
-        }
+            message: "Bar",
+        },
     ]);
 
     manager.setMarkers(new URI('file:/foo/foo.txt'), 'me', [
@@ -74,28 +74,28 @@ before(() => {
             range: {
                 start: {
                     line: 1,
-                    character: 1
+                    character: 1,
                 },
                 end: {
                     line: 1,
-                    character: 1
-                }
+                    character: 1,
+                },
             },
-            message: "Foo"
+            message: "Foo",
         },
         {
             range: {
                 start: {
                     line: 1,
-                    character: 1
+                    character: 1,
                 },
                 end: {
                     line: 1,
-                    character: 2
-                }
+                    character: 2,
+                },
             },
-            message: "Bar"
-        }
+            message: "Bar",
+        },
     ]);
 });
 
@@ -111,28 +111,28 @@ describe('problem-manager', () => {
                 range: {
                     start: {
                         line: 2,
-                        character: 3
+                        character: 3,
                     },
                     end: {
                         line: 2,
-                        character: 1
-                    }
+                        character: 1,
+                    },
                 },
-                message: "Foo"
+                message: "Foo",
             },
             {
                 range: {
                     start: {
                         line: 1,
-                        character: 1
+                        character: 1,
                     },
                     end: {
                         line: 1,
-                        character: 1
-                    }
+                        character: 1,
+                    },
                 },
-                message: "Bar"
-            }
+                message: "Bar",
+            },
         ]);
         expect(previous.length).equal(2);
         expect(events).equal(1);
@@ -141,20 +141,20 @@ describe('problem-manager', () => {
 
     it('should find markers with filter', () => {
         expect(manager.findMarkers({
-            owner: 'me'
+            owner: 'me',
         }).length).equal(4);
 
         expect(manager.findMarkers({
-            owner: 'you'
+            owner: 'you',
         }).length).equal(0);
 
         expect(manager.findMarkers({
             uri: new URI('file:/foo/foo.txt'),
-            owner: 'me'
+            owner: 'me',
         }).length).equal(2);
 
         expect(manager.findMarkers({
-            dataFilter: data => data.range.end.character > 1
+            dataFilter: data => data.range.end.character > 1,
         }).length).equal(1);
     });
 });

--- a/packages/markers/src/browser/problem/problem-tree-model.ts
+++ b/packages/markers/src/browser/problem/problem-tree-model.ts
@@ -39,7 +39,7 @@ export class ProblemTreeModel extends MarkerTreeModel {
     protected getOpenerOptionsByMarker(node: MarkerNode): OpenerOptions | undefined {
         if (ProblemMarker.is(node.marker)) {
             return {
-                selection: node.marker.data.range
+                selection: node.marker.data.range,
             };
         }
         return undefined;

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -30,7 +30,7 @@ export class ProblemWidget extends TreeWidget {
         @inject(ProblemManager) protected readonly problemManager: ProblemManager,
         @inject(TreeProps) readonly treeProps: TreeProps,
         @inject(ProblemTreeModel) readonly model: ProblemTreeModel,
-        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(treeProps, model, contextMenuRenderer);
 

--- a/packages/merge-conflicts/src/browser/merge-conflict-resolver.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict-resolver.ts
@@ -28,15 +28,15 @@ export class MergeConflictResolver {
     protected readonly editorManager: EditorManager;
 
     readonly acceptCurrent: CommandHandler = {
-        execute: args => this.doAcceptCurrent(args)
+        execute: args => this.doAcceptCurrent(args),
     };
 
     readonly acceptIncoming: CommandHandler = {
-        execute: args => this.doAcceptIncoming(args)
+        execute: args => this.doAcceptIncoming(args),
     };
 
     readonly acceptBoth: CommandHandler = {
-        execute: args => this.doAcceptBoth(args)
+        execute: args => this.doAcceptBoth(args),
     };
 
     protected doAcceptCurrent(argument: MergeConflictCommandArgument) {

--- a/packages/merge-conflicts/src/browser/merge-conflict.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict.ts
@@ -37,14 +37,14 @@ export interface MergeConflictCommandArgument {
 export namespace MergeConflictsCommands {
     export const AcceptCurrent: Command = {
         id: 'merge-conflicts:accept.current',
-        label: 'Merge Conflict: Accept Current Change'
+        label: 'Merge Conflict: Accept Current Change',
     };
     export const AcceptIncoming: Command = {
         id: 'merge-conflicts:accept.incoming',
-        label: 'Merge Conflict: Accept Incoming Change'
+        label: 'Merge Conflict: Accept Incoming Change',
     };
     export const AcceptBoth: Command = {
         id: 'merge-conflicts:accept.both',
-        label: 'Merge Conflict: Accept Both Changes'
+        label: 'Merge Conflict: Accept Both Changes',
     };
 }

--- a/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-code-lense-provider.ts
@@ -42,9 +42,9 @@ export class MergeConflictsCodeLensProvider implements CodeLensProvider {
                 command: {
                     command: cmd.id,
                     title: cmd.label || '',
-                    arguments: [<MergeConflictCommandArgument>{ uri, conflict }]
+                    arguments: [<MergeConflictCommandArgument>{ uri, conflict }],
                 },
-                range: conflict.current.marker!
+                range: conflict.current.marker!,
             });
         }
         return result;

--- a/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-decorations.ts
@@ -52,7 +52,7 @@ export namespace MergeConflictsDecorations {
     export const Options = {
         CurrentMarker: <EditorDecorationOptions>{
             isWholeLine: true,
-            className: 'merge-conflict-current-marker'
+            className: 'merge-conflict-current-marker',
         },
         CurrentContent: <EditorDecorationOptions>{
             isWholeLine: true,
@@ -60,11 +60,11 @@ export namespace MergeConflictsDecorations {
             overviewRuler: {
                 position: OverviewRulerLane.Full,
                 color: 'rgba(0, 255, 0, 0.3)',
-            }
+            },
         },
         BaseMarker: <EditorDecorationOptions>{
             isWholeLine: true,
-            className: 'merge-conflict-base-marker'
+            className: 'merge-conflict-base-marker',
         },
         BaseContent: <EditorDecorationOptions>{
             isWholeLine: true,
@@ -72,11 +72,11 @@ export namespace MergeConflictsDecorations {
             overviewRuler: {
                 position: OverviewRulerLane.Full,
                 color: 'rgba(125, 125, 125, 0.3)',
-            }
+            },
         },
         IncomingMarker: <EditorDecorationOptions>{
             isWholeLine: true,
-            className: 'merge-conflict-incoming-marker'
+            className: 'merge-conflict-incoming-marker',
         },
         IncomingContent: <EditorDecorationOptions>{
             isWholeLine: true,
@@ -84,7 +84,7 @@ export namespace MergeConflictsDecorations {
             overviewRuler: {
                 position: OverviewRulerLane.Full,
                 color: 'rgba(0, 0, 255, 0.3)',
-            }
+            },
         },
     };
 }

--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
@@ -34,6 +34,6 @@ export default new ContainerModule(bind => {
     bind(MergeConflictsFrontendContribution).toSelf().inSingletonScope();
     bind(MergeConflictsProvider).toSelf().inSingletonScope();
     [CommandContribution, FrontendApplicationContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(c => c.container.get(MergeConflictsFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toDynamicValue(c => c.container.get(MergeConflictsFrontendContribution)).inSingletonScope(),
     );
 });

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.spec.ts
@@ -50,7 +50,7 @@ bar changed on master
 foo on branch
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];
@@ -81,7 +81,7 @@ last line`;
         const total = conflict.total!;
         expect(total, 'total range').to.deep.equal({
             start: { line: 1, character: 0 },
-            end: { line: 10, character: 14 }
+            end: { line: 10, character: 14 },
         });
         expect(substring(content, total)).to.equal(`<<<<<<< HEAD
 foo changed on master
@@ -97,7 +97,7 @@ bar on branch
         const currentContent = conflict.current.content!;
         expect(currentContent).to.deep.equal({
             start: { line: 2, character: 0 },
-            end: { line: 3, character: 21 }
+            end: { line: 3, character: 21 },
         });
         expect(substring(content, currentContent)).to.equal(`foo changed on master
 bar changed on master`);
@@ -105,7 +105,7 @@ bar changed on master`);
         const baseContent = conflict.bases[0].content!;
         expect(baseContent).to.deep.equal({
             start: { line: 5, character: 0 },
-            end: { line: 6, character: 3 }
+            end: { line: 6, character: 3 },
         });
         expect(substring(content, baseContent)).to.equal(`foo
 bar`);
@@ -113,7 +113,7 @@ bar`);
         const incomingContent = conflict.incoming.content!;
         expect(incomingContent).to.deep.equal({
             start: { line: 8, character: 0 },
-            end: { line: 9, character: 13 }
+            end: { line: 9, character: 13 },
         });
         expect(substring(content, incomingContent)).to.equal(`foo on branch
 bar on branch`);
@@ -143,7 +143,7 @@ bar changed on master
 =======
 foo on branch
 bar on branch
->>>>>>> branch`
+>>>>>>> branch`,
         );
         expect(conflicts).to.have.lengthOf(3);
     });
@@ -162,7 +162,7 @@ common base 3
 foo on branch
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];
@@ -174,7 +174,7 @@ bar on branch
         expect(base1Content).to.not.be.undefined;
         expect(base1Content).to.deep.equal({
             start: { line: 4, character: 0 },
-            end: { line: 4, character: 13 }
+            end: { line: 4, character: 13 },
         });
 
         const base2Content = bases[1].content;
@@ -184,7 +184,7 @@ bar on branch
         expect(base3Content).to.not.be.undefined;
         expect(base3Content).to.deep.equal({
             start: { line: 7, character: 0 },
-            end: { line: 7, character: 13 }
+            end: { line: 7, character: 13 },
         });
     });
 
@@ -198,7 +198,7 @@ bar changed on master
 foo on branch
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];
@@ -207,7 +207,7 @@ bar on branch
         expect(total).to.not.be.undefined;
         expect(total).to.deep.equal({
             start: { line: 1, character: 0 },
-            end: { line: 7, character: 14 }
+            end: { line: 7, character: 14 },
         });
     });
 
@@ -221,7 +221,7 @@ foo on branch
 <<<<<<< HEAD
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(0);
     });
@@ -236,7 +236,7 @@ bar changed on master
 foo on branch
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(0);
     });
@@ -251,7 +251,7 @@ foo on branch
 =======
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(0);
     });
@@ -272,7 +272,7 @@ bar changed on master
 foo on branch
 bar on branch
 >>>>>>> branch
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];
@@ -281,7 +281,7 @@ bar on branch
         expect(total).to.not.be.undefined;
         expect(total).to.deep.equal({
             start: { line: 7, character: 0 },
-            end: { line: 13, character: 14 }
+            end: { line: 13, character: 14 },
         });
     });
 
@@ -293,7 +293,7 @@ a
 b
 =======
 >>>>>>>
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];
@@ -310,7 +310,7 @@ b
 =======
 a
 >>>>>>>
-`
+`,
         );
         expect(conflicts).to.have.lengthOf(1);
         const conflict = conflicts[0];

--- a/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-parser.ts
@@ -120,7 +120,7 @@ export class MergeConflictsParser {
             ctx.new.incoming.marker = markerRange;
             ctx.new.total = {
                 start: ctx.new.current.marker!.start,
-                end: markerRange.end
+                end: markerRange.end,
             };
         };
         push.onEnter = (input, ctx) => {
@@ -155,7 +155,7 @@ export namespace MergeConflictsParser {
         new: MergeConflict = {
             current: {},
             incoming: {},
-            bases: []
+            bases: [],
         };
         all: MergeConflict[] = [];
     }

--- a/packages/messages/src/browser/notification-preferences.ts
+++ b/packages/messages/src/browser/notification-preferences.ts
@@ -20,7 +20,7 @@ import {
     PreferenceProxy,
     PreferenceService,
     PreferenceContribution,
-    PreferenceSchema
+    PreferenceSchema,
 } from '@theia/core/lib/browser/preferences';
 
 export const NotificationConfigSchema: PreferenceSchema = {
@@ -29,9 +29,9 @@ export const NotificationConfigSchema: PreferenceSchema = {
         "notification.timeout": {
             "type": "number",
             "description": "The time before auto-dismiss the notification.",
-            "default": 5000 // time express in millisec. 0 means : Do not remove
-        }
-    }
+            "default": 5000, // time express in millisec. 0 means : Do not remove
+        },
+    },
 };
 
 export interface NotificationConfiguration {

--- a/packages/messages/src/browser/notifications-message-client.ts
+++ b/packages/messages/src/browser/notifications-message-client.ts
@@ -18,7 +18,7 @@ import { injectable, inject } from 'inversify';
 import {
     MessageClient,
     MessageType,
-    Message
+    Message,
 } from '@theia/core/lib/common';
 import { Notifications, NotificationAction } from './notifications';
 import { NotificationPreferences } from "./notification-preferences";
@@ -44,7 +44,7 @@ export class NotificationsMessageClient extends MessageClient {
         const text = message.text;
         const actions = (message.actions || []).map(action => <NotificationAction>{
             label: action,
-            fn: element => onCloseFn(action)
+            fn: element => onCloseFn(action),
         });
 
         const timeout = actions.length > 0 ? undefined
@@ -54,13 +54,13 @@ export class NotificationsMessageClient extends MessageClient {
 
         actions.push(<NotificationAction>{
             label: 'Close',
-            fn: element => onCloseFn(undefined)
+            fn: element => onCloseFn(undefined),
         });
         this.notifications.show({
             icon,
             text,
             actions,
-            timeout
+            timeout,
         });
     }
 

--- a/packages/messages/src/node/messages-backend-module.ts
+++ b/packages/messages/src/node/messages-backend-module.ts
@@ -27,6 +27,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
             dispatching.clients.add(client);
             client.onDidCloseConnection(() => dispatching.clients.delete(client));
             return dispatching;
-        })
+        }),
     ).inSingletonScope();
 });

--- a/packages/metrics/src/node/metrics-backend-application-contribution.ts
+++ b/packages/metrics/src/node/metrics-backend-application-contribution.ts
@@ -26,7 +26,7 @@ import { MetricsContribution } from './metrics-contribution';
 export class MetricsBackendApplicationContribution implements BackendApplicationContribution {
     constructor(
         @inject(ContributionProvider) @named(MetricsContribution)
-        protected readonly metricsProviders: ContributionProvider<MetricsContribution>
+        protected readonly metricsProviders: ContributionProvider<MetricsContribution>,
     ) {
     }
 

--- a/packages/metrics/src/node/metrics-backend-module.ts
+++ b/packages/metrics/src/node/metrics-backend-module.ts
@@ -23,7 +23,7 @@ import {
     MetricsProjectPath,
     MetricsBackendApplicationContribution,
     ExtensionMetricsContribution,
-    MetricsCliContribution
+    MetricsCliContribution,
 } from './';
 
 export default new ContainerModule(bind => {

--- a/packages/metrics/src/node/metrics-cli.ts
+++ b/packages/metrics/src/node/metrics-cli.ts
@@ -28,7 +28,7 @@ export class MetricsCliContribution implements CliContribution {
     configure(conf: yargs.Argv): void {
         conf.option(metricsProjectPath, {
             description: "Sets the application project directory (used in metrics extension)",
-            default: process.cwd()
+            default: process.cwd(),
         });
     }
 

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -39,7 +39,7 @@ export default new ContainerModule(bind => {
             const child = container.createChild();
             child.bind(MiniBrowserProps).toConstantValue(props);
             return child.get(MiniBrowser);
-        }
+        },
     })).inSingletonScope();
 
     bind(MiniBrowserOpenHandler).toSelf().inSingletonScope();

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -105,14 +105,14 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> imple
                 iconClass,
                 // Make sure the toolbar is not visible. We have the `iframe.src` anyway.
                 toolbar: 'hide',
-                resetBackground
+                resetBackground,
             };
         }
         if (options) {
             // Explicit options overrule everything.
             result = {
                 ...result,
-                ...options
+                ...options,
             };
         }
         return result;
@@ -128,7 +128,7 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> imple
             mode: 'activate',
             widgetOptions: { area: 'main' },
             sandbox: MiniBrowserProps.SandboxOptions.DEFAULT,
-            toolbar: 'show'
+            toolbar: 'show',
         };
     }
 

--- a/packages/mini-browser/src/browser/mini-browser.ts
+++ b/packages/mini-browser/src/browser/mini-browser.ts
@@ -134,7 +134,7 @@ export namespace MiniBrowserProps {
          * Allows the embedded browsing context to navigate (load) content to the top-level browsing context only when initiated by a user gesture.
          * If this keyword is not used, this operation is not allowed.
          */
-        'allow-top-navigation-by-user-activation'
+        'allow-top-navigation-by-user-activation',
     }
 
     export namespace SandboxOptions {
@@ -149,7 +149,7 @@ export namespace MiniBrowserProps {
             SandboxOptions['allow-scripts'],
             SandboxOptions['allow-popups'],
             SandboxOptions['allow-forms'],
-            SandboxOptions['allow-modals']
+            SandboxOptions['allow-modals'],
         ];
 
     }
@@ -195,7 +195,7 @@ export class MiniBrowserMouseClickTracker implements FrontendApplicationContribu
         const { layout } = this.applicationShell;
         if (layout instanceof PanelLayout) {
             this.toDispose.pushAll(
-                layout.widgets.filter(MiniBrowserMouseClickTracker.isSplitPanel).map(splitPanel => addEventListener(splitPanel.node, 'mousedown', this.mousedownListener, true))
+                layout.widgets.filter(MiniBrowserMouseClickTracker.isSplitPanel).map(splitPanel => addEventListener(splitPanel.node, 'mousedown', this.mousedownListener, true)),
             );
         }
         // Track the `mousedown` on each `DockPanel`.
@@ -210,7 +210,7 @@ export class MiniBrowserMouseClickTracker implements FrontendApplicationContribu
         this.toDispose.pushAll([
             this.mousedownEmitter,
             this.mouseupEmitter,
-            Disposable.create(() => document.removeEventListener('mouseup', this.mouseupListener, true))
+            Disposable.create(() => document.removeEventListener('mouseup', this.mouseupListener, true)),
         ]);
     }
 
@@ -301,7 +301,7 @@ export class MiniBrowser extends BaseWidget {
             this.navigateBackEmitter,
             this.navigateForwardEmitter,
             this.refreshEmitter,
-            this.openEmitter
+            this.openEmitter,
         ]);
     }
 
@@ -486,7 +486,7 @@ export class MiniBrowser extends BaseWidget {
                         input.select();
                     }
                 }
-            })
+            }),
         ]);
         parent.appendChild(input);
         return input;
@@ -596,7 +596,7 @@ export class MiniBrowser extends BaseWidget {
                     this.frame.style.display = 'none';
                     PDFObject.embed(url, this.pdfContainer, {
                         // tslint:disable-next-line:max-line-length
-                        fallbackLink: `<p style="padding: 0px 15px 0px 15px">Your browser does not support inline PDFs. Click on this <a href='[url]' target="_blank">link</a> to open the PDF in a new tab.</p>`
+                        fallbackLink: `<p style="padding: 0px 15px 0px 15px">Your browser does not support inline PDFs. Click on this <a href='[url]' target="_blank">link</a> to open the PDF in a new tab.</p>`,
                     });
                     this.hideLoadIndicator();
                 } else {

--- a/packages/monaco/src/browser/monaco-browser-module.ts
+++ b/packages/monaco/src/browser/monaco-browser-module.ts
@@ -22,7 +22,7 @@ export { ContainerModule };
 export default loadVsRequire(window)
     .then(vsRequire => loadMonaco(vsRequire))
     .then(() =>
-        import('./monaco-frontend-module')
+        import('./monaco-frontend-module'),
     ).then(module =>
-        module.default
+        module.default,
     );

--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -31,7 +31,7 @@ export class MonacoCommandRegistry {
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
         @inject(EditorManager) protected readonly editorManager: EditorManager,
-        @inject(SelectionService) protected readonly selectionService: SelectionService
+        @inject(SelectionService) protected readonly selectionService: SelectionService,
     ) { }
 
     protected prefix(command: string): string {
@@ -46,7 +46,7 @@ export class MonacoCommandRegistry {
     registerCommand(command: Command, handler: MonacoEditorCommandHandler): void {
         this.commands.registerCommand({
             ...command,
-            id: this.prefix(command.id)
+            id: this.prefix(command.id),
         }, this.newHandler(handler));
     }
 
@@ -58,7 +58,7 @@ export class MonacoCommandRegistry {
         return {
             execute: (...args) => this.execute(monacoHandler, ...args),
             isEnabled: (...args) => this.isEnabled(monacoHandler, ...args),
-            isVisible: (...args) => this.isVisible(monacoHandler, ...args)
+            isVisible: (...args) => this.isVisible(monacoHandler, ...args),
         };
     }
 

--- a/packages/monaco/src/browser/monaco-command-service.ts
+++ b/packages/monaco/src/browser/monaco-command-service.ts
@@ -33,7 +33,7 @@ export class MonacoCommandService implements ICommandService {
     protected readonly delegateListeners = new DisposableCollection();
 
     constructor(
-        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry
+        @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
     ) { }
 
     get onWillExecuteCommand(): monaco.IEvent<ICommandEvent> {
@@ -45,7 +45,7 @@ export class MonacoCommandService implements ICommandService {
         this.delegate = delegate;
         if (this.delegate) {
             this.delegateListeners.push(this.delegate.onWillExecuteCommand(event =>
-                this.onWillExecuteCommandEmitter.fire(event)
+                this.onWillExecuteCommandEmitter.fire(event),
             ));
         }
     }

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -34,7 +34,7 @@ export namespace MonacoCommands {
     export const REDO = 'redo';
     export const COMMON_KEYBOARD_ACTIONS = new Set([UNDO, REDO]);
     export const COMMON_ACTIONS: {
-        [action: string]: string
+        [action: string]: string,
     } = {};
     COMMON_ACTIONS[UNDO] = CommonCommands.UNDO.id;
     COMMON_ACTIONS[REDO] = CommonCommands.REDO.id;
@@ -58,7 +58,7 @@ export namespace MonacoCommands {
     export const SELECTION_SELECT_ALL_OCCURRENCES = 'editor.action.selectHighlights';
 
     export const ACTIONS: MonacoCommand[] = [
-        { id: SELECTION_SELECT_ALL, label: 'Select All', delegate: 'editor.action.selectAll' }
+        { id: SELECTION_SELECT_ALL, label: 'Select All', delegate: 'editor.action.selectAll' },
     ];
     export const EXCLUDE_ACTIONS = new Set([
         ...Object.keys(COMMON_ACTIONS),
@@ -131,9 +131,9 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                     'editor.action.showReferences',
                     monaco.Uri.parse(uri),
                     this.p2m.asPosition(position),
-                    locations.map(l => this.p2m.asLocation(l))
+                    locations.map(l => this.p2m.asLocation(l)),
                 );
-            }
+            },
         };
     }
     protected newConfigIndentationHandler(): MonacoEditorCommandHandler {
@@ -147,16 +147,16 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                                 this.configTabSize(editor, useSpaces);
                             }
                             return false;
-                        }
-                    })
+                        },
+                    }),
                 );
                 this.open(options, 'Select Action');
-            }
+            },
         };
     }
     protected newConfigTabSizeHandler(useSpaces: boolean): MonacoEditorCommandHandler {
         return {
-            execute: (editor: MonacoEditor) => this.configTabSize(editor, useSpaces)
+            execute: (editor: MonacoEditor) => this.configTabSize(editor, useSpaces),
         };
     }
     private configTabSize(editor: MonacoEditor, useSpaces: boolean) {
@@ -174,11 +174,11 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                         }
                         editorModel.textEditorModel.updateOptions({
                             tabSize: size || tabSize,
-                            insertSpaces: useSpaces
+                            insertSpaces: useSpaces,
                         });
                         return true;
-                    }
-                })
+                    },
+                }),
             );
             this.open(tabSizeOptions,
                 'Select Tab Size for Current File',
@@ -195,14 +195,14 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             placeholder,
             fuzzyMatchLabel: true,
             fuzzySort: false,
-            selectIndex
+            selectIndex,
         });
     }
     private getQuickOpenModel(items: QuickOpenItem[]): QuickOpenModel {
         return {
             onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
                 acceptor(items);
-            }
+            },
         };
     }
 
@@ -219,18 +219,18 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
 
     protected newKeyboardHandler(action: string): MonacoEditorCommandHandler {
         return {
-            execute: (editor, ...args) => editor.getControl().cursor.trigger('keyboard', action, args)
+            execute: (editor, ...args) => editor.getControl().cursor.trigger('keyboard', action, args),
         };
     }
     protected newCommandHandler(action: string): MonacoEditorCommandHandler {
         return {
-            execute: (editor, ...args) => editor.commandService.executeCommand(action, ...args)
+            execute: (editor, ...args) => editor.commandService.executeCommand(action, ...args),
         };
     }
     protected newActionHandler(action: string): MonacoEditorCommandHandler {
         return {
             execute: editor => editor.runAction(action),
-            isEnabled: editor => editor.isActionSupported(action)
+            isEnabled: editor => editor.isActionSupported(action),
         };
     }
 

--- a/packages/monaco/src/browser/monaco-context-menu.ts
+++ b/packages/monaco/src/browser/monaco-context-menu.ts
@@ -38,7 +38,7 @@ export class MonacoContextMenuService implements IContextMenuService {
             delegate.getActions().then(actions => {
                 const commands = new CommandRegistry();
                 const menu = new Menu({
-                    commands
+                    commands,
                 });
 
                 for (const action of actions) {
@@ -48,11 +48,11 @@ export class MonacoContextMenuService implements IContextMenuService {
                         className: action.class,
                         isToggled: () => action.checked,
                         isEnabled: () => action.enabled,
-                        execute: () => action.run()
+                        execute: () => action.run(),
                     });
                     menu.addItem({
                         type: 'command',
-                        command: commandId
+                        command: commandId,
                     });
                 }
                 menu.aboutToClose.connect(() => delegate.onHide(false));

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -76,7 +76,7 @@ export class MonacoDiffEditor extends MonacoEditor {
     protected create(options?: IDiffEditorConstructionOptions, override?: monaco.editor.IEditorOverrideServices): Disposable {
         this._diffEditor = monaco.editor.createDiffEditor(this.node, <IDiffEditorConstructionOptions>{
             ...options,
-            fixedOverflowWidgets: true
+            fixedOverflowWidgets: true,
         }, override);
         this.editor = this._diffEditor.getModifiedEditor();
         return this._diffEditor;

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -21,7 +21,7 @@ import { DisposableCollection, Disposable, Emitter, Event, Resource, Cancellatio
 import ITextEditorModel = monaco.editor.ITextEditorModel;
 
 export {
-    TextDocumentSaveReason
+    TextDocumentSaveReason,
 };
 
 export interface WillSaveMonacoModelEvent {
@@ -58,7 +58,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     constructor(
         protected readonly resource: Resource,
         protected readonly m2p: MonacoToProtocolConverter,
-        protected readonly p2m: ProtocolToMonacoConverter
+        protected readonly p2m: ProtocolToMonacoConverter,
     ) {
         this.toDispose.push(resource);
         this.toDispose.push(this.toDisposeOnAutoSave);
@@ -196,7 +196,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         const range = this.m2p.asRange(this.model.getFullModelRange());
         this.applyEdits([this.p2m.asTextEdit({ range, newText }) as monaco.editor.IIdentifiedSingleEditOperation], {
             ignoreDirty: true,
-            ignoreContentChanges: true
+            ignoreContentChanges: true,
         });
     }
 
@@ -218,7 +218,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
                 this.scheduleSave(TextDocumentSaveReason.AfterDelay, token);
             }, this.autoSaveDelay);
             this.toDisposeOnAutoSave.push(Disposable.create(() =>
-                window.clearTimeout(handle))
+                window.clearTimeout(handle)),
             );
         }
     }
@@ -268,12 +268,12 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
 
     protected applyEdits(
         operations: monaco.editor.IIdentifiedSingleEditOperation[],
-        options?: Partial<MonacoEditorModel.ApplyEditsOptions>
+        options?: Partial<MonacoEditorModel.ApplyEditsOptions>,
     ): monaco.editor.IIdentifiedSingleEditOperation[] {
         const resolvedOptions: MonacoEditorModel.ApplyEditsOptions = {
             ignoreDirty: false,
             ignoreContentChanges: false,
-            ...options
+            ...options,
         };
         const { ignoreDirtyEdits, ignoreContentChanges } = this;
         this.ignoreDirtyEdits = resolvedOptions.ignoreDirty;
@@ -322,10 +322,10 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
                             resolve();
                         }
                         this.applyEdits(operations, {
-                            ignoreDirty: true
+                            ignoreDirty: true,
                         });
                         resolve();
-                    })
+                    }),
             });
         });
     }

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -65,7 +65,7 @@ export class MonacoEditorProvider {
             editorService,
             textModelService,
             contextMenuService,
-            commandService
+            commandService,
         };
 
         const toDispose = new DisposableCollection();
@@ -186,7 +186,7 @@ export class MonacoEditorProvider {
                         control.revealRangeInCenterIfOutsideViewport(selection);
                     }
                     editor.focus();
-                }
+                },
             });
         };
     }
@@ -202,7 +202,7 @@ export class MonacoEditorProvider {
 
             referencesController._editorService.openEditor({
                 resource: uri,
-                options: { selection: range }
+                options: { selection: range },
             }).done(openedEditor => {
                 referencesController._ignoreModelChangeEvent = false;
                 if (!openedEditor) {
@@ -223,7 +223,7 @@ export class MonacoEditorProvider {
                     const modelPromise = Promise.resolve(model) as any;
                     modelPromise.cancel = () => { };
                     openedEditor.getControl()._contributions['editor.contrib.referencesController'].toggleWidget(range, modelPromise, {
-                        getMetaTitle: m => m.references.length > 1 ? ` – ${m.references.length} references` : ''
+                        getMetaTitle: m => m.references.length > 1 ? ` – ${m.references.length} references` : '',
                     });
                     return;
                 }

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -30,7 +30,7 @@ export class MonacoEditorService implements IEditorService {
 
     constructor(
         @inject(OpenerService) protected readonly openerService: OpenerService,
-        @inject(MonacoToProtocolConverter) protected readonly m2p: MonacoToProtocolConverter
+        @inject(MonacoToProtocolConverter) protected readonly m2p: MonacoToProtocolConverter,
     ) { }
 
     openEditor(input: IResourceInput, sideBySide?: boolean | undefined): monaco.Promise<IEditorReference | undefined> {
@@ -53,7 +53,7 @@ export class MonacoEditorService implements IEditorService {
         const options = {
             preserveFocus: false,
             revealIfVisible: true,
-            ...input.options
+            ...input.options,
         };
         if (options.preserveFocus) {
             return 'reveal';

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -73,7 +73,7 @@ export class MonacoEditor implements TextEditor, IEditorReference {
             this.onCursorPositionChangedEmitter,
             this.onSelectionChangedEmitter,
             this.onFocusChangedEmitter,
-            this.onDocumentContentChangedEmitter
+            this.onDocumentContentChangedEmitter,
         ]);
         this.documents.add(document);
         this.autoSizing = options && options.autoSizing !== undefined ? options.autoSizing : false;
@@ -92,8 +92,8 @@ export class MonacoEditor implements TextEditor, IEditorReference {
                 verticalHasArrows: false,
                 horizontalHasArrows: false,
                 verticalScrollbarSize: 10,
-                horizontalScrollbarSize: 10
-            }
+                horizontalScrollbarSize: 10,
+            },
         }, override);
     }
 
@@ -105,7 +105,7 @@ export class MonacoEditor implements TextEditor, IEditorReference {
             this.onDocumentContentChangedEmitter.fire({ document: this.document, contentChanges: e.changes.map(this.mapModelContentChange.bind(this)) });
         }));
         this.toDispose.push(codeEditor.onDidChangeCursorPosition(() =>
-            this.onCursorPositionChangedEmitter.fire(this.cursor)
+            this.onCursorPositionChangedEmitter.fire(this.cursor),
         ));
         this.toDispose.push(codeEditor.onDidChangeCursorSelection(e => {
             this.onSelectionChangedEmitter.fire(this.selection);
@@ -114,7 +114,7 @@ export class MonacoEditor implements TextEditor, IEditorReference {
             this.onFocusChangedEmitter.fire(this.isFocused());
         }));
         this.toDispose.push(codeEditor.onDidBlurEditor(() =>
-            this.onFocusChangedEmitter.fire(this.isFocused())
+            this.onFocusChangedEmitter.fire(this.isFocused()),
         ));
     }
 
@@ -122,7 +122,7 @@ export class MonacoEditor implements TextEditor, IEditorReference {
         return {
             range: this.m2p.asRange(change.range),
             rangeLength: change.rangeLength,
-            text: change.text
+            text: change.text,
         };
     }
 
@@ -358,10 +358,10 @@ export class MonacoEditor implements TextEditor, IEditorReference {
                 forceMoveMarkers: true,
                 identifier: {
                     major: range.startLineNumber,
-                    minor: range.startColumn
+                    minor: range.startColumn,
                 },
                 range,
-                text: param.text
+                text: param.text,
             };
         });
         return this.editor.executeEdits(params.source, edits);

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -67,11 +67,11 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoCommandService).toSelf().inTransientScope();
     bind(MonacoCommandServiceFactory).toAutoFactory(MonacoCommandService);
     bind(TextEditorProvider).toProvider(context =>
-        uri => context.container.get(MonacoEditorProvider).get(uri)
+        uri => context.container.get(MonacoEditorProvider).get(uri),
     );
     bind(MonacoDiffNavigatorFactory).toSelf().inSingletonScope();
     bind(DiffNavigatorProvider).toFactory(context =>
-        editor => context.container.get(MonacoEditorProvider).getDiffNavigator(editor)
+        editor => context.container.get(MonacoEditorProvider).getDiffNavigator(editor),
     );
 
     bind(MonacoOutlineContribution).toSelf().inSingletonScope();
@@ -88,7 +88,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(MonacoQuickOpenService).toSelf().inSingletonScope();
     rebind(QuickOpenService).toDynamicValue(ctx =>
-        ctx.container.get(MonacoQuickOpenService)
+        ctx.container.get(MonacoQuickOpenService),
     ).inSingletonScope();
 
     MonacoTextmateModuleBinder(bind, unbind, isBound, rebind);

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -52,7 +52,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                     registry.registerKeybinding({
                         command,
                         keybinding: this.keyCode(keybinding).toString(),
-                        context: EditorKeybindingContexts.editorTextFocus
+                        context: EditorKeybindingContexts.editorTextFocus,
                     });
                 } else {
                     // FIXME support chord keybindings properly, KeyCode does not allow it right now
@@ -66,7 +66,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             registry.registerKeybinding({
                 command: selectAllCommand,
                 keybinding: "ctrlcmd+a",
-                context: EditorKeybindingContexts.editorTextFocus
+                context: EditorKeybindingContexts.editorTextFocus,
             });
         }
     }
@@ -83,7 +83,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
         const keyCode = keybinding.keyCode;
         const sequence: Keystroke = {
             first: Key.getKey(monaco2BrowserKeyCode(keyCode & 255)),
-            modifiers: []
+            modifiers: [],
         };
         if (keybinding.ctrlKey) {
             sequence.modifiers!.push(KeyModifier.CtrlCmd);

--- a/packages/monaco/src/browser/monaco-languages.ts
+++ b/packages/monaco/src/browser/monaco-languages.ts
@@ -34,7 +34,7 @@ export class MonacoLanguages extends BaseMonacoLanguages implements Languages {
     constructor(
         @inject(ProtocolToMonacoConverter) p2m: ProtocolToMonacoConverter,
         @inject(MonacoToProtocolConverter) m2p: MonacoToProtocolConverter,
-        @inject(ProblemManager) protected readonly problemManager: ProblemManager
+        @inject(ProblemManager) protected readonly problemManager: ProblemManager,
     ) {
         super(p2m, m2p);
     }
@@ -55,7 +55,7 @@ export class MonacoLanguages extends BaseMonacoLanguages implements Languages {
                 for (const uri of uris) {
                     this.problemManager.setMarkers(new URI(uri), owner, []);
                 }
-            }
+            },
         };
     }
 
@@ -65,7 +65,7 @@ export class MonacoLanguages extends BaseMonacoLanguages implements Languages {
             dispose: () => {
                 const index = this.workspaceSymbolProviders.indexOf(provider);
                 this.workspaceSymbolProviders = this.workspaceSymbolProviders.splice(index, 1);
-            }
+            },
         };
     }
 
@@ -73,7 +73,7 @@ export class MonacoLanguages extends BaseMonacoLanguages implements Languages {
         const monacoLanguages: monaco.languages.ILanguageExtensionPoint[] = monaco.languages.getLanguages();
         return monacoLanguages.map((monacoLang: monaco.languages.ILanguageExtensionPoint) => ({
             id: monacoLang.id,
-            name: monacoLang.aliases && monacoLang.aliases.length > 0 ? monacoLang.aliases[0] : monacoLang.id
+            name: monacoLang.aliases && monacoLang.aliases.length > 0 ? monacoLang.aliases[0] : monacoLang.id,
         }));
     }
 

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -36,7 +36,7 @@ export function loadVsRequire(context: any): Promise<any> {
                 resolve(amdRequire);
             });
             document.body.appendChild(vsLoader);
-        }, { once: true })
+        }, { once: true }),
     );
 }
 

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -34,8 +34,8 @@ export namespace MonacoMenus {
         actions: [
             MonacoCommands.SELECTION_SELECT_ALL,
             MonacoCommands.SELECTION_EXPAND_SELECTION,
-            MonacoCommands.SELECTION_SHRINK_SELECTION
-        ]
+            MonacoCommands.SELECTION_SHRINK_SELECTION,
+        ],
     };
 
     export const SELECTION_MOVE_GROUP: MonacoActionGroup = {
@@ -44,8 +44,8 @@ export namespace MonacoMenus {
             MonacoCommands.SELECTION_COPY_LINE_UP,
             MonacoCommands.SELECTION_COPY_LINE_DOWN,
             MonacoCommands.SELECTION_MOVE_LINE_UP,
-            MonacoCommands.SELECTION_MOVE_LINE_DOWN
-        ]
+            MonacoCommands.SELECTION_MOVE_LINE_DOWN,
+        ],
     };
 
     export const SELECTION_CURSOR_GROUP: MonacoActionGroup = {
@@ -56,14 +56,14 @@ export namespace MonacoMenus {
             MonacoCommands.SELECTION_ADD_CURSOR_TO_LINE_END,
             MonacoCommands.SELECTION_ADD_NEXT_OCCURRENCE,
             MonacoCommands.SELECTION_ADD_PREVIOUS_OCCURRENCE,
-            MonacoCommands.SELECTION_SELECT_ALL_OCCURRENCES
-        ]
+            MonacoCommands.SELECTION_SELECT_ALL_OCCURRENCES,
+        ],
     };
 
     export const SELECTION_GROUPS = [
         SELECTION_GROUP,
         SELECTION_MOVE_GROUP,
-        SELECTION_CURSOR_GROUP
+        SELECTION_CURSOR_GROUP,
     ];
 }
 
@@ -71,7 +71,7 @@ export namespace MonacoMenus {
 export class MonacoEditorMenuContribution implements MenuContribution {
 
     constructor(
-        @inject(MonacoCommandRegistry) protected readonly commands: MonacoCommandRegistry
+        @inject(MonacoCommandRegistry) protected readonly commands: MonacoCommandRegistry,
     ) { }
 
     registerMenus(registry: MenuModelRegistry) {

--- a/packages/monaco/src/browser/monaco-outline-contribution.ts
+++ b/packages/monaco/src/browser/monaco-outline-contribution.ts
@@ -44,10 +44,10 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
             if (open) {
                 this.toDisposeOnClose.push(this.toDisposeOnEditor);
                 this.toDisposeOnClose.push(DocumentSymbolProviderRegistry.onDidChange(
-                    debounce(() => this.updateOutline())
+                    debounce(() => this.updateOutline()),
                 ));
                 this.toDisposeOnClose.push(this.editorManager.onCurrentEditorChanged(
-                    debounce(() => this.handleCurrentEditorChanged(), 50)
+                    debounce(() => this.handleCurrentEditorChanged(), 50),
                 ));
                 this.handleCurrentEditorChanged();
             } else {
@@ -59,7 +59,7 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
                 const uri = new URI(node.uri);
                 await this.editorManager.open(uri, {
                     mode: 'reveal',
-                    selection: node.range
+                    selection: node.range,
                 });
             }
         });
@@ -67,8 +67,8 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
             if (MonacoOutlineSymbolInformationNode.is(node)) {
                 this.editorManager.open(new URI(node.uri), {
                     selection: <Range>{
-                        start: node.range.start
-                    }
+                        start: node.range.start,
+                    },
                 });
             }
         });
@@ -184,12 +184,12 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
         return {
             end: {
                 character: symbolInformation.location.range.endColumn - 1,
-                line: symbolInformation.location.range.endLineNumber - 1
+                line: symbolInformation.location.range.endLineNumber - 1,
             },
             start: {
                 character: symbolInformation.location.range.startColumn - 1,
-                line: symbolInformation.location.range.startLineNumber - 1
-            }
+                line: symbolInformation.location.range.startLineNumber - 1,
+            },
         };
     }
 
@@ -204,7 +204,7 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
             uri: symbol.location.uri.toString(),
             range: this.getRangeFromSymbolInformation(symbol),
             selected: false,
-            expanded: this.shouldExpand(symbol)
+            expanded: this.shouldExpand(symbol),
         };
     }
 

--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -68,13 +68,13 @@ export class QuickInputService {
 
         const inputItem = new InputOpenItemOptions(options.prompt);
         this.opts = new MonacoQuickInputControllerOptsImpl({
-            onType: (s, a) => this.validateInput(s, a, inputItem)
+            onType: (s, a) => this.validateInput(s, a, inputItem),
         },
             options,
             {
                 prefix: options.value,
                 placeholder: options.placeHolder,
-                onClose: () => inputItem.resolve(undefined)
+                onClose: () => inputItem.resolve(undefined),
             });
         this.quickOpenService.internalOpen(this.opts);
 
@@ -152,7 +152,7 @@ class MonacoQuickInputControllerOptsImpl extends MonacoQuickOpenControllerOptsIm
     constructor(
         model: QuickOpenModel,
         inputOptions: QuickInputOptions,
-        options?: QuickOpenOptions
+        options?: QuickOpenOptions,
     ) {
         super(model, options);
         if (inputOptions.password) {

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from 'inversify';
 import {
     QuickOpenService, QuickOpenModel, QuickOpenOptions,
-    QuickOpenItem, QuickOpenGroupItem, QuickOpenMode, KeySequence
+    QuickOpenItem, QuickOpenGroupItem, QuickOpenMode, KeySequence,
 } from "@theia/core/lib/browser";
 import { KEY_CODE_MAP } from './monaco-keycode-map';
 import { ILogger } from '@theia/core';
@@ -93,7 +93,7 @@ export class MonacoQuickOpenService extends QuickOpenService {
                 this.onClose(true);
             },
             onType: lookFor => this.onType(lookFor || ''),
-            onFocusLost: () => (this.opts && this.opts.ignoreFocusOut !== undefined) ? this.opts.ignoreFocusOut : false
+            onFocusLost: () => (this.opts && this.opts.ignoreFocusOut !== undefined) ? this.opts.ignoreFocusOut : false,
         }, {});
         this.attachQuickOpenStyler();
         this._widget.create();
@@ -140,7 +140,7 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
 
     constructor(
         protected readonly model: QuickOpenModel,
-        options?: QuickOpenOptions
+        options?: QuickOpenOptions,
     ) {
         this.model = model;
         this.options = QuickOpenOptions.resolve(options);
@@ -208,13 +208,13 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
             const idx = this.options.selectIndex(lookFor);
             if (idx >= 0) {
                 return {
-                    autoFocusIndex: idx
+                    autoFocusIndex: idx,
                 };
             }
         }
         return {
             autoFocusFirstEntry: true,
-            autoFocusPrefixMatch: lookFor
+            autoFocusPrefixMatch: lookFor,
         };
     }
 
@@ -223,7 +223,7 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
 export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
 
     constructor(
-        public readonly item: QuickOpenItem
+        public readonly item: QuickOpenItem,
     ) {
         super();
     }
@@ -278,7 +278,7 @@ export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
                     keyCode.shift,
                     keyCode.alt,
                     keyCode.meta,
-                    KEY_CODE_MAP[keyCode.key.keyCode]
+                    KEY_CODE_MAP[keyCode.key.keyCode],
                 );
                 return new monaco.keybindings.USLayoutResolvedKeybinding(simple, monaco.platform.OS);
             }
@@ -293,7 +293,7 @@ export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
                     first.shift,
                     first.alt,
                     first.meta,
-                    KEY_CODE_MAP[first.key.keyCode]
+                    KEY_CODE_MAP[first.key.keyCode],
                 );
 
                 const secondPart = new monaco.keybindings.SimpleKeybinding(
@@ -301,7 +301,7 @@ export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
                     second.shift,
                     second.alt,
                     second.meta,
-                    KEY_CODE_MAP[second.key.keyCode]
+                    KEY_CODE_MAP[second.key.keyCode],
                 );
 
                 return new monaco.keybindings.USLayoutResolvedKeybinding(
@@ -332,7 +332,7 @@ export class QuickOpenEntry extends monaco.quickOpen.QuickOpenEntry {
 export class QuickOpenEntryGroup extends monaco.quickOpen.QuickOpenEntryGroup {
 
     constructor(
-        public readonly item: QuickOpenGroupItem
+        public readonly item: QuickOpenGroupItem,
     ) {
         super(new QuickOpenEntry(item));
     }

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -27,7 +27,7 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
 
     constructor(
         @inject(EditorManager) protected readonly editorManager: EditorManager,
-        @inject(StatusBar) protected readonly statusBar: StatusBar
+        @inject(StatusBar) protected readonly statusBar: StatusBar,
     ) { }
 
     onStart(app: FrontendApplication): void {
@@ -61,7 +61,7 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
                 text: `${useSpaceOrTab}: ${tabSize}`,
                 alignment: StatusBarAlignment.RIGHT,
                 priority: 10,
-                command: EditorCommands.CONFIG_INDENTATION.id
+                command: EditorCommands.CONFIG_INDENTATION.id,
             });
         }
     }

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -25,7 +25,7 @@ import { MonacoEditorModel } from "./monaco-editor-model";
 export class MonacoTextModelService implements monaco.editor.ITextModelService {
 
     protected readonly _models = new ReferenceCollection<string, MonacoEditorModel>(
-        uri => this.loadModel(new URI(uri))
+        uri => this.loadModel(new URI(uri)),
     );
 
     @inject(ResourceProvider)
@@ -69,10 +69,10 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
     }
 
     protected readonly modelOptions: {
-        [name: string]: (keyof monaco.editor.ITextModelUpdateOptions | undefined)
+        [name: string]: (keyof monaco.editor.ITextModelUpdateOptions | undefined),
     } = {
             'editor.tabSize': 'tabSize',
-            'editor.insertSpaces': 'insertSpaces'
+            'editor.insertSpaces': 'insertSpaces',
         };
 
     protected updateModel(model: MonacoEditorModel, change: EditorPreferenceChange): void {
@@ -94,7 +94,7 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
     protected getModelOptions(): monaco.editor.ITextModelUpdateOptions {
         return {
             tabSize: this.editorPreferences['editor.tabSize'],
-            insertSpaces: this.editorPreferences['editor.insertSpaces']
+            insertSpaces: this.editorPreferences['editor.insertSpaces'],
         };
     }
 
@@ -102,7 +102,7 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
         return {
             dispose(): void {
                 // no-op
-            }
+            },
         };
     }
 }

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -44,14 +44,14 @@ export class MonacoWorkspace implements lang.Workspace {
     readonly capabilities = {
         applyEdit: true,
         workspaceEdit: {
-            documentChanges: true
-        }
+            documentChanges: true,
+        },
     };
 
     readonly synchronization = {
         didSave: true,
         willSave: true,
-        willSaveWaitUntil: true
+        willSaveWaitUntil: true,
     };
 
     protected resolveReady: () => void;
@@ -143,26 +143,26 @@ export class MonacoWorkspace implements lang.Workspace {
         const { model, contentChanges } = event;
         this.onDidChangeTextDocumentEmitter.fire({
             textDocument: model,
-            contentChanges
+            contentChanges,
         });
     }
 
     protected fireWillSave(event: WillSaveMonacoModelEvent): void {
         const { reason } = event;
         const timeout = new Promise<TextEdit[]>(resolve =>
-            setTimeout(() => resolve([]), 1000)
+            setTimeout(() => resolve([]), 1000),
         );
         const resolveEdits = new Promise<TextEdit[]>(resolve =>
             this.onWillSaveTextDocumentEmitter.fire({
                 textDocument: event.model,
                 reason,
-                waitUntil: thenable => thenable.then(resolve)
-            })
+                waitUntil: thenable => thenable.then(resolve),
+            }),
         );
         event.waitUntil(
             Promise.race([resolveEdits, timeout]).then(edits =>
-                this.p2m.asTextEdits(edits).map(edit => edit as monaco.editor.IIdentifiedSingleEditOperation)
-            )
+                this.p2m.asTextEdits(edits).map(edit => edit as monaco.editor.IIdentifiedSingleEditOperation),
+            ),
         );
     }
 
@@ -208,7 +208,7 @@ export class MonacoWorkspace implements lang.Workspace {
         const onFileEvent = onFileEventEmitter.event;
         return {
             onFileEvent,
-            dispose: () => disposables.dispose()
+            dispose: () => disposables.dispose(),
         };
     }
 
@@ -235,7 +235,7 @@ export class MonacoWorkspace implements lang.Workspace {
                     identifier: undefined!,
                     forceMoveMarkers: false,
                     range: new monaco.Range(edit.range.startLineNumber, edit.range.startColumn, edit.range.endLineNumber, edit.range.endColumn),
-                    text: edit.text
+                    text: edit.text,
                 }));
                 // start a fresh operation
                 model.pushStackElement();

--- a/packages/monaco/src/browser/textmate/monaco-builtin-theme-provider.ts
+++ b/packages/monaco/src/browser/textmate/monaco-builtin-theme-provider.ts
@@ -50,7 +50,7 @@ export class BuiltinMonacoThemeProvider {
                     inherit: true,
                     rules: [],
                     colors: {},
-                }
+                },
             );
 
             monaco.editor.defineTheme(theme.name, theme);
@@ -93,7 +93,7 @@ export class BuiltinMonacoThemeProvider {
                     }, {});
 
                     monacoTheme.rules.push({
-                        ...settings, token: scope
+                        ...settings, token: scope,
                     });
                 }
             }

--- a/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
@@ -67,9 +67,9 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
                 }
                 return {
                     format: 'json',
-                    content: '{}'
+                    content: '{}',
                 };
-            }
+            },
         });
 
         this.toDispose.push(this.monacoModelService.onDidCreate(model => {
@@ -96,7 +96,7 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
         await this.onigasmPromise;
         try {
             monaco.languages.setTokensProvider(languageId, createTextmateTokenizer(
-                await this.grammarRegistry.loadGrammarWithConfiguration(scopeName, initialLanguage, configuration)
+                await this.grammarRegistry.loadGrammarWithConfiguration(scopeName, initialLanguage, configuration),
             ));
         } catch (err) {
             this.logger.warn('No grammar for this language id', languageId);

--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -19,7 +19,7 @@ import { INITIAL, StackElement, IGrammar } from "monaco-textmate";
 export class State implements monaco.languages.IState {
 
     constructor(
-        public ruleStack: StackElement
+        public ruleStack: StackElement,
     ) { }
 
     clone(): monaco.languages.IState {
@@ -57,7 +57,7 @@ export function createTextmateTokenizer(grammar: IGrammar): monaco.languages.Tok
                         if (defaultForeground !== foregroundColor) {
                             return {
                                 ...token,
-                                scopes: scope!
+                                scopes: scope!,
                             };
                         }
                     }
@@ -67,6 +67,6 @@ export function createTextmateTokenizer(grammar: IGrammar): monaco.languages.Tok
                     };
                 }),
             };
-        }
+        },
     };
 }

--- a/packages/navigator/src/browser/fuzzy-search.spec.ts
+++ b/packages/navigator/src/browser/fuzzy-search.spec.ts
@@ -27,15 +27,15 @@ describe('fuzzy-search', () => {
                 {
                     item: 'alma',
                     ranges: [
-                        { offset: 0, length: 1 }
-                    ]
-                }
-            ]
+                        { offset: 0, length: 1 },
+                    ],
+                },
+            ],
         },
         {
             pattern: 'a',
             items: ['körte'],
-            expected: []
+            expected: [],
         },
         {
             pattern: 'bcn',
@@ -46,23 +46,23 @@ describe('fuzzy-search', () => {
                     ranges: [
                         { offset: 0, length: 1 },
                         { offset: 2, length: 1 },
-                        { offset: 4, length: 1 }
-                    ]
+                        { offset: 4, length: 1 },
+                    ],
                 },
                 {
                     item: 'a mighty bear canoe',
                     ranges: [
                         { offset: 9, length: 1 },
                         { offset: 14, length: 1 },
-                        { offset: 16, length: 1 }
-                    ]
-                }
-            ]
-        }
+                        { offset: 16, length: 1 },
+                    ],
+                },
+            ],
+        },
     ] as {
         readonly pattern: string,
         readonly items: string[],
-        readonly expected: FuzzySearch.Match<string>[]
+        readonly expected: FuzzySearch.Match<string>[],
     }[]).forEach(test => {
         const { pattern, items, expected } = test;
         it(`should match ${expected.length} item${expected.length === 1 ? '' : 's'} when filtering [${items.join(', ')}] with pattern: '${pattern}'`, async () => {
@@ -72,7 +72,7 @@ describe('fuzzy-search', () => {
 
     ([
         ['con', ['configs', 'base.tsconfig.json', 'tsconfig.json', 'base.nyc.json', 'CONTRIBUTING.MD']],
-        ['bcn', ['baconing', 'narwhal', 'a mighty bear canoe'], ['baconing', 'a mighty bear canoe']]
+        ['bcn', ['baconing', 'narwhal', 'a mighty bear canoe'], ['baconing', 'a mighty bear canoe']],
     ] as ([string, string[], string[]])[]).forEach(test => {
         const [pattern, items, expected] = test;
         it(`should match the order of items after the filtering with pattern: '${pattern}'`, async () => {
@@ -92,7 +92,7 @@ describe('fuzzy-search', () => {
         return new FuzzySearch().filter({
             items,
             pattern,
-            transform: arg => arg
+            transform: arg => arg,
         });
     }
 

--- a/packages/navigator/src/browser/fuzzy-search.ts
+++ b/packages/navigator/src/browser/fuzzy-search.ts
@@ -30,7 +30,7 @@ export class FuzzySearch {
         return fuzzy.filter(input.pattern, input.items.slice(), {
             pre: FuzzySearch.PRE,
             post: FuzzySearch.POST,
-            extract: input.transform
+            extract: input.transform,
         }).sort(this.sortResults.bind(this)).map(this.mapResult.bind(this));
     }
 
@@ -41,7 +41,7 @@ export class FuzzySearch {
     protected mapResult<T>(result: fuzzy.FilterResult<T>): FuzzySearch.Match<T> {
         return {
             item: result.original,
-            ranges: this.mapRanges(result.string)
+            ranges: this.mapRanges(result.string),
         };
     }
 
@@ -59,7 +59,7 @@ export class FuzzySearch {
         while (preIndex !== -1 && postIndex !== -1) {
             ranges.push({
                 offset: preIndex,
-                length: postIndex - preIndex - 1
+                length: postIndex - preIndex - 1,
             });
             copy.splice(postIndex, 1);
             copy.splice(preIndex, 1);

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -28,7 +28,7 @@ import { FileNavigatorSearch } from './navigator-search';
 export const FILE_NAVIGATOR_PROPS = <TreeProps>{
     ...defaultTreeProps,
     contextMenuPath: NAVIGATOR_CONTEXT_MENU,
-    multiSelect: true
+    multiSelect: true,
 };
 
 export function createFileNavigatorContainer(parent: interfaces.Container): Container {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -30,11 +30,11 @@ import { FileNavigatorFilter } from "./navigator-filter";
 export namespace FileNavigatorCommands {
     export const REVEAL_IN_NAVIGATOR = {
         id: 'navigator.reveal',
-        label: 'Reveal in Files'
+        label: 'Reveal in Files',
     };
     export const TOGGLE_HIDDEN_FILES = {
         id: 'navigator.toggle.hidden.files',
-        label: 'Toggle Hidden Files'
+        label: 'Toggle Hidden Files',
     };
 }
 
@@ -55,17 +55,17 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
     constructor(
         @inject(FileNavigatorPreferences) protected readonly fileNavigatorPreferences: FileNavigatorPreferences,
         @inject(OpenerService) protected readonly openerService: OpenerService,
-        @inject(FileNavigatorFilter) protected readonly fileNavigatorFilter: FileNavigatorFilter
+        @inject(FileNavigatorFilter) protected readonly fileNavigatorFilter: FileNavigatorFilter,
     ) {
         super({
             widgetId: FILE_NAVIGATOR_ID,
             widgetName: 'Files',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 100
+                rank: 100,
             },
             toggleCommandId: 'fileNavigator:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+e'
+            toggleKeybinding: 'ctrlcmd+shift+e',
         });
     }
 
@@ -84,14 +84,14 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerCommand(FileNavigatorCommands.REVEAL_IN_NAVIGATOR, {
             execute: () => this.openView({ activate: true }).then(() => this.selectWidgetFileNode(this.shell.currentWidget)),
             isEnabled: () => Navigatable.is(this.shell.currentWidget),
-            isVisible: () => Navigatable.is(this.shell.currentWidget)
+            isVisible: () => Navigatable.is(this.shell.currentWidget),
         });
         registry.registerCommand(FileNavigatorCommands.TOGGLE_HIDDEN_FILES, {
             execute: () => {
                 this.fileNavigatorFilter.toggleHiddenFiles();
             },
             isEnabled: () => true,
-            isVisible: () => true
+            isVisible: () => true,
         });
     }
 
@@ -100,18 +100,18 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
             commandId: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
             label: 'Reveal in Files',
-            order: '5'
+            order: '5',
         });
 
         registry.registerMenuAction(NavigatorContextMenu.OPEN, {
-            commandId: CommonCommands.OPEN.id
+            commandId: CommonCommands.OPEN.id,
         });
         registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, 'Open With');
         this.openerService.getOpeners().then(openers => {
             for (const opener of openers) {
                 const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
                 registry.registerMenuAction(NavigatorContextMenu.OPEN_WITH, {
-                    commandId: openWithCommand.id
+                    commandId: openWithCommand.id,
                 });
             }
         });
@@ -121,32 +121,32 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         // });
 
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
-            commandId: CommonCommands.COPY.id
+            commandId: CommonCommands.COPY.id,
         });
         registry.registerMenuAction(NavigatorContextMenu.CLIPBOARD, {
-            commandId: CommonCommands.PASTE.id
+            commandId: CommonCommands.PASTE.id,
         });
 
         registry.registerMenuAction(NavigatorContextMenu.MOVE, {
-            commandId: WorkspaceCommands.FILE_RENAME.id
+            commandId: WorkspaceCommands.FILE_RENAME.id,
         });
         registry.registerMenuAction(NavigatorContextMenu.MOVE, {
-            commandId: WorkspaceCommands.FILE_DELETE.id
+            commandId: WorkspaceCommands.FILE_DELETE.id,
         });
         registry.registerMenuAction(NavigatorContextMenu.MOVE, {
             commandId: FileDownloadCommands.DOWNLOAD.id,
             label: 'Download',
-            order: 'z' // Should be the last item in the "move" menu group.
+            order: 'z', // Should be the last item in the "move" menu group.
         });
 
         registry.registerMenuAction(NavigatorContextMenu.NEW, {
-            commandId: WorkspaceCommands.NEW_FILE.id
+            commandId: WorkspaceCommands.NEW_FILE.id,
         });
         registry.registerMenuAction(NavigatorContextMenu.NEW, {
-            commandId: WorkspaceCommands.NEW_FOLDER.id
+            commandId: WorkspaceCommands.NEW_FOLDER.id,
         });
         registry.registerMenuAction(NavigatorContextMenu.DIFF, {
-            commandId: WorkspaceCommands.FILE_COMPARE.id
+            commandId: WorkspaceCommands.FILE_COMPARE.id,
         });
     }
 
@@ -154,32 +154,32 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         super.registerKeybindings(registry);
         registry.registerKeybinding({
             command: FileNavigatorCommands.REVEAL_IN_NAVIGATOR.id,
-            keybinding: "alt+r"
+            keybinding: "alt+r",
         });
 
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_DELETE.id,
             keybinding: "del",
-            context: NavigatorKeybindingContexts.navigatorActive
+            context: NavigatorKeybindingContexts.navigatorActive,
         });
         if (isOSX) {
             registry.registerKeybinding({
                 command: WorkspaceCommands.FILE_DELETE.id,
                 keybinding: "cmd+backspace",
-                context: NavigatorKeybindingContexts.navigatorActive
+                context: NavigatorKeybindingContexts.navigatorActive,
             });
         }
 
         registry.registerKeybinding({
             command: WorkspaceCommands.FILE_RENAME.id,
             keybinding: "f2",
-            context: NavigatorKeybindingContexts.navigatorActive
+            context: NavigatorKeybindingContexts.navigatorActive,
         });
 
         registry.registerKeybinding({
             command: FileNavigatorCommands.TOGGLE_HIDDEN_FILES.id,
             keybinding: "ctrlcmd+i",
-            context: NavigatorKeybindingContexts.navigatorActive
+            context: NavigatorKeybindingContexts.navigatorActive,
         });
     }
 

--- a/packages/navigator/src/browser/navigator-filter.spec.ts
+++ b/packages/navigator/src/browser/navigator-filter.spec.ts
@@ -47,68 +47,68 @@ describe('navigator-filter-glob', () => {
         '/src/foo/test/bar/b.js',
 
         '/test/baz/bar/a.js',
-        '/test/baz/bar/b.js'
+        '/test/baz/bar/b.js',
     ].map(toItem);
 
     ([
         {
             patterns: {
-                '**/.git/**': true
+                '**/.git/**': true,
             },
             includes: [
-                '/src/foo/'
+                '/src/foo/',
             ],
             excludes: [
                 '/.git/',
                 '/.git/a',
-                '/.git/b'
-            ]
-        },
-        {
-            patterns: {
-                '*.js': true
-            },
-            includes: [
-                '/src/foo/a.ts',
-                '/.git/'
+                '/.git/b',
             ],
-            excludes: [
-                '/src/foo/a.js',
-                '/test/baz/bar/a.js'
-            ]
-        },
-        {
-            patterns: {
-                '**/test/bar/**': true
-            },
-            includes: [
-                '/test/baz/bar/a.js',
-                '/test/baz/bar/b.js',
-                '/.git/'
-            ],
-            excludes: [
-                '/src/foo/test/bar/a.js',
-                '/src/foo/test/bar/b.js'
-            ]
         },
         {
             patterns: {
                 '*.js': true,
-                '**/.git/**': true
             },
             includes: [
-                '/src/foo/a.ts'
+                '/src/foo/a.ts',
+                '/.git/',
+            ],
+            excludes: [
+                '/src/foo/a.js',
+                '/test/baz/bar/a.js',
+            ],
+        },
+        {
+            patterns: {
+                '**/test/bar/**': true,
+            },
+            includes: [
+                '/test/baz/bar/a.js',
+                '/test/baz/bar/b.js',
+                '/.git/',
+            ],
+            excludes: [
+                '/src/foo/test/bar/a.js',
+                '/src/foo/test/bar/b.js',
+            ],
+        },
+        {
+            patterns: {
+                '*.js': true,
+                '**/.git/**': true,
+            },
+            includes: [
+                '/src/foo/a.ts',
             ],
             excludes: [
                 '/.git/',
                 '/src/foo/a.js',
-                '/test/baz/bar/a.js'
-            ]
+                '/test/baz/bar/a.js',
+            ],
         },
         {
             patterns: {
                 '*.js': false,
-                '**/.git/**': false
+                '**/.git/**': false,
             },
             includes: [
                 '/.git/',
@@ -122,12 +122,12 @@ describe('navigator-filter-glob', () => {
                 '/src/foo/test/bar/a.js',
                 '/src/foo/test/bar/b.js',
                 '/test/baz/bar/a.js',
-                '/test/baz/bar/b.js'
+                '/test/baz/bar/b.js',
             ],
             excludes: [
 
-            ]
-        }
+            ],
+        },
     ] as Input[]).forEach((test, index) => {
         it(`${index < 10 ? `0${index + 1}` : `${index + 1}`} glob-filter: (${Object.keys(test.patterns).map(key => `${key} [${test.patterns[key]}]`).join(', ')}) `, () => {
             const filter = new FileNavigatorFilterPredicate(test.patterns);

--- a/packages/navigator/src/browser/navigator-filter.ts
+++ b/packages/navigator/src/browser/navigator-filter.ts
@@ -81,7 +81,7 @@ export class FileNavigatorFilter {
     protected interceptExclusions(exclusions: FileNavigatorFilter.Exclusions): FileNavigatorFilter.Exclusions {
         return {
             ...exclusions,
-            '**/.*': this.showHiddenFiles
+            '**/.*': this.showHiddenFiles,
         };
     }
 
@@ -111,7 +111,7 @@ export namespace FileNavigatorFilter {
          */
         export function and(...predicates: Predicate[]): Predicate {
             return {
-                filter: id => predicates.every(predicate => predicate.filter(id))
+                filter: id => predicates.every(predicate => predicate.filter(id)),
             };
         }
 
@@ -145,7 +145,7 @@ export class FileNavigatorFilterPredicate implements FileNavigatorFilter.Predica
     protected createDelegate(pattern: string): FileNavigatorFilter.Predicate {
         const delegate = new Minimatch(pattern, { matchBase: true });
         return {
-            filter: item => !delegate.match(item.id)
+            filter: item => !delegate.match(item.id),
         };
     }
 

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -42,14 +42,14 @@ export default new ContainerModule(bind => {
         (options: SearchBoxProps) => {
             const debounce = new SearchBoxDebounce(options);
             return new SearchBox(options, debounce);
-        }
+        },
     );
 
     bind(FileNavigatorWidget).toDynamicValue(ctx =>
-        createFileNavigatorWidget(ctx.container)
+        createFileNavigatorWidget(ctx.container),
     );
     bind(WidgetFactory).toDynamicValue(context => ({
         id: FILE_NAVIGATOR_ID,
-        createWidget: () => context.container.get<FileNavigatorWidget>(FileNavigatorWidget)
+        createWidget: () => context.container.get<FileNavigatorWidget>(FileNavigatorWidget),
     }));
 });

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -25,17 +25,17 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
         'navigator.autoReveal': {
             type: 'boolean',
             description: 'Selects file under editing in the navigator.',
-            default: true
+            default: true,
         },
         'navigator.exclude': {
             type: 'object',
             description: `
 Configure glob patterns for excluding files and folders from the navigator. A resource that matches any of the enabled patterns, will be filtered out from the navigator. For more details about the exclusion patterns, see: \`man 5 gitignore\`.`,
             default: {
-                "**/.git": true
-            }
-        }
-    }
+                "**/.git": true,
+            },
+        },
+    },
 };
 
 export interface FileNavigatorConfiguration {

--- a/packages/navigator/src/browser/navigator-search.ts
+++ b/packages/navigator/src/browser/navigator-search.ts
@@ -45,7 +45,7 @@ export class FileNavigatorSearch implements Disposable, TreeDecorator {
         this.disposables.pushAll([
             this.decorationEmitter,
             this.filteredNodesEmitter,
-            this.tree.onChanged(() => this.filter(undefined))
+            this.tree.onChanged(() => this.filter(undefined)),
         ]);
     }
 
@@ -70,7 +70,7 @@ export class FileNavigatorSearch implements Disposable, TreeDecorator {
         this._filterResult = await this.fuzzySearch.filter({
             items,
             pattern,
-            transform
+            transform,
         });
         this._filteredNodes = this._filterResult.map(match => match.item);
         this.fireDidChangeDecorations(() => new Map(this._filterResult.map(m => [m.item.id, this.toDecorator(m)] as [string, TreeDecoration.Data])));
@@ -111,8 +111,8 @@ export class FileNavigatorSearch implements Disposable, TreeDecorator {
     protected toDecorator(match: FuzzySearch.Match<TreeNode>): TreeDecoration.Data {
         return {
             highlight: {
-                ranges: match.ranges.map(this.mapRange.bind(this))
-            }
+                ranges: match.ranges.map(this.mapRange.bind(this)),
+            },
         };
     }
 
@@ -120,7 +120,7 @@ export class FileNavigatorSearch implements Disposable, TreeDecorator {
         const { offset, length } = range;
         return {
             offset,
-            length
+            length,
         };
     }
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -49,7 +49,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         @inject(FileNavigatorSearch) protected readonly navigatorSearch: FileNavigatorSearch,
         @inject(SearchBoxFactory) protected readonly searchBoxFactory: SearchBoxFactory,
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
-        @inject(FileSystem) protected readonly fileSystem: FileSystem
+        @inject(FileSystem) protected readonly fileSystem: FileSystem,
     ) {
         super(props, model, contextMenuRenderer);
         this.id = FILE_NAVIGATOR_ID;
@@ -88,7 +88,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
                         this.model.expandNode(child);
                     }
                 }
-            })
+            }),
         ]);
     }
 

--- a/packages/navigator/src/browser/search-box-debounce.ts
+++ b/packages/navigator/src/browser/search-box-debounce.ts
@@ -37,7 +37,7 @@ export namespace SearchBoxDebounceOptions {
      * The default debounce option.
      */
     export const DEFAULT: SearchBoxDebounceOptions = {
-        delay: 200
+        delay: 200,
     };
 
 }

--- a/packages/navigator/src/browser/search-box.ts
+++ b/packages/navigator/src/browser/search-box.ts
@@ -47,7 +47,7 @@ export class SearchBox extends BaseWidget {
 
     private static SPECIAL_KEYS = [
         Key.ESCAPE,
-        Key.BACKSPACE
+        Key.BACKSPACE,
     ];
 
     protected readonly nextEmitter = new Emitter<void>();
@@ -66,7 +66,7 @@ export class SearchBox extends BaseWidget {
             this.closeEmitter,
             this.textChangeEmitter,
             this.debounce,
-            this.debounce.onChanged(data => this.fireTextChange(data))
+            this.debounce.onChanged(data => this.fireTextChange(data)),
         ]);
         this.hide();
         this.update();
@@ -165,7 +165,7 @@ export class SearchBox extends BaseWidget {
         input: HTMLInputElement,
         previous: HTMLElement | undefined,
         next: HTMLElement | undefined,
-        close: HTMLElement | undefined
+        close: HTMLElement | undefined,
     } {
 
         this.addClass(SearchBox.Styles.SEARCH_BOX);
@@ -176,7 +176,7 @@ export class SearchBox extends BaseWidget {
         input.type = 'text';
         input.classList.add(
             SearchBox.Styles.SEARCH_INPUT,
-            SearchBox.Styles.NON_SELECTABLE
+            SearchBox.Styles.NON_SELECTABLE,
         );
         this.node.appendChild(input);
 
@@ -188,7 +188,7 @@ export class SearchBox extends BaseWidget {
             previous = document.createElement('div');
             previous.classList.add(
                 SearchBox.Styles.BUTTON,
-                SearchBox.Styles.BUTTON_PREVIOUS
+                SearchBox.Styles.BUTTON_PREVIOUS,
             );
             previous.title = 'Previous (Up)';
             this.node.appendChild(previous);
@@ -197,7 +197,7 @@ export class SearchBox extends BaseWidget {
             next = document.createElement('div');
             next.classList.add(
                 SearchBox.Styles.BUTTON,
-                SearchBox.Styles.BUTTON_NEXT
+                SearchBox.Styles.BUTTON_NEXT,
             );
             next.title = 'Next (Down)';
             this.node.appendChild(next);
@@ -206,7 +206,7 @@ export class SearchBox extends BaseWidget {
             close = document.createElement('div');
             close.classList.add(
                 SearchBox.Styles.BUTTON,
-                SearchBox.Styles.BUTTON_CLOSE
+                SearchBox.Styles.BUTTON_CLOSE,
             );
             close.title = 'Close (Escape)';
             this.node.appendChild(close);
@@ -218,7 +218,7 @@ export class SearchBox extends BaseWidget {
             input,
             previous,
             next,
-            close
+            close,
         };
 
     }

--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -30,10 +30,10 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
             widgetName: 'Outline',
             defaultWidgetOptions: {
                 area: 'right',
-                rank: 500
+                rank: 500,
             },
             toggleCommandId: 'outlineView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+o'
+            toggleKeybinding: 'ctrlcmd+shift+o',
         });
     }
 

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -23,7 +23,7 @@ import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widg
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>
-        () => createOutlineViewWidget(ctx.container)
+        () => createOutlineViewWidget(ctx.container),
     );
 
     bind(OutlineViewService).toSelf().inSingletonScope();

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -23,7 +23,7 @@ import {
     TreeProps,
     ContextMenuRenderer,
     TreeModel,
-    ExpandableTreeNode
+    ExpandableTreeNode,
 } from "@theia/core/lib/browser";
 import { Message } from '@phosphor/messaging';
 import { Emitter } from '@theia/core';
@@ -51,7 +51,7 @@ export class OutlineViewWidget extends TreeWidget {
     constructor(
         @inject(TreeProps) protected readonly treeProps: TreeProps,
         @inject(TreeModel) model: TreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(treeProps, model, contextMenuRenderer);
 
@@ -67,7 +67,7 @@ export class OutlineViewWidget extends TreeWidget {
             name: 'Outline Root',
             visible: false,
             children: nodes,
-            parent: undefined
+            parent: undefined,
         } as CompositeTreeNode;
     }
 

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -26,10 +26,10 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> {
             widgetId: OUTPUT_WIDGET_KIND,
             widgetName: 'Output',
             defaultWidgetOptions: {
-                area: 'bottom'
+                area: 'bottom',
             },
             toggleCommandId: 'output:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+u'
+            toggleKeybinding: 'ctrlcmd+shift+u',
         });
     }
 

--- a/packages/output/src/browser/output-frontend-module.ts
+++ b/packages/output/src/browser/output-frontend-module.ts
@@ -28,7 +28,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WidgetFactory).toDynamicValue(context => ({
         id: OUTPUT_WIDGET_KIND,
-        createWidget: () => context.container.get<OutputWidget>(OutputWidget)
+        createWidget: () => context.container.get<OutputWidget>(OutputWidget),
     }));
 
     bindViewContribution(bind, OutputContribution);

--- a/packages/output/src/common/output-preferences.ts
+++ b/packages/output/src/common/output-preferences.ts
@@ -20,7 +20,7 @@ import {
     PreferenceProxy,
     PreferenceService,
     PreferenceContribution,
-    PreferenceSchema
+    PreferenceSchema,
 } from '@theia/core/lib/browser/preferences';
 
 export const OutputConfigSchema: PreferenceSchema = {
@@ -29,9 +29,9 @@ export const OutputConfigSchema: PreferenceSchema = {
         "output.maxChannelHistory": {
             "type": "number",
             "description": "The maximum number of entries in an output channel.",
-            "default": 1000
-        }
-    }
+            "default": 1000,
+        },
+    },
 };
 
 export interface OutputConfiguration {

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
@@ -26,5 +26,5 @@ export default new ContainerModule(bind => {
     bind(PluginDeployerDirectoryHandler).to(PluginVsCodeDirectoryHandler).inSingletonScope();
     bind(PluginScanner).to(VsCodePluginScanner).inSingletonScope();
     bind(PluginDeployerResolver).to(VsCodePluginDeployerResolver).inSingletonScope();
-}
+},
 );

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -17,7 +17,7 @@
 import {
     PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginPackage, PluginDeployerDirectoryHandlerContext,
-    PluginDeployerEntryType
+    PluginDeployerEntryType,
 } from "@theia/plugin-ext";
 import { injectable } from "inversify";
 import * as fs from "fs";

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -46,7 +46,7 @@ export const doInitialization: BackendInitializationFn = (rpc: any, pluginMetada
         id: vscodeModuleName,
         filename: vscodeModuleName,
         loaded: true,
-        exports: g[vscodeModuleName]
+        exports: g[vscodeModuleName],
     };
 
     // save original resolve method

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
@@ -33,7 +33,7 @@ export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
 
     private static HEADERS = {
         'Content-Type': 'application/json',
-        'Accept': 'application/json;api-version=3.0-preview.1'
+        'Accept': 'application/json;api-version=3.0-preview.1',
     };
 
     private unpackedFolder: string;
@@ -64,16 +64,16 @@ export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
             const json = {
                 "filters": [{
                     "criteria": [{ "filterType": 7, "value": extensionName }], "pageNumber": 1,
-                    "pageSize": 1, "sortBy": 0, "sortOrder": 0
+                    "pageSize": 1, "sortBy": 0, "sortOrder": 0,
                 }], "assetTypes": ["Microsoft.VisualStudio.Services.VSIXPackage"],
-                "flags": 131
+                "flags": 131,
             };
 
             const options = {
                 url: VsCodePluginDeployerResolver.MARKET_PLACE_ENDPOINT,
                 headers: VsCodePluginDeployerResolver.HEADERS,
                 method: 'POST',
-                json: json
+                json: json,
             };
 
             request(options, (error, response, body) => {

--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -34,11 +34,11 @@ export class VsCodePluginScanner implements PluginScanner {
             description: plugin.description,
             engine: {
                 type: this._apiType,
-                version: plugin.engines[this._apiType]
+                version: plugin.engines[this._apiType],
             },
             entryPoint: {
-                backend: plugin.main
-            }
+                backend: plugin.main,
+            },
         };
     }
 
@@ -47,7 +47,7 @@ export class VsCodePluginScanner implements PluginScanner {
             startMethod: 'activate',
             stopMethod: 'deactivate',
 
-            backendInitPath: __dirname + '/plugin-vscode-init.js'
+            backendInitPath: __dirname + '/plugin-vscode-init.js',
         };
     }
 }

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -157,7 +157,7 @@ export interface WorkspaceExt {
 export enum EditorPosition {
     ONE = 0,
     TWO = 1,
-    THREE = 2
+    THREE = 2,
 }
 
 export interface Position {
@@ -221,7 +221,7 @@ export enum TextEditorRevealType {
     Default = 0,
     InCenter = 1,
     InCenterIfOutsideViewport = 2,
-    AtTop = 3
+    AtTop = 3,
 }
 
 export interface SelectionChangeEvent {
@@ -438,12 +438,12 @@ export interface PreferenceRegistryMain {
         target: boolean | ConfigurationTarget | undefined,
         key: string,
         value: any,
-        resource: any | undefined
+        resource: any | undefined,
     ): PromiseLike<void>;
     $removeConfigurationOption(
         target: boolean | ConfigurationTarget | undefined,
         key: string,
-        resource: any | undefined
+        resource: any | undefined,
     ): PromiseLike<void>;
 }
 export interface PreferenceRegistryExt {
@@ -468,7 +468,7 @@ export const PLUGIN_RPC_CONTEXT = {
     ENV_MAIN: createProxyIdentifier<EnvMain>('EnvMain'),
     TERMINAL_MAIN: createProxyIdentifier<TerminalServiceMain>('TerminalServiceMain'),
     PREFERENCE_REGISTRY_MAIN: createProxyIdentifier<PreferenceRegistryMain>('PreferenceRegistryMain'),
-    OUTPUT_CHANNEL_REGISTRY_MAIN: <ProxyIdentifier<OutputChannelRegistryMain>>createProxyIdentifier<OutputChannelRegistryMain>('OutputChannelRegistryMain')
+    OUTPUT_CHANNEL_REGISTRY_MAIN: <ProxyIdentifier<OutputChannelRegistryMain>>createProxyIdentifier<OutputChannelRegistryMain>('OutputChannelRegistryMain'),
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -482,5 +482,5 @@ export const MAIN_RPC_CONTEXT = {
     DOCUMENTS_EXT: createProxyIdentifier<DocumentsExt>('DocumentsExt'),
     ENV_EXT: createProxyIdentifier<EnvExt>('EnvExt'),
     TERMINAL_EXT: createProxyIdentifier<TerminalServiceExt>('TerminalServiceExt'),
-    PREFERENCE_REGISTRY_EXT: createProxyIdentifier<PreferenceRegistryExt>('PreferenceRegistryExt')
+    PREFERENCE_REGISTRY_EXT: createProxyIdentifier<PreferenceRegistryExt>('PreferenceRegistryExt'),
 };

--- a/packages/plugin-ext/src/api/rpc-protocol.ts
+++ b/packages/plugin-ext/src/api/rpc-protocol.ts
@@ -91,7 +91,7 @@ export class RPCProtocolImpl implements RPCProtocol {
                         this.remoteCall(proxyId, name, myArgs);
                 }
                 return target[name];
-            }
+            },
         };
         return new Proxy(Object.create(null), handler);
     }
@@ -270,7 +270,7 @@ class MessageFactory {
 const enum MessageType {
     Request = 1,
     Reply = 2,
-    ReplyErr = 3
+    ReplyErr = 3,
 }
 
 class RequestMessage {
@@ -310,7 +310,7 @@ export function transformErrorForSerialization(error: Error): SerializedError {
             $isError: true,
             name,
             message,
-            stack
+            stack,
         };
     }
 

--- a/packages/plugin-ext/src/common/editor-options.ts
+++ b/packages/plugin-ext/src/common/editor-options.ts
@@ -51,7 +51,7 @@ export enum TextEditorCursorStyle {
     /**
      * As a thin horizontal line, under a character
      */
-    UnderlineThin = 6
+    UnderlineThin = 6,
 }
 
 export function cursorStyleToString(cursorStyle: TextEditorCursorStyle): string {

--- a/packages/plugin-ext/src/common/env.ts
+++ b/packages/plugin-ext/src/common/env.ts
@@ -15,5 +15,5 @@
  ********************************************************************************/
 
 export type QueryParameters = {
-    [key: string]: string | string[]
+    [key: string]: string | string[],
 };

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -117,7 +117,7 @@ export enum PluginDeployerEntryType {
 
     FRONTEND,
 
-    BACKEND
+    BACKEND,
 }
 
 export interface PluginDeployerEntry {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
@@ -64,7 +64,7 @@ export class HostedPluginInformer implements FrontendApplicationContribution {
                         text: `$(cube) ${HostedPluginInformer.DEVELOPMENT_HOST_TITLE}`,
                         tooltip: `Hosted Plugin '${pluginMetadata.model.name}'`,
                         alignment: StatusBarAlignment.LEFT,
-                        priority: 100
+                        priority: 100,
                     };
 
                     this.frontendApplicationStateService.reachedState('ready').then(() => {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
@@ -26,7 +26,7 @@ export class HostedPluginWatcher {
             postMessage(message: string): Promise<void> {
                 messageEmitter.fire(JSON.parse(message));
                 return Promise.resolve();
-            }
+            },
         };
     }
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -42,7 +42,7 @@ export class HostedPluginSupport {
     private frontendApiInitialized = false;
 
     constructor(
-        @inject(PreferenceServiceImpl) private readonly preferenceServiceImpl: PreferenceServiceImpl
+        @inject(PreferenceServiceImpl) private readonly preferenceServiceImpl: PreferenceServiceImpl,
     ) {
         this.theiaReadyPromise = Promise.all([this.preferenceServiceImpl.ready]);
     }
@@ -84,7 +84,7 @@ export class HostedPluginSupport {
                 const plugin: Plugin = {
                     pluginPath: pluginModel.entryPoint.frontend!,
                     model: pluginModel,
-                    lifecycle: pluginLifecycle
+                    lifecycle: pluginLifecycle,
                 };
                 let frontendInitPath = pluginLifecycle.frontendInitPath;
                 if (frontendInitPath) {
@@ -109,7 +109,7 @@ export class HostedPluginSupport {
                 const plugin: Plugin = {
                     pluginPath: pluginModel.entryPoint.backend!,
                     model: pluginModel,
-                    lifecycle: pluginLifecycle
+                    lifecycle: pluginLifecycle,
                 };
                 let backendInitPath = pluginLifecycle.backendInitPath;
                 if (backendInitPath) {
@@ -130,7 +130,7 @@ export class HostedPluginSupport {
     private createServerRpc(): RPCProtocol {
         return new RPCProtocolImpl({
             onMessage: this.watcher.onPostMessageEvent,
-            send: message => { this.server.onMessage(JSON.stringify(message)); }
+            send: message => { this.server.onMessage(JSON.stringify(message)); },
         });
     }
 }

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -29,7 +29,7 @@ const rpc = new RPCProtocolImpl({
     onMessage: emitter.event,
     send: (m: {}) => {
         ctx.postMessage(m);
-    }
+    },
 });
 addEventListener('message', (message: any) => {
     emitter.fire(message.data);
@@ -65,7 +65,7 @@ rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, new HostedPluginManagerExtIm
                 plugins.delete(pluginId);
             }
         });
-    }
+    },
 }));
 
 function isElectron() {

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
@@ -67,7 +67,7 @@ const HOSTED_INSTANCE_START_TIMEOUT_MS = 30000;
 const THEIA_INSTANCE_REGEX = /.*Theia app listening on (.*).*\./;
 const PROCESS_OPTIONS = {
     cwd: process.cwd(),
-    env: { ...process.env }
+    env: { ...process.env },
 };
 delete PROCESS_OPTIONS.env.ELECTRON_RUN_AS_NODE;
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -73,7 +73,7 @@ export class HostedPluginSupport {
                 if (childProcess.send) {
                     childProcess.send(JSON.stringify(m));
                 }
-            }
+            },
         });
         const hostedPluginManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
         hostedPluginManager.$stopPlugin('').then(() => {
@@ -89,7 +89,7 @@ export class HostedPluginSupport {
         this.cp = this.fork({
             serverName: "hosted-plugin",
             logger: this.logger,
-            args: []
+            args: [],
         });
         this.cp.on('message', message => {
             if (this.client) {
@@ -109,7 +109,7 @@ export class HostedPluginSupport {
             silent: true,
             env: env,
             execArgv: [],
-            stdio: ['pipe', 'pipe', 'pipe', 'ipc']
+            stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
         };
         const inspectArgPrefix = `--${options.serverName}-inspect`;
         const inspectArg = process.argv.find(v => v.startsWith(inspectArgPrefix));

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -22,7 +22,7 @@ export class MetadataScanner {
     private scanners: Map<string, PluginScanner> = new Map();
 
     constructor(
-        @multiInject(PluginScanner) scanners: PluginScanner[]
+        @multiInject(PluginScanner) scanners: PluginScanner[],
     ) {
         scanners.forEach((scanner: PluginScanner) => {
             this.scanners.set(scanner.apiType, scanner);
@@ -34,7 +34,7 @@ export class MetadataScanner {
         return {
             source: plugin,
             model: scanner.getModel(plugin),
-            lifecycle: scanner.getLifecycle(plugin)
+            lifecycle: scanner.getLifecycle(plugin),
         };
     }
 

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -43,7 +43,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
             /*
             client.onDidCloseConnection(() => server.dispose());*/
             return server;
-        })
+        }),
     ).inSingletonScope();
 }
 

--- a/packages/plugin-ext/src/hosted/node/plugin-host.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host.ts
@@ -32,7 +32,7 @@ const rpc = new RPCProtocolImpl({
         if (process.send) {
             process.send(JSON.stringify(m));
         }
-    }
+    },
 });
 process.on('message', (message: any) => {
     try {
@@ -72,5 +72,5 @@ rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, new HostedPluginManagerExtIm
                 plugins.delete(pluginId);
             }
         });
-    }
+    },
 }));

--- a/packages/plugin-ext/src/hosted/node/scanners/backend-init-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/backend-init-theia.ts
@@ -33,7 +33,7 @@ export const doInitialization: BackendInitializationFn = (rpc: any) => {
             id: moduleName,
             filename: moduleName,
             loaded: true,
-            exports: theia
+            exports: theia,
         };
     });
 

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -21,7 +21,7 @@ import {
     PluginPackage,
     PluginScanner,
     PluginLifecycle,
-    buildFrontendModuleName
+    buildFrontendModuleName,
 } from '../../../common/plugin-protocol';
 
 @injectable()
@@ -41,12 +41,12 @@ export class TheiaPluginScanner implements PluginScanner {
             description: plugin.description,
             engine: {
                 type: this._apiType,
-                version: plugin.engines[this._apiType]
+                version: plugin.engines[this._apiType],
             },
             entryPoint: {
                 frontend: plugin.theiaPlugin!.frontend,
-                backend: plugin.theiaPlugin!.backend
-            }
+                backend: plugin.theiaPlugin!.backend,
+            },
         };
     }
 
@@ -56,7 +56,7 @@ export class TheiaPluginScanner implements PluginScanner {
             stopMethod: 'stop',
             frontendModuleName: buildFrontendModuleName(plugin),
 
-            backendInitPath: __dirname + '/backend-init-theia.js'
+            backendInitPath: __dirname + '/backend-init-theia.js',
         };
     }
 }

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -37,7 +37,7 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
                     this.proxy.$executeCommand(command.id);
                 },
                 isEnabled() { return true; },
-                isVisible() { return true; }
+                isVisible() { return true; },
             }));
     }
     $unregisterCommand(id: string): void {

--- a/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
+++ b/packages/plugin-ext/src/main/browser/dialogs/modal-notification.ts
@@ -22,7 +22,7 @@ import '../../../../src/main/browser/dialogs/style/modal-notification.css';
 export enum MessageType {
     Error = 'error',
     Warning = 'warning',
-    Info = 'info'
+    Info = 'info',
 }
 
 const NOTIFICATION = 'theia-Notification';

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -35,7 +35,7 @@ export class DocumentsMainImpl implements DocumentsMain {
         editorsAndDocuments: EditorsAndDocumentsMain,
         modelService: EditorModelService,
         rpc: RPCProtocol,
-        private editorManger: EditorManager
+        private editorManger: EditorManager,
     ) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.DOCUMENTS_EXT);
 
@@ -78,8 +78,8 @@ export class DocumentsMainImpl implements DocumentsMain {
                         text: c.text,
                         range: c.range,
                         rangeLength: c.rangeLength,
-                        rangeOffset: 0
-                    }))
+                        rangeOffset: 0,
+                    })),
             }, model.dirty);
         }));
 

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -130,7 +130,7 @@ export class EditorsAndDocumentsMain {
             lines: model.textEditorModel.getLinesContent(),
             EOL: model.textEditorModel.getEOL(),
             modeId: model.languageId,
-            isDirty: model.dirty
+            isDirty: model.dirty,
         };
     }
 
@@ -142,7 +142,7 @@ export class EditorsAndDocumentsMain {
             options: properties!.options,
             selections: properties!.selections,
             visibleRanges: properties!.visibleRanges,
-            editorPosition: this.findEditorPosition(textEditor)
+            editorPosition: this.findEditorPosition(textEditor),
         };
 
     }
@@ -193,7 +193,7 @@ class EditorAndDocumentStateComputer {
             [],
             [],
             undefined,
-            undefined
+            undefined,
         ));
     }
 
@@ -269,7 +269,7 @@ class EditorAndDocumentStateDelta {
         readonly removedEditors: EditorSnapshot[],
         readonly addedEditors: EditorSnapshot[],
         readonly oldActiveEditor: string | undefined,
-        readonly newActiveEditor: string | undefined
+        readonly newActiveEditor: string | undefined,
     ) {
         this.isEmpty = this.removedDocuments.length === 0
             && this.addedDocuments.length === 0
@@ -295,7 +295,7 @@ class EditorAndDocumentState {
                 [],
                 Array.from(after.editors.values()),
                 undefined,
-                after.activeEditor
+                after.activeEditor,
             );
         }
 
@@ -309,7 +309,7 @@ class EditorAndDocumentState {
             editorDelta.removed,
             editorDelta.added,
             oldActiveEditor,
-            newActiveEditor
+            newActiveEditor,
         );
     }
 }

--- a/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
@@ -95,7 +95,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
             priority: 100,
             onclick: e => {
                 this.showMenu(e.clientX, e.clientY);
-            }
+            },
         };
 
         this.entry.className = HostedPluginController.HOSTED_PLUGIN;
@@ -111,7 +111,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
         this.entry = {
             text: `$(cog~spin) Hosted Plugin: Starting`,
             alignment: StatusBarAlignment.LEFT,
-            priority: 100
+            priority: 100,
         };
 
         this.entry.className = HostedPluginController.HOSTED_PLUGIN;
@@ -130,7 +130,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
             priority: 100,
             onclick: e => {
                 this.showMenu(e.clientX, e.clientY);
-            }
+            },
         };
 
         this.entry.className = HostedPluginController.HOSTED_PLUGIN;
@@ -149,7 +149,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
             priority: 100,
             onclick: e => {
                 this.showMenu(e.clientX, e.clientY);
-            }
+            },
         };
 
         this.entry.className = HostedPluginController.HOSTED_PLUGIN_FAILED;
@@ -166,7 +166,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
                 const offlineElement = {
                     text: `Hosted Plugin: Stopped`,
                     alignment: StatusBarAlignment.LEFT,
-                    priority: 100
+                    priority: 100,
                 };
 
                 this.entry.className = HostedPluginController.HOSTED_PLUGIN_OFFLINE;
@@ -192,7 +192,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
     protected showMenu(x: number, y: number): void {
         const commands = new CommandRegistry();
         const menu = new Menu({
-            commands
+            commands,
         });
 
         if (this.pluginState === 'running') {
@@ -211,23 +211,23 @@ export class HostedPluginController implements FrontendApplicationContribution {
         commands.addCommand(HostedPluginCommands.STOP.id, {
             label: 'Stop Instance',
             icon: 'fa fa-stop',
-            execute: () => setTimeout(() => this.hostedPluginManagerClient.stop(), 100)
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.stop(), 100),
         });
 
         menu.addItem({
             type: 'command',
-            command: HostedPluginCommands.STOP.id
+            command: HostedPluginCommands.STOP.id,
         });
 
         commands.addCommand(HostedPluginCommands.RESTART.id, {
             label: 'Restart Instance',
             icon: 'fa fa-repeat',
-            execute: () => setTimeout(() => this.hostedPluginManagerClient.restart(), 100)
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.restart(), 100),
         });
 
         menu.addItem({
             type: 'command',
-            command: HostedPluginCommands.RESTART.id
+            command: HostedPluginCommands.RESTART.id,
         });
     }
 
@@ -238,12 +238,12 @@ export class HostedPluginController implements FrontendApplicationContribution {
         commands.addCommand(HostedPluginCommands.START.id, {
             label: "Start Instance",
             icon: 'fa fa-play',
-            execute: () => setTimeout(() => this.hostedPluginManagerClient.start(), 100)
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.start(), 100),
         });
 
         menu.addItem({
             type: 'command',
-            command: HostedPluginCommands.START.id
+            command: HostedPluginCommands.START.id,
         });
     }
 

--- a/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
@@ -28,7 +28,7 @@ export class PluginExtDeployCommandService implements QuickOpenModel {
 
     public static COMMAND: Command = {
         id: 'plugin-ext:deploy-plugin-id',
-        label: 'Plugin: Deploy a plugin\'s id'
+        label: 'Plugin: Deploy a plugin\'s id',
     };
 
     @inject(QuickOpenService)

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -66,7 +66,7 @@ export default new ContainerModule(bind => {
 
             setUpPluginApi(worker.rpc, ctx.container);
             ctx.container.get(HostedPluginSupport).checkAndLoadPlugin(ctx.container);
-        }
+        },
     }));
     bind(HostedPluginServer).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
@@ -79,7 +79,7 @@ export default new ContainerModule(bind => {
     bind(PluginWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: PluginFrontendViewContribution.PLUGINS_WIDGET_FACTORY_ID,
-        createWidget: () => ctx.container.get(PluginWidget)
+        createWidget: () => ctx.container.get(PluginWidget),
     }));
 
     bind(PluginExtDeployCommandService).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -32,7 +32,7 @@ export class PluginWidget extends ReactWidget {
 
     constructor(
         @inject(HostedPluginServer) protected readonly hostedPluginServer: HostedPluginServer,
-        @inject(OpenerService) protected readonly openerService: OpenerService
+        @inject(OpenerService) protected readonly openerService: OpenerService,
     ) {
         super();
         this.id = 'plugins';

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -30,25 +30,25 @@ export class PluginApiFrontendContribution implements CommandContribution {
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(HostedPluginCommands.START, {
-            execute: () => this.hostedPluginManagerClient.start()
+            execute: () => this.hostedPluginManagerClient.start(),
         });
         commands.registerCommand(HostedPluginCommands.STOP, {
-            execute: () => this.hostedPluginManagerClient.stop()
+            execute: () => this.hostedPluginManagerClient.stop(),
         });
         commands.registerCommand(HostedPluginCommands.RESTART, {
-            execute: () => this.hostedPluginManagerClient.restart()
+            execute: () => this.hostedPluginManagerClient.restart(),
         });
         commands.registerCommand(HostedPluginCommands.SELECT_PATH, {
-            execute: () => this.hostedPluginManagerClient.selectPluginPath()
+            execute: () => this.hostedPluginManagerClient.selectPluginPath(),
         });
 
         commands.registerCommand(PluginExtDeployCommandService.COMMAND, {
-            execute: () => this.pluginExtDeployCommandService.deploy()
+            execute: () => this.pluginExtDeployCommandService.deploy(),
         });
 
         // this command only for compatibility reason
         commands.registerCommand({ id: 'workbench.action.closeActiveEditor' }, {
-            execute: () => commands.executeCommand('core.close.tab')
+            execute: () => commands.executeCommand('core.close.tab'),
         });
     }
 

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
@@ -32,7 +32,7 @@ export class PluginFrontendViewContribution extends AbstractViewContribution<Plu
             widgetName: 'Plugins',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 300
+                rank: 300,
             },
             toggleCommandId: 'pluginsView:toggle',
         });

--- a/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
@@ -30,19 +30,19 @@ import { HostedPluginServer } from '../../common/plugin-protocol';
 export namespace HostedPluginCommands {
     export const START: Command = {
         id: 'hosted-plugin:start',
-        label: 'Hosted Plugin: Start Instance'
+        label: 'Hosted Plugin: Start Instance',
     };
     export const STOP: Command = {
         id: 'hosted-plugin:stop',
-        label: 'Hosted Plugin: Stop Instance'
+        label: 'Hosted Plugin: Stop Instance',
     };
     export const RESTART: Command = {
         id: 'hosted-plugin:restart',
-        label: 'Hosted Plugin: Restart Instance'
+        label: 'Hosted Plugin: Restart Instance',
     };
     export const SELECT_PATH: Command = {
         id: 'hosted-plugin:select-path',
-        label: 'Hosted Plugin: Select Path'
+        label: 'Hosted Plugin: Select Path',
     };
 }
 
@@ -54,7 +54,7 @@ export enum HostedPluginState {
     Starting = 'starting',
     Running = 'running',
     Stopping = 'stopping',
-    Failed = 'failed'
+    Failed = 'failed',
 }
 
 /**
@@ -83,7 +83,7 @@ export class HostedPluginManagerClient {
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
         @inject(WindowService) protected readonly windowService: WindowService,
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
     ) {
         this.openNewTabAskDialog = new OpenHostedInstanceLinkDialog(windowService);
     }
@@ -216,7 +216,7 @@ class OpenHostedInstanceLinkDialog extends AbstractDialog<string> {
 
     constructor(windowService: WindowService) {
         super({
-            title: 'Your browser prevented opening of a new tab'
+            title: 'Your browser prevented opening of a new tab',
         });
         this.windowService = windowService;
 

--- a/packages/plugin-ext/src/main/browser/plugin-worker.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-worker.ts
@@ -34,7 +34,7 @@ export class PluginWorker {
             onMessage: emmitter.event,
             send: (m: {}) => {
                 this.worker.postMessage(m);
-            }
+            },
         });
 
     }

--- a/packages/plugin-ext/src/main/browser/preference-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/preference-registry-main.ts
@@ -17,7 +17,7 @@
 import {
     PreferenceService,
     PreferenceServiceImpl,
-    PreferenceScope
+    PreferenceScope,
 } from '@theia/core/lib/browser/preferences';
 import { interfaces } from 'inversify';
 import {

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -57,7 +57,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
             placeholder: options.placeHolder,
             onClose: () => {
                 this.cleanUp();
-            }
+            },
         });
 
         return new Promise((resolve, reject) => {
@@ -81,7 +81,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
                         this.cleanUp();
                     }
                     return true;
-                }
+                },
             }));
         }
         if (this.acceptor) {

--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -44,7 +44,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color,
             tooltip,
-            command
+            command,
         };
 
         return this.delegate.setElement(id, entry).then(() => Promise.resolve(id));

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -50,7 +50,7 @@ export class TerminalServiceMainImpl implements TerminalServiceMain {
             env: options.env,
             destroyTermOnClose: true,
             useServerTitle: false,
-            id: this.TERM_ID_PREFIX + counter
+            id: this.TERM_ID_PREFIX + counter,
         };
         let id: number;
         try {

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -24,7 +24,7 @@ import {
     ApplyEditsOptions,
     Range,
     UndoStopOptions,
-    DecorationOptions
+    DecorationOptions,
 } from "../../api/plugin-api";
 import { DisposableCollection, Emitter, Event } from "@theia/core";
 import { TextEditorCursorStyle, cursorStyleToString } from "../../common/editor-options";
@@ -42,7 +42,7 @@ export class TextEditorMain {
     constructor(
         private id: string,
         private model: monaco.editor.IModel,
-        editor: MonacoEditor
+        editor: MonacoEditor,
     ) {
         this.properties = undefined;
         this.modelListeners.push(this.model.onDidChangeOptions(e => {
@@ -140,7 +140,7 @@ export class TextEditorMain {
         if (newConfiguration.cursorStyle) {
             const newCursorStyle = cursorStyleToString(newConfiguration.cursorStyle);
             this.editor.getControl().updateOptions({
-                cursorStyle: newCursorStyle
+                cursorStyle: newCursorStyle,
             });
         }
 
@@ -157,7 +157,7 @@ export class TextEditorMain {
                     lineNumbers = 'off';
             }
             this.editor.getControl().updateOptions({
-                lineNumbers: lineNumbers
+                lineNumbers: lineNumbers,
             });
         }
     }
@@ -234,7 +234,7 @@ export class TextEditorMain {
             ({
                 range: monaco.Range.lift(edit.range),
                 text: edit.text!,
-                forceMoveMarkers: edit.forceMoveMarkers
+                forceMoveMarkers: edit.forceMoveMarkers,
             }));
 
         if (opts.undoStopBefore) {
@@ -304,7 +304,7 @@ export class TextEditorPropertiesMain {
     constructor(
         readonly selections: monaco.Selection[],
         readonly options: TextEditorConfiguration,
-        readonly visibleRanges: monaco.Range[]
+        readonly visibleRanges: monaco.Range[],
     ) {
     }
 
@@ -312,13 +312,13 @@ export class TextEditorPropertiesMain {
         const result: EditorChangedPropertiesData = {
             options: undefined,
             selections: undefined,
-            visibleRanges: undefined
+            visibleRanges: undefined,
         };
 
         if (!old || !TextEditorPropertiesMain.selectionsEqual(old.selections, this.selections)) {
             result.selections = {
                 selections: this.selections,
-                source: source
+                source: source,
             };
         }
 

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -26,7 +26,7 @@ import {
     ApplyEditsOptions,
     UndoStopOptions,
     DecorationRenderOptions,
-    DecorationOptions
+    DecorationOptions,
 } from "../../api/plugin-api";
 import { EditorsAndDocumentsMain } from "./editors-and-documents-main";
 import { RPCProtocol } from "../../api/rpc-protocol";

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -38,17 +38,17 @@ export class WorkspaceMain {
                 const folder: WorkspaceFolder = {
                     uri: this.workspaceRoot,
                     name: workspacePath.base,
-                    index: 0
+                    index: 0,
                 } as WorkspaceFolder;
 
                 this.proxy.$onWorkspaceFoldersChanged({
                     added: [folder],
-                    removed: []
+                    removed: [],
                 } as WorkspaceFoldersChangeEvent);
             } else {
                 this.proxy.$onWorkspaceFoldersChanged({
                     added: [],
-                    removed: []
+                    removed: [],
                 } as WorkspaceFoldersChangeEvent);
             }
         });

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-directory-handler.ts
@@ -17,7 +17,7 @@
 import {
     PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginPackage, PluginDeployerDirectoryHandlerContext,
-    PluginDeployerEntryType
+    PluginDeployerEntryType,
 } from "../../../common/plugin-protocol";
 import { injectable } from "inversify";
 import * as fs from "fs";

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -20,7 +20,7 @@ import { BackendApplicationContribution } from "@theia/core/lib/node";
 import { PluginDeployerContribution } from "./plugin-deployer-contribution";
 import {
     PluginDeployer, PluginDeployerResolver, PluginDeployerFileHandler,
-    PluginDeployerDirectoryHandler, PluginServer, pluginServerJsonRpcPath
+    PluginDeployerDirectoryHandler, PluginServer, pluginServerJsonRpcPath,
 } from "../../common/plugin-protocol";
 import { PluginDeployerImpl } from "./plugin-deployer-impl";
 import { LocalDirectoryPluginDeployerResolver } from "./resolvers/plugin-local-dir-resolver";
@@ -49,7 +49,7 @@ export function bindMainBackend(bind: interfaces.Bind): void {
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(pluginServerJsonRpcPath, () =>
-            ctx.container.get(PluginServer)
-        )
+            ctx.container.get(PluginServer),
+        ),
     ).inSingletonScope();
 }

--- a/packages/plugin-ext/src/main/node/plugin-github-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-github-resolver.ts
@@ -77,7 +77,7 @@ export class GithubPluginDeployerResolver implements PluginDeployerResolver {
 
             // disable redirect to grab the release
             const options = {
-                followRedirect: false
+                followRedirect: false,
             };
             // if latest, resolve first the real version
             if (version === 'latest') {

--- a/packages/plugin-ext/src/plugin/document-data.ts
+++ b/packages/plugin-ext/src/plugin/document-data.ts
@@ -94,7 +94,7 @@ export class DocumentDataExt {
                 positionAt(offset) { return that.positionAt(offset); },
                 validateRange(ran) { return that.validateRange(ran); },
                 validatePosition(pos) { return that.validatePosition(pos); },
-                getWordRangeAtPosition(pos, regexp?) { return that.getWordRangeAtPosition(pos, regexp); }
+                getWordRangeAtPosition(pos, regexp?) { return that.getWordRangeAtPosition(pos, regexp); },
             };
         }
         return Object.freeze(this._document);
@@ -111,7 +111,7 @@ export class DocumentDataExt {
             this.setLineText(position.line - 1,
                 this.lines[position.line - 1].substring(0, position.character - 1)
                 + insertLines[0]
-                + this.lines[position.line - 1].substring(position.character - 1)
+                + this.lines[position.line - 1].substring(position.character - 1),
             );
             return;
         }
@@ -122,7 +122,7 @@ export class DocumentDataExt {
         // Delete overflowing text from first line and insert text on first line
         this.setLineText(position.line - 1,
             this.lines[position.line - 1].substring(0, position.character - 1)
-            + insertLines[0]
+            + insertLines[0],
         );
 
         // Insert new lines & store lengths
@@ -148,7 +148,7 @@ export class DocumentDataExt {
             // Delete text on the affected line
             this.setLineText(range.startLineNumber - 1,
                 this.lines[range.startLineNumber - 1].substring(0, range.startColumn - 1)
-                + this.lines[range.startLineNumber - 1].substring(range.endColumn - 1)
+                + this.lines[range.startLineNumber - 1].substring(range.endColumn - 1),
             );
             return;
         }
@@ -156,7 +156,7 @@ export class DocumentDataExt {
         // Take remaining text on last line and append it to remaining text on first line
         this.setLineText(range.startLineNumber - 1,
             this.lines[range.startLineNumber - 1].substring(0, range.startColumn - 1)
-            + this.lines[range.endLineNumber - 1].substring(range.endColumn - 1)
+            + this.lines[range.endLineNumber - 1].substring(range.endColumn - 1),
         );
 
         // Delete middle lines
@@ -285,7 +285,7 @@ export class DocumentDataExt {
                 rangeIncludingLineBreak,
                 text,
                 firstNonWhitespaceCharacterIndex,
-                isEmptyOrWhitespace: firstNonWhitespaceCharacterIndex === text.length
+                isEmptyOrWhitespace: firstNonWhitespaceCharacterIndex === text.length,
             });
 
             this.textLines[line] = result;
@@ -341,7 +341,7 @@ export class DocumentDataExt {
             position.character + 1,
             ensureValidWordDefinition(regexp),
             this.lines[position.line],
-            0
+            0,
         );
 
         if (wordAtText) {

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -46,7 +46,7 @@ export class DocumentsExtImpl implements DocumentsExt {
                 for (const document of documents) {
                     this._onDidAddDocument.fire(document.document);
                 }
-            })
+            }),
         );
 
         this.toDispose.push(
@@ -54,7 +54,7 @@ export class DocumentsExtImpl implements DocumentsExt {
                 for (const data of documents) {
                     this._onDidRemoveDocument.fire(data.document);
                 }
-            })
+            }),
         );
     }
     $acceptModelModeChanged(startUrl: UriComponents, oldModeId: string, newModeId: string): void {
@@ -85,7 +85,7 @@ export class DocumentsExtImpl implements DocumentsExt {
             data.acceptIsDirty(isDirty);
             this._onDidChangeDocument.fire({
                 document: data.document,
-                contentChanges: []
+                contentChanges: [],
             });
         }
     }
@@ -103,8 +103,8 @@ export class DocumentsExtImpl implements DocumentsExt {
                         range: Converter.toRange(change.range),
                         rangeOffset: change.rangeOffset,
                         rangeLength: change.rangeLength,
-                        text: change.text
-                    }))
+                        text: change.text,
+                    })),
             });
         }
     }

--- a/packages/plugin-ext/src/plugin/editors-and-documents.ts
+++ b/packages/plugin-ext/src/plugin/editors-and-documents.ts
@@ -71,7 +71,7 @@ export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
                     data.EOL,
                     data.modeId,
                     data.versionId,
-                    data.isDirty
+                    data.isDirty,
                 );
                 this.documents.set(resource.toString(), documentData);
                 addedDocuments.push(documentData);
@@ -102,7 +102,7 @@ export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
                     data.selections.map(Converter.toSelection),
                     data.options,
                     data.visibleRanges.map(Converter.toRange),
-                    Converter.toViewColumn(data.editorPosition)
+                    Converter.toViewColumn(data.editorPosition),
                 );
                 this.editors.set(data.id, editor);
             }

--- a/packages/plugin-ext/src/plugin/message-registry.ts
+++ b/packages/plugin-ext/src/plugin/message-registry.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    PLUGIN_RPC_CONTEXT as Ext, MessageRegistryMain
+    PLUGIN_RPC_CONTEXT as Ext, MessageRegistryMain,
 } from '../api/plugin-api';
 import {RPCProtocol} from '../api/rpc-protocol';
 import {MessageItem, MessageOptions} from "@theia/plugin";

--- a/packages/plugin-ext/src/plugin/output-channel-registry.ts
+++ b/packages/plugin-ext/src/plugin/output-channel-registry.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
-    PLUGIN_RPC_CONTEXT as Ext, OutputChannelRegistryMain
+    PLUGIN_RPC_CONTEXT as Ext, OutputChannelRegistryMain,
 } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
 import * as theia from '@theia/plugin';

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -86,7 +86,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
         // tslint:disable-next-line:no-any
         registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable {
             return commandRegistryExt.registerHandler(commandId, handler);
-        }
+        },
     };
 
     const window: typeof theia.window = {
@@ -181,7 +181,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
 
         createTextEditorDecorationType(options: theia.DecorationRenderOptions): theia.TextEditorDecorationType {
             return editors.createTextEditorDecorationType(options);
-        }
+        },
     };
 
     const workspace: typeof theia.workspace = {
@@ -231,7 +231,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
                     const data = documents.getDocumentData(uri);
                     return data && data.document;
                 }));
-        }
+        },
     };
 
     const env: typeof theia.env = {
@@ -243,7 +243,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
         },
         getQueryParameters(): QueryParameters {
             return envExt.getQueryParameters();
-        }
+        },
     };
 
     return <typeof theia>{

--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -19,7 +19,7 @@ import * as theia from '@theia/plugin';
 import {
     PLUGIN_RPC_CONTEXT,
     PreferenceRegistryExt,
-    PreferenceRegistryMain
+    PreferenceRegistryMain,
 } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { isObject } from '../common/types';
@@ -120,7 +120,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                                 cloneTarget();
                                 Object.defineProperty(clonedTarget, prop, descr);
                                 return true;
-                            }
+                            },
                         });
                     };
                     return cloneOnWriteProxy(result, key);
@@ -136,7 +136,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
             },
             inspect: <T>(key: string): ConfigurationInspect<T> => {
                 throw new Error('Not implemented yet.');
-            }
+            },
         };
         return configuration;
     }
@@ -158,7 +158,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                     throw new Error(`TypeError: Cannot set prototype for a readonly object`);
                 },
                 isExtensible: () => false,
-                preventExtensions: () => true
+                preventExtensions: () => true,
             })
             : target;
         return readonlyProxy(data);
@@ -190,7 +190,7 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                     .reverse()
                     .reduce((prevValue: any, curValue: any) => ({ [curValue]: prevValue }), eventData.newValue);
                 return !!lookUp(tree, section);
-            }
+            },
         });
     }
 

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -56,7 +56,7 @@ export class QuickOpenExtImpl implements QuickOpenExt {
             autoFocus: { autoFocusFirstEntry: true },
             matchOnDescription: options && options.machOnDescription,
             matchOnDetail: options && options.machOnDetail,
-            ignoreFocusLost: options && options.ignoreFocusOut
+            ignoreFocusLost: options && options.ignoreFocusOut,
         });
 
         const promise = anyPromise(<PromiseLike<number | Item[]>[]>[widgetPromise, itemPromise]).then(values => {
@@ -81,7 +81,7 @@ export class QuickOpenExtImpl implements QuickOpenExt {
                         description,
                         handle,
                         detail,
-                        picked
+                        picked,
                     });
                 }
 

--- a/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
+++ b/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
@@ -16,7 +16,7 @@
 import {Disposable, StatusBarAlignment} from './types-impl';
 import {StatusBarItem} from '@theia/plugin';
 import {
-    PLUGIN_RPC_CONTEXT as Ext, StatusBarMessageRegistryMain
+    PLUGIN_RPC_CONTEXT as Ext, StatusBarMessageRegistryMain,
 } from '../api/plugin-api';
 import {RPCProtocol} from '../api/rpc-protocol';
 import {StatusBarItemImpl} from "./status-bar/status-bar-item";

--- a/packages/plugin-ext/src/plugin/status-bar/vscolor-const.ts
+++ b/packages/plugin-ext/src/plugin/status-bar/vscolor-const.ts
@@ -17,5 +17,5 @@ export const VS_COLORS: {[vsColorId: string]: string} = {
     'statusBar.foreground': '--theia-layout-color4',
     'editorOverviewRuler.errorForeground': '--theia-error-color0',
     'editorOverviewRuler.warningForeground': '--theia-warn-color0',
-    'editorOverviewRuler.infoForeground': '--theia-info-color0'
+    'editorOverviewRuler.infoForeground': '--theia-info-color0',
 };

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -41,7 +41,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
             options = {
                 name: nameOrOptions,
                 shellPath: shellPath,
-                shellArgs: shellArgs
+                shellArgs: shellArgs,
             };
         }
 

--- a/packages/plugin-ext/src/plugin/text-editor.ts
+++ b/packages/plugin-ext/src/plugin/text-editor.ts
@@ -178,7 +178,7 @@ export class TextEditorExt implements theia.TextEditor {
                 return this.proxy.$trySetDecorations(
                     this.id,
                     decorationType.key,
-                    Converter.fromRangeOrRangeWithMessage(rangesOrOptions)
+                    Converter.fromRangeOrRangeWithMessage(rangesOrOptions),
                 );
             } else {
                 const ranges: number[] = new Array<number>(4 * rangesOrOptions.length);
@@ -193,7 +193,7 @@ export class TextEditorExt implements theia.TextEditor {
                 return this.proxy.$trySetDecorationsFast(
                     this.id,
                     decorationType.key,
-                    ranges
+                    ranges,
                 );
             }
         });
@@ -228,7 +228,7 @@ export class TextEditorExt implements theia.TextEditor {
 
             if (nextRangeStart.isBefore(rangeEnd)) {
                 return Promise.reject(
-                    new Error('Overlapping ranges are not allowed!')
+                    new Error('Overlapping ranges are not allowed!'),
                 );
             }
         }
@@ -238,13 +238,13 @@ export class TextEditorExt implements theia.TextEditor {
             ({
                 range: Converter.fromRange(e.range)!,
                 text: e.text,
-                forceMoveMarkers: e.forceMoveMarkers
+                forceMoveMarkers: e.forceMoveMarkers,
             }));
 
         return this.proxy.$tryApplyEdits(this.id, editData.documentVersionId, edits, {
             setEndOfLine: editData.setEndOfLine,
             undoStopBefore: editData.undoStopBefore,
-            undoStopAfter: editData.undoStopAfter
+            undoStopAfter: editData.undoStopAfter,
         });
     }
 
@@ -299,7 +299,7 @@ export class TextEditorOptionsExt implements theia.TextEditorOptions {
             this.tabSize = tabSize;
         }
         warnOnError(this.proxy.$trySetOptions(this.id, {
-            tabSize
+            tabSize,
         }));
     }
 
@@ -452,7 +452,7 @@ export class TextEditorEdit {
             edits: this.collectedEdits,
             setEndOfLine: this.eol,
             undoStopAfter: this.undoStopAfter,
-            undoStopBefore: this.undoStopBefore
+            undoStopBefore: this.undoStopBefore,
         };
     }
 
@@ -497,7 +497,7 @@ export class TextEditorEdit {
         this.collectedEdits.push({
             range: validatedRange,
             forceMoveMarkers: moveMarkers,
-            text: text
+            text: text,
         });
     }
 }

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -70,7 +70,7 @@ export class TextEditorsExtImpl implements TextEditorsExt {
         if (props.options) {
             this._onDidChangeTextEditorOptions.fire({
                 textEditor,
-                options: props.options
+                options: props.options,
             });
         }
 
@@ -80,7 +80,7 @@ export class TextEditorsExtImpl implements TextEditorsExt {
             this._onDidChangeTextEditorSelection.fire({
                 textEditor,
                 selections,
-                kind
+                kind,
             });
         }
 
@@ -88,7 +88,7 @@ export class TextEditorsExtImpl implements TextEditorsExt {
             const visibleRanges = props.visibleRanges.map(Converters.toRange);
             this._onDidChangeTextEditorVisibleRanges.fire({
                 textEditor,
-                visibleRanges
+                visibleRanges,
             });
         }
     }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -47,7 +47,7 @@ export function fromSelection(selection: types.Selection): Selection {
         selectionStartLineNumber: anchor.line + 1,
         selectionStartColumn: anchor.character + 1,
         positionLineNumber: active.line + 1,
-        positionColumn: active.character + 1
+        positionColumn: active.character + 1,
     };
 }
 
@@ -69,7 +69,7 @@ export function fromRange(range: theia.Range): Range | undefined {
         startLineNumber: start.line + 1,
         startColumn: start.character + 1,
         endLineNumber: end.line + 1,
-        endColumn: end.character + 1
+        endColumn: end.character + 1,
     };
 }
 
@@ -105,13 +105,13 @@ export function fromRangeOrRangeWithMessage(ranges: theia.Range[] | theia.Decora
                 range: fromRange(r.range)!,
                 hoverMessage: hoverMessage,
                 // tslint:disable-next-line:no-any
-                renderOptions: <any> /* URI vs Uri */r.renderOptions
+                renderOptions: <any> /* URI vs Uri */r.renderOptions,
             };
         });
     } else {
         return ranges.map((r): DecorationOptions =>
             ({
-                range: fromRange(r)!
+                range: fromRange(r)!,
             }));
     }
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -39,13 +39,13 @@ export class Disposable {
 
 export enum StatusBarAlignment {
     Left = 1,
-    Right = 2
+    Right = 2,
 }
 
 export enum TextEditorLineNumbersStyle {
     Off = 0,
     On = 1,
-    Relative = 2
+    Relative = 2,
 }
 
 /**
@@ -56,7 +56,7 @@ export enum ViewColumn {
     Active = -1,
     One = 1,
     Two = 2,
-    Three = 3
+    Three = 3,
 }
 
 /**
@@ -67,7 +67,7 @@ export enum TextEditorSelectionChangeKind {
 
     Mouse = 2,
 
-    Command = 3
+    Command = 3,
 }
 
 export namespace TextEditorSelectionChangeKind {
@@ -399,7 +399,7 @@ export class Selection extends Range {
 
 export enum EndOfLine {
     LF = 1,
-    CRLF = 2
+    CRLF = 2,
 }
 
 export class SnippetString {
@@ -522,7 +522,7 @@ export enum TextEditorRevealType {
     Default = 0,
     InCenter = 1,
     InCenterIfOutsideViewport = 2,
-    AtTop = 3
+    AtTop = 3,
 }
 
 /**
@@ -544,7 +544,7 @@ export enum DecorationRangeBehavior {
     /**
      * TrackedRangeStickiness.GrowsOnlyWhenTypingAfter
      */
-    ClosedOpen = 3
+    ClosedOpen = 3,
 }
 
 /**
@@ -554,10 +554,10 @@ export enum OverviewRulerLane {
     Left = 1,
     Center = 2,
     Right = 4,
-    Full = 7
+    Full = 7,
 }
 
 export enum ConfigurationTarget {
     User = 0,
-    Workspace = 1
+    Workspace = 1,
 }

--- a/packages/plugin-ext/src/plugin/word-helper.ts
+++ b/packages/plugin-ext/src/plugin/word-helper.ts
@@ -101,7 +101,7 @@ function getWordAtPosFast(column: number, wordDefinition: RegExp, text: string, 
             return {
                 word: match[0],
                 startColumn: textOffset + 1 + match.index!,
-                endColumn: textOffset + 1 + wordDefinition.lastIndex
+                endColumn: textOffset + 1 + wordDefinition.lastIndex,
             };
         }
     }
@@ -129,7 +129,7 @@ function getWordAtPosSlow(column: number, wordDefinition: RegExp, text: string, 
             return {
                 word: match[0],
                 startColumn: textOffset + 1 + match.index!,
-                endColumn: textOffset + 1 + wordDefinition.lastIndex
+                endColumn: textOffset + 1 + wordDefinition.lastIndex,
             };
         }
     }

--- a/packages/preferences/src/browser/preference-frontend-contribution.ts
+++ b/packages/preferences/src/browser/preference-frontend-contribution.ts
@@ -25,11 +25,11 @@ import { UserStorageService } from "@theia/userstorage/lib/browser";
 export namespace PreferenceCommands {
     export const OPEN_USER_PREFERENCES: Command = {
         id: 'preferences:open_user',
-        label: 'Open User Preferences'
+        label: 'Open User Preferences',
     };
     export const OPEN_WORKSPACE_PREFERENCES: Command = {
         id: 'preferences:open_workspace',
-        label: 'Open Workspace Preferences'
+        label: 'Open Workspace Preferences',
     };
 }
 
@@ -45,21 +45,21 @@ export class PreferenceFrontendContribution implements CommandContribution, Menu
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(PreferenceCommands.OPEN_USER_PREFERENCES, {
             isEnabled: () => true,
-            execute: () => this.openUserPreferences()
+            execute: () => this.openUserPreferences(),
         });
 
         commands.registerCommand(PreferenceCommands.OPEN_WORKSPACE_PREFERENCES, {
             isEnabled: () => true,
-            execute: () => this.openWorkspacePreferences()
+            execute: () => this.openWorkspacePreferences(),
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: PreferenceCommands.OPEN_USER_PREFERENCES.id
+            commandId: PreferenceCommands.OPEN_USER_PREFERENCES.id,
         });
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: PreferenceCommands.OPEN_WORKSPACE_PREFERENCES.id
+            commandId: PreferenceCommands.OPEN_WORKSPACE_PREFERENCES.id,
         });
     }
 

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -27,7 +27,7 @@ import * as temp from 'temp';
 import { Emitter } from '@theia/core/lib/common';
 import {
     PreferenceService, PreferenceScope,
-    PreferenceProviders, PreferenceServiceImpl, PreferenceProvider
+    PreferenceProviders, PreferenceServiceImpl, PreferenceProvider,
 } from '@theia/core/lib/browser/preferences';
 import { FileSystem } from '@theia/filesystem/lib/common/';
 import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watcher';
@@ -71,17 +71,17 @@ before(async () => {
         const workspaceProvider = ctx.container.get(WorkspacePreferenceProvider);
 
         sinon.stub(userProvider, 'onDidPreferencesChanged').get(() =>
-            mockUserPreferenceEmitter.event
+            mockUserPreferenceEmitter.event,
         );
         sinon.stub(workspaceProvider, 'onDidPreferencesChanged').get(() =>
-            mockWorkspacePreferenceEmitter.event
+            mockWorkspacePreferenceEmitter.event,
         );
         return scope === PreferenceScope.User ? userProvider : workspaceProvider;
     });
     testContainer.bind(PreferenceServiceImpl).toSelf().inSingletonScope();
 
     testContainer.bind(PreferenceService).toDynamicValue(ctx =>
-        ctx.container.get(PreferenceServiceImpl)
+        ctx.container.get(PreferenceServiceImpl),
     ).inSingletonScope();
 
     testContainer.bind(FileSystemPreferences).toDynamicValue(ctx => {
@@ -111,18 +111,18 @@ before(async () => {
             },
             saveContents(content: string, options?: { encoding?: string }): Promise<void> {
                 return fs.writeFile(tempPath, content);
-            }
+            },
         }));
         return resourceProvider;
     });
     testContainer.bind(ResourceProvider).toProvider(context =>
-        uri => context.container.get(MockResourceProvider).get(uri)
+        uri => context.container.get(MockResourceProvider).get(uri),
     );
 
     /* FS mocks and bindings */
     testContainer.bind(FileSystemWatcherServer).to(MockFilesystemWatcherServer);
     testContainer.bind(FileSystemWatcher).toSelf().onActivation((_, watcher) =>
-        watcher
+        watcher,
     );
     testContainer.bind(FileSystem).to(MockFilesystem);
 
@@ -168,7 +168,7 @@ describe('Preference Service', function () {
 
         const userProvider = testContainer.get(UserPreferenceProvider);
         const stubGet = sinon.stub(userProvider, 'getPreferences').returns({
-            'testPref': prefValue
+            'testPref': prefValue,
         });
 
         mockUserPreferenceEmitter.fire(undefined);
@@ -180,11 +180,11 @@ describe('Preference Service', function () {
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
         const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
-            'test.number': 1
+            'test.number': 1,
         });
         const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
-            'test.number': 0
+            'test.number': 0,
         });
         mockUserPreferenceEmitter.fire(undefined);
 
@@ -204,11 +204,11 @@ describe('Preference Service', function () {
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
         const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
-            'test.number': 1
+            'test.number': 1,
         });
         const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
-            'test.number': 0
+            'test.number': 0,
         });
         mockUserPreferenceEmitter.fire(undefined);
 
@@ -228,8 +228,8 @@ describe('Preference Service', function () {
         const userProvider = testContainer.get(UserPreferenceProvider);
         const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.immutable': [
-                'test', 'test', 'test'
-            ]
+                'test', 'test', 'test',
+            ],
         });
         mockUserPreferenceEmitter.fire(undefined);
 
@@ -248,11 +248,11 @@ describe('Preference Service', function () {
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
         let stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
-            'test.number': 1
+            'test.number': 1,
         });
         const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
-            'test.number': 0
+            'test.number': 0,
         });
         mockUserPreferenceEmitter.fire(undefined);
 
@@ -262,7 +262,7 @@ describe('Preference Service', function () {
 
         stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
-            'test.number': 4
+            'test.number': 4,
         });
         mockUserPreferenceEmitter.fire(undefined);
 

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -110,21 +110,21 @@ See <a href="https://github.com/theia-ide/theia">here</a>.</p>
 function mockOffsetProperties() {
     Object.defineProperties(HTMLElement.prototype, {
         offsetLeft: {
-            get: () => 0
+            get: () => 0,
         },
         offsetTop: {
             get: function () {
                 const element = this as HTMLElement;
                 const line = Number.parseInt(element.getAttribute('data-line') || '0');
                 return offsetForLine(line);
-            }
+            },
         },
         offsetHeight: {
-            get: () => 0
+            get: () => 0,
         },
         offsetWidth: {
-            get: () => 0
-        }
+            get: () => 0,
+        },
     });
 }
 

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -116,7 +116,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                     return NodeFilter.FILTER_SKIP;
                 }
                 return NodeFilter.FILTER_SKIP;
-            }
+            },
         };
         const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter, false);
         while (treeWalker.nextNode()) {
@@ -184,7 +184,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                     return NodeFilter.FILTER_SKIP;
                 }
                 return NodeFilter.FILTER_REJECT;
-            }
+            },
         };
         const treeWalker = document.createTreeWalker(content, NodeFilter.SHOW_ELEMENT, filter, false);
         const lineElements: HTMLElement[] = [];
@@ -213,7 +213,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                         } catch { }
                     }
                     return '<pre class="hljs"><code><div>' + engine.utils.escapeHtml(str) + '</div></code></pre>';
-                }
+                },
             });
             const renderers = ['heading_open', 'paragraph_open', 'list_item_open', 'blockquote_open', 'code_block', 'image'];
             for (const renderer of renderers) {

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -31,7 +31,7 @@ import debounce = require('lodash.debounce');
 export namespace PreviewCommands {
     export const OPEN: Command = {
         id: 'preview:open',
-        label: 'Open Preview'
+        label: 'Open Preview',
     };
 }
 
@@ -58,12 +58,12 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
 
     protected readonly defaultOpenFromEditorOptions: PreviewOpenerOptions = {
         widgetOptions: { area: 'main', mode: 'split-right' },
-        mode: 'reveal'
+        mode: 'reveal',
     };
 
     protected readonly defaultOpenOptions: PreviewOpenerOptions = {
         widgetOptions: { area: 'main', mode: 'tab-after' },
-        mode: 'activate'
+        mode: 'activate',
     };
 
     onStart() {
@@ -117,12 +117,12 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
             editor.revealRange({
                 start: {
                     line,
-                    character: 0
+                    character: 0,
                 },
                 end: {
                     line: line + 1,
-                    character: 0
-                }
+                    character: 0,
+                },
             }, { at: 'top' });
         });
     }
@@ -133,7 +133,7 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
             const { editor } = await this.editorManager.open(new URI(location.uri), {
                 widgetOptions: ref ?
                     { area: 'main', mode: 'tab-after', ref } :
-                    { area: 'main', mode: 'split-left' }
+                    { area: 'main', mode: 'split-left' },
             });
             editor.revealPosition(location.range.start);
             editor.selection = location.range;
@@ -236,7 +236,7 @@ export class PreviewContribution extends WidgetOpenHandler<PreviewWidget> implem
             ... this.defaultOpenFromEditorOptions,
             widgetOptions: ref ?
                 { area: 'main', mode: 'tab-after', ref } :
-                { area: 'main', mode: 'split-right' }
+                { area: 'main', mode: 'split-right' },
         });
     }
 

--- a/packages/preview/src/browser/preview-frontend-module.ts
+++ b/packages/preview/src/browser/preview-frontend-module.ts
@@ -44,11 +44,11 @@ export default new ContainerModule(bind => {
             const child = container.createChild();
             child.bind<PreviewWidgetOptions>(PreviewWidgetOptions).toConstantValue({ resource });
             return child.get(PreviewWidget);
-        }
+        },
     })).inSingletonScope();
 
     bind(PreviewContribution).toSelf().inSingletonScope();
     [CommandContribution, MenuContribution, OpenHandler, FrontendApplicationContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toService(PreviewContribution)
+        bind(serviceIdentifier).toService(PreviewContribution),
     );
 });

--- a/packages/preview/src/browser/preview-handler.ts
+++ b/packages/preview/src/browser/preview-handler.ts
@@ -39,12 +39,12 @@ export class PreviewHandlerProvider {
 
     constructor(
         @inject(ContributionProvider) @named(PreviewHandler)
-        protected readonly previewHandlerContributions: ContributionProvider<PreviewHandler>
+        protected readonly previewHandlerContributions: ContributionProvider<PreviewHandler>,
     ) { }
 
     findContribution(uri: URI): PreviewHandler[] {
         const prioritized = Prioritizeable.prioritizeAllSync(this.previewHandlerContributions.getContributions(), contrib =>
-            contrib.canHandle(uri)
+            contrib.canHandle(uri),
         );
         return prioritized.map(c => c.value);
     }

--- a/packages/preview/src/browser/preview-preferences.ts
+++ b/packages/preview/src/browser/preview-preferences.ts
@@ -20,7 +20,7 @@ import {
   PreferenceProxy,
   PreferenceService,
   PreferenceContribution,
-  PreferenceSchema
+  PreferenceSchema,
 } from "@theia/core/lib/browser";
 
 export const PreviewConfigSchema: PreferenceSchema = {
@@ -29,9 +29,9 @@ export const PreviewConfigSchema: PreferenceSchema = {
     "preview.openByDefault": {
       type: "boolean",
       description: "Open the preview instead of the editor by default.",
-      default: true
-    }
-  }
+      default: true,
+    },
+  },
 };
 
 export interface PreviewConfiguration {
@@ -42,7 +42,7 @@ export const PreviewPreferences = Symbol("PreviewPreferences");
 export type PreviewPreferences = PreferenceProxy<PreviewConfiguration>;
 
 export function createPreviewPreferences(
-  preferences: PreferenceService
+  preferences: PreferenceService,
 ): PreviewPreferences {
   return createPreferenceProxy(preferences, PreviewConfigSchema);
 }

--- a/packages/preview/src/browser/preview-widget.ts
+++ b/packages/preview/src/browser/preview-widget.ts
@@ -257,7 +257,7 @@ export class PreviewWidget extends BaseWidget {
         }
         this.onDidDoubleClickEmitter.fire({
             uri: this.resource.uri.toString(),
-            range: Range.create({ line, character: 0 }, { line, character: 0 })
+            range: Range.create({ line, character: 0 }, { line, character: 0 }),
         });
     }
 

--- a/packages/process/src/node/multi-ring-buffer.ts
+++ b/packages/process/src/node/multi-ring-buffer.ts
@@ -33,7 +33,7 @@ export class MultiRingBufferReadableStream extends stream.Readable implements Di
 
     constructor(protected readonly ringBuffer: MultiRingBuffer,
         protected readonly reader: number,
-        protected readonly encoding = 'utf8'
+        protected readonly encoding = 'utf8',
     ) {
         super();
         this.setEncoding(encoding);

--- a/packages/process/src/node/process-backend-module.ts
+++ b/packages/process/src/node/process-backend-module.ts
@@ -37,7 +37,7 @@ export default new ContainerModule(bind => {
 
             child.bind(RawProcessOptions).toConstantValue(options);
             return child.get(RawProcess);
-        }
+        },
     );
 
     bind(TerminalProcess).toSelf().inTransientScope();
@@ -48,7 +48,7 @@ export default new ContainerModule(bind => {
 
             child.bind(TerminalProcessOptions).toConstantValue(options);
             return child.get(TerminalProcess);
-        }
+        },
     );
 
     bind(MultiRingBuffer).toSelf().inTransientScope();

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -25,7 +25,7 @@ export interface IProcessExitEvent {
 
 export enum ProcessType {
     'Raw',
-    'Terminal'
+    'Terminal',
 }
 
 export interface ProcessOptions {

--- a/packages/python/src/browser/python-client-contribution.ts
+++ b/packages/python/src/browser/python-client-contribution.ts
@@ -27,14 +27,14 @@ export class PythonClientContribution extends BaseLanguageClientContribution {
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
-        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
+        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
     ) {
         super(workspace, languages, languageClientFactory);
     }
 
     protected get globPatterns() {
         return [
-            '**/*.py'
+            '**/*.py',
         ];
     }
 

--- a/packages/python/src/browser/python-grammar-contribution.ts
+++ b/packages/python/src/browser/python-grammar-contribution.ts
@@ -29,7 +29,7 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
         brackets: [
             ['{', '}'],
             ['[', ']'],
-            ['(', ')']
+            ['(', ')'],
         ],
         autoClosingPairs: [
             { open: '[', close: ']' },
@@ -48,15 +48,15 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
         folding: {
             markers: {
                 start: new RegExp("^\\s*#pragma\\s+region\\b"),
-                end: new RegExp("^\\s*#pragma\\s+endregion\\b")
-            }
+                end: new RegExp("^\\s*#pragma\\s+endregion\\b"),
+            },
         },
         onEnterRules: [
             {
                 beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async).*?:\s*$/,
-                action: { indentAction: monaco.languages.IndentAction.Indent }
-            }
-        ]
+                action: { indentAction: monaco.languages.IndentAction.Indent },
+            },
+        ],
     };
 
     registerTextmateLanguage(registry: TextmateRegistry) {
@@ -74,9 +74,9 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: platformGrammar
+                    content: platformGrammar,
                 };
-            }
+            },
         });
 
         const cGrammar = require('../../data/MagicRegExp.tmLanguage.json');
@@ -84,9 +84,9 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: cGrammar
+                    content: cGrammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(PYTHON_LANGUAGE_ID, 'source.python');
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -24,16 +24,16 @@ import URI from "@theia/core/lib/common/uri";
 
 export namespace SearchInWorkspaceCommands {
     export const TOGGLE_SIW_WIDGET = {
-        id: "search-in-workspace.toggle"
+        id: "search-in-workspace.toggle",
     };
     export const OPEN_SIW_WIDGET = {
         id: "search-in-workspace.open",
-        label: "Search In Workspace"
+        label: "Search In Workspace",
 
     };
     export const FIND_IN_FOLDER = {
         id: "search-in-workspace.in-folder",
-        label: "Find In Folder..."
+        label: "Find In Folder...",
     };
 }
 
@@ -48,9 +48,9 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             widgetId: SearchInWorkspaceWidget.ID,
             widgetName: SearchInWorkspaceWidget.LABEL,
             defaultWidgetOptions: {
-                area: "left"
+                area: "left",
             },
-            toggleCommandId: SearchInWorkspaceCommands.TOGGLE_SIW_WIDGET.id
+            toggleCommandId: SearchInWorkspaceCommands.TOGGLE_SIW_WIDGET.id,
         });
     }
 
@@ -58,18 +58,18 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         super.registerCommands(commands);
         commands.registerCommand(SearchInWorkspaceCommands.OPEN_SIW_WIDGET, {
             execute: () => this.openView({
-                activate: true
-            })
+                activate: true,
+            }),
         });
 
         commands.registerCommand(SearchInWorkspaceCommands.FIND_IN_FOLDER, this.newUriAwareCommandHandler({
             execute: async fileUri => {
                 const widget: SearchInWorkspaceWidget = await this.openView({
-                    activate: true
+                    activate: true,
                 });
                 const uriStr = this.labelProvider.getLongName(fileUri);
                 widget.findInFolder(uriStr);
-            }
+            },
         }));
     }
 
@@ -77,17 +77,17 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         super.registerKeybindings(keybindings);
         keybindings.registerKeybinding({
             command: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,
-            keybinding: "ctrlcmd+shift+f"
+            keybinding: "ctrlcmd+shift+f",
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
         menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '6_find'], {
-            commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id
+            commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id,
         });
         menus.registerMenuAction(CommonMenus.EDIT_FIND, {
-            commandId: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id
+            commandId: SearchInWorkspaceCommands.OPEN_SIW_WIDGET.id,
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -30,7 +30,7 @@ export default new ContainerModule(bind => {
     bind(SearchInWorkspaceWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory).toDynamicValue(ctx => ({
         id: SearchInWorkspaceWidget.ID,
-        createWidget: () => ctx.container.get(SearchInWorkspaceWidget)
+        createWidget: () => ctx.container.get(SearchInWorkspaceWidget),
     }));
     bind(SearchInWorkspaceResultTreeWidget).toDynamicValue(ctx => createSearchTreeWidget(ctx.container));
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -26,7 +26,7 @@ import {
     LabelProvider,
     TreeExpansionService,
     ApplicationShell,
-    DiffUris
+    DiffUris,
 } from "@theia/core/lib/browser";
 import { SearchInWorkspaceResult, SearchInWorkspaceOptions } from "../common/search-in-workspace-interface";
 import { SearchInWorkspaceService } from "./search-in-workspace-service";
@@ -86,7 +86,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
         @inject(TreeModel) readonly model: TreeModel,
-        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer
+        @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer,
     ) {
         super(props, model, contextMenuRenderer);
 
@@ -95,7 +95,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             name: "ResultTree",
             parent: undefined,
             visible: false,
-            children: []
+            children: [],
         } as CompositeTreeNode;
 
         this.toDispose.push(model.onSelectionChanged(nodes => {
@@ -187,7 +187,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                             id: path + "-" + name,
                             parent: this.model.root,
                             icon,
-                            file: result.file
+                            file: result.file,
                         };
                         resultElement.children.push(this.createResultLineNode(result, resultElement));
                         this.resultTree.set(result.file, resultElement);
@@ -199,7 +199,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     return;
                 }
                 this.refreshModelChildren();
-            }
+            },
         }, searchOptions);
         token.onCancellationRequested(() => {
             this.searchService.cancel(searchId);
@@ -255,7 +255,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             selected: false,
             id: result.file + "-" + result.line + "-" + result.character + "-" + result.length,
             name: result.lineText,
-            parent: resultNode
+            parent: resultNode,
         };
     }
 
@@ -327,17 +327,17 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 range: {
                     start: {
                         line: resultLineNode.line - 1,
-                        character: resultLineNode.character - 1
+                        character: resultLineNode.character - 1,
                     },
                     end: {
                         line: resultLineNode.line - 1,
-                        character: resultLineNode.character - 1 + resultLineNode.length
-                    }
-                }
+                        character: resultLineNode.character - 1 + resultLineNode.length,
+                    },
+                },
             } as ReplaceOperation));
             await widget.editor.replaceText({
                 source,
-                replaceOperations
+                replaceOperations,
             });
         }
     }
@@ -426,14 +426,14 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
             selection: {
                 start: {
                     line: node.line - 1,
-                    character: node.character - 1
+                    character: node.character - 1,
                 },
                 end: {
                     line: node.line - 1,
-                    character: node.character - 1 + node.length
-                }
+                    character: node.character - 1 + node.length,
+                },
             },
-            mode: "reveal"
+            mode: "reveal",
         });
 
         this.decorateEditor(resultNode, editorWidget);
@@ -478,21 +478,21 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     range: {
                         start: {
                             line: res.line - 1,
-                            character: res.character - 1
+                            character: res.character - 1,
                         },
                         end: {
                             line: res.line - 1,
-                            character: res.character - 1 + res.length
-                        }
+                            character: res.character - 1 + res.length,
+                        },
                     },
                     options: {
                         overviewRuler: {
                             color: "rgba(230, 0, 0, 1)",
-                            position: OverviewRulerLane.Full
+                            position: OverviewRulerLane.Full,
                         },
                         className: res.selected ? "current-search-in-workspace-editor-match" : "search-in-workspace-editor-match",
-                        stickiness: TrackedRangeStickiness.GrowsOnlyWhenTypingBefore
-                    }
+                        stickiness: TrackedRangeStickiness.GrowsOnlyWhenTypingBefore,
+                    },
                 });
             });
         }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -72,22 +72,22 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.matchCaseState = {
             className: "match-case",
             enabled: false,
-            title: "Match Case"
+            title: "Match Case",
         };
         this.wholeWordState = {
             className: "whole-word",
             enabled: false,
-            title: "Match Whole Word"
+            title: "Match Whole Word",
         };
         this.regExpState = {
             className: "use-regexp",
             enabled: false,
-            title: "Use Regular Expression"
+            title: "Use Regular Expression",
         };
         this.includeIgnoredState = {
             className: "include-ignored fa fa-eye",
             enabled: false,
-            title: "Include Ignored Files"
+            title: "Include Ignored Files",
         };
         this.searchInWorkspaceOptions = {
             matchCase: false,
@@ -96,7 +96,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             includeIgnored: false,
             include: [],
             exclude: [],
-            maxResults: 2000
+            maxResults: 2000,
         };
         this.toDispose.push(this.resultTreeWidget.onChange(r => {
             this.hasResults = r.size > 0;
@@ -121,7 +121,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             searchInWorkspaceOptions: this.searchInWorkspaceOptions,
             searchTerm: this.searchTerm,
             replaceTerm: this.replaceTerm,
-            showReplaceField: this.showReplaceField
+            showReplaceField: this.showReplaceField,
         };
     }
 

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -127,7 +127,7 @@ beforeEach(() => {
 
                 child.bind(RawProcessOptions).toConstantValue(options);
                 return child.get(RawProcess);
-            }
+            },
         );
     });
 
@@ -194,7 +194,7 @@ describe('ripgrep-search-in-workspace-server', function () {
                 { file: 'carrots', line: 3, character: 28, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 3, character: 52, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 4, character: 1, length: pattern.length, lineText: '' },
-                { file: 'potatoes', line: 1, character: 18, length: pattern.length, lineText: '' }
+                { file: 'potatoes', line: 1, character: 18, length: pattern.length, lineText: '' },
             ];
 
             compareSearchResults(expected, client.results);
@@ -213,7 +213,7 @@ describe('ripgrep-search-in-workspace-server', function () {
                 { file: 'carrots', line: 2, character: 6, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 2, character: 35, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 3, character: 28, length: pattern.length, lineText: '' },
-                { file: 'potatoes', line: 1, character: 18, length: pattern.length, lineText: '' }
+                { file: 'potatoes', line: 1, character: 18, length: pattern.length, lineText: '' },
             ];
 
             compareSearchResults(expected, client.results);
@@ -221,7 +221,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         });
         ripgrepServer.setClient(client);
         ripgrepServer.search(pattern, rootDir, {
-            matchCase: true
+            matchCase: true,
         });
     });
 
@@ -233,7 +233,7 @@ describe('ripgrep-search-in-workspace-server', function () {
                 { file: 'carrots', line: 1, character: 11, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 3, character: 28, length: pattern.length, lineText: '' },
                 { file: 'carrots', line: 3, character: 52, length: pattern.length, lineText: '' },
-                { file: 'carrots', line: 4, character: 1, length: pattern.length, lineText: '' }
+                { file: 'carrots', line: 4, character: 1, length: pattern.length, lineText: '' },
             ];
 
             compareSearchResults(expected, client.results);
@@ -241,7 +241,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         });
         ripgrepServer.setClient(client);
         ripgrepServer.search(pattern, rootDir, {
-            matchWholeWord: true
+            matchWholeWord: true,
         });
     });
 
@@ -251,7 +251,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         const client = new ResultAccumulator(() => {
             const expected: SearchInWorkspaceResult[] = [
                 { file: 'carrots', line: 1, character: 11, length: pattern.length, lineText: '' },
-                { file: 'carrots', line: 3, character: 28, length: pattern.length, lineText: '' }
+                { file: 'carrots', line: 3, character: 28, length: pattern.length, lineText: '' },
             ];
 
             compareSearchResults(expected, client.results);
@@ -260,7 +260,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         ripgrepServer.setClient(client);
         ripgrepServer.search(pattern, rootDir, {
             matchWholeWord: true,
-            matchCase: true
+            matchCase: true,
         });
     });
 
@@ -389,7 +389,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         });
         ripgrepServer.setClient(client);
         ripgrepServer.search(pattern, rootDir, {
-            useRegExp: true
+            useRegExp: true,
         });
     });
 
@@ -399,7 +399,7 @@ describe('ripgrep-search-in-workspace-server', function () {
 
         const client = new ResultAccumulator(() => {
             const expected: SearchInWorkspaceResult[] = [
-                { file: 'regexes', line: 1, character: 5, length: 6, lineText: '' }
+                { file: 'regexes', line: 1, character: 5, length: 6, lineText: '' },
             ];
 
             compareSearchResults(expected, client.results);
@@ -407,7 +407,7 @@ describe('ripgrep-search-in-workspace-server', function () {
         });
         ripgrepServer.setClient(client);
         ripgrepServer.search(pattern, rootDir, {
-            useRegExp: false
+            useRegExp: false,
         });
     });
 
@@ -422,7 +422,7 @@ describe('ripgrep-search-in-workspace-server', function () {
 
             if (!isWindows) {
                 expected.push(
-                    { file: 'file:with:some:colons', line: 1, character: 28, length: 7, lineText: '' }
+                    { file: 'file:with:some:colons', line: 1, character: 28, length: 7, lineText: '' },
                 );
             }
 
@@ -444,7 +444,7 @@ describe('ripgrep-search-in-workspace-server', function () {
 
             if (!isWindows) {
                 expected.push(
-                    { file: 'file:with:some:colons', line: 1, character: 27, length: 8, lineText: '' }
+                    { file: 'file:with:some:colons', line: 1, character: 27, length: 8, lineText: '' },
                 );
             }
 

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -101,7 +101,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
         }
         const processOptions: RawProcessOptions = {
             command: rgPath,
-            args: [...args, what, ...globs, root]
+            args: [...args, what, ...globs, root],
         };
         const process: RawProcess = this.rawProcessFactory(processOptions);
         this.ongoingSearches.set(searchId, process);

--- a/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
+++ b/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
@@ -28,6 +28,6 @@ export default new ContainerModule(bind => {
                 server.setClient(client);
                 client.onDidCloseConnection(() => server.dispose());
                 return server;
-            })
+            }),
     );
 });

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -46,9 +46,9 @@ export class ProcessTaskResolver implements TaskResolver {
             windows: processTaskConfig.windows ? {
                 command: await this.variableResolverService.resolve(processTaskConfig.windows.command),
                 args: processTaskConfig.args ? await this.variableResolverService.resolveArray(processTaskConfig.args) : undefined,
-                options: processTaskConfig.windows.options
+                options: processTaskConfig.windows.options,
             } : undefined,
-            cwd: await this.variableResolverService.resolve(processTaskConfig.cwd ? processTaskConfig.cwd : '${workspaceFolder}')
+            cwd: await this.variableResolverService.resolve(processTaskConfig.cwd ? processTaskConfig.cwd : '${workspaceFolder}'),
         };
         return result;
     }

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -28,7 +28,7 @@ export class QuickOpenTask implements QuickOpenModel {
     constructor(
         @inject(TaskService) protected readonly taskService: TaskService,
         @inject(TaskConfigurations) protected readonly taskConfigurations: TaskConfigurations,
-        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService
+        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
     ) { }
 
     async open(): Promise<void> {
@@ -47,7 +47,7 @@ export class QuickOpenTask implements QuickOpenModel {
         this.quickOpenService.open(this, {
             placeholder: 'Type the name of a task you want to execute',
             fuzzyMatchLabel: true,
-            fuzzySort: true
+            fuzzySort: true,
         });
     }
 
@@ -62,15 +62,15 @@ export class QuickOpenTask implements QuickOpenModel {
                         new TaskAttachQuickOpenItem(
                             task,
                             this.getRunningTaskLabel(task),
-                            this.taskService
-                        )
+                            this.taskService,
+                        ),
                     );
                 }
             }
             this.quickOpenService.open(this, {
                 placeholder: 'Choose task to open',
                 fuzzyMatchLabel: true,
-                fuzzySort: true
+                fuzzySort: true,
             });
         });
     }
@@ -94,7 +94,7 @@ export class TaskRunQuickOpenItem extends QuickOpenItem {
     constructor(
         protected readonly task: TaskConfiguration,
         protected taskService: TaskService,
-        protected readonly provided: boolean
+        protected readonly provided: boolean,
     ) {
         super();
     }
@@ -122,7 +122,7 @@ export class TaskAttachQuickOpenItem extends QuickOpenItem {
     constructor(
         protected readonly task: TaskInfo,
         protected readonly taskLabel: string,
-        protected taskService: TaskService
+        protected taskService: TaskService,
     ) {
         super();
     }

--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -51,7 +51,7 @@ export class TaskConfigurations implements Disposable {
     constructor(
         @inject(ILogger) @named('task') protected readonly logger: ILogger,
         @inject(FileSystemWatcherServer) protected readonly watcherServer: FileSystemWatcherServer,
-        @inject(FileSystem) protected readonly fileSystem: FileSystem
+        @inject(FileSystem) protected readonly fileSystem: FileSystem,
     ) {
         this.toDispose.push(watcherServer);
 
@@ -68,7 +68,7 @@ export class TaskConfigurations implements Disposable {
                 } catch (err) {
                     this.logger.error(err);
                 }
-            }
+            },
         });
 
         this.toDispose.push(Disposable.create(() => {
@@ -95,7 +95,7 @@ export class TaskConfigurations implements Disposable {
             this.watchedConfigFileUri = configFile;
             const watchId = await this.watcherServer.watchFileChanges(configFile);
             this.toDispose.push(Disposable.create(() =>
-                this.watcherServer.unwatchFileChanges(watchId))
+                this.watcherServer.unwatchFileChanges(watchId)),
             );
             this.refreshTasks();
         }

--- a/packages/task/src/browser/task-contribution.ts
+++ b/packages/task/src/browser/task-contribution.ts
@@ -50,7 +50,7 @@ export class TaskResolverRegistry {
     register(type: string, resolver: TaskResolver): Disposable {
         this.resolvers.set(type, resolver);
         return {
-            dispose: () => this.resolvers.delete(type)
+            dispose: () => this.resolvers.delete(type),
         };
     }
 
@@ -73,7 +73,7 @@ export class TaskProviderRegistry {
     register(type: string, resolver: TaskProvider): Disposable {
         this.providers.set(type, resolver);
         return {
-            dispose: () => this.providers.delete(type)
+            dispose: () => this.providers.delete(type),
         };
     }
 

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -35,12 +35,12 @@ export namespace TaskCommands {
     // run task command
     export const TASK_RUN: Command = {
         id: 'task:run',
-        label: 'Tasks: Run...'
+        label: 'Tasks: Run...',
     };
 
     export const TASK_ATTACH: Command = {
         id: 'task:attach',
-        label: 'Tasks: Attach...'
+        label: 'Tasks: Attach...',
     };
 }
 
@@ -83,15 +83,15 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_RUN,
             {
                 isEnabled: () => true,
-                execute: () => this.quickOpenTask.open()
-            }
+                execute: () => this.quickOpenTask.open(),
+            },
         );
         registry.registerCommand(
             TaskCommands.TASK_ATTACH,
             {
                 isEnabled: () => true,
-                execute: () => this.quickOpenTask.attach()
-            }
+                execute: () => this.quickOpenTask.attach(),
+            },
         );
     }
 
@@ -101,13 +101,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         menus.registerMenuAction(TaskCommands.RUN_GROUP, {
             commandId: TaskCommands.TASK_RUN.id,
             label: TaskCommands.TASK_RUN.label ? TaskCommands.TASK_RUN.label.slice('Tasks: '.length) : TaskCommands.TASK_RUN.label,
-            order: '0'
+            order: '0',
         });
 
         menus.registerMenuAction(TaskCommands.RUN_GROUP, {
             commandId: TaskCommands.TASK_ATTACH.id,
             label: TaskCommands.TASK_ATTACH.label ? TaskCommands.TASK_ATTACH.label.slice('Tasks: '.length) : TaskCommands.TASK_ATTACH.label,
-            order: '1'
+            order: '1',
         });
     }
 }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -222,7 +222,7 @@ export class TaskService implements TaskConfigurationClient {
                 id: 'task-' + taskId,
                 caption: `Task #${taskId}`,
                 label: `Task #${taskId}`,
-                destroyTermOnClose: true
+                destroyTermOnClose: true,
             });
         this.shell.addWidget(widget, { area: 'bottom' });
         this.shell.activateWidget(widget.id);

--- a/packages/task/src/common/task-watcher.ts
+++ b/packages/task/src/common/task-watcher.ts
@@ -30,7 +30,7 @@ export class TaskWatcher {
             },
             onTaskExit(event: TaskExitedEvent) {
                 exitEmitter.fire(event);
-            }
+            },
         };
     }
 

--- a/packages/task/src/node/process/process-task-runner-backend-module.ts
+++ b/packages/task/src/node/process/process-task-runner-backend-module.ts
@@ -29,7 +29,7 @@ export function bindProcessTaskRunnerModule(bind: interfaces.Bind) {
             child.parent = ctx.container;
             child.bind(TaskProcessOptions).toConstantValue(options);
             return child.get(ProcessTask);
-        }
+        },
     );
     bind(ProcessTaskRunner).toSelf().inSingletonScope();
     bind(ProcessTaskRunnerContribution).toSelf().inSingletonScope();

--- a/packages/task/src/node/process/process-task-runner.ts
+++ b/packages/task/src/node/process/process-task-runner.ts
@@ -23,7 +23,7 @@ import {
     TerminalProcessOptions,
     RawProcessOptions,
     RawProcessFactory,
-    TerminalProcessFactory
+    TerminalProcessFactory,
 } from '@theia/process/lib/node';
 import URI from '@theia/core/lib/common/uri';
 import { TaskFactory } from './process-task';
@@ -85,7 +85,7 @@ export class ProcessTaskRunner implements TaskRunner {
         // new process, so e.g. we can re-use the system path
         options = {
             cwd: cwd,
-            env: process.env
+            env: process.env,
         };
 
         // When we create a process to execute a command, it's difficult to know if it failed
@@ -103,7 +103,7 @@ export class ProcessTaskRunner implements TaskRunner {
                     proc = this.rawProcessFactory(<RawProcessOptions>{
                         command: command,
                         args: args,
-                        options: options
+                        options: options,
                     });
                 } else {
                     // all Task types without specific TaskRunner will be run as a shell process e.g.: npm, gulp, etc.
@@ -111,7 +111,7 @@ export class ProcessTaskRunner implements TaskRunner {
                     proc = this.terminalProcessFactory(<TerminalProcessOptions>{
                         command: command,
                         args: args,
-                        options: options
+                        options: options,
                     });
                 }
                 return this.taskFactory(
@@ -121,7 +121,7 @@ export class ProcessTaskRunner implements TaskRunner {
                         process: proc,
                         processType: processType,
                         context: ctx,
-                        config: taskConfig
+                        config: taskConfig,
                     });
             } catch (error) {
                 this.logger.error(`Error occurred while creating task: ${error}`);

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -38,7 +38,7 @@ export class ProcessTask extends Task {
     constructor(
         @inject(TaskManager) protected readonly taskManager: TaskManager,
         @inject(ILogger) @named('task') protected readonly logger: ILogger,
-        @inject(TaskProcessOptions) protected readonly options: TaskProcessOptions
+        @inject(TaskProcessOptions) protected readonly options: TaskProcessOptions,
     ) {
         super(taskManager, logger, options);
 
@@ -49,7 +49,7 @@ export class ProcessTask extends Task {
                     taskId: this.taskId,
                     ctx: this.options.context,
                     code: event.code,
-                    signal: event.signal
+                    signal: event.signal,
                 });
             });
 
@@ -75,7 +75,7 @@ export class ProcessTask extends Task {
             taskId: this.id,
             ctx: this.context,
             config: this.options.config,
-            terminalId: (this.processType === 'shell') ? this.process.id : undefined
+            terminalId: (this.processType === 'shell') ? this.process.id : undefined,
         };
     }
     get process() {

--- a/packages/task/src/node/task-backend-application-contribution.ts
+++ b/packages/task/src/node/task-backend-application-contribution.ts
@@ -30,7 +30,7 @@ export class TaskBackendApplicationContribution implements BackendApplicationCon
 
     onStart(): void {
         this.contributionProvider.getContributions().forEach(contrib =>
-            contrib.registerRunner(this.taskRunnerRegistry)
+            contrib.registerRunner(this.taskRunnerRegistry),
         );
     }
 }

--- a/packages/task/src/node/task-backend-module.ts
+++ b/packages/task/src/node/task-backend-module.ts
@@ -40,7 +40,7 @@ export default new ContainerModule(bind => {
                 taskServer.disconnectClient(client);
             });
             return taskServer;
-        })
+        }),
     ).inSingletonScope();
 
     createCommonBindings(bind);

--- a/packages/task/src/node/task-manager.ts
+++ b/packages/task/src/node/task-manager.ts
@@ -32,7 +32,7 @@ export class TaskManager implements BackendApplicationContribution {
     protected readonly deleteEmitter = new Emitter<number>();
 
     constructor(
-        @inject(ILogger) @named('task') protected readonly logger: ILogger
+        @inject(ILogger) @named('task') protected readonly logger: ILogger,
     ) { }
 
     register(task: Task, ctx?: string): number {

--- a/packages/task/src/node/task-runner.ts
+++ b/packages/task/src/node/task-runner.ts
@@ -54,7 +54,7 @@ export class TaskRunnerRegistry {
     registerRunner(type: string, runner: TaskRunner): Disposable {
         this.runners.set(type, runner);
         return {
-            dispose: () => this.runners.delete(type)
+            dispose: () => this.runners.delete(type),
         };
     }
 

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -318,10 +318,10 @@ function createTaskConfig(taskType: string, command: string, args: string[]): Ta
                 "/c",
                 command
                 ,
-                (args[0] !== undefined) ? args[0] : ''
-            ]
+                (args[0] !== undefined) ? args[0] : '',
+            ],
         },
-        cwd: wsRoot
+        cwd: wsRoot,
     };
     return options;
 }
@@ -338,10 +338,10 @@ function createProcessTaskConfig(processType: ProcessType, command: string, args
                 "/c",
                 command
                 ,
-                (args[0] !== undefined) ? args[0] : ''
-            ]
+                (args[0] !== undefined) ? args[0] : '',
+            ],
         },
-        cwd: wsRoot
+        cwd: wsRoot,
     };
     return options;
 }
@@ -352,7 +352,7 @@ function createProcessTaskConfig2(processType: ProcessType, command: string, arg
         type: processType,
         command: command,
         args: args,
-        cwd: wsRoot
+        cwd: wsRoot,
     };
 }
 
@@ -367,9 +367,9 @@ function createTaskConfigTaskLongRunning(processType: ProcessType): TaskConfigur
             command: "cmd.exe",
             args: [
                 "/c",
-                commandLongRunningWindows
-            ]
-        }
+                commandLongRunningWindows,
+            ],
+        },
     };
 }
 

--- a/packages/task/src/node/task.ts
+++ b/packages/task/src/node/task.ts
@@ -34,7 +34,7 @@ export abstract class Task {
     constructor(
         protected readonly taskManager: TaskManager,
         protected readonly logger: ILogger,
-        protected readonly options: TaskOptions
+        protected readonly options: TaskOptions,
     ) {
         this.taskId = this.taskManager.register(this, this.options.context);
         this.exitEmitter = new Emitter<TaskExitedEvent>();

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -21,11 +21,11 @@ import {
     CommandRegistry,
     MenuContribution,
     MenuModelRegistry,
-    isOSX
+    isOSX,
 } from '@theia/core/lib/common';
 import {
     CommonMenus, ApplicationShell, KeybindingContribution, KeyCode, Key,
-    KeyModifier, KeybindingRegistry
+    KeyModifier, KeybindingRegistry,
 } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -37,7 +37,7 @@ import { TerminalWidgetOptions, TerminalWidget } from './base/terminal-widget';
 export namespace TerminalCommands {
     export const NEW: Command = {
         id: 'terminal:new',
-        label: 'Open New Terminal'
+        label: 'Open New Terminal',
     };
 }
 
@@ -47,7 +47,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     constructor(
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
         @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
@@ -58,20 +58,20 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                 const termWidget = await this.newTerminal({});
                 termWidget.start();
                 this.activateTerminal(termWidget);
-            }
+            },
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_NEW, {
-            commandId: TerminalCommands.NEW.id
+            commandId: TerminalCommands.NEW.id,
         });
     }
 
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: TerminalCommands.NEW.id,
-            keybinding: "ctrl+`"
+            keybinding: "ctrl+`",
         });
 
         /* Register passthrough keybindings for combinations recognized by
@@ -95,7 +95,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             keybindings.registerKeybinding({
                 command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
                 keybinding: KeyCode.createKeyCode({ first: k, modifiers: [KeyModifier.Alt] }).toString(),
-                context: TerminalKeybindingContexts.terminalActive
+                context: TerminalKeybindingContexts.terminalActive,
             });
         };
 
@@ -106,7 +106,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         for (let i = 0; i < 26; i++) {
             regCtrl({
                 keyCode: Key.KEY_A.keyCode + i,
-                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i)
+                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i),
             });
         }
 
@@ -135,7 +135,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         for (let i = 0; i < 26; i++) {
             regAlt({
                 keyCode: Key.KEY_A.keyCode + i,
-                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i)
+                code: 'Key' + String.fromCharCode('A'.charCodeAt(0) + i),
             });
         }
 
@@ -146,7 +146,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         for (let i = 0; i < 10; i++) {
             regAlt({
                 keyCode: Key.DIGIT0.keyCode + i,
-                code: 'Digit' + String.fromCharCode('0'.charCodeAt(0) + i)
+                code: 'Digit' + String.fromCharCode('0'.charCodeAt(0) + i),
             });
         }
         if (isOSX) {
@@ -154,7 +154,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             keybindings.registerKeybinding({
                 command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
                 keybinding: "ctrlcmd+a",
-                context: TerminalKeybindingContexts.terminalActive
+                context: TerminalKeybindingContexts.terminalActive,
             });
         }
     }
@@ -162,7 +162,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     async newTerminal(options: TerminalWidgetOptions): Promise<TerminalWidget> {
         const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(TERMINAL_WIDGET_FACTORY_ID, <TerminalWidgetFactoryOptions>{
             created: new Date().toString(),
-            ...options
+            ...options,
         });
         return widget;
     }

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -48,13 +48,13 @@ export default new ContainerModule(bind => {
                 title: 'Terminal ' + counter,
                 useServerTitle: true,
                 destroyTermOnClose: true,
-                ...options
+                ...options,
             };
             child.bind(TerminalWidgetOptions).toConstantValue(widgetOptions);
             child.bind("terminal-dom-id").toConstantValue(domId);
 
             return child.get(TerminalWidget);
-        }
+        },
     }));
 
     bind(TerminalFrontendContribution).toSelf().inSingletonScope();

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -83,7 +83,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
         if (this.options.destroyTermOnClose === true) {
             this.toDispose.push(Disposable.create(() =>
-                this.term.destroy()
+                this.term.destroy(),
             ));
         }
 
@@ -101,7 +101,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 foreground: cssProps.foreground,
                 background: cssProps.background,
                 cursor: cssProps.foreground,
-                selection: cssProps.selection
+                selection: cssProps.selection,
             },
         });
 
@@ -111,7 +111,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 foreground: changedProps.foreground,
                 background: changedProps.background,
                 cursor: changedProps.foreground,
-                selection: cssProps.selection
+                selection: cssProps.selection,
             });
         }));
 
@@ -208,7 +208,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             fontFamily,
             foreground,
             background,
-            selection
+            selection,
         };
     }
 
@@ -250,7 +250,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             env: this.options.env,
             rootURI,
             cols,
-            rows
+            rows,
         });
         if (IBaseTerminalServer.validateId(terminalId)) {
             return terminalId;
@@ -330,7 +330,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 this.toDisposeOnConnect.push(connection);
                 connection.listen();
                 this.waitForConnection.resolve(connection);
-            }
+            },
         }, { reconnecting: false });
     }
     protected async reconnectTerminalProcess(): Promise<void> {

--- a/packages/terminal/src/common/terminal-watcher.ts
+++ b/packages/terminal/src/common/terminal-watcher.ts
@@ -30,7 +30,7 @@ export class TerminalWatcher {
             },
             onTerminalError(event: IBaseTerminalErrorEvent) {
                 errorEmitter.fire(event);
-            }
+            },
         };
     }
 

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -88,7 +88,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
                 this.client.onTerminalError(
                     {
                         'terminalId': term.id,
-                        'error': error
+                        'error': error,
                     });
             }
         }));
@@ -99,7 +99,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
                     {
                         'terminalId': term.id,
                         'code': event.code,
-                        'signal': event.signal
+                        'signal': event.signal,
                     });
             }
         }));

--- a/packages/terminal/src/node/shell-process.ts
+++ b/packages/terminal/src/node/shell-process.ts
@@ -72,7 +72,7 @@ export class ShellProcess extends TerminalProcess {
         @inject(ShellProcessOptions) options: ShellProcessOptions,
         @inject(ProcessManager) processManager: ProcessManager,
         @inject(MultiRingBuffer) ringBuffer: MultiRingBuffer,
-        @inject(ILogger) @named("terminal") logger: ILogger
+        @inject(ILogger) @named("terminal") logger: ILogger,
     ) {
         super(<TerminalProcessOptions>{
             command: options.shell || ShellProcess.getShellExecutablePath(),
@@ -83,7 +83,7 @@ export class ShellProcess extends TerminalProcess {
                 rows: options.rows || ShellProcess.defaultRows,
                 cwd: getRootPath(options.rootURI),
                 env: setUpEnvVariables(options.env),
-            }
+            },
         }, processManager, ringBuffer, logger);
     }
 

--- a/packages/terminal/src/node/terminal-backend-module.ts
+++ b/packages/terminal/src/node/terminal-backend-module.ts
@@ -32,7 +32,7 @@ export function bindTerminalServer(bind: interfaces.Bind, { path, identifier, co
     identifier: interfaces.ServiceIdentifier<IBaseTerminalServer>,
     constructor: {
         new(...args: any[]): IBaseTerminalServer;
-    }
+    },
 }): void {
     const dispatchingClient = new DispatchingBaseTerminalClient();
     bind<IBaseTerminalServer>(identifier).to(constructor).inSingletonScope().onActivation((context, terminalServer) => {
@@ -48,7 +48,7 @@ export function bindTerminalServer(bind: interfaces.Bind, { path, identifier, co
             const disposable = dispatchingClient.push(client);
             client.onDidCloseConnection(() => disposable.dispose());
             return ctx.container.get(identifier);
-        })
+        }),
     ).inSingletonScope();
 }
 
@@ -62,19 +62,19 @@ export default new ContainerModule(bind => {
             child.parent = ctx.container;
             child.bind(ShellProcessOptions).toConstantValue(options);
             return child.get(ShellProcess);
-        }
+        },
     );
 
     bind(TerminalWatcher).toSelf().inSingletonScope();
     bindTerminalServer(bind, {
         path: terminalPath,
         identifier: ITerminalServer,
-        constructor: TerminalServer
+        constructor: TerminalServer,
     });
     bindTerminalServer(bind, {
         path: shellTerminalPath,
         identifier: IShellTerminalServer,
-        constructor: ShellTerminalServer
+        constructor: ShellTerminalServer,
     });
 
     createCommonBindings(bind);

--- a/packages/terminal/src/node/terminal-server.ts
+++ b/packages/terminal/src/node/terminal-server.ts
@@ -18,7 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import { ILogger } from '@theia/core/lib/common/logger';
 import {
     ITerminalServer,
-    ITerminalServerOptions
+    ITerminalServerOptions,
 } from '../common/terminal-protocol';
 import { BaseTerminalServer } from './base-terminal-server';
 import { TerminalProcessFactory, ProcessManager } from '@theia/process/lib/node';

--- a/packages/textmate-grammars/src/browser/bat.ts
+++ b/packages/textmate-grammars/src/browser/bat.ts
@@ -27,16 +27,16 @@ export class BatContribution implements LanguageGrammarDefinitionContribution {
         monaco.languages.register({
             id: this.id,
             extensions: ['.bat', '.cmd'],
-            aliases: ['Batch', 'bat']
+            aliases: ['Batch', 'bat'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
-                lineComment: 'REM'
+                lineComment: 'REM',
             },
             brackets: [
                 ['{', '}'],
                 ['[', ']'],
-                ['(', ')']
+                ['(', ')'],
             ],
             autoClosingPairs: [
                 { open: '{', close: '}' },
@@ -52,18 +52,18 @@ export class BatContribution implements LanguageGrammarDefinitionContribution {
             folding: {
                 markers: {
                     start: new RegExp("^\\s*(::\\s*|REM\\s+)#region"),
-                    end: new RegExp("^\\s*(::\\s*|REM\\s+)#endregion")
-                }
-            }
+                    end: new RegExp("^\\s*(::\\s*|REM\\s+)#endregion"),
+                },
+            },
         });
         const grammar = require('../../data/bat.tmLanguage.json');
         registry.registerTextMateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/css.ts
+++ b/packages/textmate-grammars/src/browser/css.ts
@@ -28,19 +28,19 @@ export class CssContribution implements LanguageGrammarDefinitionContribution {
             id: this.id,
             extensions: ['.css'],
             aliases: ['CSS', 'css'],
-            mimetypes: ['text/css']
+            mimetypes: ['text/css'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             wordPattern: /(#?-?\d*\.\d\w*%?)|((::|[@#.!:])?[\w-?]+%?)|::|[@#.!:]/g,
 
             comments: {
-                blockComment: ['/*', '*/']
+                blockComment: ['/*', '*/'],
             },
 
             brackets: [
                 ['{', '}'],
                 ['[', ']'],
-                ['(', ')']
+                ['(', ')'],
             ],
 
             autoClosingPairs: [
@@ -48,7 +48,7 @@ export class CssContribution implements LanguageGrammarDefinitionContribution {
                 { open: '[', close: ']', notIn: ['string', 'comment'] },
                 { open: '(', close: ')', notIn: ['string', 'comment'] },
                 { open: '"', close: '"', notIn: ['string', 'comment'] },
-                { open: '\'', close: '\'', notIn: ['string', 'comment'] }
+                { open: '\'', close: '\'', notIn: ['string', 'comment'] },
             ],
 
             surroundingPairs: [
@@ -56,24 +56,24 @@ export class CssContribution implements LanguageGrammarDefinitionContribution {
                 { open: '[', close: ']' },
                 { open: '(', close: ')' },
                 { open: '"', close: '"' },
-                { open: '\'', close: '\'' }
+                { open: '\'', close: '\'' },
             ],
 
             folding: {
                 markers: {
                     start: new RegExp("^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/"),
-                    end: new RegExp("^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/")
-                }
-            }
+                    end: new RegExp("^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"),
+                },
+            },
         });
         const grammar = require('../../data/css.tmLanguage.json');
         registry.registerTextMateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/html.ts
+++ b/packages/textmate-grammars/src/browser/html.ts
@@ -36,14 +36,14 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
             wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
 
             comments: {
-                blockComment: ['<!--', '-->']
+                blockComment: ['<!--', '-->'],
             },
 
             brackets: [
                 ['<!--', '-->'],
                 ['<', '>'],
                 ['{', '}'],
-                ['(', ')']
+                ['(', ')'],
             ],
 
             autoClosingPairs: [
@@ -51,7 +51,7 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
                 { open: '[', close: ']' },
                 { open: '(', close: ')' },
                 { open: '"', close: '"' },
-                { open: '\'', close: '\'' }
+                { open: '\'', close: '\'' },
             ],
 
             surroundingPairs: [
@@ -67,20 +67,20 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
                 {
                     beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
                     afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>$/i,
-                    action: { indentAction: monaco.languages.IndentAction.IndentOutdent }
+                    action: { indentAction: monaco.languages.IndentAction.IndentOutdent },
                 },
                 {
                     beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
-                    action: { indentAction: monaco.languages.IndentAction.Indent }
-                }
+                    action: { indentAction: monaco.languages.IndentAction.Indent },
+                },
             ],
 
             folding: {
                 markers: {
                     start: new RegExp("^\\s*<!--\\s*#region\\b.*-->"),
-                    end: new RegExp("^\\s*<!--\\s*#endregion\\b.*-->")
-                }
-            }
+                    end: new RegExp("^\\s*<!--\\s*#endregion\\b.*-->"),
+                },
+            },
         });
 
         const grammar = require('../../data/html.tmLanguage.json');
@@ -88,9 +88,9 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/less.ts
+++ b/packages/textmate-grammars/src/browser/less.ts
@@ -34,7 +34,7 @@ export class LessContribution implements LanguageGrammarDefinitionContribution {
             wordPattern: /(#?-?\d*\.\d\w*%?)|([@#!.:]?[\w-?]+%?)|[@#!.]/g,
             comments: {
                 blockComment: ['/*', '*/'],
-                lineComment: '//'
+                lineComment: '//',
             },
             brackets: [
                 ['{', '}'],
@@ -58,9 +58,9 @@ export class LessContribution implements LanguageGrammarDefinitionContribution {
             folding: {
                 markers: {
                     start: new RegExp("^\\s*\\/\\*\\s*#region\\b\\s*(.*?)\\s*\\*\\/"),
-                    end: new RegExp("^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/")
-                }
-            }
+                    end: new RegExp("^\\s*\\/\\*\\s*#endregion\\b.*\\*\\/"),
+                },
+            },
         });
 
         const grammar = require('../../data/less.tmLanguage.json');
@@ -68,9 +68,9 @@ export class LessContribution implements LanguageGrammarDefinitionContribution {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/markdown.ts
+++ b/packages/textmate-grammars/src/browser/markdown.ts
@@ -27,22 +27,22 @@ export class MarkdownContribution implements LanguageGrammarDefinitionContributi
         monaco.languages.register({
             id: this.id,
             extensions: ['.md', '.markdown', '.mdown', '.mkdn', '.mkd', '.mdwn', '.mdtxt', '.mdtext'],
-            aliases: ['Markdown', 'markdown']
+            aliases: ['Markdown', 'markdown'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
-                blockComment: ['<!--', '-->']
+                blockComment: ['<!--', '-->'],
             },
             brackets: [
                 ['{', '}'],
                 ['[', ']'],
-                ['(', ')']
+                ['(', ')'],
             ],
             autoClosingPairs: [
                 { open: '{', close: '}' },
                 { open: '[', close: ']' },
                 { open: '(', close: ')' },
-                { open: '<', close: '>', notIn: ['string'] }
+                { open: '<', close: '>', notIn: ['string'] },
             ],
             surroundingPairs: [
                 { open: '(', close: ')' },
@@ -52,9 +52,9 @@ export class MarkdownContribution implements LanguageGrammarDefinitionContributi
             folding: {
                 markers: {
                     start: new RegExp("^\\s*<!--\\s*#?region\\b.*-->"),
-                    end: new RegExp("^\\s*<!--\\s*#?endregion\\b.*-->")
-                }
-            }
+                    end: new RegExp("^\\s*<!--\\s*#?endregion\\b.*-->"),
+                },
+            },
         });
 
         const grammar = require('../../data/markdown.tmLanguage.json');
@@ -62,9 +62,9 @@ export class MarkdownContribution implements LanguageGrammarDefinitionContributi
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/shell.ts
+++ b/packages/textmate-grammars/src/browser/shell.ts
@@ -27,7 +27,7 @@ export class ShellContribution implements LanguageGrammarDefinitionContribution 
         monaco.languages.register({
             id: this.id,
             extensions: ['.sh', '.bash'],
-            aliases: ['Shell', 'sh']
+            aliases: ['Shell', 'sh'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
@@ -57,9 +57,9 @@ export class ShellContribution implements LanguageGrammarDefinitionContribution 
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/xml.ts
+++ b/packages/textmate-grammars/src/browser/xml.ts
@@ -83,18 +83,18 @@ export class XmlContribution implements LanguageGrammarDefinitionContribution {
                 ".xliff",
                 ".xpdl",
                 ".xul",
-                ".xoml"
+                ".xoml",
             ],
             firstLine: "(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)",
             aliases: ["XML", "xml"],
-            mimetypes: ['text/xml', 'application/xml', 'application/xaml+xml', 'application/xml-dtd']
+            mimetypes: ['text/xml', 'application/xml', 'application/xaml+xml', 'application/xml-dtd'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
                 blockComment: ['<!--', '-->'],
             },
             brackets: [
-                ['<', '>']
+                ['<', '>'],
             ],
             autoClosingPairs: [
                 { open: '<', close: '>' },
@@ -105,7 +105,7 @@ export class XmlContribution implements LanguageGrammarDefinitionContribution {
                 { open: '<', close: '>' },
                 { open: '\'', close: '\'' },
                 { open: '"', close: '"' },
-            ]
+            ],
         });
 
         const grammar = require('../../data/xml.tmLanguage.json');
@@ -113,9 +113,9 @@ export class XmlContribution implements LanguageGrammarDefinitionContribution {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/xsl.ts
+++ b/packages/textmate-grammars/src/browser/xsl.ts
@@ -28,18 +28,18 @@ export class XslContribution implements LanguageGrammarDefinitionContribution {
             id: this.id,
             extensions: [
                 ".xsl",
-                ".xslt"
+                ".xslt",
             ],
-            aliases: ["XSL", "xsl"]
+            aliases: ["XSL", "xsl"],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
                 lineComment: "",
-                blockComment: ["<!--", "-->"]
+                blockComment: ["<!--", "-->"],
             },
             brackets: [
-                ["<", ">"]
-            ]
+                ["<", ">"],
+            ],
         });
 
         const grammar = require('../../data/xsl.tmLanguage.json');
@@ -47,9 +47,9 @@ export class XslContribution implements LanguageGrammarDefinitionContribution {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/textmate-grammars/src/browser/yaml.ts
+++ b/packages/textmate-grammars/src/browser/yaml.ts
@@ -28,24 +28,24 @@ export class YamlContribution implements LanguageGrammarDefinitionContribution {
             id: this.id,
             aliases: [
                 "YAML",
-                "yaml"
+                "yaml",
             ],
             extensions: [
                 ".yml",
                 ".eyaml",
                 ".eyml",
-                ".yaml"
+                ".yaml",
             ],
-            firstLine: "^#cloud-config"
+            firstLine: "^#cloud-config",
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {
-                lineComment: '#'
+                lineComment: '#',
             },
             brackets: [
                 ['{', '}'],
                 ['[', ']'],
-                ['(', ')']
+                ['(', ')'],
             ],
             autoClosingPairs: [
                 { open: '{', close: '}' },
@@ -62,8 +62,8 @@ export class YamlContribution implements LanguageGrammarDefinitionContribution {
                 { open: '\'', close: '\'' },
             ],
             folding: {
-                offSide: true
-            }
+                offSide: true,
+            },
         });
 
         const grammar = require('../../data/shell.tmLanguage.json');
@@ -71,9 +71,9 @@ export class YamlContribution implements LanguageGrammarDefinitionContribution {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
-                    content: grammar
+                    content: grammar,
                 };
-            }
+            },
         });
         registry.mapLanguageIdToTextmateGrammar(this.id, this.scopeName);
     }

--- a/packages/typescript/src/browser/javascript-language-config.ts
+++ b/packages/typescript/src/browser/javascript-language-config.ts
@@ -31,7 +31,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
                     format: 'json',
                     content: grammar,
                 };
-            }
+            },
         });
 
         registry.registerTextMateGrammarScope('source.js.regexp', {
@@ -40,7 +40,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
                     format: 'plist',
                     content: regExpGrammar,
                 };
-            }
+            },
         });
 
         registry.registerGrammarConfiguration(JAVASCRIPT_LANGUAGE_ID, {
@@ -48,14 +48,14 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
                 "meta.tag.js": getEncodedLanguageId("jsx-tags"),
                 "meta.tag.without-attributes.js": getEncodedLanguageId("jsx-tags"),
                 "meta.tag.attributes.js.jsx": getEncodedLanguageId("javascriptreact"),
-                "meta.embedded.expression.js": getEncodedLanguageId("javascriptreact")
+                "meta.embedded.expression.js": getEncodedLanguageId("javascriptreact"),
             },
             tokenTypes: {
                 "entity.name.type.instance.jsdoc": StandardTokenType.Other,
                 "entity.name.function.tagged-template": StandardTokenType.Other,
                 "meta.import string.quoted": StandardTokenType.Other,
-                "variable.other.jsdoc": StandardTokenType.Other
-            }
+                "variable.other.jsdoc": StandardTokenType.Other,
+            },
         });
 
         registry.mapLanguageIdToTextmateGrammar(JAVASCRIPT_LANGUAGE_ID, 'source.js');
@@ -67,7 +67,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
                     format: 'json',
                     content: jsxGrammar,
                 };
-            }
+            },
         });
 
         registry.mapLanguageIdToTextmateGrammar(JAVASCRIPT_REACT_LANGUAGE_ID, 'source.jsx');
@@ -79,21 +79,21 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
             aliases: [
                 JAVASCRIPT_LANGUAGE_NAME,
                 "javascript",
-                "js"
+                "js",
             ],
             extensions: [
                 ".js",
                 ".es6",
                 ".mjs",
-                ".pac"
+                ".pac",
             ],
             filenames: [
-                "jakefile"
+                "jakefile",
             ],
             firstLine: "^#!.*\\bnode",
             mimetypes: [
-                "text/javascript"
-            ]
+                "text/javascript",
+            ],
         });
 
         monaco.languages.onLanguage(JAVASCRIPT_LANGUAGE_ID, () => {
@@ -104,11 +104,11 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
             id: JAVASCRIPT_REACT_LANGUAGE_ID,
             aliases: [
                 JAVASCRIPT_REACT_LANGUAGE_NAME,
-                "jsx"
+                "jsx",
             ],
             extensions: [
-                ".jsx"
-            ]
+                ".jsx",
+            ],
         });
         monaco.languages.onLanguage(JAVASCRIPT_REACT_LANGUAGE_ID, () => {
             monaco.languages.setLanguageConfiguration(JAVASCRIPT_LANGUAGE_ID, this.configuration);
@@ -118,12 +118,12 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
     protected configuration: monaco.languages.LanguageConfiguration = {
         "comments": {
             "lineComment": "//",
-            "blockComment": ["/*", "*/"]
+            "blockComment": ["/*", "*/"],
         },
         "brackets": [
             ["{", "}"],
             ["[", "]"],
-            ["(", ")"]
+            ["(", ")"],
         ],
         "autoClosingPairs": [
             { "open": "{", "close": "}" },
@@ -132,7 +132,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
             { "open": "'", "close": "'", "notIn": ["string", "comment"] },
             { "open": "\"", "close": "\"", "notIn": ["string"] },
             { "open": "`", "close": "`", "notIn": ["string", "comment"] },
-            { "open": "/**", "close": " */", "notIn": ["string"] }
+            { "open": "/**", "close": " */", "notIn": ["string"] },
         ],
         "surroundingPairs": [
             { "open": "{", "close": "}" },
@@ -140,14 +140,14 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
             { "open": "(", "close": ")" },
             { "open": "'", "close": "'" },
             { "open": "\"", "close": "\"" },
-            { "open": "`", "close": "`" }
+            { "open": "`", "close": "`" },
         ],
         "folding": {
             "markers": {
                 "start": new RegExp("^\\s*//\\s*#?region\\b"),
-                "end": new RegExp("^\\s*//\\s*#?endregion\\b")
-            }
-        }
+                "end": new RegExp("^\\s*//\\s*#?endregion\\b"),
+            },
+        },
     };
 }
 

--- a/packages/typescript/src/browser/typescript-client-contribution.ts
+++ b/packages/typescript/src/browser/typescript-client-contribution.ts
@@ -27,7 +27,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
-        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory
+        @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
     ) {
         super(workspace, languages, languageClientFactory);
     }
@@ -37,7 +37,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
             '**/*.ts',
             '**/*.tsx',
             '**/*.js',
-            '**/*.jsx'
+            '**/*.jsx',
         ];
     }
 
@@ -46,7 +46,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
             TYPESCRIPT_LANGUAGE_ID,
             TYPESCRIPT_REACT_LANGUAGE_ID,
             JAVASCRIPT_LANGUAGE_ID,
-            JAVASCRIPT_REACT_LANGUAGE_ID
+            JAVASCRIPT_REACT_LANGUAGE_ID,
         ];
     }
 
@@ -60,7 +60,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
         // ];
         return [
             "tsconfig.json",
-            "jsconfig.json"
+            "jsconfig.json",
         ];
     }
 

--- a/packages/typescript/src/browser/typescript-language-config.ts
+++ b/packages/typescript/src/browser/typescript-language-config.ts
@@ -30,7 +30,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
                     format: 'json',
                     content: grammar,
                 };
-            }
+            },
         });
 
         registry.mapLanguageIdToTextmateGrammar(TYPESCRIPT_LANGUAGE_ID, 'source.ts');
@@ -42,7 +42,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
                     format: 'json',
                     content: jsxGrammar,
                 };
-            }
+            },
         });
 
         registry.mapLanguageIdToTextmateGrammar(TYPESCRIPT_REACT_LANGUAGE_ID, 'source.tsx');
@@ -54,14 +54,14 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
             aliases: [
                 TYPESCRIPT_LANGUAGE_NAME,
                 "typescript",
-                "ts"
+                "ts",
             ],
             extensions: [
-                ".ts"
+                ".ts",
             ],
             mimetypes: [
-                "text/typescript"
-            ]
+                "text/typescript",
+            ],
         });
 
         monaco.languages.onLanguage(TYPESCRIPT_LANGUAGE_ID, () => {
@@ -72,11 +72,11 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
             id: TYPESCRIPT_REACT_LANGUAGE_ID,
             aliases: [
                 TYPESCRIPT_REACT_LANGUAGE_NAME,
-                "tsx"
+                "tsx",
             ],
             extensions: [
-                ".tsx"
-            ]
+                ".tsx",
+            ],
         });
         monaco.languages.onLanguage(TYPESCRIPT_REACT_LANGUAGE_ID, () => {
             monaco.languages.setLanguageConfiguration(TYPESCRIPT_LANGUAGE_ID, this.configuration);
@@ -86,12 +86,12 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
     protected configuration: monaco.languages.LanguageConfiguration = {
         "comments": {
             "lineComment": "//",
-            "blockComment": ["/*", "*/"]
+            "blockComment": ["/*", "*/"],
         },
         "brackets": [
             ["{", "}"],
             ["[", "]"],
-            ["(", ")"]
+            ["(", ")"],
         ],
         "autoClosingPairs": [
             { "open": "{", "close": "}" },
@@ -100,7 +100,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
             { "open": "'", "close": "'", "notIn": ["string", "comment"] },
             { "open": "\"", "close": "\"", "notIn": ["string"] },
             { "open": "`", "close": "`", "notIn": ["string", "comment"] },
-            { "open": "/**", "close": " */", "notIn": ["string"] }
+            { "open": "/**", "close": " */", "notIn": ["string"] },
         ],
         "surroundingPairs": [
             { "open": "{", "close": "}" },
@@ -108,13 +108,13 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
             { "open": "(", "close": ")" },
             { "open": "'", "close": "'" },
             { "open": "\"", "close": "\"" },
-            { "open": "`", "close": "`" }
+            { "open": "`", "close": "`" },
         ],
         "folding": {
             "markers": {
                 "start": new RegExp("^\\s*//\\s*#?region\\b"),
-                "end": new RegExp("^\\s*//\\s*#?endregion\\b")
-            }
-        }
+                "end": new RegExp("^\\s*//\\s*#?endregion\\b"),
+            },
+        },
     };
 }

--- a/packages/typescript/src/node/typescript-contribution.ts
+++ b/packages/typescript/src/node/typescript-contribution.ts
@@ -28,7 +28,7 @@ export class TypeScriptContribution extends BaseLanguageServerContribution {
         const command = "node";
         const args: string[] = [
             __dirname + "/startserver.js",
-            '--stdio'
+            '--stdio',
         ];
         const serverConnection = this.createProcessStreamConnection(command, args);
         this.forward(clientConnection, serverConnection);

--- a/packages/userstorage/src/browser/user-storage-resource.ts
+++ b/packages/userstorage/src/browser/user-storage-resource.ts
@@ -26,7 +26,7 @@ export class UserStorageResource implements Resource {
     protected readonly toDispose = new DisposableCollection();
     constructor(
         public uri: URI,
-        protected readonly service: UserStorageService
+        protected readonly service: UserStorageService,
     ) {
         this.toDispose.push(this.service.onUserStorageChanged(e => {
             for (const changedUri of e.uris) {
@@ -60,7 +60,7 @@ export class UserStorageResource implements Resource {
 export class UserStorageResolver implements ResourceResolver {
 
     constructor(
-        @inject(UserStorageService) protected readonly service: UserStorageService
+        @inject(UserStorageService) protected readonly service: UserStorageService,
 
     ) { }
 

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
@@ -57,8 +57,8 @@ before(async () => {
             'files.watcherExclude': {
                 "**/.git/objects/**": true,
                 "**/.git/subtree-cache/**": true,
-                "**/node_modules/**": true
-            }
+                "**/node_modules/**": true,
+            },
         });
         return createFileSystemPreferences(preferences);
     }).inSingletonScope();
@@ -67,7 +67,7 @@ before(async () => {
     testContainer.bind(FileSystemWatcherServer).to(MockFilesystemWatcherServer).inSingletonScope();
     testContainer.bind(FileSystemWatcher).toSelf().inSingletonScope().onActivation((_, watcher) => {
         sinon.stub(watcher, 'onFilesChanged').get(() =>
-            mockOnFileChangedEmitter.event
+            mockOnFileChangedEmitter.event,
         );
         return watcher;
     });
@@ -82,13 +82,13 @@ before(async () => {
             {
                 uri: 'file://' + homeDir,
                 lastModification: 0,
-                isDirectory: true
+                isDirectory: true,
             }));
 
         sinon.stub(fs, 'resolveContent').callsFake((uri): Promise<{ stat: FileStat, content: string }> => {
             const content = files[uri];
             return Promise.resolve(
-                { stat: { uri: uri, lastModification: 0, isDirectory: false }, content: content }
+                { stat: { uri: uri, lastModification: 0, isDirectory: false }, content: content },
             );
         });
 
@@ -98,7 +98,7 @@ before(async () => {
         });
 
         sinon.stub(fs, 'getFileStat').callsFake(uri =>
-            Promise.resolve({ uri, lastModification: 0, isDirectory: false })
+            Promise.resolve({ uri, lastModification: 0, isDirectory: false }),
         );
 
         return fs;
@@ -160,8 +160,8 @@ describe('User Storage Service (Filesystem implementation)', () => {
         mockOnFileChangedEmitter.fire([
             {
                 type: FileChangeType.UPDATED,
-                uri: userStorageFolder.resolve(testFile)
-            }
+                uri: userStorageFolder.resolve(testFile),
+            },
         ]);
 
     }).timeout(2000);
@@ -212,8 +212,8 @@ describe('User Storage Resource (Filesystem implementation)', () => {
         mockOnFileChangedEmitter.fire([
             {
                 type: FileChangeType.UPDATED,
-                uri: userStorageFolder.resolve(testFile)
-            }
+                uri: userStorageFolder.resolve(testFile),
+            },
         ]);
     }).timeout(2000);
 

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -34,14 +34,14 @@ export class UserStorageServiceFilesystemImpl implements UserStorageService {
     constructor(
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
         @inject(FileSystemWatcher) protected readonly watcher: FileSystemWatcher,
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
 
     ) {
         this.userStorageFolder = this.fileSystem.getCurrentUserHome().then(home => {
             if (home) {
                 const userStorageFolderUri = new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);
                 watcher.watchFileChanges(userStorageFolderUri).then(disposable =>
-                    this.toDispose.push(disposable)
+                    this.toDispose.push(disposable),
                 );
                 this.toDispose.push(this.watcher.onFilesChanged(changes => this.onDidFilesChanged(changes)));
                 return new URI(home.uri).resolve(THEIA_USER_STORAGE_FOLDER);

--- a/packages/variable-resolver/src/browser/variable-quick-open-service.ts
+++ b/packages/variable-resolver/src/browser/variable-quick-open-service.ts
@@ -25,19 +25,19 @@ export class VariableQuickOpenService implements QuickOpenModel {
 
     constructor(
         @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
-        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService
+        @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService,
     ) { }
 
     open(): void {
         this.items = this.variableRegistry.getVariables().map(
-            v => new VariableQuickOpenItem(v.name, v.description)
+            v => new VariableQuickOpenItem(v.name, v.description),
         );
 
         this.quickOpenService.open(this, {
             placeholder: 'Registered variables',
             fuzzyMatchLabel: true,
             fuzzyMatchDescription: true,
-            fuzzySort: true
+            fuzzySort: true,
         });
     }
 
@@ -50,7 +50,7 @@ export class VariableQuickOpenItem extends QuickOpenItem {
 
     constructor(
         protected readonly name: string,
-        protected readonly description?: string
+        protected readonly description?: string,
     ) {
         super();
     }

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
@@ -85,12 +85,12 @@ export class TestVariableContribution implements VariableContribution {
         variables.registerVariable({
             name: 'file',
             description: 'Resolves to file name opened in the current editor',
-            resolve: () => Promise.resolve('package.json')
+            resolve: () => Promise.resolve('package.json'),
         });
         variables.registerVariable({
             name: 'lineNumber',
             description: 'Resolves to current line number',
-            resolve: () => Promise.resolve('5')
+            resolve: () => Promise.resolve('5'),
         });
     }
 }

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.ts
@@ -22,7 +22,7 @@ import { VariableQuickOpenService } from './variable-quick-open-service';
 
 export const LIST_VARIABLES: Command = {
     id: 'variable.list',
-    label: 'Variable: List All'
+    label: 'Variable: List All',
 };
 
 @injectable()
@@ -32,19 +32,19 @@ export class VariableResolverFrontendContribution implements FrontendApplication
         @inject(ContributionProvider) @named(VariableContribution)
         protected readonly contributionProvider: ContributionProvider<VariableContribution>,
         @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
-        @inject(VariableQuickOpenService) protected readonly variableQuickOpenService: VariableQuickOpenService
+        @inject(VariableQuickOpenService) protected readonly variableQuickOpenService: VariableQuickOpenService,
     ) { }
 
     onStart(): void {
         this.contributionProvider.getContributions().forEach(contrib =>
-            contrib.registerVariables(this.variableRegistry)
+            contrib.registerVariables(this.variableRegistry),
         );
     }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(LIST_VARIABLES, {
             isEnabled: () => true,
-            execute: () => this.variableQuickOpenService.open()
+            execute: () => this.variableQuickOpenService.open(),
         });
     }
 }

--- a/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.spec.ts
@@ -53,13 +53,13 @@ describe('variable-resolver-service', () => {
             {
                 name: 'file',
                 description: 'current file',
-                resolve: () => Promise.resolve('package.json')
+                resolve: () => Promise.resolve('package.json'),
             },
             {
                 name: 'lineNumber',
                 description: 'current line number',
-                resolve: () => Promise.resolve('6')
-            }
+                resolve: () => Promise.resolve('6'),
+            },
         ];
         variables.forEach(v => variableRegistry.registerVariable(v));
     });

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -26,7 +26,7 @@ export class VariableResolverService {
     protected static VAR_REGEXP = /\$\{(.*?)\}/g;
 
     constructor(
-        @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry
+        @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
     ) { }
 
     /**

--- a/packages/variable-resolver/src/browser/variable.spec.ts
+++ b/packages/variable-resolver/src/browser/variable.spec.ts
@@ -59,13 +59,13 @@ describe('variable api', () => {
             {
                 name: 'workspaceRoot',
                 description: 'workspace root URI',
-                resolve: () => Promise.resolve('')
+                resolve: () => Promise.resolve(''),
             },
             {
                 name: 'workspaceRoot',
                 description: 'workspace root URI 2',
-                resolve: () => Promise.resolve('')
-            }
+                resolve: () => Promise.resolve(''),
+            },
         ];
         variables.forEach(v => variableRegistry.registerVariable(v));
 
@@ -98,7 +98,7 @@ describe('variable api', () => {
 
 const TEST_VARIABLE: Variable = {
     name: 'workspaceRoot',
-    resolve: () => Promise.resolve('')
+    resolve: () => Promise.resolve(''),
 };
 
 function registerTestVariable(): Disposable {

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -58,7 +58,7 @@ export class VariableRegistry implements Disposable {
     protected readonly toDispose = new DisposableCollection();
 
     constructor(
-        @inject(ILogger) protected readonly logger: ILogger
+        @inject(ILogger) protected readonly logger: ILogger,
     ) { }
 
     dispose(): void {
@@ -76,7 +76,7 @@ export class VariableRegistry implements Disposable {
         }
         this.variables.set(variable.name, variable);
         const disposable = {
-            dispose: () => this.variables.delete(variable.name)
+            dispose: () => this.variables.delete(variable.name),
         };
         this.toDispose.push(disposable);
         return disposable;

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -33,36 +33,36 @@ const validFilename: (arg: string) => boolean = require('valid-filename');
 export namespace WorkspaceCommands {
     export const OPEN: Command = {
         id: 'workspace:open',
-        label: 'Open...'
+        label: 'Open...',
     };
     export const CLOSE: Command = {
         id: 'workspace:close',
-        label: 'Close Workspace'
+        label: 'Close Workspace',
     };
     export const NEW_FILE: Command = {
         id: 'file.newFile',
-        label: 'New File'
+        label: 'New File',
     };
     export const NEW_FOLDER: Command = {
         id: 'file.newFolder',
-        label: 'New Folder'
+        label: 'New Folder',
     };
     export const FILE_OPEN_WITH = (opener: OpenHandler): Command => ({
         id: `file.openWith.${opener.id}`,
         label: opener.label,
-        iconClass: opener.iconClass
+        iconClass: opener.iconClass,
     });
     export const FILE_RENAME: Command = {
         id: 'file.rename',
-        label: 'Rename'
+        label: 'Rename',
     };
     export const FILE_DELETE: Command = {
         id: 'file.delete',
-        label: 'Delete'
+        label: 'Delete',
     };
     export const FILE_COMPARE: Command = {
         id: 'file.compare',
-        label: 'Compare with Each Other'
+        label: 'Compare with Each Other',
     };
 }
 
@@ -71,10 +71,10 @@ export class FileMenuContribution implements MenuContribution {
 
     registerMenus(registry: MenuModelRegistry) {
         registry.registerMenuAction(CommonMenus.FILE_NEW, {
-            commandId: WorkspaceCommands.NEW_FILE.id
+            commandId: WorkspaceCommands.NEW_FILE.id,
         });
         registry.registerMenuAction(CommonMenus.FILE_NEW, {
-            commandId: WorkspaceCommands.NEW_FOLDER.id
+            commandId: WorkspaceCommands.NEW_FOLDER.id,
         });
     }
 
@@ -89,7 +89,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
         @inject(SelectionService) protected readonly selectionService: SelectionService,
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(FrontendApplication) protected readonly app: FrontendApplication,
-        @inject(MessageService) protected readonly messageService: MessageService
+        @inject(MessageService) protected readonly messageService: MessageService,
 
     ) { }
 
@@ -100,7 +100,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 registry.registerCommand(openWithCommand, this.newUriAwareCommandHandler({
                     execute: uri => opener.open(uri),
                     isEnabled: uri => opener.canHandle(uri) > 0,
-                    isVisible: uri => opener.canHandle(uri) > 0
+                    isVisible: uri => opener.canHandle(uri) > 0,
                 }));
             }
         });
@@ -112,7 +112,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const dialog = new SingleTextInputDialog({
                         title: `New File`,
                         initialValue: vacantChildUri.path.base,
-                        validate: name => this.validateFileName(name, parent)
+                        validate: name => this.validateFileName(name, parent),
                     });
                     dialog.open().then(name => {
                         const fileUri = parentUri.resolve(name);
@@ -121,7 +121,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         });
                     });
                 }
-            })
+            }),
         }));
         registry.registerCommand(WorkspaceCommands.NEW_FOLDER, this.newWorkspaceRootUriAwareCommandHandler({
             execute: uri => this.getDirectory(uri).then(parent => {
@@ -131,13 +131,13 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const dialog = new SingleTextInputDialog({
                         title: `New Folder`,
                         initialValue: vacantChildUri.path.base,
-                        validate: name => this.validateFileName(name, parent)
+                        validate: name => this.validateFileName(name, parent),
                     });
                     dialog.open().then(name =>
-                        this.fileSystem.createFolder(parentUri.resolve(name).toString())
+                        this.fileSystem.createFolder(parentUri.resolve(name).toString()),
                     );
                 }
-            })
+            }),
         }));
         registry.registerCommand(WorkspaceCommands.FILE_RENAME, this.newUriAwareCommandHandler({
             execute: uri => this.getParent(uri).then(parent => {
@@ -145,13 +145,13 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     const dialog = new SingleTextInputDialog({
                         title: 'Rename File',
                         initialValue: uri.path.base,
-                        validate: name => this.validateFileName(name, parent)
+                        validate: name => this.validateFileName(name, parent),
                     });
                     dialog.open().then(name =>
-                        this.fileSystem.move(uri.toString(), uri.parent.resolve(name).toString())
+                        this.fileSystem.move(uri.toString(), uri.parent.resolve(name).toString()),
                     );
                 }
-            })
+            }),
         }));
         let rootUri: URI | undefined;
         this.workspaceService.root.then(root => {
@@ -190,7 +190,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                     uris.sort((left, right) => right.toString().length - left.toString().length);
                     await Promise.all(uris.map(uri => uri.toString()).map(uri => this.fileSystem.delete(uri)));
                 }
-            }
+            },
         }));
         registry.registerCommand(WorkspaceCommands.FILE_COMPARE, this.newMultiUriAwareCommandHandler({
             isVisible: uris => uris.length === 2,
@@ -198,7 +198,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 const [left, right] = uris;
                 const [leftExists, rightExists] = await Promise.all([
                     this.fileSystem.exists(left.toString()),
-                    this.fileSystem.exists(right.toString())
+                    this.fileSystem.exists(right.toString()),
                 ]);
                 if (leftExists && rightExists) {
                     const [leftStat, rightStat] = await Promise.all([
@@ -226,7 +226,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         }
                     }
                 }
-            }
+            },
         }));
     }
 
@@ -294,7 +294,7 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
     constructor(
         protected readonly workspaceService: WorkspaceService,
         protected readonly selectionService: SelectionService,
-        protected readonly handler: UriCommandHandler<URI>
+        protected readonly handler: UriCommandHandler<URI>,
     ) {
         super(selectionService, handler);
         workspaceService.root.then(root => {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -32,26 +32,26 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
         @inject(OpenerService) protected readonly openerService: OpenerService,
         @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
         @inject(StorageService) protected readonly workspaceStorage: StorageService,
-        @inject(LabelProvider) protected readonly labelProvider: LabelProvider
+        @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(WorkspaceCommands.OPEN, {
             isEnabled: () => true,
-            execute: () => this.showFileDialog()
+            execute: () => this.showFileDialog(),
         });
         commands.registerCommand(WorkspaceCommands.CLOSE, {
             isEnabled: () => this.workspaceService.opened,
-            execute: () => this.closeWorkspace()
+            execute: () => this.closeWorkspace(),
         });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: WorkspaceCommands.OPEN.id
+            commandId: WorkspaceCommands.OPEN.id,
         });
         menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
-            commandId: WorkspaceCommands.CLOSE.id
+            commandId: WorkspaceCommands.CLOSE.id,
         });
     }
 
@@ -88,7 +88,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
     protected async closeWorkspace(): Promise<void> {
         const dialog = new ConfirmDialog({
             title: 'Close Workspace',
-            msg: 'Do you really want to close the workspace?'
+            msg: 'Do you really want to close the workspace?',
         });
         if (await dialog.open()) {
             this.workspaceService.close();

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -43,13 +43,13 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(WorkspaceFrontendContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, MenuContribution]) {
         bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(WorkspaceFrontendContribution)
+            ctx.container.get(WorkspaceFrontendContribution),
         ).inSingletonScope();
     }
 
     bind(FileDialogFactory).toFactory(ctx =>
         (props: FileDialogProps) =>
-            createFileDialog(ctx.container, props)
+            createFileDialog(ctx.container, props),
     );
     bind(CommandContribution).to(WorkspaceCommandContribution).inSingletonScope();
     bind(MenuContribution).to(FileMenuContribution).inSingletonScope();

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -20,7 +20,7 @@ import {
     PreferenceProxy,
     PreferenceService,
     PreferenceSchema,
-    PreferenceContribution
+    PreferenceContribution,
 } from '@theia/core/lib/browser/preferences';
 
 export const workspacePreferenceSchema: PreferenceSchema = {
@@ -29,11 +29,11 @@ export const workspacePreferenceSchema: PreferenceSchema = {
         "workspace.preserveWindow": {
             "description": "Enable opening workspaces in current window",
             "additionalProperties": {
-                "type": "boolean"
+                "type": "boolean",
             },
-            "default": false
-        }
-    }
+            "default": false,
+        },
+    },
 };
 
 export interface WorkspaceConfiguration {

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -104,7 +104,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
             // Option passed as parameter has the highest priority (for api developers), then the preference, then the default.
             const { preserveWindow } = {
                 preserveWindow: this.preferences['workspace.preserveWindow'] || !(await this.root),
-                ...options
+                ...options,
             };
             await this.server.setRoot(rootUri);
             if (preserveWindow) {

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -35,7 +35,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: async () => {
                 const uri = await this.getWorkspaceRootUri();
                 return uri ? uri.path.toString() : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'workspaceFolderBasename',
@@ -43,7 +43,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: async () => {
                 const uri = await this.getWorkspaceRootUri();
                 return uri ? uri.displayName : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'file',
@@ -51,7 +51,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const uri = this.getCurrentURI();
                 return uri ? uri.path.toString() : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'fileBasename',
@@ -59,7 +59,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const uri = this.getCurrentURI();
                 return uri ? uri.path.base : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'fileBasenameNoExtension',
@@ -67,7 +67,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const uri = this.getCurrentURI();
                 return uri ? uri.path.name : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'fileDirname',
@@ -75,7 +75,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const uri = this.getCurrentURI();
                 return uri ? uri.path.dir.toString() : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'fileExtname',
@@ -83,7 +83,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const uri = this.getCurrentURI();
                 return uri ? uri.path.ext : undefined;
-            }
+            },
         });
         variables.registerVariable({
             name: 'relativeFile',
@@ -91,7 +91,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
             resolve: () => {
                 const currentURI = this.getCurrentURI();
                 return currentURI ? this.getWorkspaceRelativePath(currentURI) : undefined;
-            }
+            },
         });
     }
 

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -89,7 +89,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         this.root = new Deferred();
         this.root.resolve(uri);
         this.writeToUserHome({
-            recentRoots: [uri]
+            recentRoots: [uri],
         });
     }
 

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -25,12 +25,12 @@ export default new ContainerModule(bind => {
     bind(CliContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceCliContribution));
     bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
     bind(WorkspaceServer).toDynamicValue(ctx =>
-        ctx.container.get(DefaultWorkspaceServer)
+        ctx.container.get(DefaultWorkspaceServer),
     ).inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(workspacePath, () =>
-            ctx.container.get(WorkspaceServer)
-        )
+            ctx.container.get(WorkspaceServer),
+        ),
     ).inSingletonScope();
 });


### PR DESCRIPTION
I like when people use a trailing comma in comma-separated definitions.
Turns out there is a tslint rule for it!  And it also has an autofixer,
so I ran tslint --fix to generate this patch.  I sampled a few files and
the results seems good.

For example, I would prefer this:

    const foo = [
      A,
      B,
      C,
    ];

rather than:

    const foo = [
      A,
      B,
      C
    ];

The main reason is that it simplifies diffs where you add a new item.
You don't need to change the line containing "C".

With the "multiline" setting, things like this are not affected:

    const foo = [ A, B, C ];

If you want to add "D", you'll need to change the line anyway, so the
comma would not help here.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>