### PR TITLE
gray-out nodes in file dialog when needed

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -80,6 +80,14 @@
     background: var(--theia-accent-color4);
 }
 
+.theia-TreeNode.theia-mod-not-selectable {
+    color: var(--theia-ui-font-color2);
+}
+.theia-TreeNode.theia-mod-not-selectable:hover {
+    background: none;
+    cursor: default;
+}
+
 .theia-TreeNodeSegment {
     flex-grow: 0;
     user-select: none;

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-tree.ts
@@ -33,14 +33,7 @@ export class FileDialogTree extends FileTree {
      * @param fileExtensions array of extensions
      */
     setFilter(fileExtensions: string[]): void {
-        this.fileExtensions = [];
-
-        if (fileExtensions) {
-            fileExtensions.forEach(e => {
-                this.fileExtensions.push(e);
-            });
-        }
-
+        this.fileExtensions = fileExtensions.slice();
         this.refresh();
     }
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -237,6 +237,9 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         @inject(FileDialogWidget) readonly widget: FileDialogWidget
     ) {
         super(props, widget);
+        if (props.canSelectFiles !== undefined) {
+            this.widget.disableFileSelection = !props.canSelectFiles;
+        }
     }
 
     protected getAcceptButtonLabel(): string {
@@ -244,45 +247,9 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
     }
 
     protected isValid(value: MaybeArray<FileStatNode>): string {
-        if (value) {
-            if (this.props.canSelectMany) {
-                if (Array.isArray(value)) {
-                    const results: Readonly<FileStatNode>[] = value;
-                    for (let i = 0; i < results.length; i++) {
-                        const error = this.validateNode(results[i]);
-                        if (error) {
-                            return error;
-                        }
-                    }
-                } else {
-                    const error = this.validateNode(value);
-                    if (error) {
-                        return error;
-                    }
-                }
-            } else {
-                if (value instanceof Array) {
-                    return 'You can select only one item';
-                }
-
-                return this.validateNode(value);
-            }
+        if (value && !this.props.canSelectMany && value instanceof Array) {
+            return 'You can select only one item';
         }
-
-        return '';
-    }
-
-    protected validateNode(node: Readonly<FileStatNode>): string {
-        if (typeof this.props.canSelectFiles === 'boolean'
-            && !this.props.canSelectFiles && !node.fileStat.isDirectory) {
-            return 'Files cannot be selected';
-        }
-
-        if (typeof this.props.canSelectFolders === 'boolean'
-            && !this.props.canSelectFolders && node.fileStat.isDirectory) {
-            return 'Folders cannot be selected';
-        }
-
         return '';
     }
 
@@ -294,6 +261,13 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         }
     }
 
+    protected accept(): void {
+        if (this.props.canSelectFolders === false && !Array.isArray(this.value)) {
+            this.widget.model.openNode(this.value);
+            return;
+        }
+        super.accept();
+    }
 }
 
 @injectable()


### PR DESCRIPTION
- gray out file nodes in open file dialog if OpenFileDialogProps.canSelectFiles = false
- gray out folder nodes in open file dialog if OpenFileDialogProps.canSelectFolders = false
- resolves #2590

Signed-off-by: elaihau <liang.huang@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
