### PR TITLE
GH-3072: Made the `startup-timeout` configurable.

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -35,9 +35,6 @@ const { BackendApplication, CliManager } = require('@theia/core/lib/node');
 const { backendApplicationModule } = require('@theia/core/lib/node/backend-application-module');
 const { messagingBackendModule } = require('@theia/core/lib/node/messaging/messaging-backend-module');
 const { loggerBackendModule } = require('@theia/core/lib/node/logger-backend-module');
-const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');
-
-BackendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.backend.config)});
 
 const container = new Container();
 container.load(backendApplicationModule);
@@ -73,6 +70,9 @@ module.exports = (port, host) => Promise.resolve()${this.compileBackendModuleImp
 
     protected compileMain(backendModules: Map<string, string>): string {
         return `// @ts-check
+const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');
+BackendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.backend.config)});
+
 const serverPath = require('path').resolve(__dirname, 'server');
 const address = require('@theia/core/lib/node/cluster/main').default(serverPath);
 address.then(function (address) {

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -87,14 +87,24 @@ export interface ApplicationConfig {
  * Application configuration for the frontend. The following properties will be injected into the `index.html`.
  */
 export interface FrontendApplicationConfig extends ApplicationConfig {
+
     /**
      * The default theme for the application. If not give, defaults to `dark`. If invalid theme is given, also defaults to `dark`.
      */
     readonly defaultTheme?: string;
+
 }
 
 /**
  * Application configuration for the backend.
  */
 export interface BackendApplicationConfig extends ApplicationConfig {
+
+    /**
+     * The default backend startup timeout in milliseconds. If specified here, then this value will be used as opposed to the default timeout.
+     * If the `--startup-timeout` option is defined, this configuration value has no effect. A negative values will disable the timeout.
+     * For more details, see [`startupTimeoutOption`](MasterProcess#startupTimeoutOption).
+     */
+    readonly startupTimeout?: number;
+
 }

--- a/packages/core/src/node/cluster/main.ts
+++ b/packages/core/src/node/cluster/main.ts
@@ -17,6 +17,7 @@
 import * as cluster from 'cluster';
 import { checkParentAlive } from '../messaging/ipc-protocol';
 import { MasterProcess } from './master-process';
+import { BackendApplicationConfigProvider } from '../backend-application-config-provider';
 
 checkParentAlive();
 
@@ -28,13 +29,16 @@ import yargs = require('yargs');
 const args = yargs.option(MasterProcess.startupTimeoutOption, {
     description: 'The number of milliseconds to wait for the server to start up. Pass a negative number to disable the timeout.',
     type: 'number',
-    default: 5000
+    default: BackendApplicationConfigProvider.get().startupTimeout || MasterProcess.defaultStartupTimeoutOption
 }).help(false).argv;
 const noCluster = args['cluster'] === false;
 const isMaster = !noCluster && cluster.isMaster;
 const development = process.env.NODE_ENV === 'development';
 
 const startupTimeout = args[MasterProcess.startupTimeoutOption] as number;
+if (isMaster) {
+    console.log(`Starting the master backend process ${Number.isInteger(startupTimeout) && startupTimeout > 0 ? `with ${startupTimeout} (ms)` : 'without a'} timeout.`);
+}
 
 if (isMaster && development) {
     // https://github.com/Microsoft/vscode/issues/3201

--- a/packages/core/src/node/cluster/master-process.ts
+++ b/packages/core/src/node/cluster/master-process.ts
@@ -24,7 +24,15 @@ class ProcessError extends Error {
 export type MasterProcessEvent = 'started' | 'restarted' | 'restarting';
 export class MasterProcess extends EventEmitter {
 
+    /**
+     * The option for the backend startup.
+     */
     static startupTimeoutOption = 'startup-timeout';
+
+    /**
+     * The default timeout (in milliseconds) for the backend startup.
+     */
+    static defaultStartupTimeoutOption = 5_000;
 
     protected serverWorker: ServerWorker | undefined;
     protected workerCount: number = 0;


### PR DESCRIPTION
Adjusted the `appProjectPath` for the backend when running from electron.
Replaced the on the fly created application module loader with a function.

Closes: #3072.
Closes: #2624.
Closes: #2992.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Ready for a preview; I am looking for early feedback. With the following application configuration (in the "main" `package.json`), one can disable the timeout:
```json
"theia": {
    "target": "electron",
    "backend": {
      "config": {
        "startupTimeout": -1
      }
    }
  }
```

 - [x] I have to apply the changes manually to the bundled electron application and verify it on Windows and OS X too.