### PR TITLE
store preferences in workspace file if there's one

### DIFF
--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -33,12 +33,9 @@ export class PreferenceProvider implements Disposable {
      */
     protected readonly _ready = new Deferred<void>();
 
-    constructor() {
-        this.toDispose.push(this.onDidPreferencesChangedEmitter);
-    }
-
     dispose(): void {
         this.toDispose.dispose();
+        this.onDidPreferencesChangedEmitter.dispose();
     }
 
     protected fireOnDidPreferencesChanged(): void {

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -114,7 +114,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
 
     protected getContainerTreeNode(): TreeNode | undefined {
         const root = this.model.root;
-        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+        if (this.workspaceService.supportMultiRootWorkspace) {
             return root;
         }
         if (WorkspaceNode.is(root)) {

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.15",
     "@theia/editor": "^0.3.15",
     "@theia/filesystem": "^0.3.15",
+    "@theia/json": "^0.3.15",
     "@theia/monaco": "^0.3.15",
     "@theia/userstorage": "^0.3.15",
     "@theia/workspace": "^0.3.15",

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -68,13 +68,17 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         if (resource.saveContents) {
             const content = await this.readContents();
             const formattingOptions = { tabSize: 3, insertSpaces: true, eol: '' };
-            const edits = jsoncparser.modify(content, [key], value, { formattingOptions });
+            const edits = jsoncparser.modify(content, this.getPath(key), value, { formattingOptions });
             const result = jsoncparser.applyEdits(content, edits);
 
             await resource.saveContents(result);
             this.preferences[key] = value;
             this.onDidPreferencesChangedEmitter.fire(undefined);
         }
+    }
+
+    protected getPath(preferenceName: string): string[] {
+        return [preferenceName];
     }
 
     protected async readPreferences(): Promise<void> {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -254,7 +254,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }));
         this.preferences.ready.then(() => {
             registry.registerCommand(WorkspaceCommands.ADD_FOLDER, this.newMultiUriAwareCommandHandler({
-                isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
+                isEnabled: () => this.workspaceService.supportMultiRootWorkspace,
                 isVisible: uris => !uris.length || this.areWorkspaceRoots(uris),
                 execute: async uris => {
                     const node = await this.fileDialogService.showOpenDialog({
@@ -282,7 +282,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
             }));
             registry.registerCommand(WorkspaceCommands.REMOVE_FOLDER, this.newMultiUriAwareCommandHandler({
                 execute: uris => this.removeFolderFromWorkspace(uris),
-                isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
+                isEnabled: () => this.workspaceService.supportMultiRootWorkspace,
                 isVisible: uris => this.areWorkspaceRoots(uris) && this.workspaceService.saved
             }));
         });
@@ -396,7 +396,7 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
 
     protected getUri(): URI | undefined {
         const uri = super.getUri();
-        if (this.workspaceService.isMultiRootWorkspaceOpened) {
+        if (this.workspaceService.supportMultiRootWorkspace) {
             return uri;
         }
         if (uri) {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -63,7 +63,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             execute: () => this.quickOpenWorkspace.select()
         });
         commands.registerCommand(WorkspaceCommands.SAVE_WORKSPACE_AS, {
-            isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,
+            isEnabled: () => this.workspaceService.supportMultiRootWorkspace,
             execute: () => this.saveWorkspaceAs()
         });
     }


### PR DESCRIPTION
With changes in 543b119, URIs of root folders in a multi-root workspace are stored in a file with the extension of "theia-workspace", while the workspace preferences are in the ".theia/settings.json" under the first root.

In this pull request, workspace preferences are stored
- in the workspace file under the "settings" property, if a workspace file exists, or
- in the ".theia/settings.json" if the workspace data is not saved in a workspace file.

This is the 3rd patch of #1660.

Signed-off-by: elaihau <liang.huang@ericsson.com>
