### PR TITLE
add "open save file dialog" to FileDialogService

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -230,7 +230,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                 isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
                 isVisible: uris => !uris.length || this.areWorkspaceRoots(uris),
                 execute: async uris => {
-                    const node = await this.fileDialogService.show({ title: WorkspaceCommands.ADD_FOLDER.label! });
+                    const node = await this.fileDialogService.showOpenDialog({ title: WorkspaceCommands.ADD_FOLDER.label! });
                     this.addFolderToWorkspace(node);
                 }
             }));

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -83,7 +83,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, MenuC
 
     protected showFileDialog(props: OpenFileDialogProps): void {
         this.workspaceService.roots.then(async roots => {
-            const node = await this.fileDialogService.show(props, roots[0]);
+            const node = await this.fileDialogService.showOpenDialog(props, roots[0]);
             this.openFile(node);
         });
     }


### PR DESCRIPTION
- "save file dialog" can be opened by calling FileDialogService.showSaveDialog()
- resolves #2814

Signed-off-by: elaihau <liang.huang@ericsson.com>
