### PR TITLE
GH-2711: Fixed incorrect condition in the TM tokenizer.

### DIFF
--- a/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
+++ b/packages/monaco/src/browser/textmate/monaco-textmate-service.ts
@@ -98,8 +98,8 @@ export class MonacoTextmateService implements FrontendApplicationContribution {
             const grammar = await this.grammarRegistry.loadGrammarWithConfiguration(scopeName, initialLanguage, configuration);
             const options = configuration.tokenizerOption ? configuration.tokenizerOption : TokenizerOption.DEFAULT;
             monaco.languages.setTokensProvider(languageId, createTextmateTokenizer(grammar, options));
-        } catch {
-            this.logger.warn('No grammar for this language id', languageId);
+        } catch (error) {
+            this.logger.warn('No grammar for this language id', languageId, error);
         }
     }
 

--- a/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
+++ b/packages/monaco/src/browser/textmate/textmate-tokenizer.ts
@@ -41,10 +41,10 @@ export interface TokenizerOption {
      * Maximum line length that will be handled by the TextMate tokenizer. If the length of the actual line exceeds this
      * limit, the tokenizer terminates and the tokenization of any subsequent lines might be broken.
      *
-     * If the `lineLimit` is `false` it means, there are no line length limits. If the `lineLimit` is a number, then it must
-     * be a positive integer. Otherwise, an error will be thrown.
+     * If the `lineLimit` is not defined, it means, there are no line length limits. Otherwise, it must be a positive
+     * integer or an error will be thrown.
      */
-    readonly lineLimit: number | false;
+    readonly lineLimit?: number;
 
 }
 
@@ -58,13 +58,13 @@ export namespace TokenizerOption {
 }
 
 export function createTextmateTokenizer(grammar: IGrammar, options: TokenizerOption): monaco.languages.TokensProvider {
-    if (options.lineLimit <= 0) {
+    if (options.lineLimit !== undefined && (options.lineLimit <= 0 || !Number.isInteger(options.lineLimit))) {
         throw new Error(`The 'lineLimit' must be a positive integer. It was ${options.lineLimit}.`);
     }
     return {
         getInitialState: () => new TokenizerState(INITIAL),
         tokenize(line: string, state: TokenizerState) {
-            if (typeof options.lineLimit === 'number' && line.length > options.lineLimit) {
+            if (options.lineLimit !== undefined && line.length > options.lineLimit) {
                 console.log(`Line starting with "${line.substr(0, 10)}..." is too long to be tokenized.`);
                 return { tokens: [], endState: state };
             }


### PR DESCRIPTION
 - Corrected the bogus condition.
 - Simplified the `lineLimit` signature.
 - Logged the error.

Closes: #2711.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>