### PR TITLE
[tabbar][enhancement] Add icons and captions to view tabs

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -46,7 +46,8 @@ export class CallHierarchyTreeWidget extends TreeWidget {
 
         this.id = CALLHIERARCHY_ID;
         this.title.label = 'Call Hierarchy';
-        this.title.iconClass = 'fa fa-arrow-circle-down';
+        this.title.caption = 'Call Hierarchy';
+        this.title.iconClass = 'fa call-hierarchy-tab-icon';
         this.title.closable = true;
         this.addClass(HIERARCHY_TREE_CLASS);
         this.toDispose.push(this.model.onSelectionChanged(selection => {

--- a/packages/callhierarchy/src/browser/style/index.css
+++ b/packages/callhierarchy/src/browser/style/index.css
@@ -60,3 +60,7 @@
     text-overflow: ellipsis;
     color: var(--theia-ui-font-color2);
 }
+
+.call-hierarchy-tab-icon::before {
+    content: "\f0ab"
+}

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -46,6 +46,7 @@
   position: relative;
   padding: 12px 8px;
   background: var(--theia-layout-color2);
+  flex-direction: column;
 }
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
@@ -84,11 +85,11 @@
   position: absolute;
   min-height: var(--theia-private-sidebar-tab-width);
   max-height: var(--theia-private-sidebar-tab-width);
+  align-items: flex-start;
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabIcon {
-  position: absolute;
-  transform: scale(1.5) translate(3px,1px);
+  transform: scale(1.5);
   max-height: 15px;
 }
 

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -235,3 +235,7 @@ div[orientation='vertical'] > .theia-debug-entry > .theia-TreeContainer > div > 
     background: var(--theia-layout-color0);
     height: 380px
 }
+
+.debug-tab-icon::before {
+    content: "\f188"
+}

--- a/packages/debug/src/browser/view/debug-frontend-contribution.ts
+++ b/packages/debug/src/browser/view/debug-frontend-contribution.ts
@@ -60,7 +60,7 @@ export class DebugWidget extends BaseWidget {
         this.title.label = debugSession.configuration.name;
         this.title.caption = debugSession.configuration.name;
         this.title.closable = true;
-        this.title.iconClass = 'fa fa-bug';
+        this.title.iconClass = 'fa debug-tab-icon';
         this.addClass(DebugStyles.DEBUG_CONTAINER);
         this.widgets = [this.toolbar, this.variables, this.threads, this.frames, this.breakpoints];
     }

--- a/packages/extension-manager/src/browser/extension-widget.tsx
+++ b/packages/extension-manager/src/browser/extension-widget.tsx
@@ -40,6 +40,8 @@ export class ExtensionWidget extends ReactWidget {
         super();
         this.id = 'extensions';
         this.title.label = 'Extensions';
+        this.title.caption = 'Extensions';
+        this.title.iconClass = 'fa extensions-tab-icon';
         this.addClass('theia-extensions');
 
         this.update();

--- a/packages/extension-manager/src/browser/style/extension-sidebar.css
+++ b/packages/extension-manager/src/browser/style/extension-sidebar.css
@@ -93,3 +93,7 @@
     align-items: center;
     flex: 3;
 }
+
+.extensions-tab-icon::before {
+    content: "\f12e"
+}

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -82,6 +82,8 @@ export class GitWidget extends ReactWidget implements StatefulWidget {
         super();
         this.id = 'theia-gitContainer';
         this.title.label = 'Git';
+        this.title.caption = 'Git';
+        this.title.iconClass = 'fa git-tab-icon';
         this.scrollContainer = GitWidget.Styles.CHANGES_CONTAINER;
         this.addClass('theia-git');
         this.node.tabIndex = 0;

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -72,6 +72,8 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         this.id = GIT_HISTORY;
         this.scrollContainer = 'git-history-list-container';
         this.title.label = 'Git History';
+        this.title.caption = 'Git History';
+        this.title.iconClass = 'fa git-history-tab-icon';
         this.addClass('theia-git');
         this.resetState();
         this.cancelIndicator = new CancellationTokenSource();

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -213,3 +213,7 @@
     align-items: center;
     justify-content: center;
 }
+
+.git-history-tab-icon::before {
+    content: "\f1da"
+}

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -319,3 +319,7 @@
  .no-select:focus {
     outline: none;
  }
+
+.git-tab-icon::before {
+    content: "\f126"
+}

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -36,7 +36,8 @@ export class ProblemWidget extends TreeWidget {
 
         this.id = 'problems';
         this.title.label = 'Problems';
-        this.title.iconClass = 'fa fa-exclamation-circle';
+        this.title.caption = 'Problems';
+        this.title.iconClass = 'fa problem-tab-icon';
         this.title.closable = true;
         this.addClass('theia-marker-container');
 

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -96,3 +96,7 @@
     height: calc(var(--theia-private-horizontal-tab-height) * 0.8);
     line-height: calc(var(--theia-private-horizontal-tab-height) * 0.8);
 }
+
+.problem-tab-icon::before {
+    content: "\f06a"
+}

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -52,6 +52,8 @@ export class FileNavigatorWidget extends FileTreeWidget {
         super(props, model, contextMenuRenderer);
         this.id = FILE_NAVIGATOR_ID;
         this.title.label = LABEL;
+        this.title.caption = LABEL;
+        this.title.iconClass = 'fa navigator-tab-icon';
         this.addClass(CLASS);
         this.initialize();
     }

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -27,6 +27,7 @@ import {
     defaultTreeProps
 } from '@theia/core/lib/browser';
 import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widget';
+import '../../src/browser/styles/index.css';
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -57,6 +57,8 @@ export class OutlineViewWidget extends TreeWidget {
 
         this.id = 'outline-view';
         this.title.label = 'Outline';
+        this.title.caption = 'Outline';
+        this.title.iconClass = 'fa outline-view-tab-icon';
         this.addClass('theia-outline-view');
     }
 

--- a/packages/outline-view/src/browser/styles/index.css
+++ b/packages/outline-view/src/browser/styles/index.css
@@ -14,33 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.theia-navigator-container {
-    font-size: var(--theia-ui-font-size1);
-    color: var(--theia-ui-font-color1);
-    margin: 5px;
-    position: relative;
-}
-
-.theia-navigator-container .open-workspace-button-container {
-    margin: auto;
-    margin-top: 5px;
-}
-
-.p-Widget .open-workspace-button {
-    border: 1px solid var(--theia-border-color1);
-    color: var(--theia-ui-font-color1);
-    font-size: var(--theia-ui-font-size1);
-    border-radius: 0;
-    background-color: var(--theia-accent-color3);
-    outline: none;
-    cursor: pointer;
-    padding-left: 12px;
-    padding-right: 12px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    width: calc(100% - var(--theia-ui-padding)*4);
-}
-
-.navigator-tab-icon::before {
-    content: "\f0c5"
+.outline-view-tab-icon::before {
+    content: "\f03a"
 }

--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -36,7 +36,8 @@ export class OutputWidget extends ReactWidget {
         super();
         this.id = OUTPUT_WIDGET_KIND;
         this.title.label = 'Output';
-        this.title.iconClass = 'fa fa-flag';
+        this.title.caption = 'Output';
+        this.title.iconClass = 'fa output-tab-icon';
         this.title.closable = true;
         this.addClass('theia-output');
     }

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -45,3 +45,7 @@
     padding-left: 3px;
     padding-right: 15px;
 }
+
+.output-tab-icon::before {
+    content: "\f024"
+}

--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -37,6 +37,8 @@ export class PluginWidget extends ReactWidget {
         super();
         this.id = 'plugins';
         this.title.label = 'Plugins';
+        this.title.caption = 'Plugins';
+        this.title.iconClass = 'fa plugins-tab-icon';
         this.addClass('theia-plugins');
 
         this.update();

--- a/packages/plugin-ext/src/main/browser/style/plugin-sidebar.css
+++ b/packages/plugin-ext/src/main/browser/style/plugin-sidebar.css
@@ -65,3 +65,7 @@
     flex: 5;
     align-items: center;
 }
+
+.plugins-tab-icon::before {
+    content: "\f0fe"
+}

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -62,6 +62,8 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     init() {
         this.id = SearchInWorkspaceWidget.ID;
         this.title.label = SearchInWorkspaceWidget.LABEL;
+        this.title.caption = SearchInWorkspaceWidget.LABEL;
+        this.title.iconClass = 'fa search-in-workspace-tab-icon';
 
         this.contentNode = document.createElement('div');
         this.contentNode.classList.add('t-siw-search-container');

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -398,3 +398,7 @@
 .replace-all-button.disabled {
     opacity: 0.5;
 }
+
+.search-in-workspace-tab-icon::before {
+    content: "\f002"
+}


### PR DESCRIPTION
## Changes
- Adds tab icons to all current views
- Adds captions to all current views
- Adds unique classname to all tab icons for easy customization

Fixes [Theia issue 716](https://github.com/theia-ide/theia/issues/716).

Default view:
![screen shot 2018-09-12 at 17 13 32](https://user-images.githubusercontent.com/11505561/45439002-9bd92a00-b6b0-11e8-8300-701245878941.png)

Overriding CSS to display only icons on sides:
```
.p-TabBar.theia-app-sides .p-TabBar-tabLabel {
    display: none;
}
.p-TabBar.theia-app-sides .p-TabBar-tabIcon {
    display: inline-block;
}
```
![screen shot 2018-09-12 at 17 14 06](https://user-images.githubusercontent.com/11505561/45439012-a09dde00-b6b0-11e8-8324-1572c8efa555.png)

Overriding an icon:
```
.debug-tab-icon::before {
    content: "\f085";
}
```
![screen shot 2018-09-12 at 17 31 25](https://user-images.githubusercontent.com/11505561/45439601-2706ef80-b6b2-11e8-9e6c-98df679b5640.png)
