### PR TITLE
Update recent workspace name to include workspaces beginning with punctuation

### DIFF
--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -28,12 +28,11 @@ export class QuickOpenWorkspace implements QuickOpenModel {
     @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(MessageService) protected readonly messageService: MessageService;
-    protected readonly workspace: string | undefined;
 
     open(workspaces: string[]): void {
         this.items = [];
         for (const workspace of workspaces) {
-            this.items.push(new WorkspaceQuickOpenItem(this.workspaceService, workspace, this.messageService));
+            this.items.push(new WorkspaceQuickOpenItem(this.workspaceService, this.messageService, workspace));
         }
 
         this.quickOpenService.open(this, {
@@ -61,17 +60,18 @@ export class WorkspaceQuickOpenItem extends QuickOpenItem {
 
     constructor(
         private readonly workspaceService: WorkspaceService,
-        private readonly workspace: string | undefined,
-        private readonly messageService: MessageService
+        private readonly messageService: MessageService,
+        private readonly workspace: string,
     ) {
         super();
     }
 
+    /**
+     * Display the workspace name
+     * @returns workspace name
+     */
     getLabel(): string {
-        if (this.workspace) {
-            return new URI(this.workspace).path.name;
-        }
-        return '';
+        return new URI(this.workspace).path.base;
     }
 
     /**


### PR DESCRIPTION
`ex: .theia, .python-apps`

![peakcorrect](https://user-images.githubusercontent.com/40359487/43788410-53a29e92-9a3b-11e8-9aaa-9e6f824f86be.gif)


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>