### PR TITLE
Fix dependencies in @theia/debug

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -7,6 +7,7 @@
     "@theia/editor": "^0.3.15",
     "@theia/filesystem": "^0.3.15",
     "@theia/markers": "^0.3.15",
+    "@theia/messages": "^0.3.15",
     "@theia/monaco": "^0.3.15",
     "@theia/output": "^0.3.15",
     "@theia/process": "^0.3.15",

--- a/packages/debug/src/browser/view/debug-frontend-contribution.ts
+++ b/packages/debug/src/browser/view/debug-frontend-contribution.ts
@@ -29,7 +29,7 @@ import { DebugThreadsWidget } from './debug-threads-widget';
 import { DebugStackFramesWidget } from './debug-stack-frames-widget';
 import { DebugBreakpointsWidget } from './debug-breakpoints-widget';
 import { DebugVariablesWidget } from './debug-variables-widget';
-import { ExtDebugProtocol } from '@theia/debug/src/common/debug-common';
+import { ExtDebugProtocol } from '../../common/debug-common';
 import { Disposable } from '@theia/core';
 import { DebugStyles } from './base/debug-styles';
 import { DebugToolBar } from './debug-toolbar-widget';


### PR DESCRIPTION
It is using @theia/messages, which is missing from the dependency list.
Also, use a relative import to import something from inside the package.

Change-Id: I3363201947efafe962cf4b4bcee935bb2643789c
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
