### PR TITLE
revert "Open File..." to "Open..." in File menu

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -34,9 +34,9 @@ import { WorkspaceDeleteHandler } from './workspace-delete-handler';
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
 export namespace WorkspaceCommands {
-    export const OPEN_FILE: Command = {
-        id: 'workspace:openFile',
-        label: 'Open File...'
+    export const OPEN: Command = {
+        id: 'workspace:open',
+        label: 'Open...'
     };
     export const OPEN_WORKSPACE: Command = {
         id: 'workspace:openWorkspace',

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -38,11 +38,11 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(WorkspaceCommands.OPEN_FILE, {
+        commands.registerCommand(WorkspaceCommands.OPEN, {
             isEnabled: () => true,
             execute: () => this.showFileDialog({
-                title: WorkspaceCommands.OPEN_FILE.label!,
-                canSelectFolders: false,
+                title: WorkspaceCommands.OPEN.label!,
+                canSelectFolders: true,
                 canSelectFiles: true
             })
         });
@@ -66,7 +66,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
-            commandId: WorkspaceCommands.OPEN_FILE.id,
+            commandId: WorkspaceCommands.OPEN.id,
             order: 'a00'
         });
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {


### PR DESCRIPTION
- reverted the change made to the menu item File -> Open...
  - `File -> Open...` can be used to open a file or directory.
  - `File -> Open Workspace...` can be used to open a directory only.

Signed-off-by: elaihau <liang.huang@ericsson.com>