### PR TITLE
[plug-in] Provides plugin context in start lifecycle method

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -321,17 +321,29 @@ export function createAPI(rpc: RPCProtocol): typeof theia {
 }
 
 // tslint:disable-next-line:no-any
-export function startPlugin(plugin: Plugin, pluginMain: any, plugins: Map<string, () => void>): void {
+export function startPlugin(plugin: Plugin, pluginMain: any, plugins: Map<string, any>): void {
+
+    const pluginId = getPluginId(plugin.model);
+    const pluginData: any = {};
+
+    // Create pluginContext object for this plugin.
+    const subscriptions: theia.Disposable[] = [];
+    const pluginContext: theia.PluginContext = {
+        subscriptions: subscriptions
+    };
+    pluginData.pluginContext = pluginContext;
+
     if (typeof pluginMain[plugin.lifecycle.startMethod] === 'function') {
-        pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), []);
+        pluginMain[plugin.lifecycle.startMethod].apply(getGlobal(), [pluginContext]);
     } else {
-        console.log('there is no doStart method on plugin');
+        console.log('There is no start method on plugin');
     }
 
     if (typeof pluginMain[plugin.lifecycle.stopMethod] === 'function') {
-        const pluginId = getPluginId(plugin.model);
-        plugins.set(pluginId, pluginMain[plugin.lifecycle.stopMethod]);
+        pluginData.stopMethod = pluginMain[plugin.lifecycle.stopMethod];
     }
+
+    plugins.set(pluginId, pluginData);
 }
 
 // for electron

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1919,6 +1919,22 @@ declare module '@theia/plugin' {
     }
 
     /**
+	 * A plug-in context is a collection of utilities private to a
+	 * plug-in.
+	 *
+	 * An instance of a `PluginContext` is provided as the first
+	 * parameter to the `start` of a plug-in.
+	 */
+    export interface PluginContext {
+
+		/**
+		 * An array to which disposables can be added. When this
+		 * extension is deactivated the disposables will be disposed.
+		 */
+        subscriptions: { dispose(): any }[];
+    }
+
+    /**
      * Common namespace for dealing with window and editor, showing messages and user input.
      */
     export namespace window {


### PR DESCRIPTION
Provides a plugin context allowing to register disposable for terminating them on stop
Fix #2183 

Change-Id: I7be53be2cfb690674f4b1eecb382f0c20431b459
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>