### PR TITLE
Add fs-extra dependency to application-manager

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@theia/application-package": "^0.3.15",
+    "@types/fs-extra": "^4.0.2",
     "bunyan": "^1.8.10",
     "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",
@@ -38,6 +39,7 @@
     "electron-rebuild": "^1.5.11",
     "file-loader": "^1.1.11",
     "font-awesome-webpack": "0.0.5-beta.2",
+    "fs-extra": "^4.0.2",
     "ignore-loader": "^0.1.2",
     "less": "^2.7.2",
     "source-map-loader": "^0.2.1",


### PR DESCRIPTION
application-manager uses fs-extra, but does not explicitly depends on
it.  When trying to create an application with a subset of the Theia
packages, I got some errors because application-manager ended up using
an old version of fs-extra that was brought in by some random package.

Change-Id: I43137b8b8e1ee75a0e5e46295ece56d06f7ae3c6
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
