### PR TITLE
Improved git history view

### DIFF
--- a/packages/core/src/browser/widgets/react-widget.tsx
+++ b/packages/core/src/browser/widgets/react-widget.tsx
@@ -24,12 +24,12 @@ import { BaseWidget, Message } from './widget';
 export abstract class ReactWidget extends BaseWidget {
 
     protected readonly onRender = new DisposableCollection();
-    protected scrollOptions = {
-        suppressScrollX: true
-    };
 
     constructor() {
         super();
+        this.scrollOptions = {
+            suppressScrollX: true
+        };
         this.toDispose.push(Disposable.create(() => {
             ReactDOM.unmountComponentAtNode(this.node);
         }));

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -19,11 +19,15 @@
 }
 
 .theia-git .commitListElement {
-    border-bottom: 1px solid var(--theia-layout-color4);
+    border-top: 1px solid var(--theia-layout-color4);
+}
+
+.theia-git .commitListElement.first {
+    border: none;
 }
 
 .theia-git .commitListElement .containerHead {
-    width: 100%;
+    width: calc(100% - 5px);
     height: 50px;
     display: flex;
     align-items: center;
@@ -95,6 +99,14 @@
 .theia-git .commitTime {
     color: var(--theia-ui-font-color2);
     font-size: smaller;
+}
+
+.theia-git .git-diff-container .listContainer {
+    flex: 1;
+}
+
+.theia-git .git-diff-container .listContainer .commitList {
+    height: 100%;
 }
 
 .theia-git .git-diff-container .history-lazy-loading {
@@ -183,4 +195,21 @@
 .tab-git-icon {
     width: 20px!important;
     height: 20px;
+}
+
+.no-history-message {
+    background-color: var(--theia-warn-color0) !important;
+    color: var(--theia-warn-font-color0);
+    padding: 5px;
+}
+
+.no-history-message div {
+    margin: 5px;
+}
+
+.message-container {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -21,9 +21,10 @@
     background: var(--theia-layout-color0);
 }
 
-.theia-git:focus {
+.theia-git:focus, .theia-git :focus {
     outline: 0;
     box-shadow: none;
+    border: none;
 }
 
 #theia-gitContainer .flexcontainer {


### PR DESCRIPTION
The git history widget got renovated. Scrolling, loading and rendering was not working properly anymore. 
It uses [react-virtualized](https://github.com/bvaughn/react-virtualized) now. 
That renders only the part of the list which is actually visible. Furthermore it uses the react-virtualized component [InfiniteLoader](https://github.com/bvaughn/react-virtualized/blob/master/docs/InfiniteLoader.md) which is very useful with long lists. It doesn't load the whole list at once but small chunks of it once the user scrolls (as before with the lazy loading but far better :-)).
So, scrolling is very performant and stable now. 
And last but not least it uses the perfectscrollbar as it is used in the other widgets.

Fixes https://github.com/theia-ide/theia/issues/2294 - LazyLoad indicator is not shown anymore
--> the former lazy loading got replaced by InfiniteLoader of react-virtualized 
Fixes https://github.com/theia-ide/theia/issues/2295 - After loading more commits the new replacing the old
--> in the addCommits method the commit list got reset. That [got fixed](https://github.com/theia-ide/theia/pull/2627/files#diff-f151e9af88b4bffb05b2872de3e3e8efL113) 
Fixes https://github.com/theia-ide/theia/issues/2296 - After lazy loading sometimes commits are twice in the list
--> For that the CancellationTokenSource [is used in addCommit](https://github.com/theia-ide/theia/pull/2627/files#diff-f151e9af88b4bffb05b2872de3e3e8efR120) method now.