### PR TITLE
[plug-in] Create 'theia' api object per plugin

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -16,15 +16,15 @@
 
 import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext } from '@theia/plugin-ext';
 import { injectable } from 'inversify';
-import * as os from 'os';
 import * as path from 'path';
+import { getTempDir } from '@theia/plugin-ext';
 
 @injectable()
 export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
 
     private unpackedFolder: string;
     constructor() {
-        this.unpackedFolder = path.resolve(os.tmpdir(), 'vscode-unpacked');
+        this.unpackedFolder = getTempDir('vscode-unpacked');
     }
 
     accept(resolvedPlugin: PluginDeployerEntry): boolean {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -39,7 +39,7 @@ export interface PluginInitData {
 
 export interface Plugin {
     pluginPath: string;
-    initPath: string;
+    pluginFolder: string;
     model: PluginModel;
     rawModel: PluginPackage;
     lifecycle: PluginLifecycle;
@@ -56,6 +56,46 @@ export interface PluginManager {
     isRunning(pluginId: string): boolean;
     activatePlugin(pluginId: string): PromiseLike<void>;
 }
+
+export interface PluginAPIFactory {
+    (plugin: Plugin): typeof theia;
+}
+
+export const emptyPlugin: Plugin = {
+    lifecycle: {
+        startMethod: 'empty',
+        stopMethod: 'empty'
+    },
+    model: {
+        id: 'emptyPlugin',
+        name: 'emptyPlugin',
+        publisher: 'Theia',
+        version: 'empty',
+        displayName: 'empty',
+        description: 'empty',
+        engine: {
+            type: 'empty',
+            version: 'empty'
+        },
+        entryPoint: {
+
+        }
+    },
+    pluginPath: 'empty',
+    pluginFolder: 'empty',
+    rawModel: {
+        name: 'emptyPlugin',
+        publisher: 'Theia',
+        version: 'empty',
+        displayName: 'empty',
+        description: 'empty',
+        engines: {
+            type: 'empty',
+            version: 'empty'
+        },
+        packagePath: 'empty'
+    }
+};
 
 export interface PluginManagerExt {
     $stopPlugin(contextPath: string): PromiseLike<void>;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -17,7 +17,7 @@ import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { LogPart } from './types';
-import { CharacterPair, CommentRule, PluginManager } from '../api/plugin-api';
+import { CharacterPair, CommentRule, PluginAPIFactory, Plugin } from '../api/plugin-api';
 
 export const hostedServicePath = '/services/hostedPlugin';
 
@@ -361,7 +361,7 @@ export interface PluginLifecycle {
  * The export function of initialization module of backend plugin.
  */
 export interface BackendInitializationFn {
-    (rpc: RPCProtocol, manager: PluginManager, pluginMetadata: PluginMetadata): void;
+    (apiFactory: PluginAPIFactory, plugin: Plugin): void;
 }
 
 export interface BackendLoadingFn {

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -16,7 +16,7 @@
 
 import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext } from '../../../common/plugin-protocol';
 import { injectable } from 'inversify';
-import * as os from 'os';
+import { getTempDir } from '../temp-dir-util';
 import * as path from 'path';
 
 @injectable()
@@ -24,7 +24,7 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
 
     private unpackedFolder: string;
     constructor() {
-        this.unpackedFolder = path.resolve(os.tmpdir(), 'theia-unpacked');
+        this.unpackedFolder = getTempDir('theia-unpacked');
     }
 
     accept(resolvedPlugin: PluginDeployerEntry): boolean {

--- a/packages/plugin-ext/src/main/node/temp-dir-util.ts
+++ b/packages/plugin-ext/src/main/node/temp-dir-util.ts
@@ -13,13 +13,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
 
-// Exports contribution point for uri postprocessor of hosted plugin manager.
-// This could be used to alter hosted instance uri, for example, change port.
-export * from '../hosted/node/hosted-plugin-uri-postprocessor';
+export function getTempDir(name: string): string {
+    let tempDir = path.resolve(os.tmpdir(), name);
+    // for mac os 'os.tmpdir()' return symlink, but we need real path
+    if (process.platform === 'darwin') {
+        tempDir = fs.realpathSync(tempDir);
+    }
 
-// Here we expose types from @theia/plugin, so it becames a direct dependency
-export * from '../common/plugin-protocol';
-export * from '../plugin/plugin-context';
-export * from '../api/plugin-api';
-export * from '../main/node/temp-dir-util';
+    return tempDir;
+}

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -24,7 +24,7 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 export interface PluginHost {
 
     // tslint:disable-next-line:no-any
-    loadPlugin(contextPath: string, plugin: Plugin): any;
+    loadPlugin(plugin: Plugin): any;
 
     init(data: PluginMetadata[]): [Plugin[], Plugin[]];
 }
@@ -76,7 +76,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         }
         // run plugins
         for (const plugin of plugins) {
-            const pluginMain = this.host.loadPlugin(plugin.initPath, plugin);
+            const pluginMain = this.host.loadPlugin(plugin);
             this.startPlugin(plugin, pluginMain);
         }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -43,7 +43,7 @@ declare module '@theia/plugin' {
     export type PluginType = 'frontend' | 'backend';
 
     /**
-     * Represents an extension.
+     * Represents an plugin.
      *
      * To get an instance of an `Plugin` use [getPlugin](#plugins.getPlugin).
      */


### PR DESCRIPTION
Each plugin will have own `theia` object, with bundled plugin information.
Now we can track which API was called by which plugin.

It's will break all existing frontend  plugins, to make your plugin work again you should change plugin `webpack.config.js`, in section `externals` replace `"@theia/plugin": "theia"` with `"@theia/plugin": "theia.<your plugin library id>"`, for plugin library id you should use library  value in `output` section in the same `webpack.config.js` file.

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
