### PR TITLE
[plug-in] Languages API - Register formatting provider for a document

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -197,6 +197,17 @@ export interface HoverProvider {
     provideHover(model: monaco.editor.ITextModel, position: monaco.Position, token: monaco.CancellationToken): Hover | undefined | Thenable<Hover | undefined>;
 }
 
+export interface FormattingOptions {
+    tabSize: number;
+    insertSpaces: boolean;
+}
+
+export interface TextEdit {
+    range: Range;
+    text?: string;
+    eol?: monaco.editor.EndOfLineSequence;
+}
+
 export interface Location {
     uri: UriComponents;
     range: Range;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -33,6 +33,8 @@ import {
     MarkerData,
     SignatureHelp,
     Hover,
+    FormattingOptions,
+    SingleEditOperation as ModelSingleEditOperation,
     Definition,
     DefinitionLink
 } from './model';
@@ -645,6 +647,7 @@ export interface LanguagesExt {
     $provideDefinition(handle: number, resource: UriComponents, position: Position): Promise<Definition | DefinitionLink[] | undefined>;
     $provideSignatureHelp(handle: number, resource: UriComponents, position: Position): Promise<SignatureHelp | undefined>;
     $provideHover(handle: number, resource: UriComponents, position: Position): Promise<Hover | undefined>;
+    $provideDocumentFormattingEdits(handle: number, resource: UriComponents, options: FormattingOptions): Promise<ModelSingleEditOperation[] | undefined>;
 }
 
 export interface LanguagesMain {
@@ -658,6 +661,7 @@ export interface LanguagesMain {
 
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [UriComponents, MarkerData[]][]): void;
+    $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -196,6 +196,29 @@ export class LanguagesMainImpl implements LanguagesMain {
         };
     }
 
+    $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void {
+        const languageSelector = fromLanguageSelector(selector);
+        const documentFormattingEditSupport = this.createDocumentFormattingSupport(handle, languageSelector);
+        const disposable = new DisposableCollection();
+        for (const language of getLanguages()) {
+            if (this.matchLanguage(languageSelector, language)) {
+                disposable.push(monaco.languages.registerDocumentFormattingEditProvider(language, documentFormattingEditSupport));
+            }
+        }
+        this.disposables.set(handle, disposable);
+    }
+
+    createDocumentFormattingSupport(handle: number, selector: LanguageSelector | undefined): monaco.languages.DocumentFormattingEditProvider {
+        return {
+            provideDocumentFormattingEdits: (model, options, token) => {
+                if (!this.matchModel(selector, MonacoModelIdentifier.fromModel(model))) {
+                    return undefined!;
+                }
+                return this.proxy.$provideDocumentFormattingEdits(handle, model.uri, options).then(v => v!);
+            }
+        };
+    }
+
     protected matchModel(selector: LanguageSelector | undefined, model: MonacoModelIdentifier): boolean {
         if (Array.isArray(selector)) {
             return selector.some(filter => this.matchModel(filter, model));

--- a/packages/plugin-ext/src/plugin/languages/document-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/document-formatting.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import * as Converter from '../type-converters';
+import URI from 'vscode-uri/lib/umd';
+import { FormattingOptions, SingleEditOperation } from '../../api/model';
+
+export class DocumentFormattingAdapter {
+
+    constructor(
+        private readonly provider: theia.DocumentFormattingEditProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    provideDocumentFormattingEdits(resource: URI, options: FormattingOptions): Promise<SingleEditOperation[] | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There are no document for ${resource}`));
+        }
+
+        const doc = document.document;
+
+        return Promise.resolve(this.provider.provideDocumentFormattingEdits(doc, <any>options, undefined)).then(value => {
+            if (Array.isArray(value)) {
+                return value.map(Converter.fromTextEdit);
+            }
+            return undefined;
+        });
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -307,6 +307,9 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             registerHoverProvider(selector: theia.DocumentSelector, provider: theia.HoverProvider): theia.Disposable {
                 return languagesExt.registerHoverProvider(selector, provider);
             },
+            registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider): theia.Disposable {
+                return languagesExt.registerDocumentFormattingEditProvider(selector, provider);
+            }
         };
 
         const plugins: typeof theia.plugins = {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2204,7 +2204,7 @@ declare module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showInformationMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>
+        export function showInformationMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
 
         /**
          * Show an information message.
@@ -3178,7 +3178,6 @@ declare module '@theia/plugin' {
         constructor(range: Range, newText: string);
     }
 
-
     /**
      * Completion item kinds.
      */
@@ -3348,7 +3347,6 @@ declare module '@theia/plugin' {
          */
         constructor(items?: CompletionItem[], isIncomplete?: boolean);
     }
-
 
     /**
      * The completion item provider interface defines the contract between plugin and IntelliSense
@@ -3629,6 +3627,49 @@ declare module '@theia/plugin' {
         dispose(): void;
     }
 
+    /**
+     * The document formatting provider interface defines the contract between extensions and
+     * the formatting-feature.
+     */
+    export interface DocumentFormattingEditProvider {
+
+        /**
+         * Provide formatting edits for a whole document.
+         *
+         * @param document The document in which the command was invoked.
+         * @param options Options controlling formatting.
+         * @param token A cancellation token.
+         * @return A set of text edits or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined`, `null`, or an empty array.
+         */
+        provideDocumentFormattingEdits(
+            document: TextDocument,
+            options: FormattingOptions,
+            token: CancellationToken | undefined
+        ): ProviderResult<TextEdit[] | undefined>;
+    }
+
+    /**
+     * Value-object describing what options formatting should use.
+     */
+    export interface FormattingOptions {
+
+        /**
+         * Size of a tab in spaces.
+         */
+        tabSize: number;
+
+        /**
+         * Prefer spaces over tabs.
+         */
+        insertSpaces: boolean;
+
+        /**
+         * Signature for further properties.
+         */
+        [key: string]: boolean | number | string;
+    }
+
     export namespace languages {
         /**
          * Return the identifiers of all known languages.
@@ -3770,6 +3811,19 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerHoverProvider(selector: DocumentSelector, provider: HoverProvider): Disposable;
+
+        /**
+         * Register a formatting provider for a document.
+         *
+         * Multiple providers can be registered for a language. In that case providers are sorted
+         * by their [score](#languages.match) and the best-matching provider is used. Failure
+         * of the selected provider will cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A document formatting edit provider.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerDocumentFormattingEditProvider(selector: DocumentSelector, provider: DocumentFormattingEditProvider): Disposable;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

This PR adds the ability to register a formatting provider for a document. 

Resolves #2797 

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
