### PR TITLE
GH-2691: From now on, languages can specify TM tokenizer options.

### DIFF
--- a/packages/cpp/src/browser/cpp-grammar-contribution.ts
+++ b/packages/cpp/src/browser/cpp-grammar-contribution.ts
@@ -63,7 +63,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         monaco.languages.setLanguageConfiguration(C_LANGUAGE_ID, this.config);
 
         const platformGrammar = require('../../data/platform.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.c.platform', {
+        registry.registerTextmateGrammarScope('source.c.platform', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -73,7 +73,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         });
 
         const cGrammar = require('../../data/c.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.c', {
+        registry.registerTextmateGrammarScope('source.c', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -93,7 +93,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         monaco.languages.setLanguageConfiguration(CPP_LANGUAGE_ID, this.config);
 
         const cppGrammar = require('../../data/cpp.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.cpp', {
+        registry.registerTextmateGrammarScope('source.cpp', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/java/src/browser/monaco-contribution/java-textmate-contribution.ts
+++ b/packages/java/src/browser/monaco-contribution/java-textmate-contribution.ts
@@ -23,7 +23,7 @@ export class JavaTextmateContribution implements LanguageGrammarDefinitionContri
 
     registerTextmateLanguage(registry: TextmateRegistry) {
         const javaDocGrammar = require('../../../data/javadoc.tmlanguage.json');
-        registry.registerTextMateGrammarScope('text.html.javadoc', {
+        registry.registerTextmateGrammarScope('text.html.javadoc', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -33,7 +33,7 @@ export class JavaTextmateContribution implements LanguageGrammarDefinitionContri
         });
         const scope = 'source.java';
         const javaGrammar = require('../../../data/java.tmlanguage.json');
-        registry.registerTextMateGrammarScope(scope, {
+        registry.registerTextmateGrammarScope(scope, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/json/src/browser/json-grammar-contribution.ts
+++ b/packages/json/src/browser/json-grammar-contribution.ts
@@ -72,7 +72,7 @@ export class JsonGrammarContribution implements LanguageGrammarDefinitionContrib
         monaco.languages.setLanguageConfiguration(JSON_LANGUAGE_ID, this.config);
 
         const jsonGrammar = require('../../data/json.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.json', {
+        registry.registerTextmateGrammarScope('source.json', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -97,7 +97,7 @@ export class JsonGrammarContribution implements LanguageGrammarDefinitionContrib
         monaco.languages.setLanguageConfiguration(JSONC_LANGUAGE_ID, this.config);
 
         const jsoncGrammar = require('../../data/jsonc.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.json.comments', {
+        registry.registerTextmateGrammarScope('source.json.comments', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
@@ -20,7 +20,7 @@ import { ILogger, DisposableCollection, ContributionProvider } from '@theia/core
 import { FrontendApplicationContribution, isBasicWasmSupported } from '@theia/core/lib/browser';
 import { MonacoTextModelService } from '../monaco-text-model-service';
 import { LanguageGrammarDefinitionContribution, getEncodedLanguageId } from './textmate-contribution';
-import { createTextmateTokenizer } from './textmate-tokenizer';
+import { createTextmateTokenizer, TokenizerOption } from './textmate-tokenizer';
 import { TextmateRegistry } from './textmate-registry';
 
 export const OnigasmPromise = Symbol('OnigasmPromise');
@@ -95,10 +95,10 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
 
         await this.onigasmPromise;
         try {
-            monaco.languages.setTokensProvider(languageId, createTextmateTokenizer(
-                await this.grammarRegistry.loadGrammarWithConfiguration(scopeName, initialLanguage, configuration)
-            ));
-        } catch (err) {
+            const grammar = await this.grammarRegistry.loadGrammarWithConfiguration(scopeName, initialLanguage, configuration);
+            const options = configuration.tokenizerOption ? configuration.tokenizerOption : TokenizerOption.DEFAULT;
+            monaco.languages.setTokensProvider(languageId, createTextmateTokenizer(grammar, options));
+        } catch {
             this.logger.warn('No grammar for this language id', languageId);
         }
     }

--- a/packages/monaco/src/browser/textmate/textmate-registry.ts
+++ b/packages/monaco/src/browser/textmate/textmate-registry.ts
@@ -16,16 +16,27 @@
 
 import { injectable } from 'inversify';
 import { RegistryOptions, IGrammarConfiguration } from 'monaco-textmate';
+import { TokenizerOption } from './textmate-tokenizer';
+
+export interface TextmateGrammarConfiguration extends IGrammarConfiguration {
+
+    /**
+     * Optional options to further refine the tokenization of the grammar.
+     */
+    readonly tokenizerOption?: TokenizerOption;
+
+}
 
 @injectable()
 export class TextmateRegistry {
+
     readonly scopeToProvider = new Map<string, RegistryOptions>();
-    readonly languageToConfig = new Map<string, IGrammarConfiguration>();
+    readonly languageToConfig = new Map<string, TextmateGrammarConfiguration>();
     readonly languageIdToScope = new Map<string, string>();
 
-    registerTextMateGrammarScope(scope: string, provider: RegistryOptions): void {
+    registerTextmateGrammarScope(scope: string, provider: RegistryOptions): void {
         if (this.scopeToProvider.has(scope)) {
-            console.warn(new Error(`a registered grammar provider for '${scope}' scope is overriden`));
+            console.warn(new Error(`a registered grammar provider for '${scope}' scope is overridden`));
         }
         this.scopeToProvider.set(scope, provider);
     }
@@ -46,14 +57,14 @@ export class TextmateRegistry {
         return this.languageIdToScope.get(languageId);
     }
 
-    registerGrammarConfiguration(languageId: string, config: IGrammarConfiguration): void {
+    registerGrammarConfiguration(languageId: string, config: TextmateGrammarConfiguration): void {
         if (this.languageToConfig.has(languageId)) {
-            console.warn(new Error(`a registered grammar configuration for '${languageId}' language is overriden`));
+            console.warn(new Error(`a registered grammar configuration for '${languageId}' language is overridden`));
         }
         this.languageToConfig.set(languageId, config);
     }
 
-    getGrammarConfiguration(languageId: string): IGrammarConfiguration {
+    getGrammarConfiguration(languageId: string): TextmateGrammarConfiguration {
         return this.languageToConfig.get(languageId) || {};
     }
 }

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -69,7 +69,7 @@ export class PluginContributionHandler {
                     }
                 }
 
-                this.grammarsRegistry.registerTextMateGrammarScope(grammar.scope, {
+                this.grammarsRegistry.registerTextmateGrammarScope(grammar.scope, {
                     async getGrammarDefinition() {
                         return {
                             format: grammar.format,

--- a/packages/python/src/browser/python-grammar-contribution.ts
+++ b/packages/python/src/browser/python-grammar-contribution.ts
@@ -70,7 +70,7 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
         monaco.languages.setLanguageConfiguration(PYTHON_LANGUAGE_ID, this.config);
 
         const platformGrammar = require('../../data/MagicPython.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.python', {
+        registry.registerTextmateGrammarScope('source.python', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -80,7 +80,7 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
         });
 
         const cGrammar = require('../../data/MagicRegExp.tmLanguage.json');
-        registry.registerTextMateGrammarScope('source.regexp.python', {
+        registry.registerTextmateGrammarScope('source.regexp.python', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/bat.ts
+++ b/packages/textmate-grammars/src/browser/bat.ts
@@ -57,7 +57,7 @@ export class BatContribution implements LanguageGrammarDefinitionContribution {
             }
         });
         const grammar = require('../../data/bat.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/clojure.ts
+++ b/packages/textmate-grammars/src/browser/clojure.ts
@@ -39,23 +39,23 @@ export class ClojureContribution implements LanguageGrammarDefinitionContributio
                 ['(', ')']
             ],
             autoClosingPairs: [
-                {open: '{', close: '}'},
-                {open: '[', close: ']'},
-                {open: '(', close: ')'},
-                {open: '\'', close: '\''}
+                { open: '{', close: '}' },
+                { open: '[', close: ']' },
+                { open: '(', close: ')' },
+                { open: '\'', close: '\'' }
             ],
             surroundingPairs: [
-                {open: '{', close: '}'},
-                {open: '[', close: ']'},
-                {open: '(', close: ')'},
-                {open: '\'', close: '\''}
+                { open: '{', close: '}' },
+                { open: '[', close: ']' },
+                { open: '(', close: ')' },
+                { open: '\'', close: '\'' }
             ],
             folding: {
                 offSide: true
             }
         });
         const grammar = require('../../data/clojure.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/coffeescript.ts
+++ b/packages/textmate-grammars/src/browser/coffeescript.ts
@@ -62,7 +62,7 @@ export class CoffeescriptContribution implements LanguageGrammarDefinitionContri
             }
         });
         const grammar = require('../../data/coffeescript.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/csharp.ts
+++ b/packages/textmate-grammars/src/browser/csharp.ts
@@ -63,7 +63,7 @@ export class CSharpContribution implements LanguageGrammarDefinitionContribution
             }
         });
         const grammar = require('../../data/csharp.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/css.ts
+++ b/packages/textmate-grammars/src/browser/css.ts
@@ -67,7 +67,7 @@ export class CssContribution implements LanguageGrammarDefinitionContribution {
             }
         });
         const grammar = require('../../data/css.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/fsharp.ts
+++ b/packages/textmate-grammars/src/browser/fsharp.ts
@@ -61,7 +61,7 @@ export class FSharpContribution implements LanguageGrammarDefinitionContribution
             }
         });
         const grammar = require('../../data/fsharp.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/groovy.ts
+++ b/packages/textmate-grammars/src/browser/groovy.ts
@@ -57,7 +57,7 @@ export class GroovyContribution implements LanguageGrammarDefinitionContribution
             ]
         });
         const grammar = require('../../data/groovy.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/handlebars.ts
+++ b/packages/textmate-grammars/src/browser/handlebars.ts
@@ -55,7 +55,7 @@ export class HandlebarsContribution implements LanguageGrammarDefinitionContribu
             ]
         });
         const grammar = require('../../data/csharp.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/hlsl.ts
+++ b/packages/textmate-grammars/src/browser/hlsl.ts
@@ -53,7 +53,7 @@ export class HlslContribution implements LanguageGrammarDefinitionContribution {
             ]
         });
         const grammar = require('../../data/hlsl.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/html.ts
+++ b/packages/textmate-grammars/src/browser/html.ts
@@ -84,7 +84,7 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
         });
 
         const grammar = require('../../data/html.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/ini.ts
+++ b/packages/textmate-grammars/src/browser/ini.ts
@@ -55,7 +55,7 @@ export class IniContribution implements LanguageGrammarDefinitionContribution {
             ]
         });
         const grammar = require('../../data/ini.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/less.ts
+++ b/packages/textmate-grammars/src/browser/less.ts
@@ -64,7 +64,7 @@ export class LessContribution implements LanguageGrammarDefinitionContribution {
         });
 
         const grammar = require('../../data/less.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/log.ts
+++ b/packages/textmate-grammars/src/browser/log.ts
@@ -30,7 +30,7 @@ export class LogContribution implements LanguageGrammarDefinitionContribution {
             aliases: ['log']
         });
         const grammar = require('../../data/log.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/lua.ts
+++ b/packages/textmate-grammars/src/browser/lua.ts
@@ -59,7 +59,7 @@ export class LuaContribution implements LanguageGrammarDefinitionContribution {
             }
         });
         const grammar = require('../../data/lua.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/make.ts
+++ b/packages/textmate-grammars/src/browser/make.ts
@@ -47,7 +47,7 @@ export class MakeContribution implements LanguageGrammarDefinitionContribution {
             ]
         });
         const grammar = require('../../data/make.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/markdown.ts
+++ b/packages/textmate-grammars/src/browser/markdown.ts
@@ -58,7 +58,7 @@ export class MarkdownContribution implements LanguageGrammarDefinitionContributi
         });
 
         const grammar = require('../../data/markdown.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/objective-c.ts
+++ b/packages/textmate-grammars/src/browser/objective-c.ts
@@ -55,7 +55,7 @@ export class ObjectiveCContribution implements LanguageGrammarDefinitionContribu
             ]
         });
         const grammar = require('../../data/objective-c.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/perl.ts
+++ b/packages/textmate-grammars/src/browser/perl.ts
@@ -31,7 +31,7 @@ export class PerlContribution implements LanguageGrammarDefinitionContribution {
             firstLine: '^#!.*\\bperl\\b'
         });
         const grammar = require('../../data/perl.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/powershell.ts
+++ b/packages/textmate-grammars/src/browser/powershell.ts
@@ -63,7 +63,7 @@ export class PowershellContribution implements LanguageGrammarDefinitionContribu
             }
         });
         const grammar = require('../../data/powershell.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/pug.ts
+++ b/packages/textmate-grammars/src/browser/pug.ts
@@ -57,7 +57,7 @@ export class PugContribution implements LanguageGrammarDefinitionContribution {
             }
         });
         const grammar = require('../../data/pug.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/r.ts
+++ b/packages/textmate-grammars/src/browser/r.ts
@@ -52,7 +52,7 @@ export class RContribution implements LanguageGrammarDefinitionContribution {
             ]
         });
         const grammar = require('../../data/r.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/razor.ts
+++ b/packages/textmate-grammars/src/browser/razor.ts
@@ -60,7 +60,7 @@ export class RazorContribution implements LanguageGrammarDefinitionContribution 
             }
         });
         const grammar = require('../../data/razor.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/shaderlab.ts
+++ b/packages/textmate-grammars/src/browser/shaderlab.ts
@@ -53,7 +53,7 @@ export class ShaderlabContribution implements LanguageGrammarDefinitionContribut
             ]
         });
         const grammar = require('../../data/shaderlab.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/shell.ts
+++ b/packages/textmate-grammars/src/browser/shell.ts
@@ -53,7 +53,7 @@ export class ShellContribution implements LanguageGrammarDefinitionContribution 
         });
 
         const grammar = require('../../data/shell.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/sql.ts
+++ b/packages/textmate-grammars/src/browser/sql.ts
@@ -56,7 +56,7 @@ export class SqlContribution implements LanguageGrammarDefinitionContribution {
             ]
         });
         const grammar = require('../../data/sql.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/swift.ts
+++ b/packages/textmate-grammars/src/browser/swift.ts
@@ -57,7 +57,7 @@ export class SwiftContribution implements LanguageGrammarDefinitionContribution 
             ]
         });
         const grammar = require('../../data/swift.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/vb.ts
+++ b/packages/textmate-grammars/src/browser/vb.ts
@@ -60,7 +60,7 @@ export class VbContribution implements LanguageGrammarDefinitionContribution {
             }
         });
         const grammar = require('../../data/vb.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/xml.ts
+++ b/packages/textmate-grammars/src/browser/xml.ts
@@ -109,7 +109,7 @@ export class XmlContribution implements LanguageGrammarDefinitionContribution {
         });
 
         const grammar = require('../../data/xml.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/xsl.ts
+++ b/packages/textmate-grammars/src/browser/xsl.ts
@@ -43,7 +43,7 @@ export class XslContribution implements LanguageGrammarDefinitionContribution {
         });
 
         const grammar = require('../../data/xsl.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/textmate-grammars/src/browser/yaml.ts
+++ b/packages/textmate-grammars/src/browser/yaml.ts
@@ -67,7 +67,7 @@ export class YamlContribution implements LanguageGrammarDefinitionContribution {
         });
 
         const grammar = require('../../data/shell.tmLanguage.json');
