### PR TITLE
Minor style fix in "Search In Workspace" widget.

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -263,6 +263,8 @@
 
 .t-siw-search-container .resultLine .match {
     background: var(--theia-word-highlight-match-color1);
+    display: inline-block;
+    line-height: normal;
 }
 
 .t-siw-search-container .resultLine .match.strike-through {


### PR DESCRIPTION
Before
<img width="151" alt="screen shot 2018-09-01 at 12 21 10" src="https://user-images.githubusercontent.com/28291421/44945058-b0c8da00-ade1-11e8-8d0f-8f56fda2ed43.png">
Now
<img width="117" alt="screen shot 2018-09-01 at 12 21 48" src="https://user-images.githubusercontent.com/28291421/44945065-bcb49c00-ade1-11e8-9f9f-80bd6e5b5c0c.png">
