### PR TITLE
QuickOpen API enhancements

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -33,7 +33,10 @@ import { FrontendApplication, FrontendApplicationContribution, DefaultFrontendAp
 import { DefaultOpenerService, OpenerService, OpenHandler } from './opener-service';
 import { HttpOpenHandler } from './http-open-handler';
 import { CommonFrontendContribution } from './common-frontend-contribution';
-import { QuickOpenService, QuickCommandService, QuickCommandFrontendContribution, QuickPickService } from './quick-open';
+import {
+    QuickOpenService, QuickCommandService, QuickCommandFrontendContribution, QuickPickService, QuickOpenContribution,
+    QuickOpenHandlerRegistry, CommandQuickOpenContribution, HelpQuickOpenHandler, QuickOpenFrontendContribution, PrefixQuickOpenService
+} from './quick-open';
 import { LocalStorageService, StorageService } from './storage-service';
 import { WidgetFactory, WidgetManager } from './widget-manager';
 import {
@@ -101,6 +104,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(CommandRegistry).toSelf().inSingletonScope();
     bind(CommandService).toDynamicValue(context => context.container.get(CommandRegistry));
     bindContributionProvider(bind, CommandContribution);
+    bind(QuickOpenContribution).to(CommandQuickOpenContribution);
 
     bind(MenuModelRegistry).toSelf().inSingletonScope();
     bindContributionProvider(bind, MenuContribution);
@@ -124,6 +128,15 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(QuickCommandFrontendContribution)).inSingletonScope()
     );
