### PR TITLE
task-server.slow-spec.ts: Use channel.close() instead of channel.disp…

### DIFF
--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -99,7 +99,7 @@ describe('Task server / back-end', function () {
                 } else {
                     reject(`expected sub-string not found in terminal output. Expected: "${expected}" vs Actual: "${msg.toString()}"`);
                 }
-                channel.dispose();
+                channel.close();
             });
         });
     });


### PR DESCRIPTION
…ose()

We are seeing some failures like this:

  1) Task server / back-end task using raw process - task server success response shall not contain a terminal id:
     Uncaught Error: not opened
      at WebSocket.send (/home/emaisin/src/theia/packages/core/node_modules/ws/lib/WebSocket.js:359:18)
      at WebSocketChannel.doSend (/home/emaisin/src/theia/packages/core/src/node/messaging/messaging-contribution.ts:155:59)
      at WebSocketChannel.close (/home/emaisin/src/theia/packages/core/src/common/messaging/web-socket-channel.ts:83:14)
      at WebSocket.<anonymous> (/home/emaisin/src/theia/packages/core/src/node/messaging/messaging-contribution.ts:148:25)
      at WebSocket.emitClose (/home/emaisin/src/theia/packages/core/node_modules/ws/lib/WebSocket.js:211:10)
      at _receiver.cleanup (/home/emaisin/src/theia/packages/core/node_modules/ws/lib/WebSocket.js:199:39)
      at Receiver.cleanup (/home/emaisin/src/theia/packages/core/node_modules/ws/lib/Receiver.js:520:15)
      at WebSocket.finalize (/home/emaisin/src/theia/packages/core/node_modules/ws/lib/WebSocket.js:199:20)
      at endReadableNT (_stream_readable.js:1064:12)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickCallback (internal/process/next_tick.js:180:9)

We tracked it down to the previous test, "task running in terminal - expected
data is received from the terminal ws server", opening a websocket and
not closing is properly.

I am not sure of what happens, but replacing channel.dispose() with
channel.close(), as was done in commit 097482af ("[messaging] fix #1885:
allow to accept WS channels"), makes the failure go away.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
