### PR TITLE
cpp: Don't send empty compilationDatabasePath on initialization

### DIFF
--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -67,16 +67,21 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
         this.cppBuildConfigurationsStatusBarElement.show();
     }
 
-    private createClangdConfigurationParams(config: CppBuildConfiguration | undefined): ClangdConfigurationParamsChange {
-        const clangdParams: ClangdConfigurationParamsChange = {
-            compilationDatabasePath: config ? config.directory : ''
-        };
+    private createClangdConfigurationParams(config: CppBuildConfiguration | undefined, isInitialize: boolean): ClangdConfigurationParamsChange {
+        const clangdParams: ClangdConfigurationParamsChange = {};
+
+        // During initialization, we don't need to send the compile commands
+        // path if there isn't one specified (it's clangd's default).
+        if (!isInitialize || config) {
+            clangdParams.compilationDatabasePath = config ? config.directory : '';
+        }
+
         return clangdParams;
     }
 
     async onActiveBuildConfigChanged(config: CppBuildConfiguration | undefined) {
         const interfaceParams: DidChangeConfigurationParams = {
-            settings: this.createClangdConfigurationParams(config)
+            settings: this.createClangdConfigurationParams(config, false)
         };
 
         const languageClient = await this.languageClient;
@@ -104,7 +109,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
 
     protected createOptions(): LanguageClientOptions {
         const clientOptions = super.createOptions();
-        clientOptions.initializationOptions = this.createClangdConfigurationParams(this.cppBuildConfigurations.getActiveConfig());
+        clientOptions.initializationOptions = this.createClangdConfigurationParams(this.cppBuildConfigurations.getActiveConfig(), true);
 
         clientOptions.initializationFailedHandler = () => {
             const READ_INSTRUCTIONS_ACTION = 'Read Instructions';


### PR DESCRIPTION
If there is no active build configuration, we currently send an empty
string as the compilationDatabasePath to clangd in the
initializationOptions.  The intention was that clangd would interpret it
as a way to deselect any previously specified compilationDatabasePath
(in other words, go back to the initial state of not explicitly defined
compile commands path).  However, as of today, clangd understands an
empty string as a regular path, and it doesn't give good results.  The
compile_commands.json file is not found is clangd's current working
directory has changed (which happens when it analyzes a file in a
different directory).

Clearly, a fix is needed in clangd: we need a way to specify "no
compilation database path".  But in the mean time, we can mitigate this
problem by not sending anything during the initialization phase if there
is not active build configuration.  Clangd will keep its initial state
of "no compilation database path".

The case of choosing a build config and then choosing no build config
will still be broken though, as we will still send an empty string.
This will require the fix in clangd mentioned previously.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
