### PR TITLE
Add 'None' item to reset any active cpp build configuration

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.ts
@@ -133,6 +133,21 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
         const active: CppBuildConfiguration | undefined = this.cppBuildConfigurations.getActiveConfig();
         const configurations = Array.from(this.cppBuildConfigurations.getConfigs()).sort();
 
+        // Item to de-select any active build config
+        if (active) {
+            items.push(new QuickOpenItem({
+                label: 'None',
+                detail: 'Reset active build configuration',
+                run: (mode: QuickOpenMode): boolean => {
+                    if (mode !== QuickOpenMode.OPEN) {
+                        return false;
+                    }
+                    this.cppBuildConfigurations.setActiveConfig(undefined);
+                    return true;
+                },
+            }));
+        }
+
         // Add one item per build config.
         configurations.forEach(config => {
             items.push(new QuickOpenItem({

--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -65,7 +65,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     async onActiveBuildConfigChanged(config: CppBuildConfiguration | undefined) {
         const interfaceParams: DidChangeConfigurationParams = {
             settings: {
-                compilationDatabasePath: config ? config.directory : undefined,
+                compilationDatabasePath: config ? config.directory : "",
             },
         };
 


### PR DESCRIPTION
Added a **reset** ``QuickOpenItem`` to allow users the ability to reset any active cpp build configuration.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>