### PR TITLE
Make QuickOpenHandler.init return a Promise

### DIFF
--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -19,6 +19,7 @@ import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from './quick-open-model
 import { QuickOpenService, QuickOpenOptions } from './quick-open-service';
 import { Disposable, DisposableCollection } from '../../common/disposable';
 import { ILogger } from '../../common/logger';
+import { MaybePromise } from '../../common/types';
 
 export const QuickOpenContribution = Symbol('QuickOpenContribution');
 /**
@@ -49,7 +50,7 @@ export interface QuickOpenHandler {
      * the quick open widget matches this handler's prefix.
      * Allows to initialize the model with some initial data.
      */
-    init?(): void;
+    init?(): MaybePromise<void>;
 
     /**
      * A model that should be used by the quick open widget when this handler's prefix is used.

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -49,8 +49,6 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         this.quickOpenService.open(this.prefix);
     }
 
-    init(): void { }
-
     getModel(): QuickOpenModel {
         return this;
     }


### PR DESCRIPTION
In PrefixQuickOpenService.setCurrentHandler (line 172), we do an await
on QuickOpenHandler.init.  However, it the interface it doesn't return
a Promise, which Sonar complains about.

Change the interface to actually return a Promise.

Change-Id: I46baf8af0be11bb53fe581894ee3752680f43222
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
