### PR TITLE
multi-root workspace support, vsCode compatibility

### DIFF
--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -117,7 +117,7 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
 }
 
 export interface FileMoveOptions {
-	overwrite?: boolean;
+    overwrite?: boolean;
 }
 
 export interface FileDeleteOptions {
@@ -175,6 +175,15 @@ export namespace FileStat {
         return candidate.hasOwnProperty('uri')
             && candidate.hasOwnProperty('lastModification')
             && candidate.hasOwnProperty('isDirectory');
+    }
+
+    export function equals(one: object | undefined, other: object | undefined): boolean {
+        if (!one || !other || !is(one) || !is(other)) {
+            return false;
+        }
+        return one.uri === other.uri
+            && one.lastModification === other.lastModification
+            && one.isDirectory === other.isDirectory;
     }
 }
 

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -19,7 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { ResourceProvider, CommandService, MenuPath } from '@theia/core';
 import { ContextMenuRenderer, LabelProvider, DiffUris, StatefulWidget, Message } from '@theia/core/lib/browser';
 import { EditorManager, EditorWidget, EditorOpenerOptions } from '@theia/editor/lib/browser';
-import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
+import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { Git, GitFileChange, GitFileStatus, Repository, WorkingDirectoryStatus, CommitWithChanges } from '../common';
 import { GitWatcher, GitStatusChangeEvent } from '../common/git-watcher';
 import { GIT_RESOURCE_SCHEME } from './git-resource';
@@ -76,7 +76,6 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
         @inject(CommandService) protected readonly commandService: CommandService,
         @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
         @inject(GitAvatarService) protected readonly avatarService: GitAvatarService,
         @inject(GitCommitMessageValidator) protected readonly commitMessageValidator: GitCommitMessageValidator) {
 

--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -64,9 +64,9 @@ export class FileNavigatorModel extends FileTreeModel {
     }
 
     protected async createRoot(): Promise<TreeNode | undefined> {
-        const roots = await this.workspaceService.roots;
-        if (roots.length > 0) {
+        if (this.workspaceService.opened) {
             const workspaceNode = WorkspaceNode.createRoot();
+            const roots = await this.workspaceService.roots;
             for (const root of roots) {
                 workspaceNode.children.push(
                     await this.tree.createWorkspaceRoot(root, workspaceNode)

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -17,8 +17,8 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
-import { SelectionService, CommandService } from '@theia/core/lib/common';
-import { CommonCommands } from '@theia/core/lib/browser/common-frontend-contribution';
+import { CommandService, SelectionService } from '@theia/core/lib/common';
+import { CommonCommands } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeModel, TreeNode,
@@ -187,4 +187,5 @@ export class FileNavigatorWidget extends FileTreeWidget {
             </div>
         </div>;
     }
+
 }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -28,7 +28,6 @@ import {
     KeyModifier, KeybindingRegistry
 } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from './terminal-widget-impl';
 import { TerminalKeybindingContexts } from './terminal-keybinding-contexts';
 import { TerminalService } from './base/terminal-service';
@@ -50,8 +49,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
 
     constructor(
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
-        @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService
+        @inject(WidgetManager) protected readonly widgetManager: WidgetManager
     ) { }
 
     registerCommands(commands: CommandRegistry): void {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -19,9 +19,11 @@ import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegist
 import { open, OpenerService, CommonMenus, StorageService, LabelProvider, ConfirmDialog, KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/browser';
 import { FileStatNode, FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { FileSystem } from '@theia/filesystem/lib/common';
-import { WorkspaceService } from './workspace-service';
+import { WorkspaceService, THEIA_EXT, VSCODE_EXT } from './workspace-service';
 import { WorkspaceCommands } from './workspace-commands';
 import { QuickOpenWorkspace } from './quick-open-workspace';
+import { WorkspacePreferences } from './workspace-preferences';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class WorkspaceFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution {
@@ -33,25 +35,18 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         @inject(StorageService) protected readonly workspaceStorage: StorageService,
         @inject(LabelProvider) protected readonly labelProvider: LabelProvider,
         @inject(QuickOpenWorkspace) protected readonly quickOpenWorkspace: QuickOpenWorkspace,
-        @inject(FileDialogService) protected readonly fileDialogService: FileDialogService
+        @inject(FileDialogService) protected readonly fileDialogService: FileDialogService,
+        @inject(WorkspacePreferences) protected preferences: WorkspacePreferences
     ) { }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(WorkspaceCommands.OPEN, {
             isEnabled: () => true,
-            execute: () => this.showFileDialog({
-                title: WorkspaceCommands.OPEN.label!,
-                canSelectFolders: true,
-                canSelectFiles: true
-            })
+            execute: () => this.doOpen()
         });
         commands.registerCommand(WorkspaceCommands.OPEN_WORKSPACE, {
             isEnabled: () => true,
-            execute: () => this.showFileDialog({
-                title: WorkspaceCommands.OPEN_WORKSPACE.label!,
-                canSelectFolders: true,
-                canSelectFiles: false
-            })
+            execute: () => this.openWorkspace()
         });
         commands.registerCommand(WorkspaceCommands.CLOSE, {
             isEnabled: () => this.workspaceService.opened,
@@ -60,6 +55,10 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         commands.registerCommand(WorkspaceCommands.OPEN_RECENT_WORKSPACE, {
             isEnabled: () => this.workspaceService.hasHistory,
             execute: () => this.quickOpenWorkspace.select()
+        });
+        commands.registerCommand(WorkspaceCommands.SAVE_WORKSPACE_AS, {
+            isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
+            execute: () => this.saveWorkspaceAs()
         });
     }
 
@@ -72,12 +71,17 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             commandId: WorkspaceCommands.OPEN_WORKSPACE.id,
             order: 'a10'
         });
-        menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
-            commandId: WorkspaceCommands.CLOSE.id
-        });
         menus.registerMenuAction(CommonMenus.FILE_OPEN, {
             commandId: WorkspaceCommands.OPEN_RECENT_WORKSPACE.id,
             order: 'a20'
+        });
+        menus.registerMenuAction(CommonMenus.FILE_OPEN, {
+            commandId: WorkspaceCommands.SAVE_WORKSPACE_AS.id,
+            order: 'a30'
+        });
+
+        menus.registerMenuAction(CommonMenus.FILE_CLOSE, {
+            commandId: WorkspaceCommands.CLOSE.id
         });
     }
 
@@ -96,14 +100,18 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         });
     }
 
-    protected showFileDialog(props: OpenFileDialogProps): void {
+    protected doOpen(): void {
         this.workspaceService.roots.then(async roots => {
-            const node = await this.fileDialogService.showOpenDialog(props, roots[0]);
-            this.openFile(node);
+            const node = await this.fileDialogService.showOpenDialog({
+                title: WorkspaceCommands.OPEN.label!,
+                canSelectFolders: true,
+                canSelectFiles: true
+            }, roots[0]);
+            this.doOpenFileOrFolder(node);
         });
     }
 
-    protected openFile(node: Readonly<FileStatNode> | undefined): void {
+    protected doOpenFileOrFolder(node: Readonly<FileStatNode> | undefined): void {
         if (!node) {
             return;
         }
@@ -111,6 +119,27 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             this.workspaceService.open(node.uri);
         } else {
             open(this.openerService, node.uri);
+        }
+    }
+
+    protected async openWorkspace(): Promise<void> {
+        const option: OpenFileDialogProps = {
+            title: WorkspaceCommands.OPEN_WORKSPACE.label!,
+            canSelectFiles: false,
+            canSelectFolders: true,
+        };
+        await this.preferences.ready;
+        if (this.preferences['workspace.supportMultiRootWorkspace']) {
+            option.canSelectFiles = true;
+            option.filters = {
+                'Theia Workspace (*.theia-workspace)': [THEIA_EXT],
+                'VS Code Workspace (*.code-workspace)': [VSCODE_EXT]
+            };
+        }
+        const selected = await this.fileDialogService.showOpenDialog(option);
+        if (selected) {
+            // open the selected directory, or recreate a workspace from the selected file
+            this.workspaceService.open(selected.uri);
         }
     }
 
@@ -124,4 +153,40 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         }
     }
 
