### PR TITLE
Enable tslint rules await-promise and no-return-await

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -1,8 +1,10 @@
 {
   "rules": {
+    "await-promise": true,
     "no-any": {
       "severity": "warning",
       "options": true
-    }
+    },
+    "no-return-await": true
   }
 }


### PR DESCRIPTION
We have a few occurences of problems of these types in Theia.  While
they may not constitute bugs, they may be quite misleading.  For
example, doing an "await" on a function that returns void instead of
Promise<void> can make you think that we'll wait for the function to
finish its work before continuing, when in reality it's not the case
(the function may spawn some asynchronous work and return a promise, but
doesn't currently).

Change-Id: Idee435696b9f1d639afcafc63784fc41b39b6efd
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
