### PR TITLE
[debug] Fix menu definition

### DIFF
--- a/packages/debug/src/browser/debug-command.ts
+++ b/packages/debug/src/browser/debug-command.ts
@@ -30,37 +30,24 @@ export const DEBUG_SESSION_THREAD_CONTEXT_MENU: MenuPath = ['debug-session-threa
 export const DEBUG_VARIABLE_CONTEXT_MENU: MenuPath = ['debug-variable-context-menu'];
 
 export namespace DebugSessionContextMenu {
-    export const STOP = [...DEBUG_SESSION_CONTEXT_MENU, '1_stop'];
+    export const DEBUG_CONTROLS = [...DEBUG_SESSION_CONTEXT_MENU, '1_controls'];
 }
 
 export namespace DebugThreadContextMenu {
-    export const RESUME_THREAD = [...DEBUG_SESSION_THREAD_CONTEXT_MENU, '2_resume'];
-    export const SUSPEND_THREAD = [...RESUME_THREAD, '1_suspend'];
-
-    export const STEPOUT_THREAD = [...DEBUG_SESSION_THREAD_CONTEXT_MENU, '5_stepout'];
-    export const STEPIN_THREAD = [...STEPOUT_THREAD, '4_stepin'];
-    export const STEP_THREAD = [...STEPIN_THREAD, '3_next'];
+    export const DEBUG_PLAYER = [...DEBUG_SESSION_THREAD_CONTEXT_MENU, '2_player'];
+    export const DEBUG_STEPPING = [...DEBUG_SESSION_THREAD_CONTEXT_MENU, '3_stepping'];
 }
 
 export namespace DebugVariableContextMenu {
-    export const MODIFY = [...DEBUG_VARIABLE_CONTEXT_MENU, '1_modify'];
+    export const DEBUG_EDITION = [...DEBUG_VARIABLE_CONTEXT_MENU, '1_edition'];
 }
 
 export namespace DebugMenus {
     export const DEBUG = [...MAIN_MENU_BAR, '4_debug'];
-    export const DEBUG_STOP = [...DEBUG, '2_stop'];
-    export const DEBUG_START = [...DEBUG_STOP, '1_start'];
-
-    export const SUSPEND_ALL_THREADS = [...DEBUG, '4_suspend_all_threads'];
-    export const RESUME_ALL_THREADS = [...SUSPEND_ALL_THREADS, '3_resume_all_threads'];
-
-    export const STEPOUT_THREAD = [...DEBUG, '7_stepout'];
-    export const STEPIN_THREAD = [...STEPOUT_THREAD, '6_stepin'];
-    export const STEP_THREAD = [...STEPIN_THREAD, '5_next'];
-
-    export const ADD_CONFIGURATION = [...DEBUG, '9_add_configuration'];
-    export const OPEN_CONFIGURATION = [...ADD_CONFIGURATION, '8_open_configuration'];
-    export const SHOW_BREAKPOINTS = [...OPEN_CONFIGURATION, '10_breakpoinst'];
+    export const DEBUG_CONTROLS = [...DEBUG, '1_controls'];
+    export const DEBUG_THREADS = [...DEBUG, '2_threads'];
+    export const DEBUG_STEPPING = [...DEBUG, '3_stepping'];
+    export const DEBUG_CONFIGURATION = [...DEBUG, '4_configuration'];
 }
 
 export namespace DEBUG_COMMANDS {
@@ -136,60 +123,88 @@ export class DebugCommandHandlers implements MenuContribution, CommandContributi
         @inject(DebugSessionManager) protected readonly debugSessionManager: DebugSessionManager,
         @inject(DebugConfigurationManager) protected readonly debugConfigurationManager: DebugConfigurationManager,
         @inject(DebugSelectionService) protected readonly debugSelectionHandler: DebugSelectionService,
-        @inject(BreakpointsDialog) protected readonly breakpointsDialog: BreakpointsDialog) { }
+        @inject(BreakpointsDialog) protected readonly breakpointsDialog: BreakpointsDialog
+    ) { }
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerSubmenu(DebugMenus.DEBUG, 'Debug');
-        menus.registerMenuAction(DebugMenus.DEBUG_START, {
-            commandId: DEBUG_COMMANDS.START.id
+
+        menus.registerMenuAction(DebugMenus.DEBUG_CONTROLS, {
+            commandId: DEBUG_COMMANDS.START.id,
+            order: '1_start',
         });
-        menus.registerMenuAction(DebugMenus.DEBUG_STOP, {
-            commandId: DEBUG_COMMANDS.STOP.id
+        menus.registerMenuAction(DebugMenus.DEBUG_CONTROLS, {
+            commandId: DEBUG_COMMANDS.STOP.id,
+            order: '2_stop',
         });
-        menus.registerMenuAction(DebugMenus.OPEN_CONFIGURATION, {
-            commandId: DEBUG_COMMANDS.OPEN_CONFIGURATION.id
+
+        menus.registerMenuAction(DebugMenus.DEBUG_THREADS, {
+            commandId: DEBUG_COMMANDS.RESUME_ALL_THREADS.id,
+            order: '3_resume_all_threads',
         });
-        menus.registerMenuAction(DebugMenus.ADD_CONFIGURATION, {
-            commandId: DEBUG_COMMANDS.ADD_CONFIGURATION.id
+        menus.registerMenuAction(DebugMenus.DEBUG_THREADS, {
+            commandId: DEBUG_COMMANDS.SUSPEND_ALL_THREADS.id,
+            order: '4_suspend_all_threads',
         });
-        menus.registerMenuAction(DebugSessionContextMenu.STOP, {
-            commandId: DEBUG_COMMANDS.STOP.id
+
+        menus.registerMenuAction(DebugMenus.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEP.id,
+            order: '5_next',
         });
-        menus.registerMenuAction(DebugMenus.STEP_THREAD, {
-            commandId: DEBUG_COMMANDS.STEP.id
+        menus.registerMenuAction(DebugMenus.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEPIN.id,
+            order: '6_stepin',
         });
-        menus.registerMenuAction(DebugMenus.STEPIN_THREAD, {
-            commandId: DEBUG_COMMANDS.STEPIN.id
+        menus.registerMenuAction(DebugMenus.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEPOUT.id,
+            order: '7_stepout',
         });
-        menus.registerMenuAction(DebugMenus.STEPOUT_THREAD, {
-            commandId: DEBUG_COMMANDS.STEPOUT.id
+
+        menus.registerMenuAction(DebugMenus.DEBUG_CONFIGURATION, {
+            commandId: DEBUG_COMMANDS.OPEN_CONFIGURATION.id,
+            order: '8_open_configuration',
         });
-        menus.registerMenuAction(DebugMenus.SUSPEND_ALL_THREADS, {
-            commandId: DEBUG_COMMANDS.SUSPEND_ALL_THREADS.id
+        menus.registerMenuAction(DebugMenus.DEBUG_CONFIGURATION, {
+            commandId: DEBUG_COMMANDS.ADD_CONFIGURATION.id,
+            order: '9_add_configuration',
         });
-        menus.registerMenuAction(DebugMenus.RESUME_ALL_THREADS, {
-            commandId: DEBUG_COMMANDS.RESUME_ALL_THREADS.id
+        menus.registerMenuAction(DebugMenus.DEBUG_CONFIGURATION, {
+            commandId: DEBUG_COMMANDS.SHOW_BREAKPOINTS.id,
+            order: '10_breakpoints',
         });
-        menus.registerMenuAction(DebugMenus.SHOW_BREAKPOINTS, {
-            commandId: DEBUG_COMMANDS.SHOW_BREAKPOINTS.id
+
+        // debug session context
+        menus.registerMenuAction(DebugSessionContextMenu.DEBUG_CONTROLS, {
+            commandId: DEBUG_COMMANDS.STOP.id,
+            order: '1_stop',
         });
-        menus.registerMenuAction(DebugThreadContextMenu.SUSPEND_THREAD, {
-            commandId: DEBUG_COMMANDS.SUSPEND_THREAD.id
+
+        // thread context
+        menus.registerMenuAction(DebugThreadContextMenu.DEBUG_PLAYER, {
+            commandId: DEBUG_COMMANDS.SUSPEND_THREAD.id,
+            order: '1_suspend',
         });
-        menus.registerMenuAction(DebugThreadContextMenu.RESUME_THREAD, {
-            commandId: DEBUG_COMMANDS.RESUME_THREAD.id
+        menus.registerMenuAction(DebugThreadContextMenu.DEBUG_PLAYER, {
+            commandId: DEBUG_COMMANDS.RESUME_THREAD.id,
+            order: '2_resume',
         });
-        menus.registerMenuAction(DebugThreadContextMenu.STEP_THREAD, {
-            commandId: DEBUG_COMMANDS.STEP.id
+        menus.registerMenuAction(DebugThreadContextMenu.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEP.id,
+            order: '3_next',
         });
-        menus.registerMenuAction(DebugThreadContextMenu.STEPIN_THREAD, {
-            commandId: DEBUG_COMMANDS.STEPIN.id
+        menus.registerMenuAction(DebugThreadContextMenu.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEPIN.id,
+            order: '4_stepin',
         });
-        menus.registerMenuAction(DebugThreadContextMenu.STEPOUT_THREAD, {
-            commandId: DEBUG_COMMANDS.STEPOUT.id
+        menus.registerMenuAction(DebugThreadContextMenu.DEBUG_STEPPING, {
+            commandId: DEBUG_COMMANDS.STEPOUT.id,
+            order: '5_stepout',
         });
-        menus.registerMenuAction(DebugVariableContextMenu.MODIFY, {
-            commandId: DEBUG_COMMANDS.MODIFY_VARIABLE.id
+
+        // variable context
+        menus.registerMenuAction(DebugVariableContextMenu.DEBUG_EDITION, {
+            commandId: DEBUG_COMMANDS.MODIFY_VARIABLE.id,
+            order: '1_modify',
         });
     }
 


### PR DESCRIPTION
The menu creation is quite confusing, and CSS rules do remove most issues with
it. But under electron, the native menus aren't affected by CSS, and the
problem becomes quite visible. This commit only fixes the menu definition for
the `debug` extension.

Fix #2680.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
