### PR TITLE
[plug-in] Languages API - Register hover provider

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -170,3 +170,12 @@ export enum MarkerSeverity {
 export enum MarkerTag {
     Unnecessary = 1,
 }
+
+export interface Hover {
+    contents: MarkdownString[];
+    range?: Range;
+}
+
+export interface HoverProvider {
+    provideHover(model: monaco.editor.ITextModel, position: monaco.Position, token: monaco.CancellationToken): Hover | undefined | Thenable<Hover | undefined>;
+}

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -30,7 +30,8 @@ import {
     Range,
     Completion,
     CompletionResultDto,
-    MarkerData
+    MarkerData,
+    Hover
 } from './model';
 
 export interface PluginInitData {
@@ -638,6 +639,7 @@ export interface LanguagesExt {
     $provideCompletionItems(handle: number, resource: UriComponents, position: Position, context: CompletionContext): Promise<CompletionResultDto | undefined>;
     $resolveCompletionItem(handle: number, resource: UriComponents, position: Position, completion: Completion): Promise<Completion>;
     $releaseCompletionItems(handle: number, id: number): void;
+    $provideHover(handle: number, resource: UriComponents, position: Position): Promise<Hover | undefined>;
 }
 
 export interface LanguagesMain {
@@ -645,9 +647,9 @@ export interface LanguagesMain {
     $setLanguageConfiguration(handle: number, languageId: string, configuration: SerializedLanguageConfiguration): void;
     $unregister(handle: number): void;
     $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void;
-
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [UriComponents, MarkerData[]][]): void;
+    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -103,6 +103,13 @@ export class LanguagesMainImpl implements LanguagesMain {
             monaco.editor.setModelMarkers(textModel, id, markers.map(reviveMarker));
         }
     }
+
+    $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+        this.disposables.set(handle, monaco.modes.HoverProviderRegistry.register(selector, {
+            provideHover: (model: monaco.editor.ITextModel, position: monaco.Position, token: monaco.CancellationToken) =>
+                this.proxy.$provideHover(handle, model.uri, position)
+        }));
+    }
 }
 
 function reviveMarker(marker: MarkerData): monaco.editor.IMarkerData {

--- a/packages/plugin-ext/src/plugin/document-data.ts
+++ b/packages/plugin-ext/src/plugin/document-data.ts
@@ -189,7 +189,7 @@ export class DocumentDataExt {
         }
 
         if (range.isSingleLine) {
-            return this.lines[range.start.line].substring(range.start.character, range.end.character);
+            return this.lines[range.start.line - 1].substring(range.start.character, range.end.character);
         }
 
         const lineEnding = this.eol;
@@ -241,7 +241,7 @@ export class DocumentDataExt {
             character = this.lines[line].length;
             hasChanged = true;
         } else {
-            const maxCharacter = this.lines[line].length;
+            const maxCharacter = this.lines[line - 1].length;
             if (character < 0) {
                 character = 0;
                 hasChanged = true;
@@ -341,7 +341,7 @@ export class DocumentDataExt {
         const wordAtText = getWordAtText(
             position.character + 1,
             ensureValidWordDefinition(regexp),
-            this.lines[position.line],
+            this.lines[position.line - 1],
             0
         );
 

--- a/packages/plugin-ext/src/plugin/languages/hover.ts
+++ b/packages/plugin-ext/src/plugin/languages/hover.ts
@@ -1,0 +1,58 @@
+
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri/lib/umd';
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import { Hover } from '../../api/model';
+import * as Converter from '../type-converters';
+import { Range } from '../types-impl';
+import { Position } from '../../api/plugin-api';
+
+export class HoverAdapter {
+
+    constructor(
+        private readonly provider: theia.HoverProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    public provideHover(resource: URI, position: Position): Promise<Hover | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There are no document for ${resource}`));
+        }
+
+        const doc = document.document;
+        const pos = Converter.toPosition(position);
+
+        return Promise.resolve(this.provider.provideHover(doc, pos, undefined)).then(value => {
+            /* tslint:disable-next-line:no-any */
+            if (!value || !Array.isArray(value.contents) || (value.contents as Array<any>).length === 0) {
+                return undefined;
+            }
+            if (!value.range) {
+                value.range = doc.getWordRangeAtPosition(pos);
+            }
+            if (!value.range) {
+                value.range = new Range(pos, pos);
+            }
+
+            return Converter.fromHover(value);
+        });
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -54,7 +54,8 @@ import {
     DiagnosticRelatedInformation,
     DiagnosticSeverity,
     DiagnosticTag,
-    Location
+    Location,
+    Hover
 } from './types-impl';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { TextEditorsExtImpl } from './text-editors';
@@ -293,6 +294,9 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, ...triggerCharacters: string[]): theia.Disposable {
                 return languagesExt.registerCompletionItemProvider(selector, provider, triggerCharacters);
             },
+            registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
+                return languagesExt.registerHoverProvider(selector, provider);
+            },
         };
 
         const plugins: typeof theia.plugins = {
@@ -349,6 +353,7 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             Diagnostic,
             CompletionTriggerKind,
             TextEdit,
+            Hover,
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { EditorPosition, Selection, Position, DecorationOptions } from '../api/plugin-api';
-import { Range, MarkdownString, CompletionType, SingleEditOperation, MarkerData, RelatedInformation } from '../api/model';
+import { Range, Hover, MarkdownString, CompletionType, SingleEditOperation, MarkerData, RelatedInformation } from '../api/model';
 import * as theia from '@theia/plugin';
 import * as types from './types-impl';
 import { LanguageSelector, LanguageFilter, RelativePattern } from './languages';
@@ -62,15 +62,15 @@ export function toRange(range: Range): types.Range {
     return new types.Range(startLineNumber - 1, startColumn - 1, endLineNumber - 1, endColumn - 1);
 }
 
-export function fromRange(range: theia.Range): Range | undefined {
+export function fromRange(range: theia.Range | undefined): Range | undefined {
     if (!range) {
         return undefined;
     }
     const { start, end } = range;
     return {
-        startLineNumber: start.line + 1,
+        startLineNumber: start.line,
         startColumn: start.character + 1,
-        endLineNumber: end.line + 1,
+        endLineNumber: end.line,
         endColumn: end.character + 1
     };
 }
@@ -345,4 +345,11 @@ function convertTags(tags: types.DiagnosticTag[] | undefined): types.MarkerTag[]
         }
     }
     return markerTags;
+}
+
+export function fromHover(hover: theia.Hover): Hover {
+    return <Hover>{
+        range: fromRange(hover.range),
+        contents: fromManyMarkdown(hover.contents)
+    };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -18,6 +18,7 @@ import { illegalArgument } from '../common/errors';
 import * as theia from '@theia/plugin';
 import URI from 'vscode-uri';
 import { relative } from '../common/paths-util';
+import { isMarkdownString } from './type-converters';
 
 export class Disposable {
     private disposable: undefined | (() => void);
@@ -807,4 +808,27 @@ export enum MarkerSeverity {
 
 export enum MarkerTag {
     Unnecessary = 1,
+}
+
+export class Hover {
+
+    public contents: MarkdownString[] | theia.MarkedString[];
+    public range?: Range;
+
+    constructor(
+        contents: MarkdownString | theia.MarkedString | MarkdownString[] | theia.MarkedString[],
+        range?: Range
+    ) {
+        if (!contents) {
+            illegalArgument('contents must be defined');
+        }
+        if (Array.isArray(contents)) {
+            this.contents = <MarkdownString[] | theia.MarkedString[]>contents;
+        } else if (isMarkdownString(contents)) {
+            this.contents = [contents];
+        } else {
+            this.contents = [contents];
+        }
+        this.range = range;
+    }
 }

--- a/packages/plugin-ext/src/typings/monaco/index.d.ts
+++ b/packages/plugin-ext/src/typings/monaco/index.d.ts
@@ -333,4 +333,12 @@ declare module monaco.modes {
     }
 
     export const SuggestRegistry: LanguageFeatureRegistry<ISuggestSupport>;
+
+    export type ProviderResult<T> = T | undefined | PromiseLike<T | undefined>;
+
+    export interface HoverProvider {
+        provideHover(document: monaco.editor.ITextModel, position: Position, token: CancellationToken | undefined): ProviderResult<monaco.languages.Hover>;
+    }
+
+    export const HoverProviderRegistry: LanguageFeatureRegistry<HoverProvider>;
 }

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -408,3 +408,28 @@ diagnosticsCollection.forEach((uri, diagnostics) => {
 ```
 
 `dispose` method should be used when the collection is not needed any more. In case of attempt to do an operaton after disposing an error will be thrown.
+
+#### Hover Message
+
+To contribute a hover it is only needed to provide a function that can be called with a `TextDocument` and a `Position` returning hover info. Registration is done using a document selector which either a language id ('typescript', 'javascript' etc.) or a more complex filter like `{scheme: 'file', language: 'typescript'}`.
+
+For example,
+```typescript
+theia.languages.registerHoverProvider('typescript', {
+    provideHover(doc: theia.TextDocument, position: theia.Position) {
+        return new theia.Hover('Hover for all **typescript** files.');
+    }
+});
+```
+will show the hover message for all `typescript` files.
+
+The code below puts word under cursor into hover message:
+```typescript
+theia.languages.registerHoverProvider({scheme: 'file'}, {
+    provideHover(doc: theia.TextDocument, position: theia.Position) {
+        const range = doc.getWordRangeAtPosition(position);
+        const text = doc.getText(range);
+        return new theia.Hover(text);
+    }
+});
+```

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3569,6 +3569,66 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerCompletionItemProvider(selector: DocumentSelector, provider: CompletionItemProvider, ...triggerCharacters: string[]): Disposable;
+
+        /**
+         * Register a hover provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are asked in
+         * parallel and the results are merged. A failing provider (rejected promise or exception) will
+         * not cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A hover provider.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerHoverProvider(selector: DocumentSelector, provider: HoverProvider): Disposable;
+    }
+
+    /**
+     * A hover represents additional information for a symbol or word. Hovers are
+     * rendered in a tooltip-like widget.
+     */
+    export class Hover {
+
+        /**
+         * The contents of this hover.
+         */
+        contents: MarkedString[];
+
+        /**
+         * The range to which this hover applies. When missing, the
+         * editor will use the range at the current position or the
+         * current position itself.
+         */
+        range?: Range;
+
+        /**
+         * Creates a new hover object.
+         *
+         * @param contents The contents of the hover.
+         * @param range The range to which the hover applies.
+         */
+        constructor(contents: MarkedString | MarkedString[], range?: Range);
+    }
+
+    /**
+     * The hover provider interface defines the contract between extensions and
+     * the [hover](https://code.visualstudio.com/docs/editor/intellisense)-feature.
+     */
+    export interface HoverProvider {
+
+        /**
+         * Provide a hover for the given position and document. Multiple hovers at the same
+         * position will be merged by the editor. A hover can have a range which defaults
+         * to the word range at the position when omitted.
+         *
+         * @param document The document in which the command was invoked.
+         * @param position The position at which the command was invoked.
+         * @param token A cancellation token.
+         * @return A hover or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined` or `null`.
+         */
+        provideHover(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<Hover>;
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

This PR adds the ability to register custom hover provider. Now it is possible to show hover messages from a plugin. 
![selection_011](https://user-images.githubusercontent.com/16220722/45437570-bc5bb100-b6bd-11e8-8d46-712640ab0098.png)

resolves #2601 