### PR TITLE
GH-2668: Removed the superfluous `semanticHighlighting` capability.

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -106,8 +106,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         const options = super.createOptions();
         options.initializationOptions = {
             extendedClientCapabilities: {
-                classFileContentsSupport: true,
-                semanticHighlighting: true
+                classFileContentsSupport: true
             }
         };
         return options;


### PR DESCRIPTION
It is the responsibility of the highlighting feature.
There is no need to set it twice.

Closes: #2668.
Signed-off-by: Akos Kitta <kittaakos@typefox.io>


Hints for the verification:
 - open a Java file in Theia.
 - add and remove the `static` keyword for a field.
 - if it changes to *italic* back and forth, then you have the semantic highlighting feature without this extra client capability.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
