### PR TITLE
Add guard against null or undefined values in variable graphs

### DIFF
--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -50,6 +50,9 @@ export class VariableResolverService {
     }
 
     protected doResolve(value: Object | undefined, context: VariableResolverService.Context): Object | undefined {
+        if (value === undefined || value === null) {
+            return value;
+        }
         if (typeof value === 'string') {
             return this.doResolveString(value, context);
         }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Split from #3000 

While developing the debug adapter, we found that object trees with undefined values failed to pass through the variable resolver. This PR fixes that.