### PR TITLE
Add watch compilation for hosted plugin

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -297,8 +297,13 @@ export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
     isPluginValid(uri: string): Promise<boolean>;
     runHostedPluginInstance(uri: string): Promise<string>;
     terminateHostedPluginInstance(): Promise<void>;
-    isHostedTheiaRunning(): Promise<boolean>;
+    isHostedPluginInstanceRunning(): Promise<boolean>;
     getHostedPluginInstanceURI(): Promise<string>;
+    getHostedPluginURI(): Promise<string>;
+
+    runWatchCompilation(uri: string): Promise<void>;
+    stopWatchCompilation(uri: string): Promise<void>;
+    isWatchCompilationRunning(uri: string): Promise<boolean>;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-preferences.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-preferences.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+
+export const HostedPluginConfigSchema: PreferenceSchema = {
+    'type': 'object',
+    properties: {
+        'hosted-plugin.watchMode': {
+            type: 'boolean',
+            description: 'Run watcher on plugin under development',
+            default: true
+        }
+    }
+};
+
+export interface HostedPluginConfiguration {
+    'hosted-plugin.watchMode': boolean;
+}
+
+export const HostedPluginPreferences = Symbol('HostedPluginPreferences');
+export type HostedPluginPreferences = PreferenceProxy<HostedPluginConfiguration>;
+
+export function createNavigatorPreferences(preferences: PreferenceService): HostedPluginPreferences {
+    return createPreferenceProxy(preferences, HostedPluginConfigSchema);
+}
+
+export function bindHostedPluginPreferences(bind: interfaces.Bind): void {
+    bind(HostedPluginPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createNavigatorPreferences(preferences);
+    });
+    bind(PreferenceContribution).toConstantValue({ schema: HostedPluginConfigSchema });
+}

--- a/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { HostedPluginManager, ElectronNodeHostedPluginRunner } from '../node/hosted-plugin-manager';
+import { HostedInstanceManager, ElectronNodeHostedPluginRunner } from '../node/hosted-instance-manager';
 import { interfaces } from 'inversify';
 import { bindCommonHostedBackend } from '../node/plugin-ext-hosted-backend-module';
 import { PluginScanner } from '../../common/plugin-protocol';
