### PR TITLE
fix preference proxies

### DIFF
--- a/packages/core/src/browser/preferences/preference-proxy.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.ts
@@ -59,6 +59,16 @@ export function createPreferenceProxy<T>(preferences: PreferenceService, schema:
             }
             throw new Error('unexpected property: ' + property);
         },
+        ownKeys: () => Object.keys(schema.properties),
+        getOwnPropertyDescriptor: (_, property: string) => {
+            if (schema.properties[property]) {
+                return {
+                    enumerable: true,
+                    configurable: true
+                };
+            }
+            return {};
+        },
         set: unsupportedOperation,
         deleteProperty: unsupportedOperation,
         defineProperty: unsupportedOperation


### PR DESCRIPTION
Declare enumerable preference proxy properties to make `Object.keys` work again.