+
+    bind(PrefixQuickOpenService).toSelf().inSingletonScope();
+    bindContributionProvider(bind, QuickOpenContribution);
+    bind(QuickOpenHandlerRegistry).toSelf().inSingletonScope();
+    bind(QuickOpenFrontendContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(QuickOpenFrontendContribution);
+
+    bind(HelpQuickOpenHandler).toSelf().inSingletonScope();
+    bind(QuickOpenContribution).toService(HelpQuickOpenHandler);
 
     bind(LocalStorageService).toSelf().inSingletonScope();
     bind(StorageService).toService(LocalStorageService);

--- a/packages/core/src/browser/quick-open/index.ts
+++ b/packages/core/src/browser/quick-open/index.ts
@@ -19,3 +19,5 @@ export * from './quick-open-service';
 export * from './quick-pick-service';
 export * from './quick-command-service';
 export * from './quick-command-contribution';
+export * from './quick-open-frontend-contribution';
+export * from './prefix-quick-open-service';

--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -1,0 +1,286 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from './quick-open-model';
+import { QuickOpenService, QuickOpenOptions } from './quick-open-service';
+import { Disposable, DisposableCollection } from '../../common/disposable';
+import { ILogger } from '../../common/logger';
+
+export const QuickOpenContribution = Symbol('QuickOpenContribution');
+/**
+ * The quick open contribution should be implemented to register custom quick open handler.
+ */
+export interface QuickOpenContribution {
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void;
+}
+
+/**
+ * A handler allows to call it's quick open model when
+ * the handler's prefix is typed in the quick open widget.
+ */
+export interface QuickOpenHandler {
+
+    /**
+     * Prefix to trigger this handler's model.
+     */
+    readonly prefix: string;
+
+    /**
+     * A human-readable description of this handler.
+     */
+    readonly description: string;
+
+    /**
+     * Called immediately when the user's input in
+     * the quick open widget matches this handler's prefix.
+     * Allows to initialize the model with some initial data.
+     */
+    init(): void;
+
+    /**
+     * A model that should be used by the quick open widget when this handler's prefix is used.
+     */
+    getModel(): QuickOpenModel;
+
+    /**
+     * Returns the options which should be used for the quick open widget.
+     * Note, that the `prefix` and `skipPrefix` options are ignored and will be overridden.
+     * The `placeholder` option makes sense for a default handler only since it's used without a prefix in quick open widget.
+     */
+    getOptions(): QuickOpenOptions;
+}
+
+@injectable()
+export class QuickOpenHandlerRegistry implements Disposable {
+
+    protected readonly handlers: Map<string, QuickOpenHandler> = new Map();
+    protected readonly toDispose = new DisposableCollection();
+    protected defaultHandler: QuickOpenHandler | undefined;
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    /**
+     * Register the given handler.
+     * Do nothing if a handler is already registered.
+     * @param handler the handler to register
+     * @param defaultHandler default means that a handler is used when the user's
+     * input in the quick open widget doesn't match any of known prefixes
+     */
+    registerHandler(handler: QuickOpenHandler, defaultHandler: boolean = false): Disposable {
+        if (this.handlers.has(handler.prefix)) {
+            this.logger.warn(`A handler with prefix ${handler.prefix} is already registered.`);
+            return Disposable.NULL;
+        }
+        this.handlers.set(handler.prefix, handler);
+        const disposable = {
+            dispose: () => this.handlers.delete(handler.prefix)
+        };
+        this.toDispose.push(disposable);
+        if (defaultHandler) {
+            this.defaultHandler = handler;
+        }
+        return disposable;
+    }
+
+    getDefaultHandler(): QuickOpenHandler | undefined {
+        return this.defaultHandler;
+    }
+
+    isDefaultHandler(handler: QuickOpenHandler): boolean {
+        return handler === this.getDefaultHandler();
+    }
+
+    /**
+     * Return all registered handlers.
+     */
+    getHandlers(): QuickOpenHandler[] {
+        return [...this.handlers.values()];
+    }
+
+    /**
+     * Return a handler that matches the given text or the default handler if none.
+     */
+    getHandlerOrDefault(text: string): QuickOpenHandler | undefined {
+        for (const handler of this.handlers.values()) {
+            if (text.startsWith(handler.prefix)) {
+                return handler;
+            }
+        }
+        return this.getDefaultHandler();
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}
+
+/**
+ * The quick open model just delegates all the calls to another model depending on the used prefix.
+ */
+class PrefixModel implements QuickOpenModel {
+
+    /**
+     * Stores the current handler for the quick open widget opened in a prefix-aware mode.
+     * Allows to detect that another model is called.
+     */
+    protected currentHandler: QuickOpenHandler;
+
+    constructor(
+        protected readonly handlers: QuickOpenHandlerRegistry,
+        protected readonly openService: PrefixQuickOpenService
+    ) { }
+
+    onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+        const handler = this.handlers.getHandlerOrDefault(lookFor);
+        if (handler === undefined) {
+            const items: QuickOpenItem[] = [];
+            items.push(new QuickOpenItem({
+                label: lookFor.length === 0 ? 'No default handler is registered' : `No handlers matches the prefix ${lookFor} and no default handler is registered.`
+            }));
+            acceptor(items);
+        } else if (handler !== this.currentHandler) {
+            this.onHandlerChanged(handler, lookFor);
+        } else {
+            const handlerModel = handler.getModel();
+            const searchValue = this.handlers.isDefaultHandler(handler) ? lookFor : lookFor.substr(handler.prefix.length);
+            handlerModel.onType(searchValue, items => acceptor(items));
+        }
+    }
+
+    /**
+     * Handles changing the currently used handler as a result of user's typing.
+     * @param handler quick open handler that should be used
+     * @param prefix value that is currently typed in the quick open widget
+     */
+    protected async onHandlerChanged(handler: QuickOpenHandler, prefix: string): Promise<void> {
+        // need to notify the previous handler's model about closing the quick open widget
+        if (this.currentHandler) {
+            const closingHandler = this.currentHandler.getOptions().onClose;
+            if (closingHandler) {
+                closingHandler(true);
+            }
+        }
+        this.currentHandler = handler;
+        await handler.init();
+        // a prefix has been changed, so the quick open widget needs to be reopened with the new options
+        this.openService.open(prefix);
+    }
+}
+
+/** Prefix-based quick open service. */
+@injectable()
+export class PrefixQuickOpenService {
+
+    /**
+     * The internal model which is used when the quick open widget is opened in handling prefix mode.
+     */
+    protected model: QuickOpenModel;
+
+    @inject(QuickOpenHandlerRegistry)
+    protected readonly handlers: QuickOpenHandlerRegistry;
+
+    @inject(QuickOpenService)
+    protected readonly quickOpenService: QuickOpenService;
+
+    @postConstruct()
+    init() {
+        this.model = new PrefixModel(this.handlers, this);
+    }
+
+    /**
+     * Opens a quick open widget with the model that handles the known prefixes.
+     * @param prefix string that may contain a prefix of some of the known quick open handlers.
+     * A default quick open handler will be called if the provided string doesn't match any.
+     * An empty quick open will be opened if there's no default handler registered.
+     */
+    open(prefix: string): void {
+        const handler = this.handlers.getHandlerOrDefault(prefix);
+        if (handler === undefined) {
+            this.quickOpenService.open(this.model);
+            return;
+        }
+
+        let optionsPrefix = prefix;
+        // cut the prefix for a default handler
+        if (this.handlers.isDefaultHandler(handler) && prefix.startsWith(handler.prefix)) {
+            optionsPrefix = prefix.substr(handler.prefix.length);
+        }
+        const skipPrefix = this.handlers.isDefaultHandler(handler) ? 0 : handler.prefix.length;
+        const handlerOptions = QuickOpenOptions.resolve(handler.getOptions());
+        const placeholder = handlerOptions.placeholder || "Type '?' to get help on the actions you can take from here";
+        const options = QuickOpenOptions.resolve({
+            prefix: optionsPrefix,
+            placeholder,
+            skipPrefix
+        }, handlerOptions);
+        this.quickOpenService.open(this.model, options);
+    }
+}
+
+@injectable()
+export class HelpQuickOpenHandler implements QuickOpenHandler, QuickOpenContribution {
+
+    readonly prefix: string = '?';
+    readonly description: string = '';
+    protected items: QuickOpenItem[];
+
+    @inject(QuickOpenHandlerRegistry)
+    protected readonly handlers: QuickOpenHandlerRegistry;
+
+    @inject(PrefixQuickOpenService)
+    protected readonly quickOpenService: PrefixQuickOpenService;
+
+    init(): void {
+        this.items = this.handlers.getHandlers()
+            .filter(handler => handler.prefix !== this.prefix)
+            .map(handler => new QuickOpenItem({
+                label: handler.prefix,
+                description: handler.description,
+                run: (mode: QuickOpenMode) => {
+                    if (mode !== QuickOpenMode.OPEN) {
+                        return false;
+                    }
+                    this.quickOpenService.open(handler.prefix);
+                    return false;
+                }
+            }));
+
+        if (this.items.length === 0) {
+            this.items.push(new QuickOpenItem({
+                label: 'No handlers registered',
+                run: () => false
+            }));
+        }
+    }
+
+    getModel(): QuickOpenModel {
+        return {
+            onType: (lookFor: string, acceptor: (items: QuickOpenItem[]) => void) => {
+                acceptor(this.items);
+            }
+        };
+    }
+
+    getOptions(): QuickOpenOptions {
+        return {};
+    }
+
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this);
+    }
+}

