### PR TITLE
Electron App will work again, was blocked by a bug in tree widget.

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -249,7 +249,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected readonly handleScroll = (info: ScrollParams) => {
-        this.node.scrollTo({ top: info.scrollTop });
+        this.node.scrollTop = info.scrollTop;
     }
 
     protected readonly renderNodeRow = (row: TreeWidget.NodeRow) => this.doRenderNodeRow(row);
@@ -427,7 +427,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             const attrs = {
                 className,
                 style,
-                key};
+                key
+            };
             children.push(React.createElement('div', attrs, affix.data));
         }
         return <React.Fragment>{children}</React.Fragment>;


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/2739

Use Element.scrollTop to set the scrolling position instead of Element.scrollTo() which led to that error in electron app. 
