### PR TITLE
Add ability to debug the debug extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,11 +116,20 @@
             "outputCapture": "std"
         },
         {
-            "name": "Launch Frontend",
             "type": "chrome",
             "request": "launch",
+            "name": "Launch Frontend",
             "url": "http://localhost:3000/",
             "webRoot": "${workspaceRoot}"
-        }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug-Nodejs Server",
+            "program": "${workspaceRoot}/packages/debug-nodejs/lib/adapter/out/src/nodeDebug.js",
+            "args": [
+                "--server=4711"
+            ]
+        },
     ]
 }

--- a/packages/debug-nodejs/src/node/debug-nodejs.ts
+++ b/packages/debug-nodejs/src/node/debug-nodejs.ts
@@ -51,6 +51,8 @@ export class NodeJsDebugAdapterContribution implements DebugAdapterContribution 
     provideDebugAdapterExecutable(config: DebugConfiguration): DebugAdapterExecutable {
         const program = path.join(__dirname, `../../${debugAdapterDir}/out/src/nodeDebug.js`);
         return {
+            // If debugServer is set in the config, connect to that port for debugging instead of executing program
+            debugServer: config.debugServer,
             program,
             runtime: "node"
         };

--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -21,6 +21,7 @@
 
 // Some entities copied and modified from https://github.com/Microsoft/vscode-debugadapter-node/blob/master/adapter/src/protocol.ts
 
+import * as net from 'net';
 import * as WebSocket from 'ws';
 import { injectable, inject } from "inversify";
 import { ILogger, DisposableCollection, Disposable } from "@theia/core";
@@ -76,6 +77,17 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
     protected readonly processManager: ProcessManager;
 
     start(executable: DebugAdapterExecutable): CommunicationProvider {
+
+        // If debugServer is set in the debug configuration, connect to that port for debugging
+        if (executable.debugServer) {
+            const socket = net.createConnection(executable.debugServer, '127.0.0.1');
+            return {
+                input: socket,
+                output: socket,
+                dispose: () => socket.end()
+            };
+        }
+
         const process = this.spawnProcess(executable);
 
         return {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR adds support for debugging the debug extensions as outlined in the [vscode example debug adapter](https://code.visualstudio.com/docs/extensions/example-debuggers#_development-setup-for-mock-debug).

This is undertaken by adding the `debugServer` config setting to the Theia debug configuration, e.g.:

```json
  {
    "type": "node",
    "request": "attach",
    "name": "Attach by PID",
    "processId": "1234",
    "debugServer": "4711"
  }
```
The `Debug-Nodejs Server` vscode launch configuration then starts the debug extension and when debugging is started, it connects to the debugger instead of spawning it.