### PR TITLE
Add missing jsonc-parser dependency in workspace

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -9,6 +9,7 @@
     "@types/fs-extra": "^4.0.2",
     "ajv": "^6.5.4",
     "fs-extra": "^4.0.2",
+    "jsonc-parser": "^1.0.1",
     "moment": "^2.21.0",
     "valid-filename": "^2.0.1"
   },


### PR DESCRIPTION
This causes a build failure when trying to build an application with
only the workspace extension.

Change-Id: I5ca2d5a4f50bf945f89d1f270ac8277fc5ee0db9
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
