### PR TITLE
Fix type definition of keybindings widget debounce

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -68,7 +68,7 @@ export class KeybindingWidget extends ReactWidget {
         post: '</match>',
     };
 
-    protected readonly searchKeybindings = debounce(() => this.doSearchKeybindings(), 50);
+    protected readonly searchKeybindings: () => void = debounce(() => this.doSearchKeybindings(), 50);
 
     constructor() {
         super();


### PR DESCRIPTION
Fixed the type definition of `searchKeybindings` so that the compiler can correctly identify its type when used by other extensions

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
