### PR TITLE
debug console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
   - node_modules
   - packages/bunyan/node_modules
   - packages/callhierarchy/node_modules
+  - packages/console/node_modules
   - packages/core/node_modules
   - packages/cpp/node_modules
   - packages/debug-nodejs/node_modules

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -4,6 +4,7 @@
   "version": "0.3.15",
   "dependencies": {
     "@theia/callhierarchy": "^0.3.15",
+    "@theia/console": "^0.3.15",
     "@theia/core": "^0.3.15",
     "@theia/cpp": "^0.3.15",
     "@theia/debug": "^0.3.15",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@theia/callhierarchy": "^0.3.15",
+    "@theia/console": "^0.3.15",
     "@theia/core": "^0.3.15",
     "@theia/cpp": "^0.3.15",
     "@theia/debug": "^0.3.15",

--- a/packages/console/README.md
+++ b/packages/console/README.md
@@ -1,0 +1,7 @@
+# Theia - Console Extension
+
+See [here](https://github.com/theia-ide/theia) for a detailed documentation.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/console/compile.tsconfig.json
+++ b/packages/console/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,33 +1,21 @@
 {
-  "name": "@theia/debug",
+  "name": "@theia/console",
   "version": "0.3.15",
-  "description": "Theia - Debug Extension",
+  "description": "Theia - Console Extension",
   "dependencies": {
-    "@theia/console": "^0.3.15",
-    "@theia/core": "^0.3.15",
-    "@theia/editor": "^0.3.15",
-    "@theia/filesystem": "^0.3.15",
-    "@theia/markers": "^0.3.15",
-    "@theia/messages": "^0.3.15",
     "@theia/monaco": "^0.3.15",
-    "@theia/process": "^0.3.15",
-    "@theia/terminal": "^0.3.15",
-    "@theia/variable-resolver": "^0.3.15",
-    "@theia/workspace": "^0.3.15",
-    "jsonc-parser": "^2.0.2",
-    "vscode-debugprotocol": "^1.26.0"
+    "anser": "^1.4.7"
   },
   "publishConfig": {
     "access": "public"
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/debug-frontend-module",
-      "backend": "lib/node/debug-backend-module"
+      "frontend": "lib/browser/console-frontend-module"
     }
   ],
   "keywords": [
-    "theia-extension, debug"
+    "theia-extension"
   ],
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "repository": {

--- a/packages/console/src/browser/ansi-console-item.tsx
+++ b/packages/console/src/browser/ansi-console-item.tsx
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from 'react';
+import { MessageType } from '@theia/core/lib/common';
+import { ConsoleItem } from './console-session';
+import { ansiToHtml } from 'anser';
+
+export class AnsiConsoleItem implements ConsoleItem {
+
+    protected readonly htmlContent: string;
+
+    constructor(
+        public readonly content: string,
+        public readonly severity?: MessageType
+    ) {
+        this.htmlContent = ansiToHtml(this.content, {
+            use_classes: true,
+            remove_empty: true
+        });
+    }
+
+    get empty(): boolean {
+        return !this.htmlContent;
+    }
+
+    render(): React.ReactNode {
+        return <div className='theia-console-ansi-console-item' dangerouslySetInnerHTML={{ __html: this.htmlContent }} />;
+    }
+
+}

--- a/packages/console/src/browser/console-container.ts
+++ b/packages/console/src/browser/console-container.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './widget';
-export * from './virtual-renderer';
-export * from './virtual-widget';
-export * from './react-renderer';
-export * from './react-widget';
+import { interfaces, Container } from 'inversify';
+import { ConsoleWidget, ConsoleOptions } from './console-widget';
+import { ConsoleHistory } from './console-history';
+import { createConsoleContentContainer } from './content/console-content-container';
+
+export namespace ConsoleContainer {
+    export function create(parent: interfaces.Container, options: ConsoleOptions): Container {
+        const child = createConsoleContentContainer(parent);
+        child.bind(ConsoleHistory).toSelf();
+        child.bind(ConsoleOptions).toConstantValue(options);
+        child.bind(ConsoleWidget).toSelf();
+        return child;
+    }
+}

--- a/packages/console/src/browser/console-contribution.ts
+++ b/packages/console/src/browser/console-contribution.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, CommandHandler } from '@theia/core';
+import { FrontendApplicationContribution, KeybindingContribution, KeybindingRegistry, CommonCommands } from '@theia/core/lib/browser';
+import { ConsoleManager } from './console-manager';
+import { ConsoleKeybindingContexts } from './console-keybinding-contexts';
+import { ConsoleWidget } from './console-widget';
+import { CONSOLE_CONTEXT_MENU } from './content/console-content-container';
+
+export namespace ConsoleCommands {
+    export const SELECT_ALL: Command = {
+        id: 'console.selectAll'
+    };
+    export const COLLAPSE_ALL: Command = {
+        id: 'console.collapseAll'
+    };
+    export const CLEAR: Command = {
+        id: 'console.clear'
+    };
+    export const EXECUTE: Command = {
+        id: 'console.execute'
+    };
+    export const NAVIGATE_BACK: Command = {
+        id: 'console.navigatePrevious'
+    };
+    export const NAVIGATE_FORWARD: Command = {
+        id: 'console.navigateNext'
+    };
+}
+
+export namespace ConsoleContextMenu {
+    export const CLIPBOARD = [...CONSOLE_CONTEXT_MENU, '1_clipboard'];
+    export const CLEAR = [...CONSOLE_CONTEXT_MENU, '2_clear'];
+}
+
+@injectable()
+export class ConsoleContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution {
+
+    @inject(ConsoleManager)
+    protected readonly manager: ConsoleManager;
+
+    initialize(): void { }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ConsoleCommands.SELECT_ALL, this.newCommandHandler(console => console.selectAll()));
+        commands.registerCommand(ConsoleCommands.COLLAPSE_ALL, this.newCommandHandler(console => console.collapseAll()));
+        commands.registerCommand(ConsoleCommands.CLEAR, this.newCommandHandler(console => console.clear()));
+        commands.registerCommand(ConsoleCommands.EXECUTE, this.newCommandHandler(console => console.execute()));
+        commands.registerCommand(ConsoleCommands.NAVIGATE_BACK, this.newCommandHandler(console => console.navigateBack()));
+        commands.registerCommand(ConsoleCommands.NAVIGATE_FORWARD, this.newCommandHandler(console => console.navigateForward()));
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: ConsoleCommands.SELECT_ALL.id,
+            keybinding: 'ctrlcmd+a',
+            context: ConsoleKeybindingContexts.consoleContentFocus
+        });
+        keybindings.registerKeybinding({
+            command: ConsoleCommands.EXECUTE.id,
+            keybinding: 'enter',
+            context: ConsoleKeybindingContexts.consoleInputFocus
+        });
+        keybindings.registerKeybinding({
+            command: ConsoleCommands.NAVIGATE_BACK.id,
+            keybinding: 'up',
+            context: ConsoleKeybindingContexts.consoleNavigationBackEnabled
+        });
+        keybindings.registerKeybinding({
+            command: ConsoleCommands.NAVIGATE_FORWARD.id,
+            keybinding: 'down',
+            context: ConsoleKeybindingContexts.consoleNavigationForwardEnabled
+        });
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
+            commandId: CommonCommands.COPY.id,
+            label: 'Copy',
+            order: 'a1',
+        });
+        menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
+            commandId: ConsoleCommands.SELECT_ALL.id,
+            label: 'Select All',
+            order: 'a2'
+        });
+        menus.registerMenuAction(ConsoleContextMenu.CLIPBOARD, {
+            commandId: ConsoleCommands.COLLAPSE_ALL.id,
+            label: 'Collapse All',
+            order: 'a3'
+        });
+        menus.registerMenuAction(ConsoleContextMenu.CLEAR, {
+            commandId: ConsoleCommands.CLEAR.id,
+            label: 'Clear Console'
+        });
+    }
+
+    protected newCommandHandler(execute: ConsoleExecuteFunction): ConsoleCommandHandler {
+        return new ConsoleCommandHandler(this.manager, execute);
+    }
+
+}
+// tslint:disable-next-line:no-any
+export type ConsoleExecuteFunction = (console: ConsoleWidget, ...args: any[]) => any;
+export class ConsoleCommandHandler implements CommandHandler {
+
+    constructor(
+        protected readonly manager: ConsoleManager,
+        protected readonly doExecute: ConsoleExecuteFunction
+    ) { }
+
+    isEnabled() {
+        return !!this.manager.currentConsole;
+    }
+
+    isVisible() {
+        return !!this.manager.currentConsole;
+    }
+
+    execute(...args: any[]): any {
+        const { currentConsole } = this.manager;
+        if (currentConsole) {
+            return this.doExecute(currentConsole, ...args);
+        }
+    }
+
+}

