### PR TITLE
GH-2528: Fixed the incorrect module imports.

### DIFF
--- a/packages/core/src/browser/endpoint.spec.ts
+++ b/packages/core/src/browser/endpoint.spec.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as chai from 'chai';
-import { Endpoint } from '@theia/core/src/browser/endpoint';
+import { Endpoint } from './endpoint';
 
 const expect = chai.expect;
 

--- a/packages/core/src/browser/test/mock-connection-status-service.ts
+++ b/packages/core/src/browser/test/mock-connection-status-service.ts
@@ -16,7 +16,7 @@
 
 import { MockLogger } from '../../common/test/mock-logger';
 import { AbstractConnectionStatusService } from '../connection-status-service';
-import { ILogger } from '@theia/core/src/common';
+import { ILogger } from '../../common/logger';
 
 export class MockConnectionStatusService extends AbstractConnectionStatusService {
 

--- a/packages/java/src/node/java-cli-contribution.ts
+++ b/packages/java/src/node/java-cli-contribution.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Argv, Arguments } from 'yargs';
-import { CliContribution } from '@theia/core/src/node/cli';
+import { CliContribution } from '@theia/core/lib/node/cli';
 
 @injectable()
 export class JavaCliContribution implements CliContribution {


### PR DESCRIPTION
Switched from `src` to `lib`.

Closes #2528.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>