### PR TITLE
GH-2882: Replaced the `range` with the `selectionRange` in the Outline.

### DIFF
--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -76,8 +76,8 @@ export class OutlineViewWidget extends TreeWidget {
             if (OutlineSymbolInformationNode.is(node)) {
                 const treeNode = this.model.getNode(node.id);
                 if (treeNode && OutlineSymbolInformationNode.is(treeNode)) {
-                    node.expanded = treeNode.expanded;
-                    node.selected = treeNode.selected;
+                    treeNode.expanded = node.expanded;
+                    treeNode.selected = node.selected;
                 }
                 this.reconcileTreeState(Array.from(node.children));
             }


### PR DESCRIPTION
So that when one selects a tree node in the Outline view
only the name of the symbol will be selected.
Previously, it was the entire enclosing range of the symbol.
For instance, the method/function body, instead of the name.

Fixed a bug in the Outline view widget, when reconciling the tree nodes.

Added support to update the Outline view selection based on the
selection from the currently active editor.

Closes: #2882.
Closes: #2883.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>
