### PR TITLE
Fixes #2823: Support 'debugServer' property

### DIFF
--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -22,6 +22,7 @@
 // Some entities copied and modified from https://github.com/Microsoft/vscode-debugadapter-node/blob/master/adapter/src/protocol.ts
 
 import * as WebSocket from 'ws';
+import * as net from 'net';
 import { injectable, inject } from 'inversify';
 import { ILogger, DisposableCollection, Disposable } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
@@ -94,6 +95,15 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
             : executable.args;
 
         return this.processFactory({ command: command, args: args });
+    }
+
+    connect(debugServerPort: number): CommunicationProvider {
+        const socket = net.createConnection(debugServerPort);
+        return {
+            input: socket,
+            output: socket,
+            dispose: () => socket.end()
+        };
     }
 }
 

--- a/packages/debug/src/node/debug-model.ts
+++ b/packages/debug/src/node/debug-model.ts
@@ -87,6 +87,7 @@ export const DebugAdapterFactory = Symbol('DebugAdapterFactory');
  */
 export interface DebugAdapterFactory {
     start(executable: DebugAdapterExecutable): CommunicationProvider;
+    connect(debugServerPort: number): CommunicationProvider;
 }
 
 /**

--- a/packages/debug/src/node/debug-service.ts
+++ b/packages/debug/src/node/debug-service.ts
@@ -126,8 +126,13 @@ export class DebugAdapterSessionManager {
     create(config: DebugConfiguration): DebugAdapterSession {
         const sessionId = UUID.uuid4();
 
-        const executable = this.registry.provideDebugAdapterExecutable(config);
-        const communicationProvider = this.debugAdapterFactory.start(executable);
+        let communicationProvider;
+        if ('debugServer' in config) {
+            communicationProvider = this.debugAdapterFactory.connect(config.debugServer);
+        } else {
+            const executable = this.registry.provideDebugAdapterExecutable(config);
+            communicationProvider = this.debugAdapterFactory.start(executable);
+        }
 
         const sessionFactory = this.registry.debugAdapterSessionFactory(config.type) || this.debugAdapterSessionFactory;
         const session = sessionFactory.get(sessionId, communicationProvider);


### PR DESCRIPTION
Enable 'debugServer' property to connect to running debug adapter

See https://code.visualstudio.com/docs/editor/debugging optional
attributes:
"debugServer - for debug extension authors only: connect to
 the specified port instead of launching the debug adapter"

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
