### PR TITLE
Fix node debug attachment to non-default port

### DIFF
--- a/packages/debug-nodejs/package.json
+++ b/packages/debug-nodejs/package.json
@@ -4,6 +4,7 @@
   "description": "Theia - NodeJS Debug Extension",
   "dependencies": {
     "@theia/debug": "^0.3.15",
+    "ps-list": "5.0.1",
     "vscode-debugprotocol": "^1.26.0",
     "unzip-stream": "^0.3.0"
   },

--- a/packages/debug-nodejs/src/node/debug-nodejs.ts
+++ b/packages/debug-nodejs/src/node/debug-nodejs.ts
@@ -14,15 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-const path = require('path');
-const packageJson = require('../../package.json');
-const debugAdapterDir = packageJson['debugAdapter']['dir'] + '/extension';
-
 import { injectable } from 'inversify';
 import { DebugConfiguration } from '@theia/debug/lib/common/debug-common';
 import { DebugAdapterContribution, DebugAdapterExecutable } from '@theia/debug/lib/node/debug-model';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { getSchemaAttributes } from './package-json-parser';
+
+const path = require('path');
+const packageJson = require('../../package.json');
+const debugAdapterDir = packageJson['debugAdapter']['dir'] + '/extension';
+const psList = require('ps-list');
+const DEBUG_PORT_PATTERN = /--(inspect|debug)-port=(\d+)/;
+const DEFAULT_PROTOCOL = 'inspector';
+const DEFAULT_INSPECTOR_PORT = 9229;
 
 @injectable()
 export class NodeJsDebugAdapterContribution implements DebugAdapterContribution {
@@ -31,27 +35,56 @@ export class NodeJsDebugAdapterContribution implements DebugAdapterContribution 
     provideDebugConfigurations = [{
         type: this.debugType,
         request: 'attach',
-        name: 'Attach by PID',
+        name: 'Debug (Attach)',
         processId: ''
     }];
 
     getSchemaAttributes(): Promise<IJSONSchema[]> {
         return getSchemaAttributes(path.join(__dirname, `../../${debugAdapterDir}`), this.debugType);
     }
-
-    resolveDebugConfiguration(config: DebugConfiguration): DebugConfiguration {
+    async resolveDebugConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
         if (!config.request) {
             throw new Error('Debug request type is not provided.');
         }
 
-        return config;
+        switch (config.request) {
+            case 'attach': return this.resolveAttachConfiguration(config);
+            case 'launch': return this.resolveLaunchConfiguration(config);
+        }
+
+        throw new Error(`Unknown request type ${config.request}`);
     }
 
-    provideDebugAdapterExecutable(config: DebugConfiguration): DebugAdapterExecutable {
+    async provideDebugAdapterExecutable(config: DebugConfiguration): Promise<DebugAdapterExecutable> {
         const program = path.join(__dirname, `../../${debugAdapterDir}/out/src/nodeDebug.js`);
         return {
             program,
             runtime: 'node'
         };
+    }
+
+    private async resolveLaunchConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
+        return config;
+    }
+
+    private async resolveAttachConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
+        config.protocol = DEFAULT_PROTOCOL;
+        config.port = DEFAULT_INSPECTOR_PORT;
+
+        const pidToDebug = Number.parseInt(config.processId);
+
+        const tasks: [{ pid: number, cmd: string }] = await psList();
+        const taskToDebug = tasks.find(task => task.pid === pidToDebug);
+        if (taskToDebug) {
+            const matches = DEBUG_PORT_PATTERN.exec(taskToDebug.cmd);
+            if (matches && matches.length === 3) {
+                config.port = parseInt(matches[2]);
+                config.protocol = matches[1] === 'debug' ? 'legacy' : 'inspector';
+            }
+        }
+
+        delete config.processId;
+
+        return config;
     }
 }