--- a/packages/console/src/browser/console-frontend-module.ts
+++ b/packages/console/src/browser/console-frontend-module.ts
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { CommandContribution, MenuContribution } from '@theia/core';
+import { FrontendApplicationContribution, KeybindingContext, KeybindingContribution } from '@theia/core/lib/browser';
+import { ConsoleContribution } from './console-contribution';
+import { ConsoleManager } from './console-manager';
+import { ConsoleInputFocusContext, ConsoleNavigationBackEnabled, ConsoleNavigationForwardEnabled, ConsoleContentFocusContext } from './console-keybinding-contexts';
+
+import '../../src/browser/style/index.css';
+
+export default new ContainerModule(bind => {
+    bind(ConsoleManager).toSelf().inSingletonScope();
+    bind(KeybindingContext).to(ConsoleInputFocusContext).inSingletonScope();
+    bind(KeybindingContext).to(ConsoleContentFocusContext).inSingletonScope();
+    bind(KeybindingContext).to(ConsoleNavigationBackEnabled).inSingletonScope();
+    bind(KeybindingContext).to(ConsoleNavigationForwardEnabled).inSingletonScope();
+    bind(ConsoleContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ConsoleContribution);
+    bind(CommandContribution).toService(ConsoleContribution);
+    bind(KeybindingContribution).toService(ConsoleContribution);
+    bind(MenuContribution).toService(ConsoleContribution);
+});

--- a/packages/console/src/browser/console-history.ts
+++ b/packages/console/src/browser/console-history.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+
+@injectable()
+export class ConsoleHistory {
+
+    static limit = 50;
+
+    protected values: string[] = [];
+    protected index = -1;
+
+    push(value: string): void {
+        this.delete(value);
+        this.values.push(value);
+        this.trim();
+        this.index = this.values.length;
+    }
+    protected delete(value: string): void {
+        const index = this.values.indexOf(value);
+        if (index !== -1) {
+            this.values.splice(index, 1);
+        }
+    }
+    protected trim(): void {
+        const index = this.values.length - ConsoleHistory.limit;
+        if (index > 0) {
+            this.values.slice(index);
+        }
+    }
+
+    get current(): string | undefined {
+        return this.values[this.index];
+    }
+
+    get previous(): string | undefined {
+        this.index = Math.max(this.index - 1, -1);
+        return this.current;
+    }
+
+    get next(): string | undefined {
+        this.index = Math.min(this.index + 1, this.values.length);
+        return this.current;
+    }
+
+    store(): ConsoleHistory.Data {
+        const { values, index } = this;
+        return { values, index };
+    }
+
+    restore(object: ConsoleHistory): void {
+        this.values = object.values;
+        this.index = object.index;
+    }
+
+}
+export namespace ConsoleHistory {
+    export interface Data {
+        values: string[],
+        index: number
+    }
+}

--- a/packages/console/src/browser/console-keybinding-contexts.ts
+++ b/packages/console/src/browser/console-keybinding-contexts.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { KeybindingContext } from '@theia/core/lib/browser';
+import { ConsoleManager } from './console-manager';
+import { ConsoleWidget } from './console-widget';
+
+export namespace ConsoleKeybindingContexts {
+
+    /**
+     * ID of a keybinding context that is enabled when the console content has the focus.
+     */
+    export const consoleContentFocus = 'consoleContentFocus';
+
+    /**
+     * ID of a keybinding context that is enabled when the console input has the focus.
+     */
+    export const consoleInputFocus = 'consoleInputFocus';
+
+    /**
+     * ID of a keybinding context that is enabled when the console history navigation back is enabled.
+     */
+    export const consoleNavigationBackEnabled = 'consoleNavigationBackEnabled';
+
+    /**
+     * ID of a keybinding context that is enabled when the console history navigation forward is enabled.
+     */
+    export const consoleNavigationForwardEnabled = 'consoleNavigationForwardEnabled';
+
+}
+
+@injectable()
+export class ConsoleInputFocusContext implements KeybindingContext {
+
+    readonly id: string = ConsoleKeybindingContexts.consoleInputFocus;
+
+    @inject(ConsoleManager)
+    protected readonly manager: ConsoleManager;
+
+    isEnabled(): boolean {
+        const console = this.manager.activeConsole;
+        return !!console && this.isConsoleEnabled(console);
+    }
+
+    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+        return console.input.isFocused({ strict: true });
+    }
+
+}
+
+@injectable()
+export class ConsoleContentFocusContext extends ConsoleInputFocusContext {
+
+    readonly id: string = ConsoleKeybindingContexts.consoleContentFocus;
+
+    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+        return !console.input.isFocused();
+    }
+
+}
+
+@injectable()
+export class ConsoleNavigationBackEnabled extends ConsoleInputFocusContext {
+
+    readonly id: string = ConsoleKeybindingContexts.consoleNavigationBackEnabled;
+
+    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+        if (!super.isConsoleEnabled(console)) {
+            return false;
+        }
+        const editor = console.input.getControl();
+        return editor.getPosition().equals({ lineNumber: 1, column: 1 });
+    }
+
+}
+
+@injectable()
+export class ConsoleNavigationForwardEnabled extends ConsoleInputFocusContext {
+
+    readonly id: string = ConsoleKeybindingContexts.consoleNavigationForwardEnabled;
+
+    protected isConsoleEnabled(console: ConsoleWidget): boolean {
+        if (!super.isConsoleEnabled(console)) {
+            return false;
+        }
+        const editor = console.input.getControl();
+        const model = console.input.getControl().getModel();
+        const lineNumber = model.getLineCount();
+        const column = model.getLineMaxColumn(lineNumber);
+        return editor.getPosition().equals({ lineNumber, column });
+    }
+
+}

--- a/packages/console/src/browser/console-manager.ts
+++ b/packages/console/src/browser/console-manager.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,24 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './widget';
-export * from './virtual-renderer';
-export * from './virtual-widget';
-export * from './react-renderer';
-export * from './react-widget';
+import { injectable, inject } from 'inversify';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { ConsoleWidget } from './console-widget';
+
+@injectable()
+export class ConsoleManager {
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    get activeConsole(): ConsoleWidget | undefined {
+        const widget = this.shell.activeWidget;
+        return widget instanceof ConsoleWidget ? widget : undefined;
+    }
+
+    get currentConsole(): ConsoleWidget | undefined {
+        const widget = this.shell.currentWidget;
+        return widget instanceof ConsoleWidget ? widget : undefined;
+    }
+
+}

--- a/packages/console/src/browser/console-session.ts
+++ b/packages/console/src/browser/console-session.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ReactNode } from 'react';
+import { Event } from '@theia/core/lib/common/event';
+import { MaybePromise } from '@theia/core/lib/common/types';
+import { MessageType } from '@theia/core/lib/common/message-service-protocol';
+
+export interface ConsoleItem {
+    readonly severity?: MessageType
+    readonly empty: boolean
+    render(): ReactNode
+}
+export namespace ConsoleItem {
+    export const errorClassName = 'theia-console-error';
+    export const warningClassName = 'theia-console-warning';
+    export const infoClassName = 'theia-console-info';
+    export const logClassName = 'theia-console-log';
+    export function toClassName(item: ConsoleItem): string | undefined {
+        if (item.severity === MessageType.Error) {
+            return errorClassName;
+        }
+        if (item.severity === MessageType.Warning) {
+            return warningClassName;
+        }
+        if (item.severity === MessageType.Info) {
+            return infoClassName;
+        }
+        if (item.severity === MessageType.Log) {
+            return logClassName;
+        }
+        return undefined;
+    }
+}
+
+export interface CompositeConsoleItem extends ConsoleItem {
+    readonly hasChildren: boolean;
+    resolve(): MaybePromise<ConsoleItem[]>;
+}
+export namespace CompositeConsoleItem {
+    // tslint:disable:no-any
+    export function is(item: CompositeConsoleItem | any): item is CompositeConsoleItem {
+        return !!item && 'resolve' in item;
+    }
+    export function hasChildren(item: CompositeConsoleItem | any): item is CompositeConsoleItem {
+        return is(item) && item.hasChildren;
+    }
+}
+
+export interface ConsoleSession {
+    readonly id: string
+    readonly name: string
+    readonly items: ConsoleItem[]
+    readonly onDidChange: Event<void>
+    execute(value: string): MaybePromise<void>
+    clear(): MaybePromise<void>
+}

