### PR TITLE
Add preference to limit the number of recent workspaces listed

### DIFF
--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -20,6 +20,7 @@ import { WorkspaceService } from './workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { MessageService } from '@theia/core/lib/common';
 import { FileSystem, FileSystemUtils } from '@theia/filesystem/lib/common';
+import { WorkspacePreferences } from './workspace-preferences';
 
 @injectable()
 export class QuickOpenWorkspace implements QuickOpenModel {
@@ -30,6 +31,7 @@ export class QuickOpenWorkspace implements QuickOpenModel {
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(MessageService) protected readonly messageService: MessageService;
     @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
 
     async open(workspaces: string[]): Promise<void> {
         this.items = [];
@@ -80,7 +82,7 @@ export class QuickOpenWorkspace implements QuickOpenModel {
         this.items = [];
         this.workspaceService.recentWorkspaces().then(workspaceRoots => {
             if (workspaceRoots) {
-                this.open(workspaceRoots);
+                this.open(workspaceRoots.slice(0, this.preferences['workspace.recentWorkspaceLimit']));
             }
         });
     }

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -39,13 +39,21 @@ export const workspacePreferenceSchema: PreferenceSchema = {
                 type: 'boolean'
             },
             default: false
+        },
+        'workspace.recentWorkspaceLimit': {
+            description: 'Recent workspace limit',
+            additionalProperties: {
+                type: 'number'
+            },
+            default: 10
         }
     }
 };
 
 export interface WorkspaceConfiguration {
     'workspace.preserveWindow': boolean,
-    'workspace.supportMultiRootWorkspace': boolean
+    'workspace.supportMultiRootWorkspace': boolean,
+    'workspace.recentWorkspaceLimit': number
 }
 
 export const WorkspacePreferences = Symbol('WorkspacePreferences');


### PR DESCRIPTION
Added a `workspace preference` to limit the number of recent workspace listed for end users.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>