--- a/packages/debug/src/node/debug-model.ts
+++ b/packages/debug/src/node/debug-model.ts
@@ -132,7 +132,7 @@ export interface DebugAdapterContribution {
      * @param config The [debug configuration](#DebugConfiguration) to resolve.
      * @returns The resolved debug configuration.
      */
-    resolveDebugConfiguration(config: DebugConfiguration): DebugConfiguration;
+    resolveDebugConfiguration(config: DebugConfiguration): Promise<DebugConfiguration>;
 
     /**
      * Provides a [debug adapter executable](#DebugAdapterExecutable)
@@ -141,5 +141,5 @@ export interface DebugAdapterContribution {
      * @param config The resolved [debug configuration](#DebugConfiguration).
      * @returns The [debug adapter executable](#DebugAdapterExecutable).
      */
-    provideDebugAdapterExecutable(config: DebugConfiguration): DebugAdapterExecutable;
+    provideDebugAdapterExecutable(config: DebugConfiguration): Promise<DebugAdapterExecutable>;
 }

--- a/packages/debug/src/node/debug-service.ts
+++ b/packages/debug/src/node/debug-service.ts
@@ -56,7 +56,7 @@ export class DebugAdapterContributionRegistry {
      * @param debugType The registered debug type
      * @returns An array of [debug configurations](#DebugConfiguration)
      */
-    provideDebugConfigurations(debugType: string): DebugConfiguration[] {
+    async provideDebugConfigurations(debugType: string): Promise<DebugConfiguration[]> {
         const contrib = this.contribs.get(debugType);
         if (contrib) {
             return contrib.provideDebugConfigurations;
@@ -83,7 +83,7 @@ export class DebugAdapterContributionRegistry {
      * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
      * @returns The resolved debug configuration.
      */
-    resolveDebugConfiguration(config: DebugConfiguration): DebugConfiguration {
+    async resolveDebugConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
         const contrib = this.contribs.get(config.type);
         if (contrib) {
             return contrib.resolveDebugConfiguration(config);
@@ -97,7 +97,7 @@ export class DebugAdapterContributionRegistry {
      * @param config The resolved [debug configuration](#DebugConfiguration).
      * @returns The [debug adapter executable](#DebugAdapterExecutable).
      */
-    provideDebugAdapterExecutable(config: DebugConfiguration): DebugAdapterExecutable {
+    async provideDebugAdapterExecutable(config: DebugConfiguration): Promise<DebugAdapterExecutable> {
         const contrib = this.contribs.get(config.type);
         if (contrib) {
             return contrib.provideDebugAdapterExecutable(config);
@@ -139,14 +139,14 @@ export class DebugAdapterSessionManager {
      * @param config The [DebugConfiguration](#DebugConfiguration)
      * @returns The debug adapter session
      */
-    create(config: DebugConfiguration): DebugAdapterSession {
+    async create(config: DebugConfiguration): Promise<DebugAdapterSession> {
         const sessionId = UUID.uuid4();
 
         let communicationProvider;
         if ('debugServer' in config) {
             communicationProvider = this.debugAdapterFactory.connect(config.debugServer);
         } else {
-            const executable = this.registry.provideDebugAdapterExecutable(config);
+            const executable = await this.registry.provideDebugAdapterExecutable(config);
             communicationProvider = this.debugAdapterFactory.start(executable);
         }
 
@@ -216,7 +216,7 @@ export class DebugServiceImpl implements DebugService, MessagingService.Contribu
     }
 
     async provideDebugConfigurations(debugType: string): Promise<DebugConfiguration[]> {
-        return this.registry.provideDebugConfigurations(debugType);
+        return await this.registry.provideDebugConfigurations(debugType);
     }
 
     getSchemaAttributes(debugType: string): Promise<IJSONSchema[]> {
@@ -224,11 +224,11 @@ export class DebugServiceImpl implements DebugService, MessagingService.Contribu
     }
 
     async resolveDebugConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
-        return this.registry.resolveDebugConfiguration(config);
+        return await this.registry.resolveDebugConfiguration(config);
     }
 
     async create(config: DebugConfiguration): Promise<string> {
-        const session = this.sessionManager.create(config);
+        const session = await this.sessionManager.create(config);
         return session.id;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,6 +2924,18 @@ csstype@^2.2.0:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.6.tgz#2ae1db2319642d8b80a668d2d025c6196071e788"
 
+csv-parser@^1.6.0:
+  version "1.12.1"
+  resolved "http://registry.npmjs.org/csv-parser/-/csv-parser-1.12.1.tgz#391e1ef961b1f9dcb4c7c0f82eb450a1bd916158"
+  dependencies:
+    buffer-alloc "^1.1.0"
+    buffer-from "^1.0.0"
+    generate-function "^1.0.1"
+    generate-object-property "^1.0.0"
+    inherits "^2.0.1"
+    minimist "^1.2.0"
+    ndjson "^1.4.0"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4180,6 +4192,16 @@ gaze@~1.1.2:
   dependencies:
     globule "^1.0.0"
 
+generate-function@^1.0.1:
+  version "1.1.0"
+  resolved "http://registry.npmjs.org/generate-function/-/generate-function-1.1.0.tgz#54c21b080192b16d9877779c5bb81666e772365f"
+
+generate-object-property@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  dependencies:
+    is-property "^1.0.0"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -4210,7 +4232,7 @@ get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
-get-stream@^2.2.0:
+get-stream@^2.1.0, get-stream@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
   dependencies:
@@ -4936,6 +4958,12 @@ interpret@^1.0.0, interpret@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
+into-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-2.0.1.tgz#db9b003694453eae091d8a5c84cc11507b781d31"
+  dependencies:
+    from2 "^2.1.1"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -5156,6 +5184,10 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-property@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -6505,6 +6537,23 @@ ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
+ndjson@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-1.5.0.tgz#ae603b36b134bcec347b452422b0bf98d5832ec8"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    minimist "^1.2.0"
+    split2 "^2.1.0"
+    through2 "^2.0.3"
+
+neat-csv@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/neat-csv/-/neat-csv-2.1.0.tgz#06f58360c4c3b955bd467ddc85ae4511a3907a4c"
+  dependencies:
+    csv-parser "^1.6.0"
+    get-stream "^2.1.0"
+    into-stream "^2.0.0"
+
 needle@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.2.tgz#1120ca4c41f2fcc6976fd28a8968afe239929418"
@@ -7621,6 +7670,13 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
+ps-list@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ps-list/-/ps-list-5.0.1.tgz#3b2588cc291a8f2bd610d519002cfc64a88c99fd"
+  dependencies:
+    pify "^3.0.0"
+    tasklist "^3.1.0"
+
 ps-tree@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
@@ -8432,6 +8488,10 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
+sec@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sec/-/sec-1.0.0.tgz#033d60a3ad20ecf2e00940d14f97823465774335"
+
 seek-bzip@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
@@ -8817,7 +8877,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split2@^2.0.0:
+split2@^2.0.0, split2@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
   dependencies:
@@ -9148,6 +9208,14 @@ tar@^4, tar@^4.0.0, tar@^4.0.2:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+tasklist@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/tasklist/-/tasklist-3.1.1.tgz#84cb49f8359b9ed0451dd1d9b6111da18107dbd5"
+  dependencies:
+    neat-csv "^2.1.0"
+    pify "^2.2.0"
+    sec "^1.0.0"
+
 tdigest@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.1.tgz#2e3cb2c39ea449e55d1e6cd91117accca4588021"
@@ -9231,7 +9299,7 @@ through2@2.0.1:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.2, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do?
Detects port and puts it in the configuration to attach. Otherwise the default port is used.

### Reference issue
https://github.com/theia-ide/theia/issues/2829

### CQ
~~https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17675~~
https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17853