### PR TITLE
[cpp-debug] Add C/C++ Debug Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
   - packages/bunyan/node_modules
   - packages/callhierarchy/node_modules
   - packages/core/node_modules
+  - packages/cpp-debug/node_modules
   - packages/cpp/node_modules
   - packages/debug-nodejs/node_modules
   - packages/debug/node_modules

--- a/packages/cpp-debug/README.md
+++ b/packages/cpp-debug/README.md
@@ -1,0 +1,16 @@
+# Theia - C/C++ Debugging
+
+In order to use the C/C++ Debugger and correctly attach to a program, you need to have GDB
+installed on your system. Also make sure that your OS configuration allows you to attach to
+processes. One way to troubleshoot this is to try and use GDB and see if it works: `gdb -p <pid>`.
+If something went wrong GDB might tell you the instructions to follow.
+
+Under Ubuntu it would require you to set `/proc/sys/kernel/yama/ptrace_scope` to 0:
+
+```sh
+echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+```
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/cpp-debug/compile.tsconfig.json
+++ b/packages/cpp-debug/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/cpp-debug/data/cpp-debug-configuration-schema.json
+++ b/packages/cpp-debug/data/cpp-debug-configuration-schema.json
@@ -1,0 +1,260 @@
+{
+  "launch": {
+    "required": [
+      "target"
+    ],
+    "properties": {
+      "target": {
+        "type": "string",
+        "description": "Path of executable"
+      },
+      "arguments": {
+        "type": "string",
+        "description": "Arguments to append after the executable. You can also use pipes."
+      },
+      "terminal": {
+        "type": "string",
+        "description": "Leave this field undefined to keep program output in the vscode console at the bottom. If this is set to empty string the program will spawn in a new console using x-terminal-emulator on linux, otherwise with the specified terminal. On windows setting this to an empty string spawns the program in a console, but no other console is supported."
+      },
+      "cwd": {
+        "type": "string",
+        "description": "Path of project"
+      },
+      "gdbpath": {
+        "type": "string",
+        "description": "Path to the gdb executable or the command if in PATH",
+        "default": "gdb"
+      },
+      "env": {
+        "type": "object",
+        "description": "Environment overriding the gdb (and in turn also the process) environment",
+        "default": null
+      },
+      "debugger_args": {
+        "type": "array",
+        "description": "Additional arguments to pass to GDB",
+        "default": []
+      },
+      "valuesFormatting": {
+        "type": "string",
+        "description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+        "default": "parseText",
+        "enum": [
+          "disabled",
+          "parseText",
+          "prettyPrinters"
+        ]
+      },
+      "printCalls": {
+        "type": "boolean",
+        "description": "Prints all GDB calls to the console",
+        "default": false
+      },
+      "showDevDebugOutput": {
+        "type": "boolean",
+        "description": "Prints all GDB responses to the console",
+        "default": false
+      },
+      "autorun": {
+        "type": "array",
+        "description": "GDB commands to run when starting to debug",
+        "default": []
+      },
+      "ssh": {
+        "required": [
+          "host",
+          "cwd",
+          "user"
+        ],
+        "type": "object",
+        "description": "If this is set then the extension will connect to an ssh host and run GDB there",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Remote host name/ip to connect to"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Path of project on the remote"
+          },
+          "port": {
+            "type": "number",
+            "description": "Remote port number",
+            "default": 22
+          },
+          "user": {
+            "type": "string",
+            "description": "Username to connect as"
+          },
+          "password": {
+            "type": "string",
+            "description": "Plain text password (unsafe; if possible use keyfile instead)"
+          },
+          "keyfile": {
+            "type": "string",
+            "description": "Absolute path to private key"
+          },
+          "useAgent": {
+            "type": "boolean",
+            "description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
+            "default": false
+          },
+          "forwardX11": {
+            "type": "boolean",
+            "description": "If true, the server will redirect x11 to the local host",
+            "default": true
+          },
+          "x11port": {
+            "type": "number",
+            "description": "Port to redirect X11 data to (by default port = display + 6000)",
+            "default": 6000
+          },
+          "x11host": {
+            "type": "string",
+            "description": "Hostname/ip to redirect X11 data to",
+            "default": "localhost"
+          },
+          "remotex11screen": {
+            "type": "number",
+            "description": "Screen to start the application on the remote side",
+            "default": 0
+          },
+          "bootstrap": {
+            "type": "string",
+            "description": "Content will be executed on the SSH host before the debugger call."
+          }
+        }
+      }
+    }
+  },
+  "attach": {
+    "required": [
+      "target"
+    ],
+    "properties": {
+      "target": {
+        "type": "string",
+        "description": "PID of running program or program name or connection arguments (eg :2345) if remote is true"
+      },
+      "remote": {
+        "type": "boolean",
+        "description": "If true this will connect to a gdbserver instead of attaching to a PID",
+        "default": false
+      },
+      "valuesFormatting": {
+        "type": "string",
+        "description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+        "default": "parseText",
+        "enum": [
+          "disabled",
+          "parseText",
+          "prettyPrinters"
+        ]
+      },
+      "printCalls": {
+        "type": "boolean",
+        "description": "Prints all GDB calls to the console",
+        "default": false
+      },
+      "showDevDebugOutput": {
+        "type": "boolean",
+        "description": "Prints all GDB responses to the console",
+        "default": false
+      },
+      "executable": {
+        "type": "string",
+        "description": "Path of executable for debugging symbols"
+      },
+      "gdbpath": {
+        "type": "string",
+        "description": "Path to the gdb executable or the command if in PATH",
+        "default": "gdb"
+      },
+      "env": {
+        "type": "object",
+        "description": "Environment overriding the gdb (and in turn also the process) environment",
+        "default": null
+      },
+      "debugger_args": {
+        "type": "array",
+        "description": "Additional arguments to pass to GDB",
+        "default": []
+      },
+      "cwd": {
+        "type": "string",
+        "description": "Path of project",
+        "default": "${workspaceRoot}"
+      },
+      "autorun": {
+        "type": "array",
+        "description": "GDB commands to run when starting to debug",
+        "default": []
+      },
+      "ssh": {
+        "required": [
+          "host",
+          "cwd",
+          "user"
+        ],
+        "type": "object",
+        "description": "If this is set then the extension will connect to an ssh host and run GDB there",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "Remote host name/ip to connect to"
+          },
+          "cwd": {
+            "type": "string",
+            "description": "Path of project on the remote"
+          },
+          "port": {
+            "type": "number",
+            "description": "Remote port number",
+            "default": 22
+          },
+          "user": {
+            "type": "string",
+            "description": "Username to connect as"
+          },
+          "password": {
+            "type": "string",
+            "description": "Plain text password (unsafe; if possible use keyfile instead)"
+          },
+          "keyfile": {
+            "type": "string",
+            "description": "Absolute path to private key"
+          },
+          "useAgent": {
+            "type": "boolean",
+            "description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
+            "default": false
+          },
+          "forwardX11": {
+            "type": "boolean",
+            "description": "If true, the server will redirect x11 to the local host",
+            "default": true
+          },
+          "x11port": {
+            "type": "number",
+            "description": "Port to redirect X11 data to (by default port = display + 6000)",
+            "default": 6000
+          },
+          "x11host": {
+            "type": "string",
+            "description": "Hostname/ip to redirect X11 data to",
+            "default": "localhost"
+          },
+          "remotex11screen": {
+            "type": "number",
+            "description": "Screen to start the application on the remote side",
+            "default": 0
+          },
+          "bootstrap": {
+            "type": "string",
+            "description": "Content will be executed on the SSH host before the debugger call."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@theia/cpp",
+  "name": "@theia/cpp-debug",
   "version": "0.3.15",
-  "description": "Theia - Cpp Extension",
+  "description": "Theia - Cpp Debug Extension",
   "dependencies": {
     "@theia/core": "^0.3.15",
     "@theia/editor": "^0.3.15",
@@ -15,8 +15,7 @@
     "access": "public"
   },
   "theiaExtensions": [{
-    "frontend": "lib/browser/cpp-frontend-module",
-    "backend": "lib/node/cpp-backend-module"
+    "backend": "lib/node/cpp-debug-backend-module"
   }],
   "keywords": [
     "theia-extension"
@@ -26,6 +25,7 @@
     "type": "git",
     "url": "https://github.com/theia-ide/theia.git"
   },
+
   "bugs": {
     "url": "https://github.com/theia-ide/theia/issues"
   },
@@ -38,7 +38,7 @@
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
     "clean": "theiaext clean",
-    "build": "theiaext build",
+    "build": "concurrently -n download,build -c red,blue \"node ./scripts/download-code-debug.js\" \"theiaext build\"",
     "watch": "theiaext watch",
     "test": "theiaext test",
     "docs": "theiaext docs"
@@ -48,5 +48,9 @@
   },
   "nyc": {
     "extends": "../../configs/nyc.json"
+  },
+  "debugAdapter": {
+    "downloadUrl": "https://github.com/marechal-p/code-debug/releases/download/v0.22.0/code-debug.tar.gz",
+    "dir": "lib/adapter"
   }
 }

--- a/packages/cpp-debug/scripts/download-code-debug.js
+++ b/packages/cpp-debug/scripts/download-code-debug.js
@@ -1,0 +1,97 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+const fs = require('fs');
+const https = require('https');
+const http = require('http');
+const path = require('path');
+const zlib = require('zlib');
+const tar = require('tar');
+const mkdirp = require('mkdirp');
+const packageJson = require('../package.json');
+const downloadUrl = packageJson['debugAdapter']['downloadUrl'];
+const downloadPath = path.join(__dirname, '../node_modules/download');
+const archivePath = path.join(downloadPath, path.basename(downloadUrl));
+const targetPath = packageJson['debugAdapter']['dir'];
+
+function downloadDap() {
+    return new Promise((resolve, reject) => {
+        if (fs.existsSync(archivePath)) {
+            resolve();
+            return;
+        }
+
+        if (!fs.existsSync(downloadPath)) {
+            fs.mkdirSync(downloadPath);
+        }
+
+        const file = fs.createWriteStream(archivePath);
+        const downloadWithRedirect = url => {
+            const h = url.toString().startsWith('https') ? https : http;
+            h.get(url, response => {
+                const statusCode = response.statusCode;
+                const redirectLocation = response.headers.location;
+                if (statusCode >= 300 && statusCode < 400 && redirectLocation) {
+                    console.log('Redirect location: ' + redirectLocation);
+                    downloadWithRedirect(redirectLocation);
+                } else if (statusCode === 200) {
+                    response.on('end', () => resolve());
+                    response.on('error', e => {
+                        file.destroy();
+                        reject(e);
+                    });
+                    response.pipe(file);
+                } else {
+                    file.destroy();
+                    reject(new Error(`Failed to download 'VSCode Cpp Debug' with error code: ${statusCode}`));
+                }
+            })
+        };
+
+        downloadWithRedirect(downloadUrl);
+    });
+}
+
+decompressArchive = function () {
+    return new Promise((resolve, reject) => {
+        if (!fs.existsSync(archivePath)) {
+            reject(new Error(`The archive was not found at ${archivePath}.`));
+            return;
+        }
+
+        if (!fs.existsSync(targetPath)) {
+            mkdirp.sync(targetPath);
+        }
+
+        const gunzip = zlib.createGunzip({
+            finishFlush: zlib.Z_SYNC_FLUSH,
+            flush: zlib.Z_SYNC_FLUSH
+        });
+        const untar = tar.x({
+            cwd: targetPath
+        });
+        fs.createReadStream(archivePath).pipe(gunzip).pipe(untar)
+            .on('error', e => reject(e))
+            .on('end', () => resolve());
+    });
+}
+
+downloadDap().then(() => {
+    decompressArchive();
+}).catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/packages/cpp-debug/src/node/cpp-debug-backend-module.ts
+++ b/packages/cpp-debug/src/node/cpp-debug-backend-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { DebugAdapterContribution } from '@theia/debug/lib/node/debug-model';
+import { GdbDebugAdapterContribution } from './cpp-debug-contribution';
+
+export default new ContainerModule(bind => {
+    bind(DebugAdapterContribution).to(GdbDebugAdapterContribution).inSingletonScope();
+});

--- a/packages/cpp-debug/src/node/cpp-debug-contribution.ts
+++ b/packages/cpp-debug/src/node/cpp-debug-contribution.ts
@@ -1,0 +1,153 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+const path = require('path');
+const packageJson = require('../../../package.json');
+const debugAdapterDir = packageJson['debugAdapter']['dir'];
+
+import { injectable } from 'inversify';
+import { DebugConfiguration } from '@theia/debug/lib/common/debug-common';
+import { DebugAdapterContribution, DebugAdapterExecutable } from '@theia/debug/lib/node/debug-model';
+import * as Ajv from 'ajv';
+
+export const CppDebugConfigurationSchema = require('../../../data/cpp-debug-configuration-schema.json');
+export namespace cppDebugConfigurationValidators {
+    export const Launch = new Ajv().compile(CppDebugConfigurationSchema['launch']);
+    export const Attach = new Ajv().compile(CppDebugConfigurationSchema['attach']);
+}
+
+@injectable()
+export class GdbDebugAdapterContribution implements DebugAdapterContribution {
+
+    readonly debugType = 'gdb';
+    readonly filePatterns = [
+        '[.]c$',
+        '[.]cpp$',
+        '[.]d$',
+        '[.]objective-c$',
+        '[.]fortran$',
+        '[.]fortran-modern$',
+        '[.]fortran90$',
+        '[.]fortran_free-form$',
+        '[.]fortran_fixed-form$',
+        '[.]rust$',
+        '[.]pascal$',
+        '[.]objectpascal$',
+        '[.]ada$',
+        '[.]nim$',
+        '[.]arm$',
+        '[.]asm$',
+        '[.]vala$',
+        '[.]crystal$',
+    ];
+
+    provideDebugConfigurations = [
+        {
+            type: 'gdb',
+            request: 'launch',
+            name: 'Launch Program',
+            target: './bin/executable',
+            cwd: '${workspaceFolder}',
+            valuesFormatting: 'parseText'
+        },
+        {
+            type: 'gdb',
+            request: 'attach',
+            name: 'Attach to PID',
+            target: '${pid}',
+            cwd: '${workspaceFolder}',
+            valuesFormatting: 'parseText'
+        },
+        {
+            type: 'gdb',
+            request: 'attach',
+            name: 'Attach to gdbserver',
+            executable: './bin/executable',
+            target: ':2345',
+            remote: true,
+            cwd: '${workspaceFolder}',
+            valuesFormatting: 'parseText'
+        },
+        {
+            type: 'gdb',
+            request: 'launch',
+            name: 'Launch Program (SSH)',
+            target: '/bin/executable',
+            cwd: '${workspaceFolder}',
+            ssh: {
+                host: '127.0.0.1',
+                cwd: '/home/remote_user/project/',
+                keyfile: '/home/my_user/.ssh/id_rsa',
+                user: 'remote_user'
+            }
+        },
+        {
+            type: 'gdb',
+            request: 'launch',
+            name: 'Launch Program (SSH + X11)',
+            target: './bin/executable',
+            cwd: '${workspaceFolder}',
+            ssh: {
+                host: '127.0.0.1',
+                cwd: '/home/remote_user/project/',
+                keyfile: 'home/my_user/.ssh/id_rsa',
+                user: 'remote_user',
+                forwardX11: true,
+                x11host: 'localhost',
+                x11port: 6000
+            }
+        },
+        {
+            type: 'gdb',
+            request: 'launch',
+            name: 'Debug Microcontroller',
+            target: 'extended-remote /dev/cu.usbmodem00000000',
+            executable: './bin/executable.elf',
+            cwd: '${workspaceFolder}',
+            autorun: [
+                'monitor tpwr enable',
+                'monitor swdp_scan',
+                'attach 1',
+                'load ./bin/executable.elf'
+            ]
+        }
+    ];
+
+    resolveDebugConfiguration(config: DebugConfiguration): DebugConfiguration {
+
+        switch (config.request) {
+            case 'launch': return this.validateConfiguration(cppDebugConfigurationValidators.Launch, config);
+            case 'attach': return this.validateConfiguration(cppDebugConfigurationValidators.Attach, config);
+        }
+
+        throw new Error(`unknown request: "${config.request}"`);
+    }
+
+    protected validateConfiguration(validator: Ajv.ValidateFunction, config: DebugConfiguration): DebugConfiguration {
+        if (!validator(config)) {
+            throw new Error(validator.errors!.map(e => e.message).join(' // '));
+        }
+        return config;
+    }
+
+    provideDebugAdapterExecutable(config: DebugConfiguration): DebugAdapterExecutable {
+        const program = path.join(__dirname, `../../../${debugAdapterDir}/out/src/gdb.js`);
+        return {
+            program,
+            runtime: 'node',
+        };
+    }
+}

--- a/packages/cpp-debug/src/package.spec.ts
+++ b/packages/cpp-debug/src/package.spec.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+describe('bunyan package', () => {
+
+    it('support code coverage statistics', () => true);
+
+});


### PR DESCRIPTION
This extension relies on `code-debug`, which expect you to have GDB installed on your system.

https://github.com/WebFreak001/code-debug
https://www.gnu.org/software/gdb/

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