--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -1,0 +1,247 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct } from 'inversify';
+import { BaseWidget, PanelLayout, Widget, Message, MessageLoop, StatefulWidget, CompositeTreeNode } from '@theia/core/lib/browser';
+import { ConsoleSession } from './console-session';
+import { DisposableCollection } from '@theia/core/lib/common';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import URI from '@theia/core/lib/common/uri';
+import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
+import { ProtocolToMonacoConverter, MonacoToProtocolConverter } from 'monaco-languageclient/lib';
+import { ElementExt } from '@phosphor/domutils';
+import { ConsoleContentWidget } from './content/console-content-widget';
+import { ConsoleSessionNode } from './content/console-content-tree';
+import { ConsoleHistory } from './console-history';
+
+export const ConsoleOptions = Symbol('ConsoleWidgetOptions');
+export interface ConsoleOptions {
+    id: string
+    title?: {
+        label?: string
+        iconClass?: string
+        caption?: string
+    }
+    input: {
+        uri: URI
+        options?: MonacoEditor.IOptions
+    }
+}
+
+@injectable()
+export class ConsoleWidget extends BaseWidget implements StatefulWidget {
+
+    static styles = {
+        node: 'theia-console-widget',
+        content: 'theia-console-content',
+        input: 'theia-console-input',
+    };
+
+    @inject(ConsoleOptions)
+    protected readonly options: ConsoleOptions;
+
+    @inject(MonacoToProtocolConverter)
+    protected readonly m2p: MonacoToProtocolConverter;
+
+    @inject(ProtocolToMonacoConverter)
+    protected readonly p2m: ProtocolToMonacoConverter;
+
+    @inject(ConsoleContentWidget)
+    readonly content: ConsoleContentWidget;
+
+    @inject(ConsoleHistory)
+    protected readonly history: ConsoleHistory;
+
+    @inject(MonacoEditorProvider)
+    protected readonly editorProvider: MonacoEditorProvider;
+
+    protected _input: MonacoEditor;
+
+    constructor() {
+        super();
+        this.node.classList.add(ConsoleWidget.styles.node);
+    }
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        const { id, title } = this.options;
+        const { label, iconClass, caption } = Object.assign({}, title);
+        this.id = id;
+        this.title.closable = true;
+        this.title.label = label || id;
+        if (iconClass) {
+            this.title.iconClass = iconClass;
+        }
+        this.title.caption = caption || label || id;
+
+        const layout = this.layout = new PanelLayout();
+
+        this.content.node.classList.add(ConsoleWidget.styles.content);
+        this.toDispose.push(this.content);
+        layout.addWidget(this.content);
+
+        const inputWidget = new Widget();
+        inputWidget.node.classList.add(ConsoleWidget.styles.input);
+        layout.addWidget(inputWidget);
+
+        const input = this._input = await this.createInput(inputWidget.node);
+        this.toDispose.push(input);
+        this.toDispose.push(input.getControl().onDidLayoutChange(() => this.resizeContent()));
+        this.toDispose.push(input.getControl().onDidChangeConfiguration(({ fontInfo }) => fontInfo && this.updateFont()));
+        this.updateFont();
+    }
+
+    protected createInput(node: HTMLElement): Promise<MonacoEditor> {
+        return this.editorProvider.createInline(this.options.input.uri, node, this.options.input.options);
+    }
+
+    protected updateFont(): void {
+        const { fontFamily, fontSize, lineHeight } = this._input.getControl().getConfiguration().fontInfo;
+        this.content.node.style.fontFamily = fontFamily;
+        this.content.node.style.fontSize = fontSize + 'px';
+        this.content.node.style.lineHeight = lineHeight + 'px';
+    }
+
+    protected _session: ConsoleSession | undefined;
+    protected readonly toDisposeOnSession = new DisposableCollection();
+    set session(session: ConsoleSession | undefined) {
+        if (this._session === session) {
+            return;
+        }
+        this._session = session;
+        this.content.model.root = ConsoleSessionNode.to(session);
+        if (this._session) {
+            this.toDisposeOnSession.push(this._session.onDidChange(() => this.content.model.refresh()));
+            this.toDispose.push(this.toDisposeOnSession);
+        }
+    }
+    get session(): ConsoleSession | undefined {
+        return this._session;
+    }
+
+    get input(): MonacoEditor {
+        return this._input;
+    }
+
+    selectAll(): void {
+        document.getSelection().selectAllChildren(this.content.node);
+    }
+
+    collapseAll(): void {
+        const { root } = this.content.model;
+        if (CompositeTreeNode.is(root)) {
+            this.content.model.collapseAll(root);
+        }
+    }
+
+    clear(): void {
+        if (this.session) {
+            this.session.clear();
+        }
+    }
+
+    async execute(): Promise<void> {
+        const value = this._input.getControl().getValue();
+        this._input.getControl().setValue('');
+        this.history.push(value);
+        if (this.session) {
+            const listener = this.content.model.onNodeRefreshed(() => {
+                listener.dispose();
+                this.revealLastOutput();
+            });
+            await this.session.execute(value);
+        }
+    }
+
+    navigateBack(): void {
+        const value = this.history.previous;
+        if (value === undefined) {
+            return;
+        }
+        const editor = this.input.getControl();
+        editor.setValue(value);
+        editor.setPosition({
+            lineNumber: 1,
+            column: 1
+        });
+    }
+
+    navigateForward(): void {
+        const value = this.history.next || '';
+        const editor = this.input.getControl();
+        editor.setValue(value);
+        const lineNumber = editor.getModel().getLineCount();
+        const column = editor.getModel().getLineMaxColumn(lineNumber);
+        editor.setPosition({ lineNumber, column });
+    }
+
+    protected revealLastOutput(): void {
+        const { root } = this.content.model;
+        if (ConsoleSessionNode.is(root)) {
+            this.content.model.selectNode(root.children[root.children.length - 1]);
+        }
+    }
+
+    protected onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this._input.focus();
+    }
+
+    protected totalHeight = -1;
+    protected totalWidth = -1;
+    protected onResize(msg: Widget.ResizeMessage): void {
+        super.onResize(msg);
+        this.totalWidth = msg.width;
+        this.totalHeight = msg.height;
+        this._input.resizeToFit();
+        this.resizeContent();
+    }
+
+    protected resizeContent(): void {
+        this.totalHeight = this.totalHeight < 0 ? this.computeHeight() : this.totalHeight;
+        const inputHeight = this._input.getControl().getLayoutInfo().height;
+        const contentHeight = this.totalHeight - inputHeight;
+        this.content.node.style.height = `${contentHeight}px`;
+        MessageLoop.sendMessage(this.content, new Widget.ResizeMessage(this.totalWidth, contentHeight));
+    }
+
+    protected computeHeight(): number {
+        const { verticalSum } = ElementExt.boxSizing(this.node);
+        return this.node.offsetHeight - verticalSum;
+    }
+
+    storeState(): object {
+        const history = this.history.store();
+        const input = this.input.storeViewState();
+        return {
+            history,
+            input
+        };
+    }
+
+    restoreState(oldState: object): void {
+        if ('history' in oldState) {
+            // tslint:disable-next-line:no-any
+            this.history.restore((<any>oldState)['history']);
+        }
+        this.input.getControl().setValue(this.history.current || '');
+        if ('input' in oldState) {
+            // tslint:disable-next-line:no-any
+            this.input.restoreViewState((<any>oldState)['input']);
+        }
+    }
+
+}