@@ -23,6 +23,6 @@ import { TheiaPluginScannerElectron } from './scanner-theia-electron';
 export function bindElectronBackend(bind: interfaces.Bind): void {
     bindCommonHostedBackend(bind);
 
-    bind(HostedPluginManager).to(ElectronNodeHostedPluginRunner);
+    bind(HostedInstanceManager).to(ElectronNodeHostedPluginRunner);
     bind(PluginScanner).to(TheiaPluginScannerElectron).inSingletonScope();
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugins-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugins-manager.ts
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import { sep as PATH_SEPARATOR } from 'path';
+import { HostedPluginSupport } from './hosted-plugin';
+import { LogType } from '../../common/types';
+
+export const HostedPluginsManager = Symbol('HostedPluginsManager');
+
+export interface HostedPluginsManager {
+
+    /**
+     * Runs watcher script to recomple plugin on any changes along given path.
+     *
+     * @param uri uri to plugin root folder.
+     */
+    runWatchCompilation(uri: string): Promise<void>;
+
+    /**
+     * Stops watcher script.
+     *
+     * @param uri uri to plugin root folder.
+     */
+    stopWatchCompilation(uri: string): Promise<void>;
+
+    /**
+     * Chacks if watcher script to recomple plugin is running.
+     *
+     * @param uri uri to plugin root folder.
+     */
+    isWatchCompilationRunning(uri: string): Promise<boolean>;
+}
+
+@injectable()
+export class HostedPluginsManagerImpl implements HostedPluginsManager {
+
+    @inject(HostedPluginSupport)
+    protected readonly hostedPluginSupport: HostedPluginSupport;
+
+    protected watchCompilationRegistry: Map<string, cp.ChildProcess>;
+
+    constructor() {
+        this.watchCompilationRegistry = new Map();
+    }
+
+    runWatchCompilation(uri: string): Promise<void> {
+        const pluginRootPath = this.getFsPath(uri);
+
+        if (this.watchCompilationRegistry.has(pluginRootPath)) {
+            throw new Error('Watcher is already running in ' + pluginRootPath);
+        }
+
+        if (!this.checkWatchScript(pluginRootPath)) {
+            this.hostedPluginSupport.sendLog({
+                data: 'Plugin in ' + uri + ' doesn\'t have watch script',
+                type: LogType.Error
+            });
+            throw new Error('Watch script doesn\'t exist in ' + pluginRootPath + 'package.json');
+        }
+
+        return this.runWatchScript(pluginRootPath);
+    }
+
+    stopWatchCompilation(uri: string): Promise<void> {
+        const pluginPath = this.getFsPath(uri);
+
+        const watchProcess = this.watchCompilationRegistry.get(pluginPath);
+        if (!watchProcess) {
+            throw new Error('Watcher is not running in ' + pluginPath);
+        }
+
+        watchProcess.kill();
+        return Promise.resolve();
+    }
+
+    isWatchCompilationRunning(uri: string): Promise<boolean> {
+        const pluginPath = this.getFsPath(uri);
+
+        return new Promise(resolve => resolve(this.watchCompilationRegistry.has(pluginPath)));
+    }
+
+    protected runWatchScript(path: string): Promise<void> {
+        const watchProcess = cp.spawn('yarn', ['run', 'watch'], { cwd: path });
+        watchProcess.on('exit', () => this.unregisterWatchScript(path));
+
+        this.watchCompilationRegistry.set(path, watchProcess);
+        this.hostedPluginSupport.sendLog({
+            data: 'Compilation watcher has been started in ' + path,
+            type: LogType.Info
+        });
+        return Promise.resolve();
+    }
+
+    protected unregisterWatchScript(path: string) {
+        this.watchCompilationRegistry.delete(path);
+        this.hostedPluginSupport.sendLog({
+            data: 'Compilation watcher has been stopped in ' + path,
+            type: LogType.Info
+        });
+    }
+
+    /**
+     * Checks whether watch script is present into package.json by given parent folder.
+     *
+     * @param pluginPath path to plugin's root directory
+     */
+    protected checkWatchScript(pluginPath: string): boolean {
+        const pluginPackageJsonPath = pluginPath + 'package.json';
+        if (fs.existsSync(pluginPackageJsonPath)) {
+            const packageJson = require(pluginPackageJsonPath);
+            const scripts = packageJson['scripts'];
+            if (scripts && scripts['watch']) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected getFsPath(uri: string): string {
+        if (!uri.startsWith('file')) {
+            throw new Error('Plugin uri ' + uri + ' is not supported.');
+        }
+
+        const path = uri.substring(uri.indexOf('://') + 3);
+
+        if (!path.endsWith(PATH_SEPARATOR)) {
+            return path + PATH_SEPARATOR;
+        }
+
+        return path;
+    }
+
+}

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -14,10 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { HostedPluginManager, NodeHostedPluginRunner } from './hosted-plugin-manager';
-import { HostedPluginUriPostProcessorSymbolName } from './hosted-plugin-uri-postprocessor';
 import { interfaces } from 'inversify';
+import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { HostedInstanceManager, NodeHostedPluginRunner } from './hosted-instance-manager';
+import { HostedPluginUriPostProcessorSymbolName } from './hosted-plugin-uri-postprocessor';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { MetadataScanner } from './metadata-scanner';
@@ -25,6 +25,7 @@ import { HostedPluginServerImpl } from './plugin-service';
 import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginSupport } from './hosted-plugin';
 import { TheiaPluginScanner } from './scanners/scanner-theia';
+import { HostedPluginsManager, HostedPluginsManagerImpl } from './hosted-plugins-manager';
 import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath } from '../../common/plugin-protocol';
 
 export function bindCommonHostedBackend(bind: interfaces.Bind): void {
@@ -32,6 +33,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginServer).to(HostedPluginServerImpl).inSingletonScope();
     bind(HostedPluginSupport).toSelf().inSingletonScope();
     bind(MetadataScanner).toSelf().inSingletonScope();
+    bind(HostedPluginsManager).to(HostedPluginsManagerImpl).inSingletonScope();
 
     bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(HostedPluginReader)).inSingletonScope();
 