--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { QuickCommandService } from './quick-command-service';
 import { Command, CommandRegistry, CommandContribution } from '../../common';
 import { KeybindingRegistry, KeybindingContribution } from '../keybinding';
+import { PrefixQuickOpenService, QuickOpenHandlerRegistry } from './prefix-quick-open-service';
 
 export const quickCommand: Command = {
     id: 'quickCommand',
@@ -27,12 +27,14 @@ export const quickCommand: Command = {
 @injectable()
 export class QuickCommandFrontendContribution implements CommandContribution, KeybindingContribution {
 
-    @inject(QuickCommandService)
-    protected readonly quickCommandService: QuickCommandService;
+    @inject(PrefixQuickOpenService)
+    protected readonly quickOpenService: PrefixQuickOpenService;
+
+    @inject(QuickOpenHandlerRegistry) protected readonly quickOpenHandlerRegistry: QuickOpenHandlerRegistry;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickCommand, {
-            execute: () => this.quickCommandService.open()
+            execute: () => this.quickOpenService.open('>')
         });
     }
 
@@ -46,5 +48,4 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
             keybinding: 'ctrlcmd+shift+p'
         });
     }
-
 }

--- a/packages/core/src/browser/quick-open/quick-open-frontend-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-open-frontend-contribution.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, named } from 'inversify';
+import { ContributionProvider } from '../../common';
+import { FrontendApplicationContribution } from '../frontend-application';
+import { QuickOpenContribution, QuickOpenHandlerRegistry } from './prefix-quick-open-service';
+
+@injectable()
+export class QuickOpenFrontendContribution implements FrontendApplicationContribution {
+
+    @inject(QuickOpenHandlerRegistry)
+    protected readonly quickOpenHandlerRegistry: QuickOpenHandlerRegistry;
+
+    @inject(ContributionProvider) @named(QuickOpenContribution)
+    protected readonly contributionProvider: ContributionProvider<QuickOpenContribution>;
+
+    onStart(): void {
+        this.contributionProvider.getContributions().forEach(contrib =>
+            contrib.registerQuickOpenHandlers(this.quickOpenHandlerRegistry)
+        );
+    }
+}

