### PR TITLE
Disable git history for files which are not in current repository.

### DIFF
--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -94,7 +94,7 @@
 
 .theia-git .commitFileList .theia-header {
     margin-top: 5px;
-} 
+}
 
 .theia-git .commitTime {
     color: var(--theia-ui-font-color2);
@@ -130,7 +130,7 @@
     animation: showFrames ease-out 0.2s forwards;
     -webkit-animation: showFrames ease-out 0.2s forwards;
   }
-  
+
   @keyframes showFrames{
     0% {
       opacity:0;
@@ -141,14 +141,14 @@
       bottom:0px;
     }
   }
-  
+
 .theia-git .git-diff-container .history-lazy-loading.hide {
     bottom: 80px;
     opacity:1;
     animation: hideFrames ease-out 0.2s forwards;
     -webkit-animation: hideFrames ease-out 0.2s forwards;
   }
-  
+
   @keyframes hideFrames{
     0% {
       opacity:1;
@@ -197,20 +197,20 @@
     height: 20px;
 }
 
-.no-history-message {
+.theia-git .no-history-message {
     background-color: var(--theia-warn-color0) !important;
     color: var(--theia-warn-font-color0);
     padding: 5px;
 }
 
-.no-history-message div {
+.theia-git .no-history-message div {
     margin: 5px;
 }
 
-.message-container {
+.theia-git .message-container {
     height: 100%;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
 }
 


### PR DESCRIPTION
For files which are not in current repository the context navigation to git history is disabled. 
However, files which are in the same directory but not under version control (like node_modules) get a message in git history widget:
<img width="446" alt="screen shot 2018-09-27 at 14 47 02" src="https://user-images.githubusercontent.com/28291421/46146908-3ebea600-c264-11e8-9d14-facf7369a32b.png">

Fixes #2977

  