### PR TITLE
[core] Allow silencing of jsonrpc errors

### DIFF
--- a/packages/core/src/common/abstract-error.ts
+++ b/packages/core/src/common/abstract-error.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,24 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './types';
-export * from './disposable';
-export * from './reference';
-export * from './event';
-export * from './cancellation';
-export * from './command';
-export * from './menu';
-export * from './selection-service';
-export * from './objects';
-export * from './os';
-export * from './resource';
-export * from './contribution-provider';
-export * from './path';
-export * from './logger';
-export * from './messaging';
-export * from './message-service';
-export * from './message-service-protocol';
-export * from './selection';
-export * from './strings';
-export * from './abstract-error';
-export * from './silenceable';
+/**
+ * Subclass this class to create new error types
+ */
+export abstract class AbstractError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}

--- a/packages/core/src/common/messaging/proxy-factory.ts
+++ b/packages/core/src/common/messaging/proxy-factory.ts
@@ -159,9 +159,11 @@ export class JsonRpcProxyFactory<T extends object> implements ProxyHandler<T> {
             if (e instanceof ResponseError) {
                 throw e;
             }
-            const reason = e.message || '';
-            const stack = e.stack || '';
-            console.error(`Request ${method} failed with error: ${reason}`, stack);
+            if (!e.silent) {
+                const reason = e.message || '';
+                const stack = e.stack || '';
+                console.error(`Request ${method} failed with error: ${reason}`, stack);
+            }
             throw e;
         }
     }

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -22,12 +22,14 @@ import { Event } from "./event";
 import { Disposable } from "./disposable";
 import { MaybePromise } from "./types";
 import { CancellationToken } from "./cancellation";
+import { Silenceable } from './silenceable';
 
+export type ResourceContentOptions = { encoding?: string } & Silenceable;
 export interface Resource extends Disposable {
     readonly uri: URI;
-    readContents(options?: { encoding?: string }): Promise<string>;
-    saveContents?(content: string, options?: { encoding?: string }): Promise<void>;
-    saveContentChanges?(changes: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<void>;
+    readContents(options?: ResourceContentOptions): Promise<string>;
+    saveContents?(content: string, options?: ResourceContentOptions): Promise<void>;
+    saveContentChanges?(changes: TextDocumentContentChangeEvent[], options?: ResourceContentOptions): Promise<void>;
     readonly onDidChangeContents?: Event<void>;
 }
 export namespace Resource {

--- a/packages/core/src/common/silenceable.ts
+++ b/packages/core/src/common/silenceable.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,25 +13,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { AbstractError } from './abstract-error';
 
-export * from './types';
-export * from './disposable';
-export * from './reference';
-export * from './event';
-export * from './cancellation';
-export * from './command';
-export * from './menu';
-export * from './selection-service';
-export * from './objects';
-export * from './os';
-export * from './resource';
-export * from './contribution-provider';
-export * from './path';
-export * from './logger';
-export * from './messaging';
-export * from './message-service';
-export * from './message-service-protocol';
-export * from './selection';
-export * from './strings';
-export * from './abstract-error';
-export * from './silenceable';
+export interface Silenceable {
+    silent?: boolean;
+}
+export class SilenceableError extends AbstractError implements Silenceable {
+    constructor(
+        message?: string,
+        public silent?: boolean,
+    ) { super(message); }
+}

--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from "inversify";
 import { TextDocumentContentChangeEvent } from "vscode-languageserver-types";
-import { Resource, ResourceResolver, Emitter, Event, DisposableCollection } from "@theia/core";
+import { Resource, ResourceResolver, Emitter, Event, DisposableCollection, ResourceContentOptions } from "@theia/core";
 import URI from "@theia/core/lib/common/uri";
 import { FileSystem, FileStat } from "../common/filesystem";
 import { FileSystemWatcher } from "./filesystem-watcher";
@@ -57,13 +57,13 @@ export class FileResource implements Resource {
         this.toDispose.dispose();
     }
 
-    async readContents(options?: { encoding?: string }): Promise<string> {
+    async readContents(options?: ResourceContentOptions): Promise<string> {
         const { stat, content } = await this.fileSystem.resolveContent(this.uriString, options);
         this.stat = stat;
         return content;
     }
 
-    async saveContents(content: string, options?: { encoding?: string }): Promise<void> {
+    async saveContents(content: string, options?: ResourceContentOptions): Promise<void> {
         this.stat = await this.doSaveContents(content, options);
     }
     protected async doSaveContents(content: string, options?: { encoding?: string }): Promise<FileStat> {
@@ -74,7 +74,7 @@ export class FileResource implements Resource {
         return this.fileSystem.createFile(this.uriString, { content, ...options });
     }
 
-    async saveContentChanges(changes: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<void> {
+    async saveContentChanges(changes: TextDocumentContentChangeEvent[], options?: ResourceContentOptions): Promise<void> {
         if (!this.stat) {
             throw new Error(this.uriString + ' has not been read yet');
         }

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-types';
-import { JsonRpcServer } from '@theia/core/lib/common';
+import { JsonRpcServer, ResourceContentOptions } from '@theia/core/lib/common';
 
 export const fileSystemPath = '/services/filesystem';
 
@@ -40,17 +40,17 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
     /**
      * Resolve the contents of a file identified by the resource.
      */
-    resolveContent(uri: string, options?: { encoding?: string }): Promise<{ stat: FileStat, content: string }>;
+    resolveContent(uri: string, options?: ResourceContentOptions): Promise<{ stat: FileStat, content: string }>;
 
     /**
      * Updates the content replacing its previous value.
      */
-    setContent(file: FileStat, content: string, options?: { encoding?: string }): Promise<FileStat>;
+    setContent(file: FileStat, content: string, options?: ResourceContentOptions): Promise<FileStat>;
 
     /**
      * Updates the content replacing its previous value.
      */
-    updateContent(file: FileStat, contentChanges: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<FileStat>;
+    updateContent(file: FileStat, contentChanges: TextDocumentContentChangeEvent[], options?: ResourceContentOptions): Promise<FileStat>;
 
     /**
      * Moves the file to a new path identified by the resource.

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -66,7 +66,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     async setPreference(key: string, value: any): Promise<void> {
         const resource = await this.resource;
         if (resource.saveContents) {
-            const content = await resource.readContents();
+            const content = await resource.readContents({ silent: true });
             const formattingOptions = { tabSize: 3, insertSpaces: true, eol: '' };
             const edits = jsoncparser.modify(content, [key], value, { formattingOptions });
             const result = jsoncparser.applyEdits(content, edits);
@@ -86,7 +86,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
     protected async readContents(): Promise<string> {
         try {
             const resource = await this.resource;
-            return await resource.readContents();
+            return await resource.readContents({ silent: true });
         } catch {
             return '';
         }


### PR DESCRIPTION
Before, when a communication between the frontend/backend happened, the proxy would always output any error.
This commit adds a way to specify if the error should be logged, in case you know that you will catch it.

Fix #2211.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>