### PR TITLE
Add a feedback menu item to inform users when no cpp build configs exist

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.ts
@@ -133,6 +133,15 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
         const active: CppBuildConfiguration | undefined = this.cppBuildConfigurations.getActiveConfig();
         const configurations = Array.from(this.cppBuildConfigurations.getConfigs()).sort();
 
+        // Add feedback item when no configurations are present
+        if (!configurations.length) {
+            items.push(new QuickOpenItem({
+                label: 'No build configurations available',
+                run: () => false,
+            }));
+            return acceptor(items);
+        }
+
         // Item to de-select any active build config
         if (active) {
             items.push(new QuickOpenItem({


### PR DESCRIPTION
Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>