--- a/packages/console/src/browser/content/console-content-container.ts
+++ b/packages/console/src/browser/content/console-content-container.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, Container } from 'inversify';
+import { MenuPath } from '@theia/core';
+import { createTreeContainer, Tree, TreeImpl, TreeWidget, defaultTreeProps, TreeProps } from '@theia/core/lib/browser';
+import { ConsoleContentTree } from './console-content-tree';
+import { ConsoleContentWidget } from './console-content-widget';
+
+export const CONSOLE_CONTEXT_MENU: MenuPath = ['console-context-menu'];
+
+export const CONSOLE_TREE_PROPS: TreeProps = {
+    ...defaultTreeProps,
+    contextMenuPath: CONSOLE_CONTEXT_MENU
+};
+
+export function createConsoleContentContainer(parent: interfaces.Container): Container {
+    const child = createTreeContainer(parent);
+
+    child.unbind(TreeImpl);
+    child.bind(ConsoleContentTree).toSelf();
+    child.rebind(Tree).toDynamicValue(ctx => ctx.container.get(ConsoleContentTree));
+
+    child.unbind(TreeWidget);
+    child.bind(ConsoleContentWidget).toSelf();
+
+    child.rebind(TreeProps).toConstantValue(CONSOLE_TREE_PROPS);
+
+    return child;
+}

--- a/packages/console/src/browser/content/console-content-tree.ts
+++ b/packages/console/src/browser/content/console-content-tree.ts
@@ -1,0 +1,128 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable } from 'inversify';
+import { TreeImpl, CompositeTreeNode, TreeNode, SelectableTreeNode, ExpandableTreeNode } from '@theia/core/lib/browser';
+import { ConsoleSession, ConsoleItem, CompositeConsoleItem } from '../console-session';
+
+@injectable()
+export class ConsoleContentTree extends TreeImpl {
+
+    async resolveChildren(parent: ConsoleItemNodeParent): Promise<TreeNode[]> {
+        const items = await this.resolveItems(parent);
+        const nodes: TreeNode[] = [];
+        let index = 0;
+        for (const item of items) {
+            if (!item.empty) {
+                nodes.push(this.toNode(item, index++, parent));
+            }
+        }
+        return nodes;
+    }
+
+    protected async resolveItems(parent: ConsoleItemNodeParent): Promise<ConsoleItem[]> {
+        if (ConsoleSessionNode.is(parent)) {
+            return parent.session.items;
+        }
+        return await parent.item.resolve();
+    }
+
+    protected toNode(item: ConsoleItem, index: number, parent: ConsoleItemNodeParent): ConsoleItemNode {
+        const id = parent.id + ':' + index;
+        const name = id;
+        const existing = this.getNode(id);
+        const updated = existing && <ConsoleItemNode>Object.assign(existing, { item, parent });
+        if (CompositeConsoleItem.hasChildren(item)) {
+            if (updated) {
+                return updated;
+            }
+            return {
+                item,
+                parent,
+                id,
+                name,
+                selected: false,
+                expanded: false,
+                children: []
+            } as CompositeConsoleItemNode;
+        }
+        if (CompositeConsoleItemNode.is(updated)) {
+            delete updated.expanded;
+            delete updated.children;
+            return updated;
+        }
+        return {
+            item,
+            parent,
+            id,
+            name,
+            selected: false
+        };
+    }
+
+}
+
+export type ConsoleItemNodeParent = CompositeConsoleItemNode | ConsoleSessionNode;
+
+export interface ConsoleItemNode extends TreeNode, SelectableTreeNode {
+    item: ConsoleItem
+    parent: ConsoleItemNodeParent
+}
+export namespace ConsoleItemNode {
+    export function is(node: TreeNode | undefined): node is ConsoleItemNode {
+        return SelectableTreeNode.is(node) && 'item' in node;
+    }
+}
+
+export interface CompositeConsoleItemNode extends ConsoleItemNode, CompositeTreeNode, ExpandableTreeNode {
+    item: CompositeConsoleItem
+    children: ConsoleItemNode[]
+    parent: ConsoleItemNodeParent
+}
+export namespace CompositeConsoleItemNode {
+    export function is(node: TreeNode | undefined): node is CompositeConsoleItemNode {
+        return ConsoleItemNode.is(node) && CompositeTreeNode.is(node) && ExpandableTreeNode.is(node) && !!node.visible;
+    }
+}
+
+export interface ConsoleSessionNode extends CompositeTreeNode, SelectableTreeNode {
+    visible: false
+    children: ConsoleItemNode[]
+    parent: undefined
+    session: ConsoleSession
+}
+export namespace ConsoleSessionNode {
+    export function is(node: TreeNode | undefined): node is ConsoleSessionNode {
+        return CompositeTreeNode.is(node) && !node.visible && 'session' in node;
+    }
+    export function to(session: undefined): undefined;
+    export function to(session: ConsoleSession): ConsoleSessionNode;
+    export function to(session: ConsoleSession | undefined): ConsoleSessionNode | undefined;
+    export function to(session: ConsoleSession | undefined): ConsoleSessionNode | undefined {
+        if (!session) {
+            return session;
+        }
+        const { id, name } = session;
+        return {
+            id,
+            name,
+            visible: false,
+            children: [],
+            session,
+            parent: undefined,
+            selected: false
+        };
+    }
+}

--- a/packages/console/src/browser/content/console-content-widget.tsx
+++ b/packages/console/src/browser/content/console-content-widget.tsx
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from 'react';
+import { injectable } from 'inversify';
+import { TreeWidget, TreeNode } from '@theia/core/lib/browser';
+import { ConsoleItemNode } from './console-content-tree';
+import { ConsoleItem } from '../console-session';
+
+@injectable()
+export class ConsoleContentWidget extends TreeWidget {
+
+    protected renderCaption(node: TreeNode): React.ReactNode {
+        return ConsoleItemNode.is(node) && <div className={ConsoleItem.toClassName(node.item)}
+            style={{
+                width: '100%'
+            }}
+        >{node.item.render()}</div>;
+    }
+
+    storeState(): object {
+        // no-op
+        return {};
+    }
+    protected superStoreState(): object {
+        return super.storeState();
+    }
+    restoreState(state: object): void {
+        // no-op
+    }
+    protected superRestoreState(state: object): void {
+        return super.restoreState(state);
+    }
+
+}

--- a/packages/console/src/browser/monaco.d.ts
+++ b/packages/console/src/browser/monaco.d.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,4 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './widget';
-export * from './virtual-renderer';
-export * from './virtual-widget';
-export * from './react-renderer';
-export * from './react-widget';
+/// <reference types='@typefox/monaco-editor-core/monaco'/>

--- a/packages/console/src/browser/style/index.css
+++ b/packages/console/src/browser/style/index.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,33 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './widget';
-export * from './virtual-renderer';
-export * from './virtual-widget';
-export * from './react-renderer';
-export * from './react-widget';
+.theia-console-content {
+    color: var(--theia-content-font-color0);
+    font-size: var(--theia-code-font-size);
+    line-height: var(--theia-code-line-height);
+    font-family: var(--theia-code-font-family);
+}
+
+.theia-console-input {
+    padding-left: 20px;
+	border-top: var(--theia-panel-border-width) solid var(--theia-border-color1);
+}
+
+.theia-console-input:before {
+	left: 8px;
+	position: absolute;
+    content: '\276f';
+	line-height: 18px;
+}
+
+.theia-console-error {
+    color: var(--theia-error-color2);
+}
+
+.theia-console-warning {
+    color: var(--theia-warn-color2);
+}
+
+.theia-console-ansi-console-item {
+    white-space: pre-wrap;
+}

--- a/packages/console/src/package.spec.ts
+++ b/packages/console/src/package.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './widget';
-export * from './virtual-renderer';
-export * from './virtual-widget';
-export * from './react-renderer';
-export * from './react-widget';
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe('console package', () => {
+
+    it('support code coverage statistics', () => true);
+});

--- a/packages/core/src/browser/connection-status-service.ts
+++ b/packages/core/src/browser/connection-status-service.ts
@@ -108,7 +108,6 @@ export abstract class AbstractConnectionStatusService implements ConnectionStatu
         if (this.timer) {
             this.clearTimeout(this.timer);
         }
