### PR TITLE
[application-package] add guard to resolve module

### DIFF
--- a/dev-packages/application-package/src/extension-package-collector.ts
+++ b/dev-packages/application-package/src/extension-package-collector.ts
@@ -60,7 +60,15 @@ export class ExtensionPackageCollector {
         }
         this.visited.set(name, true);
 
-        const packagePath = this.resolveModule(name + '/package.json');
+        let packagePath: string | undefined;
+        try {
+            packagePath = this.resolveModule(name + '/package.json');
+        } catch (error) {
+            console.console.warn(`Failed to resolve module: ${name}`);
+        }
+        if (!packagePath) {
+            return;
+        }
         const pck: NodePackage = readJsonFile(packagePath);
         if (RawExtensionPackage.is(pck)) {
             const parent = this.parent;


### PR DESCRIPTION
`ApplicationPackage.extensionPackages` shouldn't fail if a module cannot be resolved. 

With this RP we are going to log those module like:
```
Failed to resolve module: xyz
```