### PR TITLE
Application errors

### DIFF
--- a/packages/core/src/common/application-error.ts
+++ b/packages/core/src/common/application-error.ts
@@ -1,0 +1,80 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable:no-any
+
+export interface ApplicationError<C extends number, D> extends Error {
+    readonly code: C
+    readonly data: D
+    toJson(): ApplicationError.Raw<D>
+}
+export namespace ApplicationError {
+    export interface Raw<D> {
+        message: string
+        data: D
+        stack?: string
+    }
+    export interface Literal<D> {
+        message: string
+        data: D
+    }
+    export interface Constructor<C extends number, D> {
+        (...args: any[]): ApplicationError<C, D>;
+        code: C;
+        is(arg: object | undefined): arg is ApplicationError<C, D>
+    }
+    const codes: number[] = [];
+    export function declare<C extends number, D>(code: C, factory: (...args: any[]) => Literal<D>): Constructor<C, D> {
+        if (codes.indexOf(code) !== -1) {
+            throw new Error(`An application error for '${code}' code is already declared`);
+        }
+        const constructorOpt = Object.assign((...args: any[]) => new Impl(code, factory(...args), constructorOpt), {
+            code,
+            is(arg: object | undefined): arg is ApplicationError<C, D> {
+                return arg instanceof Impl && arg.code === code;
+            }
+        });
+        return constructorOpt;
+    }
+    export function is<C extends number, D>(arg: object | undefined): arg is ApplicationError<C, D> {
+        return arg instanceof Impl;
+    }
+    export function fromJson<C extends number, D>(code: C, raw: Raw<D>): ApplicationError<C, D> {
+        return new Impl(code, raw);
+    }
+    class Impl<C extends number, D> extends Error implements ApplicationError<C, D>  {
+        readonly data: D;
+        constructor(
+            readonly code: C,
+            raw: ApplicationError.Raw<D>,
+            constructorOpt?: Function
+        ) {
+            super(raw.message);
+            this.data = raw.data;
+            Object.setPrototypeOf(this, Impl.prototype);
+            if (Error.captureStackTrace && constructorOpt) {
+                Error.captureStackTrace(this, constructorOpt);
+            }
+            if (raw.stack) {
+                this.stack = raw.stack;
+            }
+        }
+        toJson(): ApplicationError.Raw<D> {
+            const { message, data, stack } = this;
+            return { message, data, stack };
+        }
+    }
+}

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -33,3 +33,4 @@ export * from './message-service';
 export * from './message-service-protocol';
 export * from './selection';
 export * from './strings';
+export * from './application-error';

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -15,8 +15,7 @@
  ********************************************************************************/
 
 import { TextDocumentContentChangeEvent } from 'vscode-languageserver-types';
-import { JsonRpcServer } from '@theia/core/lib/common';
-
+import { JsonRpcServer, ApplicationError } from '@theia/core/lib/common';
 export const fileSystemPath = '/services/filesystem';
 
 export const FileSystem = Symbol("FileSystem");
@@ -167,4 +166,27 @@ export namespace FileStat {
             && candidate.hasOwnProperty('lastModification')
             && candidate.hasOwnProperty('isDirectory');
     }
+}
+
+export namespace FileSystemError {
+    export const FileNotFound = ApplicationError.declare(-33000, (uri: string, prefix?: string) => ({
+        message: `${prefix ? prefix + ' ' : ''}'${uri}' has not been found.`,
+        data: { uri }
+    }));
+    export const FileExists = ApplicationError.declare(-33001, (uri: string, prefix?: string) => ({
+        message: `${prefix ? prefix + ' ' : ''}'${uri}' already exists.`,
+        data: { uri }
+    }));
+    export const FileIsDirectory = ApplicationError.declare(-33002, (uri: string, prefix?: string) => ({
+        message: `${prefix ? prefix + ' ' : ''}'${uri}' is a directory.`,
+        data: { uri }
+    }));
+    export const FileNotDirectory = ApplicationError.declare(-33003, (uri: string, prefix?: string) => ({
+        message: `${prefix ? prefix + ' ' : ''}'${uri}' is not a directory.`,
+        data: { uri }
+    }));
+    export const FileIsOutOfSync = ApplicationError.declare(-33004, (file: FileStat, stat: FileStat) => ({
+        message: `'${file.uri}' is out of sync.`,
+        data: { file, stat }
+    }));
 }


### PR DESCRIPTION
It is turned out that:
- JSON-RPC already specifies a way how application errors should be declared: https://www.jsonrpc.org/specification#error_object
- `vscode-jsonrpc` supports it with proper serialization and deserialization: https://github.com/Microsoft/vscode-languageserver-node/blob/5f9c993ff38f5c369949aeb359b3e9b178172dbc/jsonrpc/src/messages.ts#L60-L101
- we don't log `ResponseError` on the backend assuming that they are application errors already: https://github.com/theia-ide/theia/blob/322e9307144536c3578cc7c8432f6814b1bc7df5/packages/core/src/common/messaging/proxy-factory.ts#L159-L161 

This PR makes use of these facts:
- to define a new application error code range:
```ts
const define = ApplicationError.reserve(-33100, -33000, 'file-system')
```
-  to declare application errors for a defined range:
```ts
    export const FileNotFound = define(-33000, (uri: string, prefix?: string) => ({
        message: `${prefix ? prefix + ' ' : ''}'${uri}' has not been found.`,
        data: { uri }
    }));
```
- to match a defined application error:
```ts
if (FileSystemError.FileNotFound.is(error)) {
    const uri = error.data.uri;
}
```