--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -28,6 +28,9 @@ export namespace QuickOpenOptions {
         readonly fuzzyMatchDescription: boolean;
         readonly fuzzySort: boolean;
 
+        /** The amount of first symbols to be ignored by quick open widget (e.g. don't affect matching). */
+        readonly skipPrefix: number;
+
         /**
          * Whether to display the items that don't have any highlight.
          */
@@ -45,6 +48,8 @@ export namespace QuickOpenOptions {
         fuzzyMatchDetail: false,
         fuzzyMatchDescription: false,
         fuzzySort: false,
+
+        skipPrefix: 0,
 
         showItemsWithoutHighlight: false,
 

--- a/packages/file-search/src/browser/file-search-frontend-module.ts
+++ b/packages/file-search/src/browser/file-search-frontend-module.ts
@@ -16,20 +16,21 @@
 
 import { ContainerModule, interfaces } from 'inversify';
 import { CommandContribution } from '@theia/core/lib/common';
-import { WebSocketConnectionProvider, KeybindingContribution } from '@theia/core/lib/browser';
+import { WebSocketConnectionProvider, KeybindingContribution, QuickOpenContribution } from '@theia/core/lib/browser';
 import { QuickFileOpenFrontendContribution } from './quick-file-open-contribution';
 import { QuickFileOpenService } from './quick-file-open';
 import { fileSearchServicePath, FileSearchService } from '../common/file-search-service';
 
-export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
+export default new ContainerModule((bind: interfaces.Bind) => {
     bind(FileSearchService).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
         return provider.createProxy<FileSearchService>(fileSearchServicePath);
     }).inSingletonScope();
 
     bind(QuickFileOpenFrontendContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(ctx => ctx.container.get(QuickFileOpenFrontendContribution));
-    bind(KeybindingContribution).toDynamicValue(ctx => ctx.container.get(QuickFileOpenFrontendContribution));
+    [CommandContribution, KeybindingContribution, QuickOpenContribution].forEach(serviceIdentifier =>
+        bind(serviceIdentifier).toService(QuickFileOpenFrontendContribution)
+    );
 
     bind(QuickFileOpenService).toSelf().inSingletonScope();
 });

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -17,12 +17,13 @@
 import { injectable, inject } from 'inversify';
 import { QuickFileOpenService, quickFileOpen } from './quick-file-open';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
-import { KeybindingRegistry, KeybindingContribution } from '@theia/core/lib/browser';
+import { KeybindingRegistry, KeybindingContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
 
 @injectable()
-export class QuickFileOpenFrontendContribution implements CommandContribution, KeybindingContribution {
+export class QuickFileOpenFrontendContribution implements CommandContribution, KeybindingContribution, QuickOpenContribution {
 
-    constructor(@inject(QuickFileOpenService) protected readonly quickFileOpenService: QuickFileOpenService) { }
+    @inject(QuickFileOpenService)
+    protected readonly quickFileOpenService: QuickFileOpenService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {
@@ -38,4 +39,7 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
         });
     }
 
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this.quickFileOpenService, true);
+    }
 }

