### PR TITLE
[WIP] GH-2965 Using the preview widget to have a text replacement

### DIFF
--- a/packages/preview/src/browser/preview-frontend-module.ts
+++ b/packages/preview/src/browser/preview-frontend-module.ts
@@ -44,7 +44,7 @@ export default new ContainerModule(bind => {
             const { container } = ctx;
             const resource = await container.get<ResourceProvider>(ResourceProvider)(new URI(options.uri));
             const child = container.createChild();
-            child.bind<PreviewWidgetOptions>(PreviewWidgetOptions).toConstantValue({ resource });
+            child.bind<PreviewWidgetOptions>(PreviewWidgetOptions).toConstantValue({ resource, container });
             return child.get(PreviewWidget);
         }
     })).inSingletonScope();


### PR DESCRIPTION
Create a file in the workspace root call catalog.json
The data in entered as key / value
Open a .md file.  The key used in the .md file is {{ key }}.
Then the data will be replaced by the value found in the catalog.json file.

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
