### PR TITLE
GH-2478: Made the Java LS download URL more flexible.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,12 @@
         {
             "type": "node",
             "request": "launch",
+            "name": "Launch with Node.js",
+            "program": "${file}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
             "name": "Launch Electron Backend",
             "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
             "windows": {

--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -11,6 +11,7 @@
     "@types/tar": "4.0.0",
     "glob": "^7.1.2",
     "mkdirp": "^0.5.0",
+    "sha1": "^1.1.1",
     "tar": "^4.0.0"
   },
   "devDependencies": {
@@ -57,7 +58,6 @@
     "extends": "../../configs/nyc.json"
   },
   "ls": {
-    "download.base": "https://www.eclipse.org/downloads/download.php?file=",
-    "download.path": "/che/che-ls-jdt/snapshots/che-jdt-language-server-latest.tar.gz"
+    "downloadUrl": "https://www.eclipse.org/downloads/download.php?file=/che/che-ls-jdt/snapshots/che-jdt-language-server-latest.tar.gz&r=1"
   }
 }

--- a/packages/java/scripts/get-dev-server.js
+++ b/packages/java/scripts/get-dev-server.js
@@ -27,7 +27,7 @@ const package = require('../package.json');
 const shared = require('./shared');
 
 const devVersion = package.ls.dev.version;
-const packagePath = path.join(__dirname, "..");
+const packagePath = path.join(__dirname, '..');
 const targetPath = path.join(packagePath, 'server');
 const archiveName = `jdt.ls.extension.product-${devVersion}.tar.gz`;
 const downloadDir = 'download';

--- a/packages/java/scripts/shared.js
+++ b/packages/java/scripts/shared.js
@@ -22,17 +22,17 @@ const mkdirp = require('mkdirp');
 exports.decompressArchive = function (archivePath, targetPath) {
     return new Promise((resolve, reject) => {
         if (!fs.existsSync(archivePath)) {
-            reject(new Error("archive not found"));
+            reject(new Error(`The archive was not found at ${archivePath}.`));
             return;
         }
         if (!fs.existsSync(targetPath)) {
             mkdirp.sync(targetPath);
         }
         const gunzip = zlib.createGunzip({ finishFlush: zlib.Z_SYNC_FLUSH, flush: zlib.Z_SYNC_FLUSH });
-        console.log(targetPath);
+        console.log(`Decompressing the archive to ${targetPath}.`);
         const untar = tar.x({ cwd: targetPath });
         fs.createReadStream(archivePath).pipe(gunzip).pipe(untar)
-            .on("error", e => reject(e))
-            .on("end", () => resolve());
+            .on('error', e => reject(e))
+            .on('end', () => resolve());
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,6 +2050,10 @@ chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
+"charenc@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
@@ -2728,6 +2732,10 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+"crypt@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -8483,6 +8491,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha1@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sha1/-/sha1-1.1.1.tgz#addaa7a93168f393f19eb2b15091618e2700f848"
+  dependencies:
+    charenc ">= 0.0.1"
+    crypt ">= 0.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Introduced a download history JSON file to track the
original file source (download URL) with the SHA1 hash
of the file name. So there is no need to hard-code
or assume anything about the file names.

Fix the broken property access of the download URL.

Closes #2478.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>