### PR TITLE
Add PR template with a reminder to update the CHANGELOG.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

Everytime a new PR is filled, a contributor will see the 'reminder' to update the [CHANGELOG.md](https://github.com/theia-ide/theia/blob/master/CHANGELOG.md) file if a proposed patch deserves it.