### PR TITLE
Actually make await-promise and no-return-await warnings

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -1,10 +1,16 @@
 {
   "rules": {
-    "await-promise": true,
+    "await-promise": {
+      "severity": "warning",
+      "options": true
+    },
     "no-any": {
       "severity": "warning",
       "options": true
     },
-    "no-return-await": true
+    "no-return-await": {
+      "severity": "warning",
+      "options": true
+    }
   }
 }


### PR DESCRIPTION
In my previous commit, I forgot that in warnings.tslint.json, we have to
explicitly set the severity of the rules to "warning".  Otherwise, they
are considered errors, due to how tslint inheritance works.

Change-Id: I78d9feab13d2b5f0148073b01595d3d2ad12b6b9
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