--- a/packages/languages/src/browser/languages-frontend-module.ts
+++ b/packages/languages/src/browser/languages-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule } from 'inversify';
 import { bindContributionProvider, CommandContribution } from '@theia/core/lib/common';
-import { FrontendApplicationContribution, KeybindingContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, KeybindingContribution, QuickOpenContribution } from '@theia/core/lib/browser';
 import { Window } from './language-client-services';
 import { WindowImpl } from './window-impl';
 import { LanguageClientFactory } from './language-client-factory';
@@ -35,8 +35,9 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).to(LanguagesFrontendContribution);
 
     bind(WorkspaceSymbolCommand).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceSymbolCommand));
-    bind(KeybindingContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceSymbolCommand));
+    for (const identifier of [CommandContribution, KeybindingContribution, QuickOpenContribution]) {
+        bind(identifier).toService(WorkspaceSymbolCommand);
+    }
 
     bind(LanguageClientProviderImpl).toSelf().inSingletonScope();
     bind(LanguageClientProvider).toDynamicValue(ctx => ctx.container.get(LanguageClientProviderImpl)).inSingletonScope();

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -184,6 +184,9 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
     }
 
     protected createEntry(item: QuickOpenItem, lookFor: string): monaco.quickOpen.QuickOpenEntry | undefined {
+        if (this.options.skipPrefix) {
+            lookFor = lookFor.substr(this.options.skipPrefix);
+        }
         const labelHighlights = this.options.fuzzyMatchLabel ? this.matchesFuzzy(lookFor, item.getLabel()) : item.getLabelHighlights();
         const descriptionHighlights = this.options.fuzzyMatchDescription ? this.matchesFuzzy(lookFor, item.getDescription()) : item.getDescriptionHighlights();
         const detailHighlights = this.options.fuzzyMatchDetail ? this.matchesFuzzy(lookFor, item.getDetail()) : item.getDetailHighlights();

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -18,7 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import { ILogger, ContributionProvider } from '@theia/core/lib/common';
 import { QuickOpenTask } from './quick-open-task';
 import { MAIN_MENU_BAR, CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
-import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplication, FrontendApplicationContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskContribution, TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
 
@@ -45,7 +45,7 @@ export namespace TaskCommands {
 }
 
 @injectable()
-export class TaskFrontendContribution implements CommandContribution, MenuContribution, FrontendApplicationContribution {
+export class TaskFrontendContribution implements CommandContribution, MenuContribution, FrontendApplicationContribution, QuickOpenContribution {
     @inject(QuickOpenTask)
     protected readonly quickOpenTask: QuickOpenTask;
 
@@ -109,5 +109,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             label: TaskCommands.TASK_ATTACH.label ? TaskCommands.TASK_ATTACH.label.slice('Tasks: '.length) : TaskCommands.TASK_ATTACH.label,
             order: '1'
         });
+    }
+
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this.quickOpenTask);
     }
 }

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, QuickOpenContribution } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { QuickOpenTask } from './quick-open-task';
@@ -32,7 +32,7 @@ export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
     bind(TaskService).toSelf().inSingletonScope();
 
-    for (const identifier of [FrontendApplicationContribution, CommandContribution, MenuContribution]) {
+    for (const identifier of [FrontendApplicationContribution, CommandContribution, MenuContribution, QuickOpenContribution]) {
         bind(identifier).toService(TaskFrontendContribution);
     }
 


### PR DESCRIPTION
closes #1680

This PR extends the Quick Open API to allow the Quick Open widget handle special prefixes which trigger one of the registered handlers. The handlers can be contributed by the extensions. In this PR I've added several handlers:
- `>` - triggers command quick open;
- `#` - triggers workspace symbol quick open;
- `task ` - triggers task quick open;
- `...` - default handler (used without prefix) triggers open file.

Short demo:
![quickopen](https://user-images.githubusercontent.com/1636395/44285889-ae0da700-a26f-11e8-9439-12298ee40203.gif)
