### PR TITLE
Display logs in the main Theia instance from hosted one

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -16,6 +16,7 @@
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
+import { LogPart } from './types';
 
 export const hostedServicePath = '/services/hostedPlugin';
 
@@ -277,6 +278,8 @@ export function buildFrontendModuleName(plugin: PluginPackage | PluginModel): st
 export const HostedPluginClient = Symbol('HostedPluginClient');
 export interface HostedPluginClient {
     postMessage(message: string): Promise<void>;
+
+    log(logPart: LogPart): void;
 }
 
 export const HostedPluginServer = Symbol('HostedPluginServer');

--- a/packages/plugin-ext/src/common/types.ts
+++ b/packages/plugin-ext/src/common/types.ts
@@ -24,3 +24,13 @@ export function isObject(obj: any): boolean {
         && !(obj instanceof RegExp)
         && !(obj instanceof Date);
 }
+
+export enum LogType {
+    Info,
+    Error
+}
+
+export interface LogPart {
+    data: string;
+    type: LogType;
+}

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-log-viewer.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-log-viewer.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from "inversify";
+import { OutputChannel, OutputChannelManager } from "@theia/output/lib/common/output-channel";
+import { OutputContribution } from "@theia/output/lib/browser/output-contribution";
+import { HostedPluginWatcher } from "./hosted-plugin-watcher";
+import { LogPart } from "../../common/types";
+
+@injectable()
+export class HostedPluginLogViewer {
+    public static OUTPUT_CHANNEL_NAME = 'hosted-instance-log';
+
+    @inject(HostedPluginWatcher)
+    protected readonly watcher: HostedPluginWatcher;
+    @inject(OutputChannelManager)
+    protected readonly outputChannelManager: OutputChannelManager;
+    @inject(OutputContribution)
+    protected readonly outputContribution: OutputContribution;
+
+    protected channel: OutputChannel;
+
+    showLogConsole(): void {
+        this.outputContribution.openView({ reveal: true }).then(view => {
+            view.activate();
+        });
+    }
+
+    @postConstruct()
+    protected init() {
+        this.channel = this.outputChannelManager.getChannel(HostedPluginLogViewer.OUTPUT_CHANNEL_NAME);
+        this.watcher.onLogMessageEvent(event => this.logMessageEventHandler(event));
+    }
+
+    protected logMessageEventHandler(event: LogPart): void {
+        this.channel.appendLine(event.data);
+    }
+
+}

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-watcher.ts
@@ -13,18 +13,27 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
 import { injectable } from "inversify";
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { HostedPluginClient } from "../../common/plugin-protocol";
+import { LogPart } from "../../common/types";
 
 @injectable()
 export class HostedPluginWatcher {
     private onPostMessage = new Emitter<string[]>();
+    private onLogMessage = new Emitter<LogPart>();
+
     getHostedPluginClient(): HostedPluginClient {
         const messageEmitter = this.onPostMessage;
+        const logEmitter = this.onLogMessage;
         return {
             postMessage(message: string): Promise<void> {
                 messageEmitter.fire(JSON.parse(message));
+                return Promise.resolve();
+            },
+            log(logPart: LogPart): Promise<void> {
+                logEmitter.fire(logPart);
                 return Promise.resolve();
             }
         };
@@ -32,5 +41,9 @@ export class HostedPluginWatcher {
 
     get onPostMessageEvent(): Event<string[]> {
         return this.onPostMessage.event;
+    }
+
+    get onLogMessageEvent(): Event<LogPart> {
+        return this.onLogMessage.event;
     }
 }

--- a/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
@@ -21,7 +21,8 @@ import { PluginScanner } from '../../common/plugin-protocol';
 import { TheiaPluginScannerElectron } from './scanner-theia-electron';
 
 export function bindElectronBackend(bind: interfaces.Bind): void {
+    bindCommonHostedBackend(bind);
+
     bind(HostedPluginManager).to(ElectronNodeHostedPluginRunner);
     bind(PluginScanner).to(TheiaPluginScannerElectron).inSingletonScope();
-    bindCommonHostedBackend(bind);
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -22,6 +22,7 @@ import { createIpcEnv } from "@theia/core/lib/node/messaging/ipc-protocol";
 import { HostedPluginClient, PluginModel } from '../../common/plugin-protocol';
 import { RPCProtocolImpl } from '../../api/rpc-protocol';
 import { MAIN_RPC_CONTEXT } from '../../api/plugin-api';
+import { LogPart } from '../../common/types';
 
 export interface IPCConnectionOptions {
     readonly serverName: string;
@@ -97,6 +98,10 @@ export class HostedPluginSupport {
             }
         });
 
+    }
+
+    public sendLog(logPart: LogPart): void {
+        this.client.log(logPart);
     }
 
     private fork(options: IPCConnectionOptions): cp.ChildProcess {

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -48,8 +48,9 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
 }
 
 export function bindHostedBackend(bind: interfaces.Bind): void {
+    bindCommonHostedBackend(bind);
+
     bind(HostedPluginManager).to(NodeHostedPluginRunner).inSingletonScope();
     bind(PluginScanner).to(TheiaPluginScanner).inSingletonScope();
     bindContributionProvider(bind, Symbol.for(HostedPluginUriPostProcessorSymbolName));
-    bindCommonHostedBackend(bind);
 }

--- a/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
@@ -24,6 +24,7 @@ import { Menu } from '@phosphor/widgets';
 import { setTimeout } from 'timers';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { ConnectionStatusService, ConnectionStatus } from '@theia/core/lib/browser/connection-status-service';
+import { HostedPluginLogViewer } from '../../hosted/browser/hosted-plugin-log-viewer';
 
 /**
  * Adds a status bar element displaying the state of secondary Theia instance with hosted plugin and
@@ -50,6 +51,9 @@ export class HostedPluginController implements FrontendApplicationContribution {
 
     @inject(ConnectionStatusService)
     protected readonly connectionStatusService: ConnectionStatusService;
+
+    @inject(HostedPluginLogViewer)
+    protected readonly hostedPluginLogViewer: HostedPluginLogViewer;
 
     private pluginState: HostedPluginState = HostedPluginState.Stopped;
 
@@ -107,6 +111,8 @@ export class HostedPluginController implements FrontendApplicationContribution {
      */
     protected async onHostedPluginStarting(): Promise<void> {
         this.pluginState = HostedPluginState.Starting;
+
+        this.hostedPluginLogViewer.showLogConsole();
 
         this.entry = {
             text: `$(cog~spin) Hosted Plugin: Starting`,

--- a/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/output-channel-registry-main.ts
@@ -13,11 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import {interfaces} from 'inversify';
-import {OutputWidget} from '@theia/output/lib/browser/output-widget';
-import {OutputContribution} from '@theia/output/lib/browser/output-contribution';
-import {OutputChannel, OutputChannelManager} from '@theia/output/lib/common/output-channel';
-import {OutputChannelRegistryMain} from '../../api/plugin-api';
+
+import { interfaces } from 'inversify';
+import { OutputWidget } from '@theia/output/lib/browser/output-widget';
+import { OutputContribution } from '@theia/output/lib/browser/output-contribution';
+import { OutputChannel, OutputChannelManager } from '@theia/output/lib/common/output-channel';
+import { OutputChannelRegistryMain } from '../../api/plugin-api';
 
 export class OutputChannelRegistryMainImpl implements OutputChannelRegistryMain {
     private outputChannelManager: OutputChannelManager;
@@ -62,7 +63,7 @@ export class OutputChannelRegistryMainImpl implements OutputChannelRegistryMain 
         const outputChannel = this.getChannel(channelName);
         if (outputChannel) {
             outputChannel.setVisibility(true);
-            return this.outputContribution.openView({activate: !preserveFocus}).then((outputWidget: OutputWidget) => {
+            return this.outputContribution.openView({ activate: !preserveFocus }).then((outputWidget: OutputWidget) => {
                 this.commonOutputWidget = outputWidget;
                 return Promise.resolve();
             });

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -23,6 +23,7 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { PluginWorker } from './plugin-worker';
 import { HostedPluginSupport } from "../../hosted/browser/hosted-plugin";
 import { HostedPluginWatcher } from "../../hosted/browser/hosted-plugin-watcher";
+import { HostedPluginLogViewer } from "../../hosted/browser/hosted-plugin-log-viewer";
 import { HostedPluginManagerClient } from "./plugin-manager-client";
 import { PluginApiFrontendContribution } from "./plugin-frontend-contribution";
 import { setUpPluginApi } from "./main-context";
@@ -46,6 +47,7 @@ export default new ContainerModule(bind => {
     bind(PluginWorker).toSelf().inSingletonScope();
     bind(HostedPluginSupport).toSelf().inSingletonScope();
     bind(HostedPluginWatcher).toSelf().inSingletonScope();
+    bind(HostedPluginLogViewer).toSelf().inSingletonScope();
     bind(HostedPluginManagerClient).toSelf().inSingletonScope();
 
     bind(FrontendApplicationContribution).to(HostedPluginInformer).inSingletonScope();


### PR DESCRIPTION
This PR adds log channel which displays hosted plugin instance log and server side log of the hosted plugin itself. Client side logs could be seen in the appropriate browser dev console.
The panel with logs becomes visible automatically each time when a user starts hosted instance.
![screenshot from 2018-07-24 17-34-24](https://user-images.githubusercontent.com/15607393/43145343-d86dd850-8f67-11e8-8ce1-61e9df642506.png)
Resolves https://github.com/theia-ide/theia/issues/2338
