### PR TITLE
GH-2272 Automatic clean-up of undefined folder in the web local storage

### DIFF
--- a/packages/core/src/browser/test/mock-storage-service.ts
+++ b/packages/core/src/browser/test/mock-storage-service.ts
@@ -43,4 +43,10 @@ export class MockStorageService implements StorageService {
         }
         return Promise.resolve(defaultValue);
     }
+
+    verifyLocalStorage(): Promise<string[] | undefined> {
+        return Promise.resolve([]);
+    }
+
+    cleanLocalStorage(path: string): void { }
 }


### PR DESCRIPTION
Fixes #2272 
- Clean up the web local storage when switching workspace. We check if all the data stored in the local storage have a valid workspace and remove data for the undefined one.

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>