-        this.logger.trace(success ? 'Connected to the backend.' : 'Cannot reach the backend.');
         const previousStatus = this.connectionStatus;
         const newStatus = success ? ConnectionStatus.ONLINE : ConnectionStatus.OFFLINE;
         if (previousStatus !== newStatus) {

--- a/packages/core/src/browser/style/ansi.css
+++ b/packages/core/src/browser/style/ansi.css
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* ANSI */
+.ansi-black-fg, .ansi-bright-black-fg { color: var(--theia-ansi-black-color); }
+.ansi-red-fg, .ansi-bright-red-fg { color: var(--theia-ansi-red-color); }
+.ansi-green-fg, .ansi-bright-green-fg { color: var(--theia-ansi-green-color); }
+.ansi-yellow-fg, .ansi-bright-yellow-fg { color: var(--theia-ansi-yellow-color); }
+.ansi-blue-fg, .ansi-bright-blue-fg { color: var(--theia-ansi-blue-color); }
+.ansi-magenta-fg, .ansi-bright-magenta-fg { color: var(--theia-ansi-magenta-color); }
+.ansi-cyan-fg, .ansi-bright-cyan-fg { color: var(--theia-ansi-cyan-color); }
+.ansi-white-fg, .ansi-bright-white-fg { color: var(--theia-ansi-white-color); }
+
+.ansi-black-bg, .ansi-bright-black-bg { background-color: var(--theia-ansi-black-background-color); }
+.ansi-red-bg, .ansi-bright-red-bg { background-color: var(--theia-ansi-red-background-color); }
+.ansi-green-bg, .ansi-bright-green-bg { background-color: var(--theia-ansi-green-background-color); }
+.ansi-yellow-bg, .ansi-bright-yellow-bg { background-color: var(--theia-ansi-yellow-background-color); }
+.ansi-blue-bg, .ansi-bright-blue-bg { background-color: var(--theia-ansi-blue-background-color); }
+.ansi-magenta-bg, .ansi-bright-magenta-bg { background-color: var(--theia-ansi-magenta-background-color); }
+.ansi-cyan-bg, .ansi-bright-cyan-bg { background-color: var(--theia-ansi-cyan-background-color); }
+.ansi-white-bg, .ansi-bright-white-bg { background-color: var(--theia-ansi-white-background-color); }

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -163,3 +163,4 @@ button[disabled], .theia-button[disabled] {
 @import './tree-decorators.css';
 @import './about.css';
 @import './search-box.css';
+@import './ansi.css';

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -74,7 +74,8 @@ is not optimized for dense, information rich UIs.
   --theia-code-font-size: 13px;
   --theia-code-line-height: 17px;
   --theia-code-padding: 5px;
-  --theia-code-font-family: monospace;
+  --theia-code-font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
+  --theia-terminal-font-family: monospace;
   --theia-ui-padding: 6px;
 
   /* Main layout colors (bright to dark)
@@ -217,4 +218,32 @@ is not optimized for dense, information rich UIs.
   --theia-ui-dialog-header-font-color: var(--theia-inverse-ui-font-color0);
   --theia-ui-dialog-color: var(--theia-layout-color0);
   --theia-ui-dialog-font-color: var(--theia-ui-font-color1);
+
+  /* Variables */
+  --theia-variable-name-color: #9B46B0;
+  --theia-variable-value-color: rgba(108, 108, 108, 0.8);
+  --theia-number-variable-color: #09885A;
+  --theia-boolean-variable-color: #0000FF;
+  --theia-string-variable-color: #A31515;
+
+  /* ANSI color */
+  --theia-ansi-black-color: gray;
+  --theia-ansi-red-color: #BE1717;
+  --theia-ansi-green-color: #338A2F;
+  --theia-ansi-yellow-color: #BEB817;
+  --theia-ansi-blue-color: darkblue;
+  --theia-ansi-magenta-color: darkmagenta;
+  --theia-ansi-cyan-color: darkcyan;
+  --theia-ansi-white-color: #BDBDBD;
+
+  /* ANSI background color */
+  --theia-ansi-black-background-color: gray;
+  --theia-ansi-red-background-color: #BE1717;
+  --theia-ansi-green-background-color: #338A2F;
+  --theia-ansi-yellow-background-color: #BEB817;
+  --theia-ansi-blue-background-color: darkblue;
+  --theia-ansi-magenta-background-color: darkmagenta;
+  --theia-ansi-cyan-background-color: darkcyan;
+  --theia-ansi-white-background-color: #BDBDBD;
+
 }

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -74,7 +74,8 @@ is not optimized for dense, information rich UIs.
   --theia-code-font-size: 13px;
   --theia-code-line-height: 17px;
   --theia-code-padding: 5px;
-  --theia-code-font-family: monospace;
+  --theia-code-font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
+  --theia-terminal-font-family: monospace;
   --theia-ui-padding: 6px;
 
   /* Main layout colors (dark to bright)
@@ -217,4 +218,32 @@ is not optimized for dense, information rich UIs.
   --theia-ui-dialog-header-font-color: var(--theia-ui-font-color1);
   --theia-ui-dialog-color: var(--theia-layout-color4);
   --theia-ui-dialog-font-color: var(--theia-ui-font-color1);
+
+  /* Variables */
+  --theia-variable-name-color: #C586C0;
+  --theia-variable-value-color: rgba(204, 204, 204, 0.6);
+  --theia-number-variable-color: #B5CEA8;
+  --theia-boolean-variable-color: #4E94CE;
+  --theia-string-variable-color: #CE9178;
+
+  /* ANSI color */
+  --theia-ansi-black-color: #A0A0A0;
+  --theia-ansi-red-color: #A74747;
+  --theia-ansi-green-color: #348F34;
+  --theia-ansi-yellow-color: #5F4C29;
+  --theia-ansi-blue-color: #6286BB;
+  --theia-ansi-magenta-color: #914191;
+  --theia-ansi-cyan-color: #218D8D;
+  --theia-ansi-white-color: #707070;
+
+  /* ANSI background color */
+  --theia-ansi-black-background-color: #A0A0A0;
+  --theia-ansi-red-background-color: #A74747;
+  --theia-ansi-green-background-color: #348F34;
+  --theia-ansi-yellow-background-color: #5F4C29;
+  --theia-ansi-blue-background-color: #6286BB;
+  --theia-ansi-magenta-background-color: #914191;
+  --theia-ansi-cyan-background-color: #218D8D;
+  --theia-ansi-white-background-color: #707070;
+
 }

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -42,6 +42,12 @@ export interface TreeModel extends Tree, TreeSelectionService, TreeExpansionServ
     collapseNode(node?: Readonly<ExpandableTreeNode>): Promise<boolean>;
 
     /**
+     * Collapses recursively. If the `node` argument is `undefined`, then collapses the currently selected tree node.
+     * If multiple tree nodes are selected, collapses the most recently selected tree node.
+     */
+    collapseAll(node?: Readonly<CompositeTreeNode>): Promise<boolean>;
+
+    /**
      * Toggles the expansion state of the given node. If not give, then it toggles the expansion state of the currently selected node.
      * If multiple nodes are selected, then the most recently selected tree node's expansion state will be toggled.
      */
@@ -232,6 +238,17 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
             if (ExpandableTreeNode.is(node)) {
                 return await this.expansionService.collapseNode(node);
             }
+        }
+        return false;
+    }
+
+    async collapseAll(raw?: Readonly<CompositeTreeNode>): Promise<boolean> {
+        const node = raw || this.selectedNodes[0];
+        if (SelectableTreeNode.is(node)) {
+            this.selectNode(node);
+        }
+        if (CompositeTreeNode.is(node)) {
+            return await this.expansionService.collapseAll(node);
         }
         return false;
     }

--- a/packages/debug/src/browser/console/debug-console-contribution.ts
+++ b/packages/debug/src/browser/console/debug-console-contribution.ts
@@ -1,0 +1,73 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, injectable } from 'inversify';
+import { AbstractViewContribution, bindViewContribution, WidgetFactory } from '@theia/core/lib/browser';
+import { ConsoleContainer } from '@theia/console/lib/browser/console-container';
+import { ConsoleWidget, ConsoleOptions } from '@theia/console/lib/browser/console-widget';
+import { DebugConsoleSession } from './debug-console-session';
+
+@injectable()
+export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWidget> {
+
+    constructor() {
+        super({
+            widgetId: DebugConsoleContribution.options.id,
+            widgetName: DebugConsoleContribution.options.title!.label!,
+            defaultWidgetOptions: {
+                area: 'bottom'
+            },
+            toggleCommandId: 'debug:console:toggle',
+            toggleKeybinding: 'ctrlcmd+shift+y'
+        });
+    }
+
+    static options: ConsoleOptions = {
+        id: 'debug-console',
+        title: {
+            label: 'Debug Console'
+        },
+        input: {
+            uri: DebugConsoleSession.uri,
+            options: {
+                autoSizing: true,
+                minHeight: 1,
+                maxHeight: 10
+            }
+        }
+    };
+
+    static create(parent: interfaces.Container): ConsoleWidget {
+        const child = ConsoleContainer.create(parent, DebugConsoleContribution.options);
+        const widget = child.get(ConsoleWidget);
+        widget.session = child.get(DebugConsoleSession);
+        return widget;
+    }
+
+    static bindContribution(bind: interfaces.Bind): void {
+        bind(DebugConsoleSession).toSelf().inSingletonScope();
+        bindViewContribution(bind, DebugConsoleContribution).onActivation((context, _) => {
+            // eagerly initialize the debug console session
+            context.container.get(DebugConsoleSession);
+            return _;
+        });
+        bind(WidgetFactory).toDynamicValue(({ container }) => ({
+            id: DebugConsoleContribution.options.id,
+            createWidget: () => DebugConsoleContribution.create(container)
+        }));
+    }
+
+}

