### PR TITLE
Add missing fuzzy dependency in @theia/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",
     "font-awesome": "^4.7.0",
+    "fuzzy": "^0.1.3",
     "inversify": "^4.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",


### PR DESCRIPTION
The core package uses fuzzy (in browser/tree/fuzzy-search.ts), without
depending on it explicitly. This causes some some problems when trying
to build an application that contains only @theia/core, for example.

Change-Id: I914093c4e8cd18b1cfd164da4d18f78c0faab373
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
