### PR TITLE
Use return value of string.replace

### DIFF
--- a/packages/git/src/browser/blame/blame-decorator.ts
+++ b/packages/git/src/browser/blame/blame-decorator.ts
@@ -158,7 +158,7 @@ export class BlameDecorator implements HoverProvider {
         const when = commitTime.fromNow();
         const contentWidth = BlameDecorator.maxWidth - when.length - 2;
         let content = commit.summary.substring(0, contentWidth + 1);
-        content.replace('\n', '↩︎');
+        content = content.replace('\n', '↩︎');
         if (content.length > contentWidth) {
             let cropAt = content.lastIndexOf(' ', contentWidth - 4);
             if (cropAt < contentWidth / 2) {


### PR DESCRIPTION
The function string.replace does not modify the string in-place, it
returns a new value.  So either this statement should be removed, or
assigned back to content.  I suppose the intention it to modify content,
so I did the latter.

Change-Id: I860e18c5c48f36b7f1adcc2e7dfe31877922b5a8
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
