### PR TITLE
[preview/md] show images from workspace

### DIFF
--- a/packages/core/src/browser/file-icons-js.d.ts
+++ b/packages/core/src/browser/file-icons-js.d.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-declare module "file-icons-js" {
+declare module 'file-icons-js' {
     function getClass(filePath: string): string;
     function getClassWithColor(filePath: string): string;
 }

--- a/packages/mini-browser/src/browser/location-mapper-service.ts
+++ b/packages/mini-browser/src/browser/location-mapper-service.ts
@@ -105,6 +105,12 @@ export class HttpsLocationMapper implements LocationMapper {
 
 }
 
+export class MiniBrowserEndpoint extends Endpoint {
+    constructor() {
+        super({ path: 'mini-browser' });
+    }
+}
+
 /**
  * `file` URI location mapper.
  */
@@ -124,7 +130,7 @@ export class FileLocationMapper implements LocationMapper {
         if (rawLocation.charAt(0) === '/') {
             rawLocation = rawLocation.substr(1);
         }
-        return new Endpoint().getRestUrl().resolve(`mini-browser/${rawLocation}`).toString();
+        return new MiniBrowserEndpoint().getRestUrl().resolve(rawLocation).toString();
     }
 
 }

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -296,7 +296,7 @@ export class SvgHandler implements MiniBrowserEndpointHandler {
     }
 
     respond(statWithContent: FileStatWithContent, response: Response): MaybePromise<Response> {
-        response.contentType('text/xml');
+        response.contentType('image/svg+xml');
         return response.send(statWithContent.content);
     }
 

--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.13",
     "@theia/editor": "^0.3.13",
     "@theia/languages": "^0.3.13",
+    "@theia/mini-browser": "^0.3.13",
     "@types/highlight.js": "^9.12.2",
     "@types/markdown-it": "^0.0.4",
     "@types/markdown-it-anchor": "^4.0.1",

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -31,6 +31,10 @@ let previewHandler: MarkdownPreviewHandler;
 
 before(() => {
     previewHandler = new MarkdownPreviewHandler();
+    (previewHandler as any).linkNormalizer = {
+        normalizeLink: (documentUri: URI, link: string) =>
+            'endpoint/' + documentUri.parent.resolve(link).path.toString().substr(1)
+    };
 });
 
 describe('markdown-preview-handler', () => {
@@ -46,6 +50,11 @@ describe('markdown-preview-handler', () => {
     it('renders html with line information', async () => {
         const contentElement = await previewHandler.renderContent({ content: exampleMarkdown1, originUri: new URI('') });
         expect(contentElement.innerHTML).equals(exampleHtml1);
+    });
+
+    it('renders images', async () => {
+        const contentElement = await previewHandler.renderContent({ content: exampleMarkdown2, originUri: new URI('file:///Users/me/workspace/DEMO.md') });
+        expect(contentElement.innerHTML).equals(exampleHtml2);
     });
 
     it('finds element for source line', () => {
@@ -102,6 +111,16 @@ const exampleHtml1 = //
 See <a href="https://github.com/theia-ide/theia">here</a>.</p>
 <h2 id="license" class="line" data-line="4">License</h2>
 <p class="line" data-line="5"><a href="https://github.com/theia-ide/theia/blob/master/LICENSE">Apache-2.0</a></p>
+`;
+
+const exampleMarkdown2 = //
+    `# Heading
+![alternativetext](subfolder/image.png)
+`;
+
+const exampleHtml2 = //
+    `<h1 id="heading" class="line" data-line="0">Heading</h1>
+<p class="line" data-line="1"><img src="endpoint/Users/me/workspace/subfolder/image.png" alt="alternativetext"></p>
 `;
 
 /**

--- a/packages/preview/src/browser/preview-frontend-module.ts
+++ b/packages/preview/src/browser/preview-frontend-module.ts
@@ -24,6 +24,7 @@ import { PreviewHandler, PreviewHandlerProvider } from './preview-handler';
 import { PreviewUri } from './preview-uri';
 import { MarkdownPreviewHandler } from './markdown';
 import { bindPreviewPreferences } from './preview-preferences';
+import { PreviewLinkNormalizer } from './preview-link-normalizer';
 
 import '../../src/browser/style/index.css';
 import '../../src/browser/markdown/style/index.css';
@@ -34,6 +35,7 @@ export default new ContainerModule(bind => {
     bindContributionProvider(bind, PreviewHandler);
     bind(MarkdownPreviewHandler).toSelf().inSingletonScope();
     bind(PreviewHandler).toService(MarkdownPreviewHandler);
+    bind(PreviewLinkNormalizer).toSelf().inSingletonScope();
 
     bind(PreviewWidget).toSelf();
     bind<WidgetFactory>(WidgetFactory).toDynamicValue(ctx => ({

--- a/packages/preview/src/browser/preview-handler.ts
+++ b/packages/preview/src/browser/preview-handler.ts
@@ -25,6 +25,12 @@ export interface RenderContentParams {
     originUri: URI;
 }
 
+export namespace RenderContentParams {
+    export function is(params: object | undefined): params is RenderContentParams {
+        return !!params && 'content' in params && 'originUri' in params;
+    }
+}
+
 export interface PreviewHandler {
     readonly iconClass?: string;
     canHandle(uri: URI): number;

--- a/packages/preview/src/browser/preview-link-normalizer.ts
+++ b/packages/preview/src/browser/preview-link-normalizer.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,23 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-declare module 'string-argv' {
-    function stringArgv(...args: string[]): string[];
-    export = stringArgv;
-}
+import { injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { Endpoint } from '@theia/core/lib/browser';
 
+@injectable()
+export class PreviewLinkNormalizer {
+
+    normalizeLink(documentUri: URI, link: string): string {
+        try {
+            const uri = new URI(link);
+            if (!uri.scheme) {
+                const location = documentUri.parent.resolve(link).path.toString();
+                return new Endpoint({ path: 'mini-browser/' + location }).getRestUrl().toString();
+            }
+        } catch {
+            // ignore
+        }
+        return link;
+    }
+}

--- a/packages/preview/src/browser/preview-link-normalizer.ts
+++ b/packages/preview/src/browser/preview-link-normalizer.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { Endpoint } from '@theia/core/lib/browser';
+import { MiniBrowserEndpoint } from '@theia/mini-browser/lib/browser/location-mapper-service';
 
 @injectable()
 export class PreviewLinkNormalizer {
@@ -26,7 +26,7 @@ export class PreviewLinkNormalizer {
             const uri = new URI(link);
             if (!uri.scheme) {
                 const location = documentUri.parent.resolve(link).path.toString();
-                return new Endpoint({ path: 'mini-browser/' + location }).getRestUrl().toString();
+                return new MiniBrowserEndpoint().getRestUrl().resolve(location).toString();
             }
         } catch {
             // ignore


### PR DESCRIPTION
this PR introduces a link normalizer for the markdown renderer, which will convert relative links (of images) to "mini-browser" links.

Closes #2055

TODO:
- [x] write some tests
- [ ] check for content types