### PR TITLE
task-server test: Remove setting of process.argv

### DIFF
--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -55,8 +55,6 @@ describe('Task server / back-end', function () {
     let taskWatcher: TaskWatcher;
 
     beforeEach(async () => {
-        process.argv.push(`--root-dir=${wsRoot}`);
-
         const testContainer = createTaskTestContainer();
         taskWatcher = testContainer.get(TaskWatcher);
         taskServer = testContainer.get(TaskServer);
@@ -65,7 +63,6 @@ describe('Task server / back-end', function () {
     });
 
     afterEach(() => {
-        process.argv.pop();
         taskServer = undefined!;
         taskWatcher = undefined!;
         const s = server;


### PR DESCRIPTION
I believe that this modification of process.argv is not useful.  I
tried to change the --root-dir value to a random directory, and the test
still passes.

What hinted me is that the code that consumes process.argv in Theia is
the CliManager class, but it is not even instantiated during these
tests.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
