### PR TITLE
Small usability improvements to C/C++ build config list

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.ts
@@ -135,8 +135,8 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
         // Add one item per build config.
         this.cppBuildConfigurations.getConfigs().forEach(config => {
             items.push(new QuickOpenItem({
-                label: config.name,
-                description: config === active ? 'active' : '',
+                label: config.name + (config === active ? ' ✔' : ''),
+                detail: config.directory,
                 run: (mode: QuickOpenMode): boolean => {
                     if (mode !== QuickOpenMode.OPEN) {
                         return false;
@@ -154,6 +154,8 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
     open() {
         this.quickOpenService.open(this, {
             placeholder: 'Choose a build configuration...',
+            fuzzyMatchLabel: true,
+            fuzzyMatchDescription: true,
         });
     }
 }


### PR DESCRIPTION
- Display a checkmark next to the active build config (just because it
  looks better than "active").
- Show the directory under the config name.
- Allow fuzzy search in the label and description.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>