### PR TITLE
Fix #2666 Add missing dispose() call

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -418,10 +418,11 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             }
             const style = this.applyFontStyles({}, affix.fontData);
             const className = classes.join(' ');
+            const key = node.id + '_' + i;
             const attrs = {
                 className,
-                style
-            };
+                style,
+                key};
             children.push(React.createElement('div', attrs, affix.data));
         }
         return <React.Fragment>{children}</React.Fragment>;


### PR DESCRIPTION
Fixes bug when preferences widget is not usable after reopening:  #2666 