### PR TITLE
Don't dispose a prefix-based quick open handler when it's called several times in a row

### DIFF
--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -154,7 +154,9 @@ export class PrefixQuickOpenService {
     protected currentHandler: QuickOpenHandler | undefined;
 
     protected async setCurrentHandler(prefix: string, handler: QuickOpenHandler | undefined): Promise<void> {
-        this.toDisposeCurrent.dispose();
+        if (handler !== this.currentHandler) {
+            this.toDisposeCurrent.dispose();
+        }
         this.currentHandler = handler;
         this.toDisposeCurrent.push(Disposable.create(() => {
             const closingHandler = handler && handler.getOptions().onClose;

--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -156,14 +156,14 @@ export class PrefixQuickOpenService {
     protected async setCurrentHandler(prefix: string, handler: QuickOpenHandler | undefined): Promise<void> {
         if (handler !== this.currentHandler) {
             this.toDisposeCurrent.dispose();
+            this.currentHandler = handler;
+            this.toDisposeCurrent.push(Disposable.create(() => {
+                const closingHandler = handler && handler.getOptions().onClose;
+                if (closingHandler) {
+                    closingHandler(true);
+                }
+            }));
         }
-        this.currentHandler = handler;
-        this.toDisposeCurrent.push(Disposable.create(() => {
-            const closingHandler = handler && handler.getOptions().onClose;
-            if (closingHandler) {
-                closingHandler(true);
-            }
-        }));
         if (!handler) {
             this.doOpen();
             return;


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

A prefix-based quick open handler shouldn't be disposed when it's called several times in a row.
Because behavior of some of the quick open services may depend on its previous state. E.g. Quick File Open shows/hides the ignored files on each call.