### PR TITLE
Add methods to unregister menu, command and keybinding contributions

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -55,6 +55,11 @@ export namespace Keybinding {
         const keyCodesString = keybinding.keybinding.split(' ');
         return KeySequence.acceleratorFor(keyCodesString.map(k => KeyCode.parse(k)), separator);
     }
+
+    /* Determine whether object is a KeyBinding */
+    export function is(arg: Keybinding | any): arg is Keybinding {
+        return !!arg && 'command' in arg && 'keybinding' in arg;
+    }
 }
 
 export interface Keybinding {
@@ -163,6 +168,31 @@ export class KeybindingRegistry {
      */
     registerKeybindings(...bindings: Keybinding[]): void {
         this.doRegisterKeybindings(bindings, KeybindingScope.DEFAULT);
+    }
+
+    /**
+     * Unregister keybinding from the registry
+     *
+     * @param binding
+     */
+    unregisterKeybinding(binding: Keybinding): void;
+    /**
+     * Unregister keybinding from the registry
+     *
+     * @param key
+     */
+    unregisterKeybinding(key: string): void;
+    unregisterKeybinding(keyOrBinding: Keybinding | string): void {
+        const key = Keybinding.is(keyOrBinding) ? keyOrBinding.keybinding : keyOrBinding;
+        const keymap = this.keymaps[KeybindingScope.DEFAULT];
+        const bindings = keymap.filter(el => el.keybinding === key);
+
+        bindings.forEach(binding => {
+            const idx = keymap.indexOf(binding);
+            if (idx >= 0) {
+                keymap.splice(idx, 1);
+            }
+        });
     }
 
     protected doRegisterKeybindings(bindings: Keybinding[], scope: KeybindingScope = KeybindingScope.DEFAULT) {

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -37,6 +37,14 @@ export interface Command {
      */
     iconClass?: string;
 }
+
+export namespace Command {
+    /* Determine whether object is a Command */
+    export function is(arg: Command | any): arg is Command {
+        return !!arg && 'id' in arg;
+    }
+}
+
 /**
  * A command handler is an implementation of a command.
  *
@@ -134,6 +142,26 @@ export class CommandRegistry implements CommandService {
                 delete this._commands[command.id];
             }
         };
+    }
+
+    /**
+     * Unregister command from the registry
+     *
+     * @param command
+     */
+    unregisterCommand(command: Command): void;
+    /**
+     * Unregister command from the registry
+     *
+     * @param id
+     */
+    unregisterCommand(id: string): void;
+    unregisterCommand(commandOrId: Command | string): void {
+        const id = Command.is(commandOrId) ? commandOrId.id : commandOrId;
+
+        if (this._commands[id]) {
+            delete this._commands[id];
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR introduces functionality to allow a plugin developer to unregister existing menus, commands or key bindings.

An example of how this works:

```typescript
import { injectable } from 'inversify';
import { CommandRegistry } from '@theia/core';
import { WorkspaceCommands } from '@theia/workspace/lib/browser';
import { MenuContribution, MenuModelRegistry, CommandContribution } from '@theia/core/lib/common';
import { KeybindingContribution, KeybindingRegistry, CommonCommands } from '@theia/core/lib/browser';

@injectable()
export class RemovalContribution implements CommandContribution, MenuContribution, KeybindingContribution {

    public registerCommands(commandRegistry: CommandRegistry): void {
        commandRegistry.unregisterCommand(CommonCommands.ABOUT_COMMAND);
    }

    public registerMenus(menus: MenuModelRegistry): void {
        menus.unregisterMenuAction(CommonCommands.ABOUT_COMMAND);
        menus.unregisterMenuAction(WorkspaceCommands.OPEN_RECENT_WORKSPACE);
        menus.unregisterMenuAction(WorkspaceCommands.OPEN_WORKSPACE);
        menus.unregisterMenuAction(WorkspaceCommands.CLOSE);
    }

    public registerKeybindings(keybindings: KeybindingRegistry): void {
        keybindings.unregisterKeybinding('f1');
    }
}
```

@svenefftinge 
