### PR TITLE
Add no-implicit-dependencies tslint rule

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -11,6 +11,39 @@
       "severity": "warning",
       "options": true
     },
+    "no-implicit-dependencies": {
+      "severity": "warning",
+      "options": [
+        true,
+        [
+          "@phosphor/algorithm",
+          "@phosphor/commands",
+          "@phosphor/coreutils",
+          "@phosphor/domutils",
+          "@phosphor/dragdrop",
+          "@phosphor/messaging",
+          "@phosphor/properties",
+          "@phosphor/signaling",
+          "@phosphor/virtualdom",
+          "@phosphor/widgets",
+          "chai",
+          "chai-string",
+          "inversify",
+          "jsdom",
+          "monaco-languageclient",
+          "react",
+          "react-dom",
+          "react-virtualized",
+          "sinon",
+          "temp",
+          "typescript",
+          "vscode-languageserver-protocol",
+          "vscode-languageserver-types",
+          "vscode-ws-jsonrpc",
+          "yargs"
+        ]
+      ]
+    },
     "no-return-await": {
       "severity": "warning",
       "options": true


### PR DESCRIPTION
This rule requires that if a package imports something from another
package, the latter must be present in the former's dependency list, in
the package.json.

Currently, it's possible to use something in package A from a package C
that was pulled in indirectly by another package B.  When trying to make
an application with A but not B, it's possible that C will not get
pulled in (because nothing in that application explicitly requires it)
and we get a build error.

Another typical mistake is to use "import ... from '@theia/foo'" from
source code in the @theia/foo extension.  In my experience, this may
cause some strange build failures, so it's better to use relative
imports in that case.

Using the no-implicit-dependencies tslint rule will prevent these two
kinds of mistakes.

Note that I whitelisted inversify (meaning it's not necessary to specify
it each the package.json file of each package), because it's so central
to Theia's design that it's not really possible that @theia/core stops
depending on it any time soon.  Since @theia/core is included in every
application, and that every extension needs inversify, it would just be
redundant to specify it everywhere.

I had to be careful for the version used for two packages:

- @phosphor/widgets 1.5.0: trying to use the latest (1.6.0) would give
  some build failures, I guess they changed their API.  So I used
  "~1.5.0" instead of "^1.5.0" or "^1.6.0".
- vscode-languageserver-protocol: We need to use the same version as
  what monaco-languageclient uses, which is 3.10.x, so I used that
  branch.  Trying to use 3.13.x gives some build failures because the
  types aren't completely compatible between th two versions.

Change-Id: I246937c424ed56a57ffda19567f3927fcdccb57b
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
