### PR TITLE
[preferences/keymaps] register JSONC for `settings.json` and `keymaps.json`

### DIFF
--- a/packages/keymaps/package.json
+++ b/packages/keymaps/package.json
@@ -4,6 +4,7 @@
   "description": "Theia - Custom Keymaps Extension",
   "dependencies": {
     "@theia/core": "^0.3.13",
+    "@theia/monaco": "^0.3.13",
     "@theia/userstorage": "^0.3.13",
     "@theia/workspace": "^0.3.13",
     "ajv": "^5.2.2",

--- a/packages/keymaps/src/browser/monaco-contribution.ts
+++ b/packages/keymaps/src/browser/monaco-contribution.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,18 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule, } from 'inversify';
-import { KeymapsService } from './keymaps-service';
-import { KeymapsFrontendContribution } from './keymaps-frontend-contribution';
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { KeymapsParser } from './keymaps-parser';
-
-import './monaco-contribution';
-
-export default new ContainerModule(bind => {
-    bind(KeymapsParser).toSelf().inSingletonScope();
-    bind(KeymapsService).toSelf().inSingletonScope();
-    bind(KeymapsFrontendContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toService(KeymapsFrontendContribution);
-    bind(MenuContribution).toService(KeymapsFrontendContribution);
+monaco.languages.register({
+    id: 'jsonc',
+    'aliases': [
+        'JSON with Comments'
+    ],
+    'filenames': [
+        'keymaps.json'
+    ]
 });

--- a/packages/keymaps/src/browser/monaco.d.ts
+++ b/packages/keymaps/src/browser/monaco.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@theia/monaco/src/typings/monaco/index"/>

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.13",
     "@theia/editor": "^0.3.13",
     "@theia/filesystem": "^0.3.13",
+    "@theia/monaco": "^0.3.13",
     "@theia/userstorage": "^0.3.13",
     "@theia/workspace": "^0.3.13",
     "@types/fs-extra": "^4.0.2",

--- a/packages/preferences/src/browser/monaco-contribution.ts
+++ b/packages/preferences/src/browser/monaco-contribution.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,18 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule, } from 'inversify';
-import { KeymapsService } from './keymaps-service';
-import { KeymapsFrontendContribution } from './keymaps-frontend-contribution';
-import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { KeymapsParser } from './keymaps-parser';
-
-import './monaco-contribution';
-
-export default new ContainerModule(bind => {
-    bind(KeymapsParser).toSelf().inSingletonScope();
-    bind(KeymapsService).toSelf().inSingletonScope();
-    bind(KeymapsFrontendContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toService(KeymapsFrontendContribution);
-    bind(MenuContribution).toService(KeymapsFrontendContribution);
+monaco.languages.register({
+    id: 'jsonc',
+    'aliases': [
+        'JSON with Comments'
+    ],
+    'filenames': [
+        'settings.json'
+    ]
 });

--- a/packages/preferences/src/browser/monaco.d.ts
+++ b/packages/preferences/src/browser/monaco.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@theia/monaco/src/typings/monaco/index"/>

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -24,6 +24,8 @@ import { createPreferencesTreeWidget } from './preference-tree-container';
 import { PreferencesMenuFactory } from './preferences-menu-factory';
 import { PreferencesContainer, PreferencesTreeWidget } from './preferences-tree-widget';
 
+import './monaco-contribution';
+
 export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind): void {
     unbind(PreferenceProvider);
 


### PR DESCRIPTION
to support comments and avoid errors for same if `@theia/json` is used.