### PR TITLE
Fix license used in package.json which was not the license declared in ts files

### DIFF
--- a/packages/debug-nodejs/package.json
+++ b/packages/debug-nodejs/package.json
@@ -17,7 +17,7 @@
   "keywords": [
     "theia-extension, debug, nodejs"
   ],
-  "license": "Apache-2.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/theia-ide/theia.git"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -21,7 +21,7 @@
   "keywords": [
     "theia-extension, debug"
   ],
-  "license": "Apache-2.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/theia-ide/theia.git"


### PR DESCRIPTION
Use expected license

Change-Id: Ica3a9f839163662e82c1b2e683f7ccbb43a90a6d
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