--- a/packages/debug/src/browser/console/debug-console-session.tsx
+++ b/packages/debug/src/browser/console/debug-console-session.tsx
@@ -1,0 +1,384 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from 'react';
+import { injectable, inject, postConstruct } from 'inversify';
+import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
+import { Event, Emitter, MessageType } from '@theia/core/lib/common';
+import { ConsoleSession, ConsoleItem, CompositeConsoleItem } from '@theia/console/lib/browser/console-session';
+import { AnsiConsoleItem } from '@theia/console/lib/browser/ansi-console-item';
+import { DebugSession } from '../debug-model';
+import { DebugSessionManager } from '../debug-session';
+import { DebugSelectionService, DebugSelection } from '../view/debug-selection-service';
+import { Languages, CompletionItem, CompletionItemKind, Position, Range, TextEdit, Workspace, TextDocument, CompletionParams } from '@theia/languages/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+
+@injectable()
+export class DebugConsoleSession implements ConsoleSession {
+
+    static uri = new URI().withScheme('debugconsole');
+
+    id = 'debug';
+    name = 'Debug';
+    items: ConsoleItem[] = [];
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    @inject(DebugSessionManager)
+    protected readonly manager: DebugSessionManager;
+
+    @inject(DebugSelectionService)
+    protected readonly selection: DebugSelectionService;
+
+    @inject(Languages)
+    protected readonly languages: Languages;
+
+    @inject(Workspace)
+    protected readonly workspace: Workspace;
+
+    protected readonly completionKinds = new Map<DebugProtocol.CompletionItemType | undefined, CompletionItemKind>();
+
+    @postConstruct()
+    init(): void {
+        this.manager.onDidCreateDebugSession(session => {
+            if (this.manager.findAll().length === 1) {
+                this.clear();
+            }
+            session.onDidOutput(event => this.logOutput(session, event));
+        });
+        this.completionKinds.set('method', CompletionItemKind.Method);
+        this.completionKinds.set('function', CompletionItemKind.Function);
+        this.completionKinds.set('constructor', CompletionItemKind.Constructor);
+        this.completionKinds.set('field', CompletionItemKind.Field);
+        this.completionKinds.set('variable', CompletionItemKind.Variable);
+        this.completionKinds.set('class', CompletionItemKind.Class);
+        this.completionKinds.set('interface', CompletionItemKind.Interface);
+        this.completionKinds.set('module', CompletionItemKind.Module);
+        this.completionKinds.set('property', CompletionItemKind.Property);
+        this.completionKinds.set('unit', CompletionItemKind.Unit);
+        this.completionKinds.set('value', CompletionItemKind.Value);
+        this.completionKinds.set('enum', CompletionItemKind.Enum);
+        this.completionKinds.set('keyword', CompletionItemKind.Keyword);
+        this.completionKinds.set('snippet', CompletionItemKind.Snippet);
+        this.completionKinds.set('text', CompletionItemKind.Text);
+        this.completionKinds.set('color', CompletionItemKind.Color);
+        this.completionKinds.set('file', CompletionItemKind.File);
+        this.completionKinds.set('reference', CompletionItemKind.Reference);
+        this.completionKinds.set('customcolor', CompletionItemKind.Color);
+        if (this.languages.registerCompletionItemProvider) {
+            this.languages.registerCompletionItemProvider([DebugConsoleSession.uri], {
+                provideCompletionItems: params => this.completions(params)
+            }, '.');
+        }
+    }
+
+    protected async completions({ textDocument: { uri }, position }: CompletionParams): Promise<CompletionItem[]> {
+        const session = this.manager.getActiveDebugSession();
+        if (session) {
+            const { capabilities } = session.state;
+            const selection = this.selection.get(session.sessionId);
+            const frameId = selection && selection.frame && selection.frame.id;
+            if (capabilities.supportsCompletionsRequest) {
+                const model = monaco.editor.getModel(monaco.Uri.parse(uri));
+                if (model) {
+                    const column = position.character + 1;
+                    const lineNumber = position.line + 1;
+                    const word = model.getWordAtPosition({ column, lineNumber });
+                    const prefixLength = word ? word.word.length : 0;
+                    const text = model.getValue();
+                    const document = TextDocument.create(uri, model.getModeId(), model.getVersionId(), text);
+                    const response = await session.completions({ frameId, text, column, line: lineNumber });
+                    return response.body.targets.map(item => this.asCompletionItem(document, position, prefixLength, item));
+                }
+            }
+        }
+        return [];
+    }
+
+    protected asCompletionItem(document: TextDocument, position: Position, prefixLength: number, item: DebugProtocol.CompletionItem): CompletionItem {
+        const { label, text, type, length } = item;
+        const newText = text || label;
+        const start = document.positionAt(document.offsetAt(position) - (length || prefixLength));
+        const replaceRange = Range.create(start, position);
+        const textEdit = TextEdit.replace(replaceRange, newText);
+        return {
+            label,
+            textEdit,
+            kind: this.completionKinds.get(type)
+        };
+    }
+
+    async execute(value: string): Promise<void> {
+        const session = this.manager.getActiveDebugSession();
+        const selection = session && this.selection.get(session!.sessionId);
+        const expression = new ExpressionItem(value, session, selection);
+        this.items.push(expression);
+        await expression.evaluate();
+        this.fireDidChange();
+    }
+
+    clear(): void {
+        this.items = [];
+        this.fireDidChange();
+    }
+
+    protected async logOutput(session: DebugSession, event: DebugProtocol.OutputEvent): Promise<void> {
+        const body = event.body;
+        const { category, variablesReference } = body;
+        if (category === 'telemetry') {
+            console.debug(`telemetry/${event.body.output}`, event.body.data);
+            return;
+        }
+        const severity = category === 'stderr' ? MessageType.Error : event.body.category === 'console' ? MessageType.Warning : MessageType.Info;
+        if (variablesReference) {
+            const items = await new ExpressionContainer({ session, variablesReference }).resolve();
+            this.items.push(...items);
+        } else if (typeof body.output === 'string') {
+            for (const line of body.output.split('\n')) {
+                this.items.push(new AnsiConsoleItem(line, severity));
+            }
+        }
+        this.fireDidChange();
+    }
+
+    protected fireDidChange(): void {
+        this.onDidChangeEmitter.fire(undefined);
+    }
+
+}
+
+export class ExpressionContainer implements CompositeConsoleItem {
+
+    private static readonly BASE_CHUNK_SIZE = 100;
+
+    protected readonly session: DebugSession | undefined;
+    protected variablesReference: number;
+    protected namedVariables: number | undefined;
+    protected indexedVariables: number | undefined;
+    protected readonly startOfVariables: number;
+
+    constructor(options: ExpressionContainer.Options) {
+        this.session = options.session;
+        this.variablesReference = options.variablesReference || 0;
+        this.namedVariables = options.namedVariables;
+        this.indexedVariables = options.indexedVariables;
+        this.startOfVariables = options.startOfVariables || 0;
+    }
+
+    get empty(): boolean {
+        return false;
+    }
+
+    render(): React.ReactNode {
+        return undefined;
+    }
+
+    get hasChildren(): boolean {
+        return !!this.variablesReference;
+    }
+
+    protected items: Promise<ConsoleItem[]> | undefined;
+    async resolve(): Promise<ConsoleItem[]> {
+        if (!this.hasChildren || !this.session) {
+            return [];
+        }
+        if (this.items) {
+            return this.items;
+        }
+        return this.items || (this.items = this.doResolve());
+    }
+    protected async doResolve(): Promise<ConsoleItem[]> {
+        const result: ConsoleItem[] = [];
+        if (this.namedVariables) {
+            this.fetch(result, 'named');
+        }
+        if (this.indexedVariables) {
+            let chunkSize = ExpressionContainer.BASE_CHUNK_SIZE;
+            while (this.indexedVariables > chunkSize * ExpressionContainer.BASE_CHUNK_SIZE) {
+                chunkSize *= ExpressionContainer.BASE_CHUNK_SIZE;
+            }
+            if (this.indexedVariables > chunkSize) {
+                const numberOfChunks = Math.ceil(this.indexedVariables / chunkSize);
+                for (let i = 0; i < numberOfChunks; i++) {
+                    const start = this.startOfVariables + i * chunkSize;
+                    const count = Math.min(chunkSize, this.indexedVariables - i * chunkSize);
+                    const { session, variablesReference } = this;
+                    result.push(new VirtualVariableItem({
+                        session, variablesReference,
+                        namedVariables: 0,
+                        indexedVariables: count,
+                        startOfVariables: start,
+                        name: `[${start}..${start + count - 1}]`
+                    }));
+                }
+                return result;
+            }
+        }
+        await this.fetch(result, 'indexed', this.startOfVariables, this.indexedVariables);
+        return result;
+    }
+
+    protected fetch(result: ConsoleItem[], filter: 'named'): Promise<void>;
+    protected fetch(result: ConsoleItem[], filter: 'indexed', start: number, count?: number): Promise<void>;
+    protected async fetch(result: ConsoleItem[], filter: 'indexed' | 'named', start?: number, count?: number): Promise<void> {
+        try {
+            const { variablesReference } = this;
+            const response = await this.session!.variables({ variablesReference, filter, start, count });
+            const { variables } = response.body;
+            const names = new Set<string>();
+            for (const variable of variables) {
+                if (!names.has(variable.name)) {
+                    result.push(new VariableItem(this.session!, variable));
+                    names.add(variable.name);
+                }
+            }
+        } catch (e) {
+            result.push({
+                severity: MessageType.Error,
+                empty: !!e.message,
+                render: () => e.message
+            });
+        }
+    }
+
+}
+export namespace ExpressionContainer {
+    export interface Options {
+        session: DebugSession | undefined,
+        variablesReference?: number
+        namedVariables?: number
+        indexedVariables?: number
+        startOfVariables?: number
+    }
+}
+
+export class VariableItem extends ExpressionContainer {
+
+    static booleanRegex = /^true|false$/i;
+    static stringRegex = /^(['"]).*\1$/;
+
+    constructor(
+        protected readonly session: DebugSession | undefined,
+        protected readonly variable: DebugProtocol.Variable
+    ) {
+        super({
+            session,
+            variablesReference: variable.variablesReference,
+            namedVariables: variable.namedVariables,
+            indexedVariables: variable.indexedVariables
+        });
+    }
+
+    render(): React.ReactNode {
+        const { type, value, name } = this.variable;
+        return <div className={this.variableClassName}>
+            <span title={type || name} className='name'>{name}{!!value && ': '}</span>
+            <span title={value} >{value}</span>
+        </div>;
+    }
+
+    protected get variableClassName(): string {
+        const { type, value } = this.variable;
+        const classNames = ['theia-debug-console-variable'];
+        if (type === 'number' || type === 'boolean' || type === 'string') {
+            classNames.push(type);
+        } else if (!isNaN(+value)) {
+            classNames.push('number');
+        } else if (VariableItem.booleanRegex.test(value)) {
+            classNames.push('boolean');
+        } else if (VariableItem.stringRegex.test(value)) {
+            classNames.push('string');
+        }
+        return classNames.join(' ');
+    }
+
+}
+
+export class VirtualVariableItem extends ExpressionContainer {
+
+    constructor(
+        protected readonly options: VirtualVariableItem.Options
+    ) {
+        super(options);
+    }
+
+    render(): React.ReactNode {
+        return this.options.name;
+    }
+}
+export namespace VirtualVariableItem {
+    export interface Options extends ExpressionContainer.Options {
+        name: string
+    }
+}
+
+export class ExpressionItem extends ExpressionContainer {
+
+    static notAvailable = 'not available';
+
+    protected value = ExpressionItem.notAvailable;
+    protected available = false;
+
+    constructor(
+        protected readonly expression: string,
+        protected readonly session: DebugSession | undefined,
+        protected readonly selection: DebugSelection | undefined
+    ) {
+        super({ session });
+    }
+
+    render(): React.ReactNode {
+        const valueClassNames: string[] = [];
+        if (!this.available) {
+            valueClassNames.push(ConsoleItem.errorClassName);
+            valueClassNames.push('theia-debug-console-unavailable');
+        }
+        return <div className={'theia-debug-console-expression'}>
+            <div>{this.expression}</div>
+            <div className={valueClassNames.join(' ')}>{this.value}</div>
+        </div>;
+    }
+
+    async evaluate(): Promise<void> {
+        if (this.session) {
+            try {
+                const { expression } = this;
+                const frameId = this.selection && this.selection.frame && this.selection.frame.id;
+                const response = await this.session.evaluate({
+                    expression,
+                    frameId,
+                    context: 'repl'
+                });
+                const body = response.body;
+                if (body) {
+                    this.value = body.result;
+                    this.available = true;
+                    this.variablesReference = body.variablesReference;
+                    this.namedVariables = body.namedVariables;
+                    this.indexedVariables = body.indexedVariables;
+                    this.items = undefined;
+                }
+            } catch (err) {
+                this.value = err.message;
+                this.available = false;
+            }
+        } else {
+            this.value = 'Please start a debug session to evaluate';
+            this.available = false;
+        }
+    }
+
+}

--- a/packages/debug/src/browser/debug-model.ts
+++ b/packages/debug/src/browser/debug-model.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { DebugConfiguration, DebugSessionState } from '../common/debug-common';
-import { Disposable } from '@theia/core';
+import { Event, Disposable } from '@theia/core';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 /**
@@ -44,7 +44,7 @@ export const INITIALIZE_ARGUMENTS = {
     pathFormat: 'path',
     supportsVariableType: false,
     supportsVariablePaging: false,
-    supportsRunInTerminalRequest: false
+    supportsRunInTerminalRequest: true
 };
 
 /**
@@ -55,10 +55,12 @@ export const DebugSession = Symbol('DebugSession');
 /**
  * The debug session.
  */
+// FIXME get rid of NodeJS.EventEmitter, replace with core events
 export interface DebugSession extends Disposable, NodeJS.EventEmitter {
     readonly sessionId: string;
     readonly configuration: DebugConfiguration;
     readonly state: DebugSessionState;
+    readonly onDidOutput: Event<DebugProtocol.OutputEvent>;
 
     initialize(args: DebugProtocol.InitializeRequestArguments): Promise<DebugProtocol.InitializeResponse>;
     configurationDone(): Promise<DebugProtocol.ConfigurationDoneResponse>;
@@ -81,6 +83,7 @@ export interface DebugSession extends Disposable, NodeJS.EventEmitter {
     stepIn(args: DebugProtocol.StepInArguments): Promise<DebugProtocol.StepInResponse>;
     stepOut(args: DebugProtocol.StepOutArguments): Promise<DebugProtocol.StepOutResponse>;
     loadedSources(args: DebugProtocol.LoadedSourcesArguments): Promise<DebugProtocol.LoadedSourcesResponse>;
+    completions(args: DebugProtocol.CompletionsArguments): Promise<DebugProtocol.CompletionsResponse>;
 }
 
 /**

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -47,7 +47,7 @@
 div[orientation='horizontal'] > .theia-debug-entry {
     width: 25%;
     float: left;
-    border-left: 1px solid var(--theia-border-color1);      
+    border-left: 1px solid var(--theia-border-color1);
     height: inherit;
 }
 
@@ -58,10 +58,10 @@ div[orientation='horizontal'] > .debug-toolbar {
 }
 
 div[orientation='horizontal'] > .theia-debug-entry.theia-Tree {
-    position: absolute; 
-    top: 30px; 
+    position: absolute;
+    top: 30px;
     height: calc(100% - 30px);
-} 
+}
 
 div[orientation='horizontal'] > .theia-debug-entry > div {
     height: inherit;
@@ -101,9 +101,9 @@ div[orientation='horizontal'] > .theia-debug-entry > .theia-TreeContainer > div 
 div[orientation='vertical'] > .theia-debug-entry {
     width: inherit;
     float: left;
-    border-left: 1px solid var(--theia-border-color1);      
+    border-left: 1px solid var(--theia-border-color1);
     height: 25%;
-} 
+}
 
 div[orientation='vertical'] > .debug-toolbar {
     width: inherit;
@@ -113,7 +113,7 @@ div[orientation='vertical'] > .debug-toolbar {
 
 div[orientation='vertical'] > .theia-debug-entry.theia-Tree {
     height: calc(25% - 30px);
-} 
+}
 
 div[orientation='vertical'] > .theia-debug-entry > div {
     height: 100%;
@@ -209,4 +209,38 @@ div[orientation='vertical'] > .theia-debug-entry > .theia-TreeContainer > div > 
 
 .debug-tab-icon::before {
     content: "\f188"
+}
+
+.theia-debug-console-unavailable {
+    font-style: italic;
+}
+
+.theia-debug-console-expression {
+    display: flex;
+    flex-direction: column;
+    white-space: pre-wrap;
+}
+
+.theia-debug-console-variable {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--theia-variable-value-color);
+}
+
+.theia-debug-console-variable.number {
+    color: var(--theia-number-variable-color);
+}
+
+.theia-debug-console-variable.boolean {
+    color: var(--theia-boolean-variable-color);
+}
+
+.theia-debug-console-variable.string {
+    color: var(--theia-string-variable-color);
+}
+
+.theia-debug-console-variable .name {
+    color: var(--theia-variable-name-color);
 }

--- a/packages/debug/src/browser/view/debug-frontend-contribution.ts
+++ b/packages/debug/src/browser/view/debug-frontend-contribution.ts
@@ -111,10 +111,10 @@ export class DebugWidget extends BaseWidget {
 
 @injectable()
 export class DebugFrontendContribution implements FrontendApplicationContribution {
-    constructor(
-        @inject(ApplicationShell) protected readonly shell: ApplicationShell,
-        @inject(WidgetManager) protected readonly widgetManager: WidgetManager,
-        @inject(DebugSessionManager) protected readonly debugSessionManager: DebugSessionManager) { }
+
+    @inject(ApplicationShell) protected readonly shell: ApplicationShell;
+    @inject(WidgetManager) protected readonly widgetManager: WidgetManager;
+    @inject(DebugSessionManager) protected readonly debugSessionManager: DebugSessionManager;
 
     @postConstruct()
     protected init() {
@@ -132,25 +132,25 @@ export class DebugFrontendContribution implements FrontendApplicationContributio
     private async onDebugSessionDestroyed(debugSession: DebugSession): Promise<void> { }
 
     private async createDebugWidget(debugSession: DebugSession): Promise<void> {
-        const options: DebugWidgetOptions = { debugSession };
+        const { sessionId } = debugSession;
+        const options: DebugWidgetOptions = { sessionId };
         const widget = <DebugWidget>await this.widgetManager.getOrCreateWidget(DEBUG_FACTORY_ID, options);
 
         const tabBar = this.shell.getTabBarFor(widget);
         if (!tabBar) {
-            this.shell.addWidget(widget, { area: 'bottom' });
+            this.shell.addWidget(widget, { area: 'left' });
         }
         this.shell.activateWidget(widget.id);
     }
 }
 
 /**
- * Debug widget options.
+ * Debug widget options. (JSON)
  */
 export const DebugWidgetOptions = Symbol('DebugWidgetOptions');
-
 export interface DebugWidgetOptions {
     /**
      * Debug session.
      */
-    readonly debugSession: DebugSession;
+    readonly sessionId: string;
 }

--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -168,6 +168,8 @@ export class DebugAdapterSessionImpl extends EventEmitter implements DebugAdapte
                             this.proceedEvent(rawData, message as DebugProtocol.Event);
                         } else if (message.type === 'response') {
                             this.proceedResponse(rawData, message as DebugProtocol.Response);
+                        } else if (this.channel) {
+                            this.channel.send(rawData);
                         }
                     }
                     continue;	// there may be more complete messages to process

--- a/packages/monaco/src/browser/monaco-keybinding-contexts.ts
+++ b/packages/monaco/src/browser/monaco-keybinding-contexts.ts
@@ -33,14 +33,11 @@ import { MonacoEditor } from './monaco-editor';
 export class MonacoStrictEditorTextFocusContext extends StrictEditorTextFocusContext {
 
     protected canHandle(widget: EditorWidget): boolean {
-        if (!super.canHandle(widget)) {
-            return false;
-        }
         const { editor } = widget;
         if (editor instanceof MonacoEditor) {
-            return !editor.isSuggestWidgetVisible() && !editor.isFindWidgetVisible() && !editor.isRenameInputVisible();
+            return editor.isFocused({ strict: true });
         }
-        return false;
+        return super.canHandle(widget);
     }
 
 }

--- a/packages/process/src/node/terminal-process.ts
+++ b/packages/process/src/node/terminal-process.ts
@@ -43,9 +43,7 @@ export class TerminalProcess extends Process {
     ) {
         super(processManager, logger, ProcessType.Terminal, options);
 
-        this.logger.debug(`Starting terminal process: ${options.command},`
-            + ` with args : ${options.args}, `
-            + ` options ${JSON.stringify(options.options)}`);
+        this.logger.debug('Starting terminal process', JSON.stringify(options, undefined, 2));
 
         this.terminal = spawn(
             options.command,

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -121,14 +121,18 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             }
         });
 
