### PR TITLE
Fill missed default values in some preference schemas

### DIFF
--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -35,10 +35,17 @@ export const cppPreferencesSchema: PreferenceSchema = {
                     }
                 },
                 required: ['name', 'directory'],
-            }
+            },
+            default: [
+                {
+                    name: '',
+                    directory: ''
+                }
+            ],
         },
         'cpp.experimentalCommands': {
             description: 'Enable experimental commands mostly intended for Clangd developers.',
+            default: false,
             type: 'boolean'
         }
     }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -43,6 +43,7 @@ export const editorPreferenceSchema: PreferenceSchema = {
                 'on',
                 'off'
             ],
+            'default': 'on',
             'description': 'Control the rendering of line numbers'
         },
         'editor.renderWhitespace': {
@@ -51,6 +52,7 @@ export const editorPreferenceSchema: PreferenceSchema = {
                 'boundary',
                 'all'
             ],
+            'default': 'none',
             'description': 'Control the rendering of whitespaces in the editor'
         },
         'editor.autoSave': {
@@ -243,6 +245,7 @@ export const editorPreferenceSchema: PreferenceSchema = {
         },
         'editor.emptySelectionClipboard': {
             'type': 'boolean',
+            'default': true,
             'description': 'Copying without a selection copies the current line.'
         },
         'editor.wordBasedSuggestions': {
@@ -297,6 +300,7 @@ export const editorPreferenceSchema: PreferenceSchema = {
         },
         'editor.useTabStops': {
             'type': 'boolean',
+            'default': true,
             'description': 'Inserting and deleting whitespace follows tab stops.'
         },
         'editor.insertSpaces': {


### PR DESCRIPTION
Some preferences values in some preferences schemas might not have default values. Added missed default values where possible.  
fixes #2470
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
