### PR TITLE
 Make it possible to pass process args when starting a backend

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -50,9 +50,13 @@ function load(raw) {
     )
 }
 
-function start(port, host) {
+function start(port, host, argv) {
+    if (argv === undefined) {
+        argv = process.argv;
+    }
+
     const cliManager = container.get(CliManager);
-    return cliManager.initializeCli().then(function () {
+    return cliManager.initializeCli(argv).then(function () {
         const application = container.get(BackendApplication);
         application.use(express.static(path.join(__dirname, '../../lib'), {
             index: 'index.html'
@@ -61,8 +65,8 @@ function start(port, host) {
     });
 }
 
-module.exports = (port, host) => Promise.resolve()${this.compileBackendModuleImports(backendModules)}
-    .then(() => start(port, host)).catch(reason => {
+module.exports = (port, host, argv) => Promise.resolve()${this.compileBackendModuleImports(backendModules)}
+    .then(() => start(port, host, argv)).catch(reason => {
         console.error('Failed to start the backend application.');
         if (reason) {
             console.error(reason);

--- a/examples/browser/test/left-panel/left-panel.ts
+++ b/examples/browser/test/left-panel/left-panel.ts
@@ -46,8 +46,8 @@ export class LeftPanel {
             && this.isPanelVisible());
     }
 
-    waitForFilesView(): void {
-        this.driver.waitForExist('#files');
+    waitForFilesViewVisible(): void {
+        this.driver.waitForVisible('#files');
         // Wait for animations to finish
         this.driver.pause(300);
     }
@@ -57,8 +57,8 @@ export class LeftPanel {
             && this.isPanelVisible());
     }
 
-    waitForGitView(): void {
-        this.driver.waitForExist('#theia-gitContainer');
+    waitForGitViewVisible(): void {
+        this.driver.waitForVisible('#theia-gitContainer');
         // Wait for animations to finish
         this.driver.pause(300);
     }
@@ -67,8 +67,8 @@ export class LeftPanel {
         return this.driver.isExisting('#extensions') && (this.driver.element('#extensions').getAttribute('class').split(' ').indexOf('theia-extensions') !== -1);
     }
 
-    waitForExtensionsView(): void {
-        this.driver.waitForExist('#extensions');
+    waitForExtensionsViewVisible(): void {
+        this.driver.waitForVisible('#extensions');
         // Wait for animations to finish
         this.driver.pause(300);
     }
@@ -78,8 +78,8 @@ export class LeftPanel {
             && this.isPanelVisible());
     }
 
-    waitForGitHistoryView(): void {
-        this.driver.waitForExist('#git-history');
+    waitForGitHistoryViewVisible(): void {
+        this.driver.waitForVisible('#git-history');
         // Wait for animations to finish
         this.driver.pause(300);
     }
@@ -88,8 +88,8 @@ export class LeftPanel {
         return this.driver.isExisting('.p-Widget div.theia-output') && this.driver.element('#plugins').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1;
     }
 
-    waitForPluginsView(): void {
-        this.driver.waitForExist('#plugins');
+    waitForPluginsViewVisible(): void {
+        this.driver.waitForVisible('#plugins');
         // Wait for animations to finish
         this.driver.pause(300);
     }
@@ -98,8 +98,8 @@ export class LeftPanel {
         return this.driver.isExisting('#search-in-workspace') && this.driver.element('#search-in-workspace').getAttribute('class').split(' ').indexOf('p-mod-hidden') === -1;
     }
 
-    waitForSearchView(): void {
-        this.driver.waitForExist('#search-in-workspace');
+    waitForSearchViewVisible(): void {
+        this.driver.waitForVisible('#search-in-workspace');
         // Wait for animations to finish
         this.driver.pause(300);
     }

--- a/examples/browser/test/right-panel/right-panel.ts
+++ b/examples/browser/test/right-panel/right-panel.ts
@@ -45,8 +45,8 @@ export class RightPanel {
         return (this.isPanelVisible() && this.driver.isExisting('#outline-view'));
     }
 
-    waitForOutlineView(): void {
-        this.driver.waitForExist('#outline-view');
+    waitForOutlineViewVisible(): void {
+        this.driver.waitForVisible('#outline-view');
         // Wait for animations to finish
         this.driver.pause(300);
     }

--- a/examples/browser/test/top-panel/top-panel.ui-spec.ts
+++ b/examples/browser/test/top-panel/top-panel.ui-spec.ts
@@ -121,7 +121,7 @@ describe('theia top panel (menubar)', () => {
         it('extensions view should toggle-on then toggle-off', () => {
             if (!leftPanel.isExtensionsContainerVisible()) {
                 topPanel.toggleExtensionsView();
-                leftPanel.waitForExtensionsView();
+                leftPanel.waitForExtensionsViewVisible();
             }
             expect(leftPanel.isExtensionsContainerVisible()).to.be.true;
             topPanel.toggleExtensionsView();
@@ -136,7 +136,7 @@ describe('theia top panel (menubar)', () => {
         it('files view should toggle-on then toggle-off', () => {
             if (!leftPanel.isFileTreeVisible()) {
                 topPanel.toggleFilesView();
-                leftPanel.waitForFilesView();
+                leftPanel.waitForFilesViewVisible();
             }
             expect(leftPanel.isFileTreeVisible()).to.be.true;
             topPanel.toggleFilesView();
@@ -152,7 +152,7 @@ describe('theia top panel (menubar)', () => {
         it('git view should toggle-on then toggle-off', () => {
             if (!leftPanel.isGitContainerVisible()) {
                 topPanel.toggleGitView();
-                leftPanel.waitForGitView();
+                leftPanel.waitForGitViewVisible();
             }
             expect(leftPanel.isGitContainerVisible()).to.be.true;
             topPanel.toggleGitView();
@@ -170,7 +170,7 @@ describe('theia top panel (menubar)', () => {
         it.skip('git history view should toggle-on then toggle-off', () => {
             if (!leftPanel.isGitHistoryContainerVisible()) {
                 topPanel.toggleGitHistoryView();
-                leftPanel.waitForGitHistoryView();
+                leftPanel.waitForGitHistoryViewVisible();
             }
             expect(leftPanel.isGitHistoryContainerVisible()).to.be.true;
             topPanel.toggleGitHistoryView();
@@ -192,7 +192,7 @@ describe('theia top panel (menubar)', () => {
         it('outline view should toggle-on then toggle-off', () => {
             if (!rightPanel.isOutlineViewVisible()) {
                 topPanel.toggleOutlineView();
-                rightPanel.waitForOutlineView();
+                rightPanel.waitForOutlineViewVisible();
             }
             expect(rightPanel.isOutlineViewVisible()).to.be.true;
 
@@ -251,7 +251,7 @@ describe('theia top panel (menubar)', () => {
         it('search view should toggle-on then toggle-off', () => {
             if (!leftPanel.isSearchViewVisible()) {
                 topPanel.toggleSearchView();
-                leftPanel.waitForSearchView();
+                leftPanel.waitForSearchViewVisible();
             }
             expect(leftPanel.isSearchViewVisible()).to.be.true;
             topPanel.toggleSearchView();

--- a/packages/core/src/node/cli.spec.ts
+++ b/packages/core/src/node/cli.spec.ts
@@ -20,21 +20,10 @@ import { CliManager, CliContribution } from './cli';
 import { Deferred } from '../common/promise-util';
 
 class TestCliManager extends CliManager {
-
-    args: string[];
-
     constructor(...contribs: CliContribution[]) {
         super({
             getContributions() { return contribs; }
         });
-    }
-
-    setArgs(...args: string[]) {
-        this.args = args;
-    }
-
-    getArgs() {
-        return this.args;
     }
 }
 
@@ -54,8 +43,7 @@ describe('CliManager', () => {
                 value.resolve(args['foo']);
             }
         });
-        mnr.setArgs('-f', 'bla');
-        await mnr.initializeCli();
+        await mnr.initializeCli(['-f', 'bla']);
         chai.assert.equal(await value.promise, 'bla');
     });
 
@@ -70,16 +58,14 @@ describe('CliManager', () => {
                 value.resolve(args['bar']);
             }
         });
-        mnr.setArgs('--foo');
-        await mnr.initializeCli();
+        await mnr.initializeCli(['--foo']);
         chai.assert.equal(await value.promise, 'my-default');
     });
 
     it('prints help and exits', async () =>
         await assertExits(async () => {
             const mnr = new TestCliManager();
-            mnr.setArgs('--help');
-            await mnr.initializeCli();
+            await mnr.initializeCli(['--help']);
         })
     );
 });

--- a/packages/core/src/node/cli.ts
+++ b/packages/core/src/node/cli.ts
@@ -35,7 +35,7 @@ export class CliManager {
     constructor(@inject(ContributionProvider) @named(CliContribution)
     protected readonly contributionsProvider: ContributionProvider<CliContribution>) { }
 
-    async initializeCli(): Promise<void> {
+    async initializeCli(argv: string[]): Promise<void> {
         const pack = require('../../package.json');
         const version = pack.version;
         const command = yargs.version(version);
@@ -47,14 +47,10 @@ export class CliManager {
             .detectLocale(false)
             .showHelpOnFail(false, 'Specify --help for available options')
             .help('help')
-            .parse(this.getArgs());
+            .parse(argv);
         for (const contrib of this.contributionsProvider.getContributions()) {
             await contrib.setArguments(args);
         }
-    }
-
-    protected getArgs() {
-        return process.argv;
     }
 
     protected isExit(): boolean {

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -55,8 +55,6 @@ describe('Task server / back-end', function () {
     let taskWatcher: TaskWatcher;
 
     beforeEach(async () => {
-        process.argv.push(`--root-dir=${wsRoot}`);
-
         const testContainer = createTaskTestContainer();
         taskWatcher = testContainer.get(TaskWatcher);
         taskServer = testContainer.get(TaskServer);
@@ -65,7 +63,6 @@ describe('Task server / back-end', function () {
     });
 
     afterEach(() => {
-        process.argv.pop();
         taskServer = undefined!;
         taskWatcher = undefined!;
         const s = server;


### PR DESCRIPTION
When doing some tests that require starting a backend (in particular the
UI tests, but not only them), we sometimes need to pass arguments to
that backend.  Right now, the only way is to modify process.argv, but
it's fragile because we don't know yet what is there in the first place
(it's the arguments to the test process).

This patch makes it possible to pass args to the backend start
function.  In the normal case, we pass process.argv, but in the tests,
we can pass an arbitrary array.