### PR TITLE
[textmate] yaml and handlebars had the wrong grammar registered

### DIFF
--- a/packages/textmate-grammars/src/browser/handlebars.ts
+++ b/packages/textmate-grammars/src/browser/handlebars.ts
@@ -54,7 +54,7 @@ export class HandlebarsContribution implements LanguageGrammarDefinitionContribu
                 { open: '\'', close: '\'' }
             ]
         });
-        const grammar = require('../../data/csharp.tmLanguage.json');
+        const grammar = require('../../data/handlebars.tmLanguage.json');
         registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {

--- a/packages/textmate-grammars/src/browser/yaml.ts
+++ b/packages/textmate-grammars/src/browser/yaml.ts
@@ -66,7 +66,7 @@ export class YamlContribution implements LanguageGrammarDefinitionContribution {
             }
         });
 
-        const grammar = require('../../data/shell.tmLanguage.json');
+        const grammar = require('../../data/yaml.tmLanguage.json');
         registry.registerTextmateGrammarScope(this.scopeName, {
             async getGrammarDefinition() {
                 return {


### PR DESCRIPTION
Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>