### PR TITLE
Fix the default editor.fontSize

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -23,6 +23,7 @@ import {
     PreferenceSchema,
     PreferenceChangeEvent
 } from '@theia/core/lib/browser/preferences';
+import { isOSX } from '@theia/core/lib/common/os';
 
 export const editorPreferenceSchema: PreferenceSchema = {
     'type': 'object',
@@ -35,7 +36,7 @@ export const editorPreferenceSchema: PreferenceSchema = {
         },
         'editor.fontSize': {
             'type': 'number',
-            'default': 12,
+            'default': (isOSX) ? 12 : 14,
             'description': 'Configure the editor font size'
         },
         'editor.lineNumbers': {


### PR DESCRIPTION
Fixed the **default** `editor.fontSize` number to align to other IDEs such as VSCode and Atom

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