-        registry.registerTextMateGrammarScope(this.scopeName, {
+        registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,7 +7,6 @@
     "@theia/core": "^0.3.13",
     "@theia/languages": "^0.3.13",
     "@theia/monaco": "^0.3.13",
-    "@theia/typescript": "^0.3.13",
     "typescript-language-server": "^0.3.0"
   },
   "publishConfig": {

--- a/packages/typescript/src/browser/javascript-language-config.ts
+++ b/packages/typescript/src/browser/javascript-language-config.ts
@@ -25,7 +25,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
     registerTextmateLanguage(registry: TextmateRegistry) {
         this.registerJavaScript();
         const grammar = require('../../data/grammars/javascript.tmlanguage.json');
-        registry.registerTextMateGrammarScope('source.js', {
+        registry.registerTextmateGrammarScope('source.js', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -34,7 +34,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
             }
         });
 
-        registry.registerTextMateGrammarScope('source.js.regexp', {
+        registry.registerTextmateGrammarScope('source.js.regexp', {
             async getGrammarDefinition() {
                 return {
                     format: 'plist',
@@ -61,7 +61,7 @@ export class JavascriptGrammarContribution implements LanguageGrammarDefinitionC
         registry.mapLanguageIdToTextmateGrammar(JAVASCRIPT_LANGUAGE_ID, 'source.js');
 
         const jsxGrammar = require('../../data/grammars/javascript.jsx.tmlanguage.json');
-        registry.registerTextMateGrammarScope('source.jsx', {
+        registry.registerTextmateGrammarScope('source.jsx', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',

--- a/packages/typescript/src/browser/typescript-language-config.ts
+++ b/packages/typescript/src/browser/typescript-language-config.ts
@@ -24,7 +24,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
     registerTextmateLanguage(registry: TextmateRegistry) {
         this.registerTypeScript();
         const grammar = require('../../data/grammars/typescript.tmlanguage.json');
-        registry.registerTextMateGrammarScope('source.ts', {
+        registry.registerTextmateGrammarScope('source.ts', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',
@@ -35,7 +35,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
 
         registry.mapLanguageIdToTextmateGrammar(TYPESCRIPT_LANGUAGE_ID, 'source.ts');
         registry.registerGrammarConfiguration(TYPESCRIPT_LANGUAGE_ID, {
-            'tokenTypes': {
+            tokenTypes: {
                 'entity.name.type.instance.jsdoc': 0,
                 'entity.name.function.tagged-template': 0,
                 'meta.import string.quoted': 0,
@@ -44,7 +44,7 @@ export class TypescriptGrammarContribution implements LanguageGrammarDefinitionC
         });
 
         const jsxGrammar = require('../../data/grammars/typescript.tsx.tmlanguage.json');
-        registry.registerTextMateGrammarScope('source.tsx', {
+        registry.registerTextmateGrammarScope('source.tsx', {
             async getGrammarDefinition() {
                 return {
                     format: 'json',


### PR DESCRIPTION
Bare minimum change to customize the maximum allowed line length for the TM tokenizer.

- I renamed the `registerTextmateGrammarScope` before the release, but it is not a must.
- Also, there was a tiny correction in the `@theia/typescript/package.json`.

Closes: #2691.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>