### PR TITLE
Fix comparison of identical expressions

### DIFF
--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -93,7 +93,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
         const linkURI = new URI(link);
         if (!linkURI.path.isAbsolute && (
             !(linkURI.scheme || linkURI.authority) ||
-            (linkURI.scheme === uri.scheme && linkURI.authority === linkURI.authority)
+            (linkURI.scheme === uri.scheme && linkURI.authority === uri.authority)
         )) {
             const resolvedUri = uri.parent.resolve(linkURI.path).withFragment(linkURI.fragment).withQuery(linkURI.query);
             return preview ? PreviewUri.encode(resolvedUri) : resolvedUri;


### PR DESCRIPTION
We are doing:

  linkURI.authority === linkURI.authority

which is always true.  I suppose the intent was to compare
linkURI.authority with uri.authority.

Change-Id: If15bd301105f29a7d07e6055c82c11f2bdb6c531
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
