### PR TITLE
Remove quotation for boolean preferences

### DIFF
--- a/packages/preferences/src/browser/preferences-menu-factory.ts
+++ b/packages/preferences/src/browser/preferences-menu-factory.ts
@@ -47,7 +47,7 @@ export class PreferencesMenuFactory {
                 commands.addCommand(commandTrue, {
                     label: 'true',
                     iconClass: savedPreference === 'true' || !savedPreference && property.default === true ? 'fa fa-check' : '',
-                    execute: () => execute(id, 'true')
+                    execute: () => execute(id, true)
                 });
                 menu.addItem({
                     type: 'command',
@@ -58,7 +58,7 @@ export class PreferencesMenuFactory {
                 commands.addCommand(commandFalse, {
                     label: 'false',
                     iconClass: savedPreference === 'false' || !savedPreference && property.default === false ? 'fa fa-check' : '',
-                    execute: () => execute(id, 'false')
+                    execute: () => execute(id, false)
                 });
                 menu.addItem({
                     type: 'command',


### PR DESCRIPTION
Fixes #2644
Fixes #2510

Removed unnecessary quotation around `boolean` type preferences which resulted in the preferences not taking effect. (Ex: `editor.minimap.enabled: "true"` to `editor.minimap.enabled: true`)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>