### PR TITLE
Vscode debug patches

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-applier.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-applier.ts
@@ -37,7 +37,9 @@ export class BreakpointsApplier {
                 for (const breakpointsBySource of DebugUtils.groupBySource(breakpoints).values()) {
                     const args: DebugProtocol.SetBreakpointsArguments = {
                         source: breakpointsBySource[0].source!,
-                        breakpoints: breakpointsBySource.map(b => b.origin as DebugProtocol.SourceBreakpoint)
+                        breakpoints: breakpointsBySource.map(b => b.origin as DebugProtocol.SourceBreakpoint),
+                        // Although marked as deprecated, some debug adapters still use lines
+                        lines: breakpointsBySource.map(b => (b.origin as DebugProtocol.SourceBreakpoint).line)
                     };
 
                     // The array elements are in the same order as the elements

--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -227,6 +227,7 @@ export class BreakpointsManager implements FrontendApplicationContribution {
 
         if (body.threadId) {
             switch (body.reason) {
+                case 'exception':
                 case 'breakpoint':
                 case 'entry':
                 case 'step': {

--- a/packages/debug/src/browser/debug-session.ts
+++ b/packages/debug/src/browser/debug-session.ts
@@ -316,6 +316,10 @@ export class DebugSessionManager {
                         const attachArgs: DebugProtocol.AttachRequestArguments = Object.assign(debugConfiguration, { __restart: false });
                         return session.attach(attachArgs);
                     }
+                    case "launch": {
+                        const launchArgs: DebugProtocol.LaunchRequestArguments = Object.assign(debugConfiguration, { __restart: false, noDebug: false });
+                        return session.launch(launchArgs);
+                    }
                     default: return Promise.reject(`Unsupported request '${request}' type.`);
                 }
             })


### PR DESCRIPTION
Some minor updates to the `vscode-debug-protocol` branch to support `launch` debugging:

- Added ability to launch a debugger (in addition to attaching)
- Added support for the deprecated `lines` array of breakpoints for older debug adapters
- Added support for the `exception` event to allow the debugger to break into the code