### PR TITLE
[core] Fix electron first menu's separator

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -69,11 +69,14 @@ export class ElectronMainMenuFactory {
                         label: menu.label,
                         submenu: this.fillMenuTemplate([], menu)
                     });
-                } else {
-                    // or just a separator?
-                    items.push({
-                        type: 'separator'
-                    });
+                } else if (menu.children.length > 0) {
+                    // do not put a separator above the first group
+                    if (items.length > 0) {
+                        // or just a separator?
+                        items.push({
+                            type: 'separator'
+                        });
+                    }
                     // followed by the elements
                     this.fillMenuTemplate(items, menu);
                 }


### PR DESCRIPTION
Before, a separator was added at the top of the first menuItem group.
This was prevented in the browser, but not in electron.
The check is now done in electron too.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

Noticed the issue after https://github.com/theia-ide/theia/pull/2606