### PR TITLE
[plug-in] Avoid using monaco internal api for hover provider

### DIFF
--- a/packages/plugin-ext/src/plugin/document-data.ts
+++ b/packages/plugin-ext/src/plugin/document-data.ts
@@ -189,7 +189,7 @@ export class DocumentDataExt {
         }
 
         if (range.isSingleLine) {
-            return this.lines[range.start.line - 1].substring(range.start.character, range.end.character);
+            return this.lines[range.start.line].substring(range.start.character, range.end.character);
         }
 
         const lineEnding = this.eol;
@@ -241,7 +241,7 @@ export class DocumentDataExt {
             character = this.lines[line].length;
             hasChanged = true;
         } else {
-            const maxCharacter = this.lines[line - 1].length;
+            const maxCharacter = this.lines[line].length;
             if (character < 0) {
                 character = 0;
                 hasChanged = true;
@@ -341,7 +341,7 @@ export class DocumentDataExt {
         const wordAtText = getWordAtText(
             position.character + 1,
             ensureValidWordDefinition(regexp),
-            this.lines[position.line - 1],
+            this.lines[position.line],
             0
         );
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -80,7 +80,7 @@ export function fromPosition(position: types.Position): Position {
 }
 
 export function toPosition(position: Position): types.Position {
-    return new types.Position(position.lineNumber, position.column);
+    return new types.Position(position.lineNumber - 1, position.column - 1);
 }
 
 // tslint:disable-next-line:no-any

--- a/packages/plugin-ext/src/typings/monaco/index.d.ts
+++ b/packages/plugin-ext/src/typings/monaco/index.d.ts
@@ -335,10 +335,4 @@ declare module monaco.modes {
     export const SuggestRegistry: LanguageFeatureRegistry<ISuggestSupport>;
 
     export type ProviderResult<T> = T | undefined | PromiseLike<T | undefined>;
-
-    export interface HoverProvider {
-        provideHover(document: monaco.editor.ITextModel, position: Position, token: CancellationToken | undefined): ProviderResult<monaco.languages.Hover>;
-    }
-
-    export const HoverProviderRegistry: LanguageFeatureRegistry<HoverProvider>;
 }


### PR DESCRIPTION
Use same approach as `monaco-languageclient` to register hover provider.
We also should provide same fix for completion provider soon.
Should also fix: #2871
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
