### PR TITLE
Plugin api: Add terminal attributes to the terminal widget options

### DIFF
--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -50,7 +50,8 @@ export class TerminalServiceMainImpl implements TerminalServiceMain {
             env: options.env,
             destroyTermOnClose: true,
             useServerTitle: false,
-            id: this.TERM_ID_PREFIX + counter
+            id: this.TERM_ID_PREFIX + counter,
+            attributes: options.attributes
         };
         let id: number;
         try {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2077,7 +2077,7 @@ declare module '@theia/plugin' {
         env?: { [key: string]: string | null };
 
         /**
-         * Terminal attributes. Can be usefull to apply some implementation specific information.
+         * Terminal attributes. Can be useful to apply some implementation specific information.
          */
         attributes?: { [key: string]: string | null };
     }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2075,6 +2075,11 @@ declare module '@theia/plugin' {
          * Environment variables for terminal in format key - value.
          */
         env?: { [key: string]: string | null };
+
+        /**
+         * Terminal attributes. Can be usefull to apply some implementation specific information.
+         */
+        attributes?: { [key: string]: string | null };
     }
 
     /**

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -94,7 +94,7 @@ export interface TerminalWidgetOptions {
     readonly id?: string;
 
     /**
-     * Terminal attributes. Can be usefull to apply some implementation specific information.
+     * Terminal attributes. Can be useful to apply some implementation specific information.
      */
     readonly attributes?: { [key: string]: string | null };
 }

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -92,4 +92,9 @@ export interface TerminalWidgetOptions {
      * Terminal id. Should be unique for all DOM.
      */
     readonly id?: string;
+
+    /**
+     * Terminal attributes. Can be usefull to apply some implementation specific information.
+     */
+    readonly attributes?: { [key: string]: string | null };
 }


### PR DESCRIPTION
Add attributes to the terminal widget options. Attributes can be useful in case if somebody wants to use own implementation terminal and need some specific terminal options for that.

Related issue:
https://github.com/eclipse/che/issues/11235

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

