### PR TITLE
Promote the majority of rules from warnings to errors

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -1,10 +1,18 @@
 {
   "defaultSeverity": "error",
   "rules": {
-    "file-header": [
-      true,
-      "SPDX-License-Identifier: EPL-2\\.0 OR GPL-2\\.0 WITH Classpath-exception-2\\.0"
-    ],
+    "arrow-parens": {
+      "options": [
+        true,
+        "ban-single-arg-parens"
+      ]
+    },
+    "arrow-return-shorthand": {
+      "options": [
+        true,
+        "multiline"
+      ]
+    },
     "class-name": true,
     "comment-format": [
       true,
@@ -12,11 +20,19 @@
     ],
     "curly": true,
     "eofline": true,
-    "forin": true,
-    "indent": [
+    "file-header": [
       true,
-      "spaces"
+      "SPDX-License-Identifier: EPL-2\\.0 OR GPL-2\\.0 WITH Classpath-exception-2\\.0"
     ],
+    "forin": true,
+    "indent": {
+      "options": [
+        true,
+        "spaces",
+        4
+      ]
+    },
+    "interface-over-type-literal": true,
     "jsdoc-format": [
       true,
       "check-multiline-start"
@@ -26,9 +42,13 @@
       180
     ],
     "no-consecutive-blank-lines": true,
+    "no-construct": true,
+    "no-magic-numbers": false,
+    "no-null-keyword": true,
     "no-shadowed-variable": true,
     "no-string-throw": true,
     "no-trailing-whitespace": true,
+    "no-unused-expression": true,
     "no-var-keyword": true,
     "one-line": [
       true,
@@ -37,6 +57,7 @@
       "check-else",
       "check-whitespace"
     ],
+    "one-variable-per-declaration": true,
     "prefer-const": {
       "options": [
         true,
@@ -51,9 +72,7 @@
       "always",
       "ignore-interfaces"
     ],
-    "trailing-comma": [
-      false
-    ],
+    "trailing-comma": false,
     "triple-equals": [
       true,
       "allow-null-check"

--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -3,10 +3,6 @@
     "no-any": {
       "severity": "warning",
       "options": true
-    },
-    "no-console": {
-      "severity": "warning",
-      "options": true
     }
   }
 }

--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -1,50 +1,10 @@
 {
   "rules": {
-    "arrow-parens": {
-      "severity": "warning",
-      "options": [
-        true,
-        "ban-single-arg-parens"
-      ]
-    },
-    "arrow-return-shorthand": {
-      "severity": "warning",
-      "options": [
-        true,
-        "multiline"
-      ]
-    },
-    "indent": {
-      "severity": "warning",
-      "options": [
-        true,
-        "spaces",
-        4
-      ]
-    },
-    "interface-over-type-literal": {
-      "severity": "warning",
-      "options": true
-    },
     "no-any": {
       "severity": "warning",
       "options": true
     },
-    "no-console": false,
-    "no-construct": {
-      "severity": "warning",
-      "options": true
-    },
-    "no-magic-numbers": false,
-    "no-null-keyword": {
-      "severity": "warning",
-      "options": true
-    },
-    "no-unused-expression": {
-      "severity": "warning",
-      "options": true
-    },
-    "one-variable-per-declaration": {
+    "no-console": {
       "severity": "warning",
       "options": true
     }

--- a/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-service-impl.ts
@@ -59,6 +59,9 @@ export class CallHierarchyContext {
     async getDefinitionLocation(location: Location): Promise<Location | undefined> {
         const uri = location.uri;
         const { line, character } = location.range.start;
+
+        // Definition can be null
+        // tslint:disable-next-line:no-null-keyword
         let locations: Location | Location[] | null = null;
         try {
             locations = await this.languageClient.sendRequest(DefinitionRequest.type, <TextDocumentPositionParams>{

--- a/packages/core/src/browser/label-parser.spec.ts
+++ b/packages/core/src/browser/label-parser.spec.ts
@@ -18,6 +18,8 @@ import { CommandService } from './../common';
 import { Container } from "inversify";
 import { expect } from 'chai';
 
+// tslint:disable:no-unused-expression
+
 let statusBarEntryUtility: LabelParser;
 
 before(() => {

--- a/packages/core/src/browser/opener-service.spec.ts
+++ b/packages/core/src/browser/opener-service.spec.ts
@@ -34,10 +34,8 @@ const openerService = new DefaultOpenerService({
 
 describe("opener-service", () => {
 
-    it("getOpeners", () => {
-        return openerService.getOpeners().then(openers => {
+    it("getOpeners", () =>
+        openerService.getOpeners().then(openers => {
             assert.deepStrictEqual([openHandler], openers);
-        });
-    });
-
+        }));
 });

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -463,7 +463,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     protected renderNode(node: TreeNode, props: NodeProps): React.ReactNode {
         if (!TreeNode.isVisible(node)) {
-            return null;
+            return undefined;
         }
         const attributes = this.createNodeAttributes(node, props);
         const content = <div className={TREE_NODE_CONTENT_CLASS}>

--- a/packages/core/src/browser/widgets/react-renderer.tsx
+++ b/packages/core/src/browser/widgets/react-renderer.tsx
@@ -35,6 +35,6 @@ export class ReactRenderer implements Disposable {
     }
 
     protected doRender(): React.ReactNode {
-        return null;
+        return undefined;
     }
 }

--- a/packages/core/src/browser/widgets/virtual-renderer.ts
+++ b/packages/core/src/browser/widgets/virtual-renderer.ts
@@ -16,6 +16,9 @@
 
 import { h, VirtualNode, VirtualText, VirtualDOM } from "@phosphor/virtualdom";
 
+// Phosphor elements can be null, so we need to disable our no-null rule
+// tslint:disable:no-null-keyword
+
 /*
  * @deprecated use ReactRenderer instead. VirtualRenderer will be removed with the next major release.
  */

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -56,7 +56,7 @@ class CallbackList {
         return this._callbacks && this._callbacks.length || 0;
     }
 
-    public add(callback: Function, context: any = null, bucket?: Disposable[]): void {
+    public add(callback: Function, context: any = undefined, bucket?: Disposable[]): void {
         if (!this._callbacks) {
             this._callbacks = [];
             this._contexts = [];
@@ -69,13 +69,13 @@ class CallbackList {
         }
     }
 
-    public remove(callback: Function, context: any = null): void {
+    public remove(callback: Function, context: any = undefined): void {
         if (!this._callbacks) {
             return;
         }
 
         let foundCallbackWithDifferentContext = false;
-        for (let i = 0, len = this._callbacks.length; i < len; i++) {
+        for (let i = 0; i < this._callbacks.length; i++) {
             if (this._callbacks[i] === callback) {
                 if (this._contexts![i] === context) {
                     // callback & context match => remove it
@@ -102,7 +102,7 @@ class CallbackList {
         const callbacks = this._callbacks.slice(0);
         const contexts = this._contexts!.slice(0);
 
-        for (let i = 0, len = callbacks.length; i < len; i++) {
+        for (let i = 0; i < callbacks.length; i++) {
             try {
                 ret.push(callbacks[i].apply(contexts[i], args));
             } catch (e) {

--- a/packages/cpp/src/package.spec.ts
+++ b/packages/cpp/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("cpp package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/editor/src/package.spec.ts
+++ b/packages/editor/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("editor package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
@@ -16,6 +16,8 @@
 
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 
+// tslint:disable:no-unused-expression
+
 const disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';

--- a/packages/java/src/package.spec.ts
+++ b/packages/java/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("java package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/languages/src/package.spec.ts
+++ b/packages/languages/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("languages package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/monaco/src/package.spec.ts
+++ b/packages/monaco/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("monaco package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/navigator/src/package.spec.ts
+++ b/packages/navigator/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("navigator package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/plugin-ext-vscode/src/node/package.spec.ts
+++ b/packages/plugin-ext-vscode/src/node/package.spec.ts
@@ -24,6 +24,5 @@
 
 describe("plugin-ext-vscode package", () => {
 
-    it("support code coverage statistics", () =>
-        true);
+    it("support code coverage statistics", () => true);
 });

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
@@ -59,7 +59,7 @@ export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
                 return;
             }
             const extensionName = extracted[1];
-            const wantedExtensionVersion = null;
+            const wantedExtensionVersion = undefined;
 
             const json = {
                 "filters": [{
@@ -103,7 +103,7 @@ export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
                     dest.addListener('finish', finish);
 
                     request.get(asset.source)
-                        .on('error', (err) => {
+                        .on('error', err => {
                             reject(err);
                         }).pipe(dest);
                 } else {

--- a/packages/plugin-ext/src/api/rpc-protocol.ts
+++ b/packages/plugin-ext/src/api/rpc-protocol.ts
@@ -64,12 +64,15 @@ export class RPCProtocolImpl implements RPCProtocol {
 
     constructor(connection: MessageConnection) {
         this.isDisposed = false;
+        // tslint:disable-next-line:no-null-keyword
         this.locals = Object.create(null);
+        // tslint:disable-next-line:no-null-keyword
         this.proxies = Object.create(null);
         this.lastMessageId = 0;
+        // tslint:disable-next-line:no-null-keyword
         this.invokedHandlers = Object.create(null);
         this.pendingRPCReplies = {};
-        this.multiplexor = new RPCMultiplexer(connection, (msg) => this.receiveOneMessage(msg));
+        this.multiplexor = new RPCMultiplexer(connection, msg => this.receiveOneMessage(msg));
     }
     getProxy<T>(proxyId: ProxyIdentifier<T>): T {
         if (!this.proxies[proxyId.id]) {
@@ -93,6 +96,7 @@ export class RPCProtocolImpl implements RPCProtocol {
                 return target[name];
             }
         };
+        // tslint:disable-next-line:no-null-keyword
         return new Proxy(Object.create(null), handler);
     }
 
@@ -165,7 +169,7 @@ export class RPCProtocolImpl implements RPCProtocol {
         const pendingReply = this.pendingRPCReplies[callId];
         delete this.pendingRPCReplies[callId];
 
-        let err: Error | null = null;
+        let err: Error | undefined = undefined;
         if (msg.err && msg.err.$isError) {
             err = new Error();
             err.name = msg.err.name;

--- a/packages/plugin-ext/src/common/env.ts
+++ b/packages/plugin-ext/src/common/env.ts
@@ -14,6 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export type QueryParameters = {
+export interface QueryParameters {
     [key: string]: string | string[]
-};
+}

--- a/packages/plugin-ext/src/main/browser/message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/message-registry-main.ts
@@ -81,9 +81,7 @@ export class MessageRegistryMainImpl implements MessageRegistryMain {
             if (options.modal) {
                 const modalNotification = new ModalNotification();
                 promise = modalNotification.showDialog(type, message, actionTitles)
-                    .then(result => {
-                        return result !== undefined ? result : onCloseAction;
-                    });
+                    .then(result => result !== undefined ? result : onCloseAction);
             } else {
                 switch (type) {
                     case MessageType.Info:

--- a/packages/plugin-ext/src/main/browser/plugin-worker.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-worker.ts
@@ -25,7 +25,7 @@ export class PluginWorker {
     constructor() {
         const emmitter = new Emitter();
         this.worker = new (require('../../hosted/browser/worker/worker-main'));
-        this.worker.onmessage = (message) => {
+        this.worker.onmessage = message => {
             emmitter.fire(message.data);
         };
         this.worker.onerror = e => console.error(e);

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -30,7 +30,7 @@ export class WorkspaceMain {
     constructor(rpc: RPCProtocol, workspaceService: WorkspaceService) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WORKSPACE_EXT);
 
-        workspaceService.root.then((root) => {
+        workspaceService.root.then(root => {
             if (root) {
                 this.workspaceRoot = Uri.parse(root.uri);
                 const workspacePath = new Path(this.workspaceRoot.path);

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -67,7 +67,7 @@ export class PluginDeployerImpl implements PluginDeployer, PluginServer {
 
         // call init on each resolver
         const pluginDeployerResolverInit: PluginDeployerResolverInit = new PluginDeployerResolverInitImpl();
-        const promises = this.pluginResolvers.map(async (pluginResolver) => {
+        const promises = this.pluginResolvers.map(async pluginResolver => {
             if (pluginResolver.init) {
                 pluginResolver.init(pluginDeployerResolverInit);
             }
@@ -151,8 +151,8 @@ export class PluginDeployerImpl implements PluginDeployer, PluginServer {
     public async applyFileHandlers(): Promise<any> {
         const waitPromises: Array<Promise<any>> = [];
 
-        this.pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map((pluginDeployerEntry) => {
-            this.pluginDeployerFileHandlers.map((pluginFileHandler) => {
+        this.pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry => {
+            this.pluginDeployerFileHandlers.map(pluginFileHandler => {
                 const proxyPluginDeployerEntry = new ProxyPluginDeployerEntry(pluginFileHandler, (pluginDeployerEntry) as PluginDeployerEntryImpl);
                 if (pluginFileHandler.accept(proxyPluginDeployerEntry)) {
                     const pluginDeployerFileHandlerContext: PluginDeployerFileHandlerContext = new PluginDeployerFileHandlerContextImpl(proxyPluginDeployerEntry);
@@ -171,8 +171,8 @@ export class PluginDeployerImpl implements PluginDeployer, PluginServer {
     public async applyDirectoryFileHandlers(): Promise<any> {
         const waitPromises: Array<Promise<any>> = [];
 
-        this.pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map((pluginDeployerEntry) => {
-            this.pluginDeployerDirectoryHandlers.map((pluginDirectoryHandler) => {
+        this.pluginDeployerEntries.filter(pluginDeployerEntry => pluginDeployerEntry.isResolved()).map(pluginDeployerEntry => {
+            this.pluginDeployerDirectoryHandlers.map(pluginDirectoryHandler => {
                 const proxyPluginDeployerEntry = new ProxyPluginDeployerEntry(pluginDirectoryHandler, (pluginDeployerEntry) as PluginDeployerEntryImpl);
                 if (pluginDirectoryHandler.accept(proxyPluginDeployerEntry)) {
                     const pluginDeployerDirectoryHandlerContext: PluginDeployerDirectoryHandlerContext = new PluginDeployerDirectoryHandlerContextImpl(proxyPluginDeployerEntry);
@@ -192,11 +192,9 @@ export class PluginDeployerImpl implements PluginDeployer, PluginServer {
         const pluginDeployerEntries: PluginDeployerEntry[] = [];
 
         // check if accepted ?
-        const promises = pluginIdList.map(async (pluginId) => {
+        const promises = pluginIdList.map(async pluginId => {
 
-            const foundPluginResolver = this.pluginResolvers.find(pluginResolver => {
-                return pluginResolver.accept(pluginId);
-            });
+            const foundPluginResolver = this.pluginResolvers.find(pluginResolver => pluginResolver.accept(pluginId));
             // there is a resolver for the input
             if (foundPluginResolver) {
 

--- a/packages/plugin-ext/src/main/node/plugin-github-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-github-resolver.ts
@@ -81,7 +81,7 @@ export class GithubPluginDeployerResolver implements PluginDeployerResolver {
             };
             // if latest, resolve first the real version
             if (version === 'latest') {
-                request.get(url, options).on('response', (response) => {
+                request.get(url, options).on('response', response => {
 
                     // should have a redirect
                     if (response.statusCode === 302) {
@@ -133,7 +133,7 @@ export class GithubPluginDeployerResolver implements PluginDeployerResolver {
         dest.addListener('finish', finish);
         const url = GithubPluginDeployerResolver.GITHUB_ENDPOINT + orgName + '/' + repoName + '/releases/download/' + version + '/' + filename;
         request.get(url)
-            .on('error', (err) => {
+            .on('error', err => {
                 reject(err);
             }).pipe(dest);
 

--- a/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
@@ -75,7 +75,7 @@ export class HttpPluginDeployerResolver implements PluginDeployerResolver {
 
             dest.addListener('finish', finish);
             request.get(pluginResolverContext.getOriginId())
-                .on('error', (err) => {
+                .on('error', err => {
                     reject(err);
                 }).pipe(dest);
         });

--- a/packages/plugin-ext/src/package.spec.ts
+++ b/packages/plugin-ext/src/package.spec.ts
@@ -24,6 +24,5 @@
 
 describe("plugin package", () => {
 
-    it("support code coverage statistics", () =>
-        true);
+    it("support code coverage statistics", () => true);
 });

--- a/packages/plugin/src/package.spec.ts
+++ b/packages/plugin/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("plugin package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/python/src/package.spec.ts
+++ b/packages/python/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("python package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/terminal/src/package.spec.ts
+++ b/packages/terminal/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("terminal package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });

--- a/packages/variable-resolver/src/browser/variable.spec.ts
+++ b/packages/variable-resolver/src/browser/variable.spec.ts
@@ -20,6 +20,8 @@ import { ILogger, Disposable } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { Variable, VariableRegistry } from './variable';
 
+// tslint:disable:no-unused-expression
+
 const expect = chai.expect;
 let variableRegistry: VariableRegistry;
 

--- a/packages/workspace/src/package.spec.ts
+++ b/packages/workspace/src/package.spec.ts
@@ -24,7 +24,5 @@
 
 describe("workspace package", () => {
 
-    it("support code coverage statistics", () => {
-        return true;
-    });
+    it("support code coverage statistics", () => true);
 });


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR promotes the majority of `tslint` warnings to errors and fixes the code so it all passes. This encourages consistent quality of the code-base. Comments have been added where rules are having to be disabled and rules have be listed alphabetically.

Specifically, these rules have been made into errors:

- arrow-parens
- arrow-return-shorthand
- interface-over-type-literal
- no-construct
- no-magic-numbers
- no-null-keyword
- no-unused-expression
- one-variable-per-declaration

This leaves just the following as warnings:

- no-any
- no-console

`no-any` isn't trivial to fix (around ~250 warnings currently) as knowledge of the code is required to specify the correct types.

`no-console` is false in the errors (no change), but I've made it true in the warnings to encourage removal of them (~150 occurrences).