### PR TITLE
Workspace Folder pick API

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -181,6 +181,21 @@ export interface OpenDialogOptionsMain {
     filters?: { [name: string]: string[] };
 }
 
+/**
+ * Options to configure the behaviour of the [workspace folder](#WorkspaceFolder) pick UI.
+ */
+export interface WorkspaceFolderPickOptionsMain {
+    /**
+     * An optional string to show as place holder in the input box to guide the user what to pick on.
+     */
+    placeHolder?: string;
+
+    /**
+     * Set to `true` to keep the picker open when focus moves to another part of the editor or to another window.
+     */
+    ignoreFocusOut?: boolean;
+}
+
 export interface QuickOpenMain {
     $show(options: PickOptions): Promise<number | number[]>;
     $setItems(items: PickOpenItem[]): Promise<any>;
@@ -189,12 +204,16 @@ export interface QuickOpenMain {
     $showOpenDialog(options: OpenDialogOptionsMain): Promise<string[] | undefined>;
 }
 
-export interface WindowStateExt {
-    $onWindowStateChanged(focus: boolean): void;
+export interface WorkspaceMain {
+    $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<theia.WorkspaceFolder | undefined>;
 }
 
 export interface WorkspaceExt {
     $onWorkspaceFoldersChanged(event: theia.WorkspaceFoldersChangeEvent): void;
+}
+
+export interface WindowStateExt {
+    $onWindowStateChanged(focus: boolean): void;
 }
 
 export enum EditorPosition {
@@ -553,6 +572,7 @@ export interface LanguagesMain {
 export const PLUGIN_RPC_CONTEXT = {
     COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
     QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
+    WORKSPACE_MAIN: createProxyIdentifier<WorkspaceMain>('WorkspaceMain'),
     MESSAGE_REGISTRY_MAIN: <ProxyIdentifier<MessageRegistryMain>>createProxyIdentifier<MessageRegistryMain>('MessageRegistryMain'),
     TEXT_EDITORS_MAIN: createProxyIdentifier<TextEditorsMain>('TextEditorsMain'),
     DOCUMENTS_MAIN: createProxyIdentifier<DocumentsMain>('DocumentsMain'),

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -21,12 +21,11 @@ import { RPCProtocol } from '../../api/rpc-protocol';
 import { PLUGIN_RPC_CONTEXT } from '../../api/plugin-api';
 import { MessageRegistryMainImpl } from './message-registry-main';
 import { WindowStateMain } from './window-state-main';
-import { WorkspaceMain } from './workspace-main';
+import { WorkspaceMainImpl } from './workspace-main';
 import { StatusBarMessageRegistryMainImpl } from './status-bar-message-registry-main';
 import { EnvMainImpl } from './env-main';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
 import { OutputChannelRegistryMainImpl } from './output-channel-registry-main';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { TerminalServiceMainImpl } from './terminal-main';
 import { LanguagesMainImpl } from './languages-main';
 
@@ -37,6 +36,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const quickOpenMain = new QuickOpenMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.QUICK_OPEN_MAIN, quickOpenMain);
 
+    const workspaceMain = new WorkspaceMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.WORKSPACE_MAIN, workspaceMain);
+
     const messageRegistryMain = new MessageRegistryMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN, messageRegistryMain);
 
@@ -45,7 +47,6 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     /* tslint:disable */
     new WindowStateMain(rpc);
-    new WorkspaceMain(rpc, container.get(WorkspaceService));
     new EditorsAndDocumentsMain(rpc, container);
     /* tslint:enable */
 

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -14,44 +14,114 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { WorkspaceExt, MAIN_RPC_CONTEXT } from '../../api/plugin-api';
+import { interfaces } from 'inversify';
+import { WorkspaceExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain } from '../../api/plugin-api';
 import { RPCProtocol } from '../../api/rpc-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import Uri from 'vscode-uri';
 import { WorkspaceFoldersChangeEvent, WorkspaceFolder } from '@theia/plugin';
 import { Path } from '@theia/core/lib/common/path';
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open/quick-open-model';
+import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
+import { FileStat } from '@theia/filesystem/lib/common';
 
-export class WorkspaceMain {
+export class WorkspaceMainImpl implements WorkspaceMain {
 
     private proxy: WorkspaceExt;
 
-    private workspaceRoot: Uri | undefined;
+    private quickOpenService: MonacoQuickOpenService;
 
-    constructor(rpc: RPCProtocol, workspaceService: WorkspaceService) {
+    private roots: FileStat[];
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WORKSPACE_EXT);
+        this.quickOpenService = container.get(MonacoQuickOpenService);
+        const workspaceService = container.get(WorkspaceService);
 
         workspaceService.roots.then(roots => {
-            const workspaceFolder = roots[0];
-            if (workspaceFolder) {
-                this.workspaceRoot = Uri.parse(workspaceFolder.uri);
-                const workspacePath = new Path(this.workspaceRoot.path);
+            this.roots = roots;
+            this.notifyWorkspaceFoldersChanged();
+        });
+    }
 
-                const folder: WorkspaceFolder = {
-                    uri: this.workspaceRoot,
-                    name: workspacePath.base,
+    notifyWorkspaceFoldersChanged() {
+        if (this.roots && this.roots.length) {
+            const folders = this.roots.map(root => {
+                const uri = Uri.parse(root.uri);
+                const path = new Path(uri.path);
+                return {
+                    uri: uri,
+                    name: path.base,
                     index: 0
                 } as WorkspaceFolder;
+            });
 
-                this.proxy.$onWorkspaceFoldersChanged({
-                    added: [folder],
-                    removed: []
-                } as WorkspaceFoldersChangeEvent);
-            } else {
-                this.proxy.$onWorkspaceFoldersChanged({
-                    added: [],
-                    removed: []
-                } as WorkspaceFoldersChangeEvent);
+            this.proxy.$onWorkspaceFoldersChanged({
+                added: folders,
+                removed: []
+            } as WorkspaceFoldersChangeEvent);
+        } else {
+            this.proxy.$onWorkspaceFoldersChanged({
+                added: [],
+                removed: []
+            } as WorkspaceFoldersChangeEvent);
+        }
+    }
+
+    $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<WorkspaceFolder | undefined> {
+        return new Promise((resolve, reject) => {
+            // Return undefined if workspace root is not set
+            if (!this.roots || !this.roots.length) {
+                resolve(undefined);
+                return;
             }
+
+            // Active before appearing the pick menu
+            const activeElement: HTMLElement | undefined = window.document.activeElement as HTMLElement;
+
+            // WorkspaceFolder to be returned
+            let returnValue: WorkspaceFolder | undefined;
+
+            const items = this.roots.map(root => {
+                const rootUri = Uri.parse(root.uri);
+                const rootPathName = rootUri.path.substring(rootUri.path.lastIndexOf('/') + 1);
+                return new QuickOpenItem({
+                    label: rootPathName,
+                    detail: rootUri.path,
+                    run: mode => {
+                        if (mode === QuickOpenMode.OPEN) {
+                            returnValue = {
+                                uri: rootUri,
+                                name: rootPathName,
+                                index: 0
+                            } as WorkspaceFolder;
+                        }
+                        return true;
+                    }
+                });
+            });
+
+            // Create quick open model
+            const model = {
+                onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+                    acceptor(items);
+                }
+            } as QuickOpenModel;
+
+            // Show pick menu
+            this.quickOpenService.open(model, {
+                fuzzyMatchLabel: true,
+                fuzzyMatchDetail: true,
+                fuzzyMatchDescription: true,
+                placeholder: options.placeHolder,
+                onClose: () => {
+                    if (activeElement) {
+                        activeElement.focus();
+                    }
+
+                    resolve(returnValue);
+                }
+            });
         });
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -67,7 +67,7 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
     const editorsAndDocuments = rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, new EditorsAndDocumentsExtImpl(rpc));
     const editors = rpc.set(MAIN_RPC_CONTEXT.TEXT_EDITORS_EXT, new TextEditorsExtImpl(rpc, editorsAndDocuments));
     const documents = rpc.set(MAIN_RPC_CONTEXT.DOCUMENTS_EXT, new DocumentsExtImpl(rpc, editorsAndDocuments));
-    const workspaceExt = rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, new WorkspaceExtImpl());
+    const workspaceExt = rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, new WorkspaceExtImpl(rpc));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const envExt = rpc.set(MAIN_RPC_CONTEXT.ENV_EXT, new EnvExtImpl(rpc));
@@ -128,6 +128,9 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
             } else {
                 return quickOpenExt.showQuickPick(items, options);
             }
+        },
+        showWorkspaceFolderPick(options?: theia.WorkspaceFolderPickOptions) {
+            return workspaceExt.pickWorkspaceFolder(options);
         },
         showInformationMessage(message: string,
             optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -14,19 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { WorkspaceFolder, WorkspaceFoldersChangeEvent } from '@theia/plugin';
+import { WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFolderPickOptions } from '@theia/plugin';
 import { Event, Emitter } from '@theia/core/lib/common/event';
-import { WorkspaceExt } from '../api/plugin-api';
+import { WorkspaceExt, WorkspaceFolderPickOptionsMain } from '../api/plugin-api';
 import { Path } from '@theia/core/lib/common/path';
+import { RPCProtocol } from '../api/rpc-protocol';
+import { WorkspaceMain, PLUGIN_RPC_CONTEXT as Ext } from '../api/plugin-api';
 
 export class WorkspaceExtImpl implements WorkspaceExt {
+
+    private proxy: WorkspaceMain;
 
     private workspaceFoldersChangedEmitter = new Emitter<WorkspaceFoldersChangeEvent>();
     public readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent> = this.workspaceFoldersChangedEmitter.event;
 
     private folders: WorkspaceFolder[] | undefined;
 
-    constructor() {
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(Ext.WORKSPACE_MAIN);
     }
 
     get workspaceFolders(): WorkspaceFolder[] | undefined {
@@ -44,6 +49,19 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     $onWorkspaceFoldersChanged(event: WorkspaceFoldersChangeEvent): void {
         this.folders = event.added;
         this.workspaceFoldersChangedEmitter.fire(event);
+    }
+
+    pickWorkspaceFolder(options?: WorkspaceFolderPickOptions): PromiseLike<WorkspaceFolder | undefined> {
+        return new Promise((resolve, reject) => {
+            const optionsMain = {
+                placeHolder: options && options.placeHolder ? options.placeHolder : undefined,
+                ignoreFocusOut: options && options.ignoreFocusOut
+            } as WorkspaceFolderPickOptionsMain;
+
+            this.proxy.$pickWorkspaceFolder(optionsMain).then(value => {
+                resolve(value);
+            });
+        });
     }
 
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1464,6 +1464,22 @@ declare module '@theia/plugin' {
         onDidSelectItem?(item: QuickPickItem | string): any;
     }
 
+	/**
+	 * Options to configure the behaviour of the [workspace folder](#WorkspaceFolder) pick UI.
+	 */
+    export interface WorkspaceFolderPickOptions {
+
+		/**
+		 * An optional string to show as place holder in the input box to guide the user what to pick on.
+		 */
+        placeHolder?: string;
+
+		/**
+		 * Set to `true` to keep the picker open when focus moves to another part of the editor or to another window.
+		 */
+        ignoreFocusOut?: boolean;
+    }
+
     /**
      * Options to configure the behavior of the input box UI.
      */
@@ -1929,6 +1945,15 @@ declare module '@theia/plugin' {
          * Shows a selection list with multiple selection allowed.
          */
         export function showQuickPick<T extends QuickPickItem>(items: T[] | PromiseLike<T[]>, options: QuickPickOptions & { canPickMany: true }, token?: CancellationToken): PromiseLike<T[] | undefined>;
+
+		/**
+		 * Shows a selection list of [workspace folders](#workspace.workspaceFolders) to pick from.
+		 * Returns `undefined` if no folder is open.
+		 *
+		 * @param options Configures the behavior of the workspace folder list.
+		 * @return A promise that resolves to the workspace folder or `undefined`.
+		 */
+        export function showWorkspaceFolderPick(options?: WorkspaceFolderPickOptions): PromiseLike<WorkspaceFolder | undefined>;
 
         /**
          * Show an information message.


### PR DESCRIPTION
Plugin API for picking workspace folder.
Should display several items in the list for multiroot workspace.
Have tested when only one folder is opened.

Issue https://github.com/theia-ide/theia/issues/2337

![sample-code-and-menu](https://user-images.githubusercontent.com/1655894/43884722-8760f532-9bbf-11e8-838d-840539230ed3.png)

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>