### PR TITLE
GH-2683: Fixed the logging in the editor navigation service.

### DIFF
--- a/packages/editor/src/browser/navigation/navigation-location-service.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.ts
@@ -58,7 +58,7 @@ export class NavigationLocationService {
                     this._lastEditLocation = location;
                 }
                 const current = this.currentLocation();
-                this.debug(`Registering new location: ${NavigationLocation.toObject(location)}.`);
+                this.debug(`Registering new location: ${NavigationLocation.toString(location)}.`);
                 if (!this.isSimilar(current, location)) {
                     this.debug('Before location registration.');
                     this.debug(this.stackDump);
@@ -79,11 +79,11 @@ export class NavigationLocationService {
                         const candidate = this.stack[i];
                         const update = this.updater.affects(candidate, location);
                         if (update === undefined) {
-                            this.debug(`Erasing obsolete location: ${NavigationLocation.toObject(candidate)}.`);
+                            this.debug(`Erasing obsolete location: ${NavigationLocation.toString(candidate)}.`);
                             this.stack.splice(i, 1);
                             this.pointer--;
                         } else if (typeof update !== 'boolean') {
-                            this.debug(`Updating location at index: ${i} => ${NavigationLocation.toObject(candidate)}.`);
+                            this.debug(`Updating location at index: ${i} => ${NavigationLocation.toString(candidate)}.`);
                             this.stack[i] = update;
                         }
                     }
@@ -91,7 +91,7 @@ export class NavigationLocationService {
                     this.debug(this.stackDump);
                 } else {
                     if (current) {
-                        this.debug(`The new location ${NavigationLocation.toObject(location)} is similar to the current one: ${NavigationLocation.toObject(current)}. Aborting.`);
+                        this.debug(`The new location ${NavigationLocation.toString(location)} is similar to the current one: ${NavigationLocation.toString(current)}. Aborting.`);
                     }
                 }
             });
@@ -177,7 +177,7 @@ export class NavigationLocationService {
             const options = this.toOpenerOptions(location);
             await open(this.openerService, uri, options);
         } catch (e) {
-            this.logger.error(`Error occurred while revealing location: ${location}.`, e);
+            this.logger.error(`Error occurred while revealing location: ${NavigationLocation.toString(location)}.`, e);
         } finally {
             this.canRegister = true;
         }

--- a/packages/editor/src/browser/navigation/navigation-location-updater.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-updater.ts
@@ -148,7 +148,7 @@ export class NavigationLocationUpdater {
                 text
             };
         }
-        throw new Error(`Unexpected navigation location: ${candidate}.`);
+        throw new Error(`Unexpected navigation location: ${NavigationLocation.toString(candidate)}.`);
     }
 
     protected handleBefore(candidate: NavigationLocation, modification: Range, lineDiff: number, startCharacter: number, endCharacter: number): NavigationLocation.Context {
@@ -178,7 +178,7 @@ export class NavigationLocationUpdater {
                 text
             };
         }
-        throw new Error(`Unexpected navigation location: ${candidate}.`);
+        throw new Error(`Unexpected navigation location: ${NavigationLocation.toString(candidate)}.`);
     }
 
     protected shiftLine(position: Position, diff: number): Position;

--- a/packages/editor/src/browser/navigation/navigation-location.ts
+++ b/packages/editor/src/browser/navigation/navigation-location.ts
@@ -183,6 +183,13 @@ export namespace NavigationLocation {
         };
     }
 
+    /**
+     * Returns with the human-consumable (JSON) string representation of the location argument.
+     */
+    export function toString(location: NavigationLocation): string {
+        return JSON.stringify(toObject(location));
+    }
+
     function toUri(arg: URI | { uri: URI } | string): URI {
         if (arg instanceof URI) {
             return arg;


### PR DESCRIPTION
Closes: #2683.
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

For reviewers:
 - Start theia with `debug` `log-level`.
 - Change the selection in the editor.
 - You should not see `[object Object]`.

After the fix, the logging is something like this:
```
root DEBUG Registering new location: {"uri":"file:///Users/akos.kitta/git/eclipse.jdt.ls/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java","type":0,"context":{"line":138,"character":25}}.
root DEBUG The new location {"uri":"file:///Users/akos.kitta/git/eclipse.jdt.ls/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java","type":0,"context":{"line":138,"character":25}} is similar to the current one: {"uri":"file:///Users/akos.kitta/git/eclipse.jdt.ls/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java","type":0,"context":{"line":140,"character":5}}. Aborting.
```