### PR TITLE
[plug-in] Languages API - Register formatting provider that works on type

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -649,6 +649,13 @@ export interface LanguagesExt {
     $provideHover(handle: number, resource: UriComponents, position: Position): Promise<Hover | undefined>;
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents, options: FormattingOptions): Promise<ModelSingleEditOperation[] | undefined>;
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range, options: FormattingOptions): Promise<ModelSingleEditOperation[] | undefined>;
+    $provideOnTypeFormattingEdits(
+        handle: number,
+        resource: UriComponents,
+        position: Position,
+        ch: string,
+        options: FormattingOptions
+    ): Promise<ModelSingleEditOperation[] | undefined>;
 }
 
 export interface LanguagesMain {
@@ -664,6 +671,7 @@ export interface LanguagesMain {
     $changeDiagnostics(id: string, delta: [UriComponents, MarkerData[]][]): void;
     $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerRangeFormattingProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+    $registerOnTypeFormattingProvider(handle: number, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -50,9 +50,10 @@ import { SignatureHelpAdapter } from './languages/signature';
 import { HoverAdapter } from './languages/hover';
 import { DocumentFormattingAdapter } from './languages/document-formatting';
 import { RangeFormattingAdapter } from './languages/range-formatting';
+import { OnTypeFormattingAdapter } from './languages/on-type-formatting';
 import { DefinitionAdapter } from './languages/definition';
 
-type Adapter = CompletionAdapter | SignatureHelpAdapter | HoverAdapter | DocumentFormattingAdapter | RangeFormattingAdapter | DefinitionAdapter;
+type Adapter = CompletionAdapter | SignatureHelpAdapter | HoverAdapter | DocumentFormattingAdapter | RangeFormattingAdapter | OnTypeFormattingAdapter | DefinitionAdapter;
 
 export class LanguagesExtImpl implements LanguagesExt {
 
@@ -242,6 +243,22 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, RangeFormattingAdapter, adapter => adapter.provideDocumentRangeFormattingEdits(URI.revive(resource), range, options));
     }
     // ### Document Range Formatting Edit end
+
+    // ### On Type Formatting Edit begin
+    registerOnTypeFormattingEditProvider(
+        selector: theia.DocumentSelector,
+        provider: theia.OnTypeFormattingEditProvider,
+        triggerCharacters: string[]
+    ): theia.Disposable {
+        const callId = this.addNewAdapter(new OnTypeFormattingAdapter(provider, this.documents));
+        this.proxy.$registerOnTypeFormattingProvider(callId, this.transformDocumentSelector(selector), triggerCharacters);
+        return this.createDisposable(callId);
+    }
+
+    $provideOnTypeFormattingEdits(handle: number, resource: UriComponents, position: Position, ch: string, options: FormattingOptions): Promise<SingleEditOperation[] | undefined> {
+        return this.withAdapter(handle, OnTypeFormattingAdapter, adapter => adapter.provideOnTypeFormattingEdits(URI.revive(resource), position, ch, options));
+    }
+    // ### On Type Formatting Edit end
 
 }
 

--- a/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import * as Converter from '../type-converters';
+import URI from 'vscode-uri/lib/umd';
+import { FormattingOptions, SingleEditOperation } from '../../api/model';
+import { Position } from '../../api/plugin-api';
+
+export class OnTypeFormattingAdapter {
+
+    constructor(
+        private readonly provider: theia.OnTypeFormattingEditProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    provideOnTypeFormattingEdits(resource: URI, position: Position, ch: string, options: FormattingOptions): Promise<SingleEditOperation[] | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There are no document for ${resource}`));
+        }
+
+        const doc = document.document;
+        const pos = Converter.toPosition(position);
+
+        return Promise.resolve(this.provider.provideOnTypeFormattingEdits(doc, pos, ch, <any>options, undefined)).then(value => {
+            if (Array.isArray(value)) {
+                return value.map(Converter.fromTextEdit);
+            }
+            return undefined;
+        });
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -312,7 +312,15 @@ export function createAPIFactory(rpc: RPCProtocol, pluginManager: PluginManager)
             },
             registerDocumentRangeFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentRangeFormattingEditProvider): theia.Disposable {
                 return languagesExt.registerDocumentRangeFormattingEditProvider(selector, provider);
-            }
+            },
+            registerOnTypeFormattingEditProvider(
+                selector: theia.DocumentSelector,
+                provider: theia.OnTypeFormattingEditProvider,
+                firstTriggerCharacter: string,
+                ...moreTriggerCharacters: string[]
+            ): theia.Disposable {
+                return languagesExt.registerOnTypeFormattingEditProvider(selector, provider, [firstTriggerCharacter].concat(moreTriggerCharacters));
+            },
         };
 
         const plugins: typeof theia.plugins = {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3698,6 +3698,35 @@ declare module '@theia/plugin' {
         [key: string]: boolean | number | string;
     }
 
+    /**
+     * The document formatting provider interface defines the contract between extensions and
+     * the formatting-feature.
+     */
+    export interface OnTypeFormattingEditProvider {
+
+        /**
+         * Provide formatting edits after a character has been typed.
+         *
+         * The given position and character should hint to the provider
+         * what range the position to expand to, like find the matching `{`
+         * when `}` has been entered.
+         *
+         * @param document The document in which the command was invoked.
+         * @param position The position at which the command was invoked.
+         * @param ch The character that has been typed.
+         * @param options Options controlling formatting.
+         * @param token A cancellation token.
+         * @return A set of text edits or a thenable that resolves to such. The lack of a result can be
+         * signaled by returning `undefined`, `null`, or an empty array.
+         */
+        provideOnTypeFormattingEdits(document: TextDocument,
+            position: Position,
+            ch: string,
+            options: FormattingOptions,
+            token: CancellationToken | undefined
+        ): ProviderResult<TextEdit[] | undefined>;
+    }
+
     export namespace languages {
         /**
          * Return the identifiers of all known languages.
@@ -3869,6 +3898,26 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerDocumentRangeFormattingEditProvider(selector: DocumentSelector, provider: DocumentRangeFormattingEditProvider): Disposable;
+
+        /**
+         * Register a formatting provider that works on type. The provider is active when the user enables the setting `editor.formatOnType`.
+         *
+         * Multiple providers can be registered for a language. In that case providers are sorted
+         * by their [score](#languages.match) and the best-matching provider is used. Failure
+         * of the selected provider will cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider An on type formatting edit provider.
+         * @param firstTriggerCharacter A character on which formatting should be triggered, like `}`.
+         * @param moreTriggerCharacter More trigger characters.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerOnTypeFormattingEditProvider(
+            selector: DocumentSelector,
+            provider: OnTypeFormattingEditProvider,
+            firstTriggerCharacter: string,
+            ...moreTriggerCharacter: string[]
+        ): Disposable;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

This PR adds the ability to register a formatting provider that works on type.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
