### PR TITLE
Add existed java extensions into jdt.ls initialization parameters

### DIFF
--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -6,6 +6,15 @@ See [here](https://github.com/theia-ide/theia) for a detailed documentation.
 Update  'jdt.ls.download.path in 'package.json' to update the jdt.ls used by the extension
 remove the key to fall-back to latest jdt.ls build.
 
+## Contribute a Java Extension
+`JavaExtensionContribution` is a contribution point for all java extensions to provide paths of bundle jar files.
+
+### Implement `JavaExtensionContribution`
+1. Put your bundle together with your extension (./bundles subfolder for example);
+2. Create new class which implements `JavaExtensionContribution`, 
+This class should return paths to the java bundles and the paths should be absolute.
+3. Don't forget to bind yor class  `bind(JavaExtensionContribution).to(MyExtension).inSingletonScope();`
+Then Java Language Server will install this bundle for later usage.
 
 ## License
 - [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)

--- a/packages/java/src/node/java-backend-module.ts
+++ b/packages/java/src/node/java-backend-module.ts
@@ -15,13 +15,17 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
+import { bindContributionProvider } from '@theia/core/lib/common';
 import { CliContribution } from '@theia/core/lib/node/cli';
 import { LanguageServerContribution } from '@theia/languages/lib/node';
 import { JavaContribution } from './java-contribution';
 import { JavaCliContribution } from './java-cli-contribution';
+import { JavaExtensionContribution } from './java-extension-model';
 
 export default new ContainerModule(bind => {
     bind(LanguageServerContribution).to(JavaContribution).inSingletonScope();
     bind(JavaCliContribution).toSelf().inSingletonScope();
     bind(CliContribution).toService(JavaCliContribution);
+
+    bindContributionProvider(bind, JavaExtensionContribution);
 });

--- a/packages/java/src/node/java-extension-model.ts
+++ b/packages/java/src/node/java-extension-model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,18 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from '../common';
-export * from './java-contribution';
-export * from './java-extension-model';
-export * from './java-backend-module';
+/**
+ * JavaExtensionContribution symbol for DI.
+ */
+export const JavaExtensionContribution = Symbol('JavaExtensionContribution');
+
+/**
+ * A contribution point for extensions to jdt.ls.
+ */
+export interface JavaExtensionContribution {
+    /**
+     * Returns an array of paths to the bundle jar files.
+     * The paths should be absolute.
+     */
+    getExtensionBundles(): string[];
+}


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
### What does this PR do:
This PR provides an ability to find all plugins(bundles) of jdt.ls in Theia's extensions and add them into `initializationOptions` when Java Language Server start initializing.

### Reference issues 
https://github.com/theia-ide/theia/issues/1878
