### PR TITLE
Add ability to clear current terminal output by calling a command

### DIFF
--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -38,6 +38,11 @@ export abstract class TerminalWidget extends BaseWidget {
     * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
     */
    abstract onTerminalDidClose: Event<TerminalWidget>;
+
+   /**
+    * Cleat terminal output.
+    */
+   abstract clearOutput(): void;
 }
 
 /**

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -39,6 +39,10 @@ export namespace TerminalCommands {
         id: 'terminal:new',
         label: 'Open New Terminal'
     };
+    export const TERMINAL_CLEAR: Command = {
+        id: 'terminal:clear',
+        label: 'Terminal: Clear'
+    };
 }
 
 @injectable()
@@ -60,6 +64,12 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
                 this.activateTerminal(termWidget);
             }
         });
+
+        commands.registerCommand(TerminalCommands.TERMINAL_CLEAR);
+        commands.registerHandler(TerminalCommands.TERMINAL_CLEAR.id, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget,
+            execute: () => (this.shell.activeWidget as TerminalWidget).clearOutput()
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -72,6 +82,10 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
         keybindings.registerKeybinding({
             command: TerminalCommands.NEW.id,
             keybinding: "ctrl+`"
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.TERMINAL_CLEAR.id,
+            keybinding: 'ctrlcmd+k'
         });
 
         /* Register passthrough keybindings for combinations recognized by

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -144,6 +144,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.toDispose.push(this.onTermDidClose);
     }
 
+    clearOutput(): void {
+        this.term.clear();
+    }
+
     storeState(): object {
         this.closeOnDispose = false;
         return { terminalId: this.terminalId, titleLabel: this.title.label };


### PR DESCRIPTION
Add ability to clear the active terminal output by command action.

![clear_terminal_output](https://user-images.githubusercontent.com/1968177/43520729-617d7814-959c-11e8-80b4-6ed1d5cc114d.gif)

Related issue: https://github.com/eclipse/che/issues/10380

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>