### PR TITLE
Fix deprecation warning on build.

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@theia/application-package": "^0.3.13",
     "bunyan": "^1.8.10",
-    "circular-dependency-plugin": "^4.0.0",
+    "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
     "electron": "1.8.2-beta.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,9 +2100,9 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circular-dependency-plugin@^4.0.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-4.4.0.tgz#f8a1a746a3f6c8e57f4dae9b54d991cd2a582f5d"
+circular-dependency-plugin@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/circular-dependency-plugin/-/circular-dependency-plugin-5.0.2.tgz#da168c0b37e7b43563fb9f912c1c007c213389ef"
 
 clap@^1.0.9:
   version "1.2.3"


### PR DESCRIPTION
Attempts to build can produce a warning related to the use of the circular-dependency-plugin node module. The reported warning is 'DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead' 

Version updated as per notes from the module to use the version that supports webpack 4.x.x

Signed-off-by: Mark Edgeworth <mark.edgeworth@arm.com>