### PR TITLE
[plug-in] Add category from VS Code command to the label of Theia command

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -30,7 +30,13 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     const contributes: any = plugin.rawModel.contributes;
     if (contributes && contributes.commands) {
         contributes.commands.forEach((commandItem: any) => {
-            vscode.commands.registerCommand({ id: commandItem.command, label: commandItem.title });
+            let commandLabel: string;
+            if (commandItem.category) { // if VS Code command has category we will add it before title, so label will looks like 'category: title'
+                commandLabel = commandItem.category + ': ' + commandItem.title;
+            } else {
+                commandLabel = commandItem.title;
+            }
+            vscode.commands.registerCommand({id: commandItem.command, label: commandLabel });
         });
     }
 


### PR DESCRIPTION
If VS Code Command will have categories field like this:
```
{
  "command": "extension.helmVersion",
  "title": "Version (Client)",
  "description": "Get the version of the local Helm client.",
  "category": "Helm"
} 
```
we will add categories to the Theia commands label field as prefix:
`command.label = "Helm: Version (Client)" `

Without categories:
![command-without-category](https://user-images.githubusercontent.com/1636592/45302693-a4006080-b51c-11e8-8a1d-f018e082d6c8.gif)
With categories:
![commna-with-categories](https://user-images.githubusercontent.com/1636592/45302715-b11d4f80-b51c-11e8-8508-2c720df4671d.gif)


Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

