### PR TITLE
disallow users to open file from "Open Workspace"

### DIFF
--- a/packages/filesystem/src/browser/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog-service.ts
@@ -31,7 +31,7 @@ export class FileDialogService {
     async show(props: FileDialogProps & { canSelectMany: true }, folder?: FileStat): Promise<MaybeArray<FileStatNode> | undefined>;
     async show(props: FileDialogProps, folder?: FileStat): Promise<FileStatNode | undefined>;
     async show(props: FileDialogProps, folder?: FileStat): Promise<MaybeArray<FileStatNode> | undefined> {
-        const title = props && props.title ? props.title : 'Open';
+        const title = props.title || 'Open';
         const folderToOpen = folder || await this.fileSystem.getCurrentUserHome();
         if (folderToOpen) {
             const rootUri = new URI(folderToOpen.uri).parent;
@@ -42,7 +42,7 @@ export class FileDialogService {
             ]);
             if (rootStat) {
                 const rootNode = DirNode.createRoot(rootStat, name, label);
-                const dialog = this.fileDialogFactory({ title });
+                const dialog = this.fileDialogFactory(Object.assign(props, { title }));
                 dialog.model.navigateTo(rootNode);
                 return await dialog.open();
             }

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -52,7 +52,8 @@ export class KeymapsFrontendContribution implements CommandContribution, MenuCon
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: KeymapsCommands.OPEN_KEYMAPS.id
+            commandId: KeymapsCommands.OPEN_KEYMAPS.id,
+            order: 'a40'
         });
     }
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -188,7 +188,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
 
     protected readonly openWorkspace = () => this.doOpenWorkspace();
     protected doOpenWorkspace() {
-        this.commandService.executeCommand(WorkspaceCommands.OPEN.id);
+        this.commandService.executeCommand(WorkspaceCommands.OPEN_WORKSPACE.id);
     }
 
     /**

--- a/packages/preferences/src/browser/preferences-contribution.ts
+++ b/packages/preferences/src/browser/preferences-contribution.ts
@@ -45,10 +45,10 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
     @inject(FileSystem) protected readonly filesystem: FileSystem;
 
     constructor() {
-        super ({
+        super({
             widgetId: PREFERENCES_CONTAINER_WIDGET_ID,
             widgetName: 'Preferences',
-            defaultWidgetOptions: {area: 'main'}
+            defaultWidgetOptions: { area: 'main' }
         });
     }
 
@@ -61,7 +61,8 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: PREFERENCES_COMMAND.id
+            commandId: PREFERENCES_COMMAND.id,
+            order: 'a30'
         });
     }
 
@@ -80,7 +81,7 @@ export class PreferencesContribution extends AbstractViewContribution<Preference
             await this.filesystem.createFile(wsUri.toString(), { content: this.getPreferenceTemplateForScope('workspace') });
         }
 
-        super.openView({activate: true});
+        super.openView({ activate: true });
     }
 
     private getPreferenceTemplateForScope(scope: string): string {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -34,9 +34,13 @@ import { WorkspaceDeleteHandler } from './workspace-delete-handler';
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
 export namespace WorkspaceCommands {
-    export const OPEN: Command = {
-        id: 'workspace:open',
-        label: 'Open...'
+    export const OPEN_FILE: Command = {
+        id: 'workspace:openFile',
+        label: 'Open File...'
+    };
+    export const OPEN_WORKSPACE: Command = {
+        id: 'workspace:openWorkspace',
+        label: 'Open Workspace...'
     };
     export const OPEN_RECENT_WORKSPACE: Command = {
         id: 'workspace:openRecent',


### PR DESCRIPTION
- differentiated opening files from opening folders by having 2 separated menu items "Open File..." & "Open Workspace..."
    - only folders can be selected from the dialog of "Open Workspace...".
    - only files can be selected from the dialog of "Open File..."
- fixes #2575

Signed-off-by: elaihau <liang.huang@ericsson.com>