@@ -50,7 +52,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
 export function bindHostedBackend(bind: interfaces.Bind): void {
     bindCommonHostedBackend(bind);
 
-    bind(HostedPluginManager).to(NodeHostedPluginRunner).inSingletonScope();
+    bind(HostedInstanceManager).to(NodeHostedPluginRunner).inSingletonScope();
     bind(PluginScanner).to(TheiaPluginScanner).inSingletonScope();
     bindContributionProvider(bind, Symbol.for(HostedPluginUriPostProcessorSymbolName));
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -24,7 +24,7 @@ import { PluginWorker } from './plugin-worker';
 import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
 import { HostedPluginWatcher } from '../../hosted/browser/hosted-plugin-watcher';
 import { HostedPluginLogViewer } from '../../hosted/browser/hosted-plugin-log-viewer';
-import { HostedPluginManagerClient } from './plugin-manager-client';
+import { HostedPluginManagerClient } from '../../hosted/browser/hosted-plugin-manager-client';
 import { PluginApiFrontendContribution } from './plugin-frontend-contribution';
 import { setUpPluginApi } from './main-context';
 import { HostedPluginServer, hostedServicePath, PluginServer, pluginServerJsonRpcPath } from '../../common/plugin-protocol';
@@ -33,7 +33,8 @@ import { PluginWidget } from './plugin-ext-widget';
 import { PluginFrontendViewContribution } from './plugin-frontend-view-contribution';
 
 import { HostedPluginInformer } from '../../hosted/browser/hosted-plugin-informer';
-import { HostedPluginController } from './hosted-plugin-controller';
+import { bindHostedPluginPreferences } from '../../hosted/browser/hosted-plugin-preferences';
+import { HostedPluginController } from '../../hosted/browser/hosted-plugin-controller';
 
 import '../../../src/main/browser/style/index.css';
 import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
@@ -42,6 +43,8 @@ import { EditorModelService, EditorModelServiceImpl } from './text-editor-model-
 import { UntitledResourceResolver } from './editor/untitled-resource';
 
 export default new ContainerModule(bind => {
+    bindHostedPluginPreferences(bind);
+
     bind(ModalNotification).toSelf().inSingletonScope();
 
     bind(PluginWorker).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from 'inversify';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
-import { HostedPluginManagerClient, HostedPluginCommands } from './plugin-manager-client';
+import { HostedPluginManagerClient, HostedPluginCommands } from '../../hosted/browser/hosted-plugin-manager-client';
 import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
 
 @injectable()


### PR DESCRIPTION
This PR:
 - Introduces watch compilation of hosted plugin, so now when a user start hosted instance with a plugin under development any changes will be automatically applied to compiled script (however plugin reload is not implemented yet).
 - adds `hosted-plugin.watchMode` preference is added which controls if watch compilation should be started with hosted instance. By default it is turned on. However, if user change its value watch compilation will be turned on/off (even if hosted instance is already running).
 - Fixes bug with wrong state of hosted instance area in the bottom panel.
- Moves hosted instance related files into hosted package.

![hosted-plugin-watchers-2](https://user-images.githubusercontent.com/15607393/43584771-04fdb696-966c-11e8-9f44-e4a345b47fe2.gif)


Resolves: https://github.com/theia-ide/theia/issues/2434

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

