### PR TITLE
[md/preview] resolve relative links in HTML images

### DIFF
--- a/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.spec.ts
@@ -48,13 +48,19 @@ describe('markdown-preview-handler', () => {
     });
 
     it('renders html with line information', async () => {
-        const contentElement = await previewHandler.renderContent({ content: exampleMarkdown1, originUri: new URI('') });
-        expect(contentElement.innerHTML).equals(exampleHtml1);
+        await assertRenderedContent(exampleMarkdown1, exampleHtml1);
     });
 
     it('renders images', async () => {
-        const contentElement = await previewHandler.renderContent({ content: exampleMarkdown2, originUri: new URI('file:///Users/me/workspace/DEMO.md') });
-        expect(contentElement.innerHTML).equals(exampleHtml2);
+        await assertRenderedContent(exampleMarkdown2, exampleHtml2);
+    });
+
+    it('renders HTML images as block', async () => {
+        await assertRenderedContent(exampleMarkdown3, exampleHtml3);
+    });
+
+    it('renders HTML images inlined', async () => {
+        await assertRenderedContent(exampleMarkdown4, exampleHtml4);
     });
 
     it('finds element for source line', () => {
@@ -96,6 +102,11 @@ describe('markdown-preview-handler', () => {
     });
 });
 
+async function assertRenderedContent(source: string, expectation: string) {
+    const contentElement = await previewHandler.renderContent({ content: source, originUri: new URI('file:///workspace/DEMO.md') });
+    expect(contentElement.innerHTML).equals(expectation);
+}
+
 const exampleMarkdown1 = //
     `# Theia - Preview Extension
 Shows a preview of supported resources.
@@ -120,7 +131,30 @@ const exampleMarkdown2 = //
 
 const exampleHtml2 = //
     `<h1 id="heading" class="line" data-line="0">Heading</h1>
-<p class="line" data-line="1"><img src="endpoint/Users/me/workspace/subfolder/image.png" alt="alternativetext"></p>
+<p class="line" data-line="1"><img src="endpoint/workspace/subfolder/image.png" alt="alternativetext"></p>
+`;
+
+const exampleMarkdown3 = //
+    `# Block HTML Image
+<img src="subfolder/image1.png" alt="tada"/>
+
+# Block HTML Image
+ <img src="subfolder/image3.png" alt="tada"/>
+`;
+
+const exampleHtml3 = //
+    `<h1 id="block-html-image" class="line" data-line="0">Block HTML Image</h1>
+<img src="endpoint/workspace/subfolder/image1.png" alt="tada"><h1 id="block-html-image-2" class="line" data-line="3">Block HTML Image</h1>
+<img src="endpoint/workspace/subfolder/image3.png" alt="tada">`;
+
+const exampleMarkdown4 = //
+    `# Inlined HTML Image
+text in paragraph <img src="subfolder/image2.png" alt="tada"/>
+`;
+
+const exampleHtml4 = //
+    `<h1 id="inlined-html-image" class="line" data-line="0">Inlined HTML Image</h1>
+<p class="line" data-line="1">text in paragraph <img src="endpoint/workspace/subfolder/image2.png" alt="tada"></p>
 `;
 
 /**


### PR DESCRIPTION
This PR extends Markdown engine to resolve relative source links of HTML `<img>`s. It should looks like this now:

<img width="1641" alt="screen shot 2018-08-23 at 09 46 17" src="https://user-images.githubusercontent.com/914497/44512071-b6c00c00-a6b9-11e8-9b16-c2108cd979d6.png">


Closes #1744