### PR TITLE
GitWidget is navigable as GitDiffWidget now

### DIFF
--- a/packages/git/src/browser/git-navigable-list-widget.ts
+++ b/packages/git/src/browser/git-navigable-list-widget.ts
@@ -40,6 +40,7 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
+        this.update();
         this.node.focus();
     }
 
@@ -90,13 +91,12 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
         return result;
     }
 
-    protected onAfterAttach(msg: Message): void {
-        super.onAfterAttach(msg);
-        this.addKeyListener(this.node, Key.ARROW_LEFT, () => this.navigateLeft());
-        this.addKeyListener(this.node, Key.ARROW_RIGHT, () => this.navigateRight());
-        this.addKeyListener(this.node, Key.ARROW_UP, () => this.navigateUp());
-        this.addKeyListener(this.node, Key.ARROW_DOWN, () => this.navigateDown());
-        this.addKeyListener(this.node, Key.ENTER, () => this.handleListEnter());
+    protected addGitListNavigationKeyListeners(container: HTMLElement) {
+        this.addKeyListener(container, Key.ARROW_LEFT, () => this.navigateLeft());
+        this.addKeyListener(container, Key.ARROW_RIGHT, () => this.navigateRight());
+        this.addKeyListener(container, Key.ARROW_UP, () => this.navigateUp());
+        this.addKeyListener(container, Key.ARROW_DOWN, () => this.navigateDown());
+        this.addKeyListener(container, Key.ENTER, () => this.handleListEnter());
     }
 
     protected navigateLeft(): void {

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -81,6 +81,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
 
     protected onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
+        this.addGitListNavigationKeyListeners(this.node);
         this.addEventListener<any>(this.node, 'ps-scroll-y', (e: Event & { target: { scrollTop: number } }) => {
             if (this.listView && this.listView.list && this.listView.list.Grid) {
                 const { scrollTop } = e.target;

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -176,7 +176,7 @@
     width: 100%;
 }
 
-.theia-git:focus .theia-mod-selected{
+.theia-git div:focus .theia-mod-selected{
     background: var(--theia-accent-color3);
 }
 
@@ -315,7 +315,7 @@
     -ms-user-select: none;
     -o-user-select: none;
  }
- 
+
  .no-select:focus {
     outline: none;
  }


### PR DESCRIPTION
Fixes theia-ide/theia#1791

This PR provides keyboard navigation for the Git widget as it is used in GitDiff widget. Plus additional keys for staging/unstaging and discarding.
 
- [x] if commit message field is focused one can use TAB to focus the list and use keyboard navigation. With SHIFT+TAB one jumps back to the textfield.
- [x] UP/DOWN: navigates through list
- [x] LEFT/RIGHT: opens file and navigates through changes without loosing focus on git list
- [x] SPACE: stages/unstages changes 
- [x] BACKSPACE: discards changes, opens dialog first 
- [x] ENTER: opens diff view without loosing focus on git list
