### PR TITLE
Add signature help languages plugin API

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -171,6 +171,23 @@ export enum MarkerTag {
     Unnecessary = 1,
 }
 
+export interface ParameterInformation {
+    label: string;
+    documentation?: string | MarkdownString;
+}
+
+export interface SignatureInformation {
+    label: string;
+    documentation?: string | MarkdownString;
+    parameters: ParameterInformation[];
+}
+
+export interface SignatureHelp {
+    signatures: SignatureInformation[];
+    activeSignature: number;
+    activeParameter: number;
+}
+
 export interface Hover {
     contents: MarkdownString[];
     range?: Range;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -31,6 +31,7 @@ import {
     Completion,
     CompletionResultDto,
     MarkerData,
+    SignatureHelp,
     Hover
 } from './model';
 
@@ -639,6 +640,8 @@ export interface LanguagesExt {
     $provideCompletionItems(handle: number, resource: UriComponents, position: Position, context: CompletionContext): Promise<CompletionResultDto | undefined>;
     $resolveCompletionItem(handle: number, resource: UriComponents, position: Position, completion: Completion): Promise<Completion>;
     $releaseCompletionItems(handle: number, id: number): void;
+
+    $provideSignatureHelp(handle: number, resource: UriComponents, position: Position): Promise<SignatureHelp | undefined>;
     $provideHover(handle: number, resource: UriComponents, position: Position): Promise<Hover | undefined>;
 }
 
@@ -647,9 +650,11 @@ export interface LanguagesMain {
     $setLanguageConfiguration(handle: number, languageId: string, configuration: SerializedLanguageConfiguration): void;
     $unregister(handle: number): void;
     $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void;
+    $registerSignatureHelpSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[]): void;
+    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [UriComponents, MarkerData[]][]): void;
-    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/plugin/languages/signature.ts
+++ b/packages/plugin-ext/src/plugin/languages/signature.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri/lib/umd';
+import * as theia from '@theia/plugin';
+import * as types from '../types-impl';
+import { DocumentsExtImpl } from '../documents';
+import { Position } from '../../api/plugin-api';
+import { SignatureHelp } from '../../api/model';
+
+export class SignatureHelpAdapter {
+
+    constructor(
+        private readonly delegate: theia.SignatureHelpProvider,
+        private readonly documents: DocumentsExtImpl) {
+
+    }
+
+    provideSignatureHelp(resource: URI, position: Position): Promise<SignatureHelp | undefined> {
+        const documentData = this.documents.getDocumentData(resource);
+        if (!documentData) {
+            return Promise.reject(new Error(`There are no document for  ${resource}`));
+        }
+
+        const document = documentData.document;
+        const zeroBasedPosition = new types.Position(position.lineNumber - 1, position.column - 1);
+
+        return Promise.resolve(this.delegate.provideSignatureHelp(document, zeroBasedPosition, undefined));
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -55,6 +55,9 @@ import {
     DiagnosticSeverity,
     DiagnosticTag,
     Location,
+    ParameterInformation,
+    SignatureInformation,
+    SignatureHelp,
     Hover
 } from './types-impl';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -283,6 +286,7 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
                 return languagesExt.onDidChangeDiagnostics;
             },
             getDiagnostics(resource?: Uri) {
+                // tslint:disable-next-line:no-any
                 return <any>languagesExt.getDiagnostics(resource);
             },
             createDiagnosticCollection(name?: string): theia.DiagnosticCollection {
@@ -293,6 +297,9 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             },
             registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, ...triggerCharacters: string[]): theia.Disposable {
                 return languagesExt.registerCompletionItemProvider(selector, provider, triggerCharacters);
+            },
+            registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, ...triggerCharacters: string[]): theia.Disposable {
+                return languagesExt.registerSignatureHelpProvider(selector, provider, ...triggerCharacters);
             },
             registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
                 return languagesExt.registerHoverProvider(selector, provider);
@@ -353,6 +360,9 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             Diagnostic,
             CompletionTriggerKind,
             TextEdit,
