### PR TITLE
Fixed the 'is' checks in contributions to be aware of primitive types

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -58,7 +58,7 @@ export namespace Keybinding {
 
     /* Determine whether object is a KeyBinding */
     export function is(arg: Keybinding | any): arg is Keybinding {
-        return !!arg && 'command' in arg && 'keybinding' in arg;
+        return !!arg && arg === Object(arg) && 'command' in arg && 'keybinding' in arg;
     }
 }
 

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -41,7 +41,7 @@ export interface Command {
 export namespace Command {
     /* Determine whether object is a Command */
     export function is(arg: Command | any): arg is Command {
-        return !!arg && 'id' in arg;
+        return !!arg && arg === Object(arg) && 'id' in arg;
     }
 }
 

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -29,7 +29,7 @@ export interface MenuAction {
 export namespace MenuAction {
     /* Determine whether object is a MenuAction */
     export function is(arg: MenuAction | any): arg is MenuAction {
-        return !!arg && 'commandId' in arg;
+        return !!arg && arg === Object(arg) && 'commandId' in arg;
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR ensures the `is` functions can handle primitive types such as string when checking for an object type.
