### PR TITLE
Fix workspace URI long names when a workspace is a prefix of filename, but not actually parent

### DIFF
--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -124,13 +124,25 @@ export interface FileDeleteOptions {
     moveToTrash?: boolean
 }
 
+/**
+ * A callback type, called when we try to save a file but realize it has been
+ * modified by somebody else since we have opened it.  `originalStat` is the
+ * stat at the moment we opened the file, `currentStat` is the stat at the
+ * moment we try to save it (after the externl modification).  The callback
+ * should return true if we still want to save the file, false otherwise.
+ */
+export const FileShouldOverwrite = Symbol('FileShouldOverwrite');
+export interface FileShouldOverwrite {
+    (originalStat: FileStat, currentStat: FileStat): Promise<boolean>;
+}
+
 export interface FileSystemClient {
 
     /**
      * Tests whether the given file can be overwritten
      * in the case if it is out of sync with the given file stat.
      */
-    shouldOverwrite(file: FileStat, stat: FileStat): Promise<boolean>;
+    shouldOverwrite: FileShouldOverwrite;
 
     onDidMove(sourceUri: string, targetUri: string): void;
 

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -29,7 +29,7 @@ import {
     PreferenceService, PreferenceScope,
     PreferenceProviderProvider, PreferenceServiceImpl, PreferenceProvider, bindPreferenceSchemaProvider
 } from '@theia/core/lib/browser/preferences';
-import { FileSystem } from '@theia/filesystem/lib/common/';
+import { FileSystem, FileShouldOverwrite, FileStat } from '@theia/filesystem/lib/common/';
 import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watcher';
 import { FileSystemWatcherServer } from '@theia/filesystem/lib/common/filesystem-watcher-protocol';
 import { FileSystemPreferences, createFileSystemPreferences } from '@theia/filesystem/lib/browser/filesystem-preferences';
@@ -125,6 +125,9 @@ before(async () => {
     testContainer.bind(FileSystemWatcher).toSelf().onActivation((_, watcher) =>
         watcher
     );
+    testContainer.bind(FileShouldOverwrite).toFunction(
+        async (originalStat: FileStat, currentStat: FileStat): Promise<boolean> => true);
+
     testContainer.bind(FileSystem).to(MockFilesystem);
 
     /* Logger mock */

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.spec.ts
@@ -14,10 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
-
-const disableJSDOM = enableJSDOM();
-
 import { Container } from 'inversify';
 import * as chai from 'chai';
 import { UserStorageServiceFilesystemImpl } from './user-storage-service-filesystem';
@@ -26,7 +22,7 @@ import { UserStorageResource } from './user-storage-resource';
 import { Emitter, } from '@theia/core/lib/common';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
-import { FileSystem, FileStat } from '@theia/filesystem/lib/common/';
+import { FileSystem, FileStat, FileShouldOverwrite } from '@theia/filesystem/lib/common/';
 import { FileSystemPreferences, createFileSystemPreferences } from '@theia/filesystem/lib/browser/filesystem-preferences';
 import { FileSystemWatcher, FileChange, FileChangeType } from '@theia/filesystem/lib/browser/filesystem-watcher';
 import { PreferenceService } from '@theia/core/lib/browser/preferences';
@@ -35,8 +31,6 @@ import { FileSystemWatcherServer } from '@theia/filesystem/lib/common/filesystem
 import { MockFilesystem, MockFilesystemWatcherServer } from '@theia/filesystem/lib/common/test';
 import { UserStorageUri } from './user-storage-uri';
 import URI from '@theia/core/lib/common/uri';
-
-disableJSDOM();
 
 import * as sinon from 'sinon';
 
@@ -77,6 +71,8 @@ before(async () => {
         );
         return watcher;
     });
+    testContainer.bind(FileShouldOverwrite).toFunction(
+        async (originalStat: FileStat, currentStat: FileStat): Promise<boolean> => true);
 
     /* Mock logger binding*/
     testContainer.bind(ILogger).to(MockLogger);

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -32,7 +32,7 @@ import { LabelProviderContribution } from '@theia/core/lib/browser/label-provide
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceServer, workspacePath } from '../common';
 import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
-import { WorkspaceService } from './workspace-service';
+import { WorkspaceService, IWorkspaceService } from './workspace-service';
 import { WorkspaceCommandContribution, FileMenuContribution } from './workspace-commands';
 import { WorkspaceVariableContribution } from './workspace-variable-contribution';
 import { WorkspaceStorageService } from './workspace-storage-service';
@@ -45,6 +45,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bindWorkspacePreferences(bind);
 
     bind(WorkspaceService).toSelf().inSingletonScope();
+    bind(IWorkspaceService).toService(WorkspaceService);
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceService));
     bind(WorkspaceServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
-import { FileSystemWatcher, FileChangeEvent } from '@theia/filesystem/lib/browser';
+import { FileSystemWatcher, FileChangeEvent } from '@theia/filesystem/lib/browser/filesystem-watcher';
 import { WorkspaceServer } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
@@ -29,6 +29,11 @@ import * as Ajv from 'ajv';
 
 export const THEIA_EXT = 'theia-workspace';
 export const VSCODE_EXT = 'code-workspace';
+
+export const IWorkspaceService = Symbol('IWorkspaceService');
+export interface IWorkspaceService {
+    roots: Promise<FileStat[]>;
+}
 
 /**
  * The workspace service.

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WorkspaceUriLabelProviderContribution } from './workspace-uri-contribution';
+import { Container, ContainerModule, injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { IWorkspaceService } from './workspace-service';
+import { FileStat, FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { expect } from 'chai';
+import { MockFilesystem } from '@theia/filesystem/lib/common/test';
+
+let labelProvider: WorkspaceUriLabelProviderContribution;
+
+@injectable()
+class MockWorkspaceService implements IWorkspaceService {
+    get roots(): Promise<FileStat[]> {
+        const stat: FileStat = {
+            uri: 'file:///workspace',
+            lastModification: 0,
+            isDirectory: true,
+        };
+        return Promise.resolve([stat]);
+    }
+}
+
+beforeEach(function() {
+
+    const module = new ContainerModule(bind => {
+        bind(WorkspaceUriLabelProviderContribution).toSelf().inSingletonScope();
+        bind(IWorkspaceService).to(MockWorkspaceService).inSingletonScope();
+        bind(FileSystem).to(MockFilesystem);
+    });
+    const container = new Container();
+    container.load(module);
+    labelProvider = container.get(WorkspaceUriLabelProviderContribution);
+});
+
+describe('getLongName', function() {
+    it('should trim workspace for a file in workspace', function() {
+        const file = new URI('file:///workspace/some/very-long/path.js');
+        const longName = labelProvider.getLongName(file);
+        expect(longName).eq('some/very-long/path.js');
+    });
+
+    it('should not trim workspace for a file not in workspace', function() {
+        const file = new URI('file:///tmp/prout.txt');
+        const longName = labelProvider.getLongName(file);
+        expect(longName).eq('/tmp/prout.txt');
+    });
+
+    it('should not trim workspace for a file not in workspace 2', function() {
+        // Test with a path that is textually a prefix of the workspace,
+        // but is not really a child in the filesystem.
+        const file = new URI('file:///workspace-2/jacques.doc');
+        const longName = labelProvider.getLongName(file);
+        expect(longName).eq('/workspace-2/jacques.doc');
+    });
+});


### PR DESCRIPTION
See commit messages for details.