### PR TITLE
[debug] Ensure threads are updated when debugger has started

### DIFF
--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -48,14 +48,17 @@ export class DebugThreadsWidget extends VirtualWidget {
         const threadEventListener = (event: DebugProtocol.ThreadEvent) => this.onThreadEvent(event);
         const connectedEventListener = () => this.updateThreads();
         const terminatedEventListener = (event: DebugProtocol.TerminatedEvent) => this.onTerminatedEvent(event);
+        const stoppedEventListener = (event: DebugProtocol.StoppedEvent) => this.onStoppedEvent(event);
 
         this.debugSession.on('thread', threadEventListener);
         this.debugSession.on('configurationDone', connectedEventListener);
         this.debugSession.on('terminated', terminatedEventListener);
+        this.debugSession.on('stopped', stoppedEventListener);
 
         this.toDispose.push(Disposable.create(() => this.debugSession.removeListener('thread', threadEventListener)));
         this.toDispose.push(Disposable.create(() => this.debugSession.removeListener('configurationDone', connectedEventListener)));
         this.toDispose.push(Disposable.create(() => this.debugSession.removeListener('terminated', terminatedEventListener)));
+        this.toDispose.push(Disposable.create(() => this.debugSession.removeListener('stopped', stoppedEventListener)));
 
         if (this.debugSession.state.isConnected) {
             this.updateThreads();
@@ -126,6 +129,10 @@ export class DebugThreadsWidget extends VirtualWidget {
 
     protected onTerminatedEvent(event: DebugProtocol.TerminatedEvent): void {
         this.threads = [];
+    }
+
+    protected onStoppedEvent(event: DebugProtocol.StoppedEvent): void {
+        this.updateThreads();
     }
 
     private onThreadEvent(event: DebugProtocol.ThreadEvent): void {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

In the cortex-debug adapter I encountered a situation where the `runToMain` flag being set tripped some sort of race condition.

It seems that thread events can be raised from the adapter when the threads aren't yet available to be read. This PR ensures that the threads are up to date and visible in the UI when the adapter reports debug is all ready to go.