+    protected async saveWorkspaceAs(): Promise<void> {
+        let exist: boolean = false;
+        let overwrite: boolean = false;
+        let selected: URI | undefined;
+        do {
+            selected = await this.fileDialogService.showSaveDialog({
+                title: WorkspaceCommands.SAVE_WORKSPACE_AS.label!,
+                filters: {
+                    'Theia Workspace (*.theia-workspace)': [THEIA_EXT],
+                    'VS Code Workspace (*.code-workspace)': [VSCODE_EXT]
+                }
+            });
+            if (selected) {
+                const displayName = selected.displayName;
+                if (!displayName.endsWith(`.${THEIA_EXT}`) && !displayName.endsWith(`.${VSCODE_EXT}`)) {
+                    selected = selected.parent.resolve(`${displayName}.${THEIA_EXT}`);
+                }
+                exist = await this.fileSystem.exists(selected.toString());
+                if (exist) {
+                    overwrite = await this.confirmOverwrite(selected);
+                }
+            }
+        } while (selected && exist && !overwrite);
+
+        if (selected) {
+            this.workspaceService.save(selected);
+        }
+    }
+
+    private async confirmOverwrite(uri: URI): Promise<boolean> {
+        const confirmed = await new ConfirmDialog({
+            title: 'Overwrite',
+            msg: `Do you really want to overwrite "${uri.toString()}"?`
+        }).open();
+        return !!confirmed;
+    }
 }


### PR DESCRIPTION
The patch 80f402c6 added the support of having multiple roots in the same workspace. In that patch, workspace meta data is stored in the `.theia` folder of the first root, and brings up the following issues / difficulties:
- using the same first root in more than one workspace becomes impossible.
- no flexibility of naming the workspace or deciding where to store the workspace meta data.
- theia opens the implicit workspace folder after all roots are removed from the workspace, causing confusion.
- preferences of the workspace folder is used across the all roots in the same workspace.
- workspace meta data is stored in more than one file, and the format is incompatible with most other (if not all) IDEs.

This is the 2nd patch for #1660.

What is included in this PR:
- workspace meta data becomes independent from the root folders. It is users' choice to decide where to store the information, and what to name the workspace.
- theia prompts users to decide where the workspace meta data is stored, if the workspace does not have a user-specified place to store the meta data.
- workspaces can be recreated from the meta data file
- "Save workspace As..." is available for users to rename workspace or change location of the meta data.
- the format of theia workspace meta data is compatible with that of vsCode. Paths relative to the parent folder of the workspace meta data file are used where applicable
- a multi root workspace can be opened by theia by running `yarn start <path of the workpsace meta data file>`

What is not inlcuded in this PR:
- the workspace preferences should be saved as part of the meta data file.
- root display names are not customizable by adding the `folders -> name` property in the workspace meta data 

Signed-off-by: elaihau <liang.huang@ericsson.com>