-        this.toDispose.push(this.terminalWatcher.onTerminalError(({ terminalId }) => {
+        this.toDispose.push(this.terminalWatcher.onTerminalError(({ terminalId, error }) => {
             if (terminalId === this.terminalId) {
-                this.title.label = '<terminal error>';
+                if (!this.title.label.endsWith('<error>')) {
+                    this.title.label = `${this.title.label} <error>`;
+                }
             }
         }));
         this.toDispose.push(this.terminalWatcher.onTerminalExit(({ terminalId }) => {
             if (terminalId === this.terminalId) {
-                this.title.label = '<terminated>';
+                if (!this.title.label.endsWith('<terminated>')) {
+                    this.title.label = `${this.title.label} <terminated>`;
+                }
                 this.onTermDidClose.fire(this);
                 this.onTermDidClose.dispose();
             }
@@ -181,7 +185,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         /* Get the CSS properties of <html> (aka :root in css).  */
         const htmlElementProps = getComputedStyle(document.documentElement);
 
-        const fontFamily = lookup(htmlElementProps, '--theia-code-font-family');
+        const fontFamily = lookup(htmlElementProps, '--theia-terminal-font-family');
         const fontSizeStr = lookup(htmlElementProps, '--theia-code-font-size');
         const foreground = lookup(htmlElementProps, '--theia-ui-font-color1');
         const background = lookup(htmlElementProps, '--theia-layout-color0');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,6 +99,9 @@
       ],
       "@theia/bunyan/lib/*": [
         "packages/bunyan/src/*"
+      ],
+      "@theia/console/lib/*": [
+        "packages/console/src/*"
       ]
     },
     "plugins": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -694,6 +694,10 @@ amdefine@>=0.0.4, amdefine@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+anser@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.7.tgz#78c0ce6aefffaa09bed267bd7d26ee5b9fb6d575"
+
 ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"


### PR DESCRIPTION
![console](https://user-images.githubusercontent.com/3082655/46472762-81412f00-c7de-11e8-8bdc-4d13b6869f32.gif)

TODO:
- [x] input history
- [x] ANSI-output pretty-rendering
- [x] render variables tree
- [x] variables pretty-rendering
- [x] expressions pretty-rendering
- [x] theming
- [x] ~figure out whether it's worth to have more than one~ - decided to go with a simple approach with one console and adjust it when real use cases come up
- [x] multiline input handling
- [x] context menu
  - [x] clear
  - [x] copy
  - [x] ~copy all~ select all
  - [x] collapse all
- [x] evaluate expressions with a proper stack frame
- [x] monospace font
- [x] keyboard navigation to traverse variables
- [x] tree resizing issues
- [x] input context menu should not be trimmed
- [x] if any content widget, as suggest, is opened then on enter execute should not be available
- [x] widget title styling
- [x] completion support
- [x] run in terminals support
- [x] telemetry logging

Follow-up TODO:
- [ ] output source rendering & navigation
- [ ] links detection
- [ ] editor: evaluate selection
- [ ] indentation based output grouping