### PR TITLE
Make field readonly

### DIFF
--- a/packages/bunyan/src/node/bunyan-logger-server.ts
+++ b/packages/bunyan/src/node/bunyan-logger-server.ts
@@ -24,7 +24,7 @@ import { ILoggerServer, ILoggerClient, ILogLevelChangedEvent, LogLevel, rootLogg
 export class BunyanLoggerServer implements ILoggerServer {
 
     /* Root logger and all child logger array.  */
-    private loggers = new Map<string, bunyan>();
+    private readonly loggers = new Map<string, bunyan>();
 
     /* Logger client to send notifications to.  */
     private client: ILoggerClient | undefined = undefined;


### PR DESCRIPTION
The loggers field of BunyanLoggerServer is never reassigned, and
therefore can be marked readonly.

Change-Id: Ibb041dd97c7916c5bf4d31163b9b8120c807c91c
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