+            ParameterInformation,
+            SignatureInformation,
+            SignatureHelp,
             Hover,
         };
     };

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -90,10 +90,10 @@ export class Position {
     private _character: number;
     constructor(line: number, char: number) {
         if (line < 0) {
-            throw new Error('line must be greater than 0');
+            throw new Error('line number cannot be negative');
         }
         if (char < 0) {
-            throw new Error('char must be greater than 0');
+            throw new Error('char number cannot be negative');
         }
         this._line = line;
         this._character = char;
@@ -808,6 +808,33 @@ export enum MarkerSeverity {
 
 export enum MarkerTag {
     Unnecessary = 1,
+}
+
+export class ParameterInformation {
+    label: string;
+    documentation?: string | MarkdownString;
+
+    constructor(label: string, documentation?: string | MarkdownString) {
+        this.label = label;
+        this.documentation = documentation;
+    }
+}
+
+export class SignatureInformation {
+    label: string;
+    documentation?: string | MarkdownString;
+    parameters: ParameterInformation[];
+
+    constructor(label: string, documentation?: string | MarkdownString) {
+        this.label = label;
+        this.documentation = documentation;
+    }
+}
+
+export class SignatureHelp {
+    signatures: SignatureInformation[];
+    activeSignature: number;
+    activeParameter: number;
 }
 
 export class Hover {

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -409,6 +409,70 @@ diagnosticsCollection.forEach((uri, diagnostics) => {
 
 `dispose` method should be used when the collection is not needed any more. In case of attempt to do an operaton after disposing an error will be thrown.
 
+#### Signature help
+
+To provide signature help form plugin it is required to register provider. For registration 3 items are needed:
+- Documents selector to describe for which files it should be applied
+- Handler which will do the work
+- Trigger characters after typing of which the handler should be invoked. Often symbols `(` and `,` are used.
+
+Example of signature help provider registration:
+
+```typescript
+const documentsSelector: theia.DocumentSelector = { scheme: 'file', language: 'typescript' };
+const handler = { provideSignatureHelp: signatureHelpHandler };
+const triggerChars = '(,';
+
+const disposable = theia.languages.registerSignatureHelpProvider(documentsSelector, handler, ...triggerChars);
+
+...
+
+function signatureHelpHandler(document: theia.TextDocument, position: theia.Position): theia.ProviderResult<theia.SignatureHelp> {
+    // code here
+}
+```
+
+Example of signature information:
+
+```typescript
+{
+    activeSignature: 0,
+    activeParameter: 0,
+    signatures: [
+        {
+            label: 'functionName(param1: number, param2: string, param3: boolean)',
+            documentation: new theia.MarkdownString('What **this** function does'),
+            parameters: [
+                {
+                    label: 'param1: number',
+                    documentation: new theia.MarkdownString('Some number. Should not be `undefined`')
+                },
+                {
+                    label: 'param2: string',
+                    documentation: 'Some string'
+                },
+                {
+                    label: 'param3: boolean',
+                    documentation: 'Some flag'
+                }
+            ]
+        }
+    ]
+}
+```
+
+Note, that:
+- `activeSignature` and `activeParameter` are zero based.
+- label is usually full method signature.
+- for documentation fields markdown partially supported (Tags aren't supported).
+- label of a parameter should be substring of the signature label. In such case the substring will be highlighted in main label when parameter is active. Otherwise has no effect.
+
+When signature help popup is shown then the handler will be invoked on each parameter edit or even cursor moving inside signature. If you have large objects it would be wise to cache them of at least reuse some parts.
+
+To hide your popup just return `undefined` from provider.
+
+In case if a few providers are registered the chain will be executed until one of the providers returns result. Next providers will be ignored for the call.
+
 #### Hover Message
 
 To contribute a hover it is only needed to provide a function that can be called with a `TextDocument` and a `Position` returning hover info. Registration is done using a document selector which either a language id ('typescript', 'javascript' etc.) or a more complex filter like `{scheme: 'file', language: 'typescript'}`.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -70,9 +70,9 @@ declare module '@theia/plugin' {
         readonly packageJSON: any;
 
         /**
-         * 
+         *
          */
-        readonly pluginType : PluginType;
+        readonly pluginType: PluginType;
 
         /**
          * The public API exported by this plug-in. It is an invalid action
@@ -1922,30 +1922,30 @@ declare module '@theia/plugin' {
         filters?: { [name: string]: string[] };
     }
 
-	/**
-	 * Options to configure the behaviour of a file save dialog.
-	 */
+    /**
+     * Options to configure the behaviour of a file save dialog.
+     */
     export interface SaveDialogOptions {
-		/**
-		 * The resource the dialog shows when opened.
-		 */
+        /**
+         * The resource the dialog shows when opened.
+         */
         defaultUri?: Uri;
 
-		/**
-		 * A human-readable string for the save button.
-		 */
+        /**
+         * A human-readable string for the save button.
+         */
         saveLabel?: string;
 
-		/**
-		 * A set of file filters that are used by the dialog. Each entry is a human readable label,
-		 * like "TypeScript", and an array of extensions, e.g.
-		 * ```ts
-		 * {
-		 * 	'Images': ['png', 'jpg']
-		 * 	'TypeScript': ['ts', 'tsx']
-		 * }
-		 * ```
-		 */
+        /**
+         * A set of file filters that are used by the dialog. Each entry is a human readable label,
+         * like "TypeScript", and an array of extensions, e.g.
+         * ```ts
+         * {
+         * 	'Images': ['png', 'jpg']
+         * 	'TypeScript': ['ts', 'tsx']
+         * }
+         * ```
+         */
         filters?: { [name: string]: string[] };
     }
 
@@ -2018,18 +2018,18 @@ declare module '@theia/plugin' {
     }
 
     /**
-	 * A plug-in context is a collection of utilities private to a
-	 * plug-in.
-	 *
-	 * An instance of a `PluginContext` is provided as the first
-	 * parameter to the `start` of a plug-in.
-	 */
+     * A plug-in context is a collection of utilities private to a
+     * plug-in.
+     *
+     * An instance of a `PluginContext` is provided as the first
+     * parameter to the `start` of a plug-in.
+     */
     export interface PluginContext {
 
-		/**
-		 * An array to which disposables can be added. When this
-		 * extension is deactivated the disposables will be disposed.
-		 */
+        /**
+         * An array to which disposables can be added. When this
+         * extension is deactivated the disposables will be disposed.
+         */
         subscriptions: { dispose(): any }[];
     }
 
@@ -2254,13 +2254,13 @@ declare module '@theia/plugin' {
          */
         export function showOpenDialog(options: OpenDialogOptions): PromiseLike<Uri[] | undefined>;
 
-		/**
-		 * Shows a file save dialog to the user which allows to select a file
-		 * for saving-purposes.
-		 *
-		 * @param options Options that control the dialog.
-		 * @returns A promise that resolves to the selected resource or `undefined`.
-		 */
+        /**
+         * Shows a file save dialog to the user which allows to select a file
+         * for saving-purposes.
+         *
+         * @param options Options that control the dialog.
+         * @returns A promise that resolves to the selected resource or `undefined`.
+         */
         export function showSaveDialog(options: SaveDialogOptions): PromiseLike<Uri | undefined>;
 
         /**
@@ -2904,6 +2904,107 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * Represents a parameter of a callable-signature. A parameter can
+     * have a label and a doc-comment.
+     */
+    export class ParameterInformation {
+
+        /**
+         * The label of this signature. Will be shown in
+         * the UI.
+         */
+        label: string;
+
+        /**
+         * The human-readable doc-comment of this signature. Will be shown
+         * in the UI but can be omitted.
+         */
+        documentation?: string | MarkdownString;
+
+        /**
+         * Creates a new parameter information object.
+         *
+         * @param label A label string.
+         * @param documentation A doc string.
+         */
+        constructor(label: string, documentation?: string | MarkdownString);
+    }
+
+    /**
+     * Represents the signature of something callable. A signature
+     * can have a label, like a function-name, a doc-comment, and
+     * a set of parameters.
+     */
+    export class SignatureInformation {
+
+        /**
+         * The label of this signature. Will be shown in
+         * the UI.
+         */
+        label: string;
+
+        /**
+         * The human-readable doc-comment of this signature. Will be shown
+         * in the UI but can be omitted.
+         */
+        documentation?: string | MarkdownString;
+
+        /**
+         * The parameters of this signature.
+         */
+        parameters: ParameterInformation[];
+
+        /**
+         * Creates a new signature information object.
+         *
+         * @param label A label string.
+         * @param documentation A doc string.
+         */
+        constructor(label: string, documentation?: string | MarkdownString);
+    }
+
+    /**
+     * Signature help represents the signature of something
+     * callable. There can be multiple signatures but only one
+     * active and only one active parameter.
+     */
+    export class SignatureHelp {
+
+        /**
+         * One or more signatures.
+         */
+        signatures: SignatureInformation[];
+
+        /**
+         * The active signature.
+         */
+        activeSignature: number;
+
+        /**
+         * The active parameter of the active signature.
+         */
+        activeParameter: number;
+    }
+
+    /**
+     * The signature help provider interface defines the contract between extensions and
+     * the [parameter hints](https://code.visualstudio.com/docs/editor/intellisense)-feature.
+     */
+    export interface SignatureHelpProvider {
+
+        /**
+         * Provide help for the signature at the given position and document.
+         *
+         * @param document The document in which the command was invoked.
+         * @param position The position at which the command was invoked.
+         * @param token A cancellation token.
+         * @return Signature help or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined` or `null`.
+         */
+        provideSignatureHelp(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<SignatureHelp>;
+    }
+
+    /**
      * How a [completion provider](#CompletionItemProvider) was triggered
      */
     export enum CompletionTriggerKind {
@@ -3231,27 +3332,27 @@ declare module '@theia/plugin' {
     }
 
     /**
-	 * Represents a location inside a resource, such as a line
-	 * inside a text file.
-	 */
+     * Represents a location inside a resource, such as a line
+     * inside a text file.
+     */
     export class Location {
 
-		/**
-		 * The resource identifier of this location.
-		 */
+        /**
+         * The resource identifier of this location.
+         */
         uri: Uri;
 
-		/**
-		 * The document range of this location.
-		 */
+        /**
+         * The document range of this location.
+         */
         range: Range;
 
-		/**
-		 * Creates a new location object.
-		 *
-		 * @param uri The resource identifier.
-		 * @param rangeOrPosition The range or position. Positions will be converted to an empty range.
-		 */
+        /**
+         * Creates a new location object.
+         *
+         * @param uri The resource identifier.
+         * @param rangeOrPosition The range or position. Positions will be converted to an empty range.
+         */
         constructor(uri: Uri, rangeOrPosition: Range | Position);
     }
 
@@ -3569,6 +3670,21 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerCompletionItemProvider(selector: DocumentSelector, provider: CompletionItemProvider, ...triggerCharacters: string[]): Disposable;
+
+        /**
+         * Register a signature help provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are sorted
+         * by their [score](#languages.match) and called sequentially until a provider returns a
+         * valid result.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A signature help provider.
+         * @param triggerCharacters Trigger signature help when the user types one of the characters, like `,` or `(`.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerSignatureHelpProvider(selector: DocumentSelector, provider: SignatureHelpProvider, ...triggerCharacters: string[]): Disposable;
+
 
         /**
          * Register a hover provider.


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

This PR adds signature help languages plugin API, so now it is possible to show methods signatures for a language from within a plugin:
![screenshot from 2018-09-12 18-02-34](https://user-images.githubusercontent.com/15607393/45434007-0fca0100-b6b6-11e8-998e-d6fe400236ba.png)

Resolves https://github.com/theia-ide/theia/issues/2792