### PR TITLE
Initial version of workbench extension with 'Open in Terminal' context menu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ cache:
   - packages/typescript/node_modules
   - packages/userstorage/node_modules
   - packages/variable-resolver/node_modules
+  - packages/workbench/node_modules
   - packages/workspace/node_modules
 # end_cache_directories
 branches:

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -41,6 +41,7 @@
     "@theia/typescript": "^0.3.15",
     "@theia/userstorage": "^0.3.15",
     "@theia/variable-resolver": "^0.3.15",
+    "@theia/workbench": "^0.3.15",
     "@theia/workspace": "^0.3.15"
   },
   "scripts": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -44,6 +44,7 @@
     "@theia/typescript": "^0.3.15",
     "@theia/userstorage": "^0.3.15",
     "@theia/variable-resolver": "^0.3.15",
+    "@theia/workbench": "^0.3.15",
     "@theia/workspace": "^0.3.15"
   },
   "scripts": {

--- a/packages/workbench/README.md
+++ b/packages/workbench/README.md
@@ -1,0 +1,7 @@
+# Theia - Workbench Extension
+
+See [here](https://www.theia-ide.org/doc/index.html) for a detailed documentation.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/workbench/compile.tsconfig.json
+++ b/packages/workbench/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/workbench/package.json
+++ b/packages/workbench/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/workbench",
+  "version": "0.3.15",
+  "description": "Theia - Workbench Extension",
+  "dependencies": {
+    "@theia/core": "^0.3.15",
+    "@theia/filesystem": "^0.3.15",
+    "@theia/navigator": "^0.3.15",
+    "@theia/terminal": "^0.3.15"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/workbench-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test",
+    "docs": "theiaext docs"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.3.15"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/workbench/src/browser/workbench-frontend-contribution.ts
+++ b/packages/workbench/src/browser/workbench-frontend-contribution.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import {
+    CommandContribution,
+    Command,
+    CommandRegistry,
+    MenuContribution,
+    MenuModelRegistry,
+    SelectionService
+} from '@theia/core/lib/common';
+import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
+import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import URI from '@theia/core/lib/common/uri';
+
+export namespace WorkbenchCommands {
+    export const WORKBENCH_TERMINAL: Command = {
+        id: 'workbench:terminal',
+        label: 'Open in Terminal'
+    };
+}
+
+@injectable()
+export class WorkbenchFrontendContribution implements CommandContribution, MenuContribution {
+
+    constructor(
+        @inject(TerminalService) protected readonly terminal: TerminalService,
+        @inject(FileSystem) protected readonly fileSystem: FileSystem,
+        @inject(SelectionService) protected readonly selectionService: SelectionService,
+    ) { }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(WorkbenchCommands.WORKBENCH_TERMINAL, new UriAwareCommandHandler<URI>(this.selectionService, {
+            execute: async uri => {
+                // Determine folder path of URI
+                const stat = await this.fileSystem.getFileStat(uri.toString());
+                if (!stat) {
+                    return;
+                }
+                const cwd = (stat.isDirectory) ? uri.toString() : uri.parent.toString();
+
+                // Open terminal
+                const termWidget = await this.terminal.newTerminal({ cwd });
+                termWidget.start();
+                this.terminal.activateTerminal(termWidget);
+            }
+        }));
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction(NavigatorContextMenu.NEW, {
+            commandId: WorkbenchCommands.WORKBENCH_TERMINAL.id
+        });
+    }
+}

--- a/packages/workbench/src/browser/workbench-frontend-module.ts
+++ b/packages/workbench/src/browser/workbench-frontend-module.ts
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule, interfaces } from 'inversify';
+import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
+import { WorkbenchFrontendContribution } from './workbench-frontend-contribution';
+
+export default new ContainerModule((bind: interfaces.Bind) => {
+    bind(WorkbenchFrontendContribution).toSelf().inSingletonScope();
+    for (const identifier of [CommandContribution, MenuContribution]) {
+        bind(identifier).toService(WorkbenchFrontendContribution);
+    }
+});

--- a/packages/workbench/src/package.spec.ts
+++ b/packages/workbench/src/package.spec.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe('workbench package', () => {
+
+    it('support code coverage statistics', () => true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "@theia/workspace/lib/*": [
         "packages/workspace/src/*"
       ],
+      "@theia/workbench/lib/*": [
+        "packages/workbench/src/*"
+      ],
       "@theia/terminal/lib/*": [
         "packages/terminal/src/*"
       ],


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Replacement for #3025 
This PR introduces a new `workbench` extension as discussed in https://github.com/theia-ide/theia/issues/1344

It partially resolves that ticket by exposing an `Open in terminal` context menu on the navigator.

<img width="312" alt="screen shot 2018-09-28 at 21 58 37" src="https://user-images.githubusercontent.com/61341/46235926-6a30b600-c374-11e8-9d62-b77aecd1d6c7.png">
