### PR TITLE
cpp: Add some "experimental" commands for development

### DIFF
--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -36,12 +36,17 @@ export const cppPreferencesSchema: PreferenceSchema = {
                 },
                 required: ["name", "directory"],
             }
+        },
+        "cpp.experimentalCommands": {
+            description: "Enable experimental commands mostly intended for Clangd developers.",
+            type: "boolean"
         }
     }
 };
 
 export class CppConfiguration {
     "cpp.buildConfigurations": CppBuildConfiguration[];
+    "cpp.experimentalCommands": boolean;
 }
 
 export const CppPreferences = Symbol("CppPreferences");


### PR DESCRIPTION
The commands being added help troubleshoot mainly the indexing feature of
Clangd. A preference enables the command so that they are not shown to the
user by default.

Signed-off-by: Marc-Andre Laperle <marc-andre.laperle@ericsson.com>