### PR TITLE
Changed color of selected text.

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -101,6 +101,10 @@ body {
   border-color: var(--theia-accent-color3);
 }
 
+::selection {
+    background: var(--theia-selected-text-background);
+}
+
 .p-Widget:focus {
     border: none;
 }

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -77,7 +77,6 @@ is not optimized for dense, information rich UIs.
   --theia-code-font-family: monospace;
   --theia-ui-padding: 6px;
 
-
   /* Main layout colors (bright to dark)
     ------------------------------------ */
 
@@ -93,7 +92,7 @@ is not optimized for dense, information rich UIs.
   --theia-brand-color1: var(--md-blue-500);
   --theia-brand-color2: var(--md-blue-300);
   --theia-brand-color3: var(--md-blue-100);
-  
+
   /* Secondary Brand colors */
 
   --theia-secondary-brand-color0: var(--md-grey-700);
@@ -123,8 +122,8 @@ is not optimized for dense, information rich UIs.
   --theia-warn-color1: var(--md-amber-400);
   --theia-warn-color2: var(--md-amber-300);
   --theia-warn-color3: var(--md-amber-200);
-  
-  --theia-warn-font-color0: var(--md-grey-900); 
+
+  --theia-warn-font-color0: var(--md-grey-900);
 
   --theia-error-color0: var(--md-red-400);
   --theia-error-color1: var(--md-red-300);
@@ -139,7 +138,7 @@ is not optimized for dense, information rich UIs.
   --theia-success-color3: var(--md-green-50);
 
   --theia-success-font-color0: var(--md-grey-300);
-  
+
   --theia-info-color0: var(--md-cyan-700);
   --theia-info-color1: var(--md-cyan-500);
   --theia-info-color2: var(--md-cyan-300);
@@ -155,7 +154,10 @@ is not optimized for dense, information rich UIs.
   --theia-added-color0: rgba(0, 255, 0, 0.8);
   --theia-removed-color0: rgba(230, 0, 0, 0.8);
   --theia-modified-color0: rgba(0, 100, 150, 0.8);
-  
+
+  /* Background for selected text */
+  --theia-selected-text-background: var(--theia-accent-color3);
+
   /* Colors to highlight words in widgets like tree or editors */
 
   --theia-word-highlight-color0: rgba(168, 172, 148, 0.7);
@@ -209,7 +211,7 @@ is not optimized for dense, information rich UIs.
   /* Expand/collapse element */
   --theia-ui-expand-button-color: var(--theia-accent-color4);
   --theia-ui-expand-button-font-color: var(--theia-ui-font-color1);
-  
+
   /* Dialogs */
   --theia-ui-dialog-header-color: var(--theia-brand-color1);
   --theia-ui-dialog-header-font-color: var(--theia-inverse-ui-font-color0);

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -77,23 +77,22 @@ is not optimized for dense, information rich UIs.
   --theia-code-font-family: monospace;
   --theia-ui-padding: 6px;
 
-
   /* Main layout colors (dark to bright)
     ------------------------------------ */
-  
+
   --theia-layout-color0: #1e1e1e;
   --theia-layout-color1: #262626;
   --theia-layout-color2: #2e2e2e;
   --theia-layout-color3: #303030;
   --theia-layout-color4: #333333;
-  
+
   /* Brand colors */
 
   --theia-brand-color0: var(--md-blue-700);
   --theia-brand-color1: var(--md-blue-500);
   --theia-brand-color2: var(--md-blue-300);
   --theia-brand-color3: var(--md-blue-100);
-  
+
   /* Secondary Brand colors */
 
   --theia-secondary-brand-color0: var(--md-grey-700);
@@ -123,7 +122,7 @@ is not optimized for dense, information rich UIs.
   --theia-warn-color1: var(--md-amber-500);
   --theia-warn-color2: var(--md-amber-400);
   --theia-warn-color3: var(--md-amber-300);
-  
+
   --theia-warn-font-color0: var(--md-grey-900);
 
   --theia-error-color0: var(--md-red-700);
@@ -156,9 +155,11 @@ is not optimized for dense, information rich UIs.
   --theia-removed-color0: rgba(230, 0, 0, 0.8);
   --theia-modified-color0: rgba(0, 100, 150, 0.8);
 
-  
+  /* Background for selected text */
+  --theia-selected-text-background: var(--theia-accent-color2);
+
   /* Colors to highlight words in widgets like tree or editors */
-  
+
   --theia-word-highlight-color0: rgba(81, 92, 106, 0.7);
   --theia-word-highlight-color1: rgba(255, 255, 255, 0.04);
   --theia-word-highlight-match-color0: rgba(234, 92, 0, 0.33);
@@ -210,7 +211,7 @@ is not optimized for dense, information rich UIs.
   /* Expand/collapse element */
   --theia-ui-expand-button-color: black;
   --theia-ui-expand-button-font-color: var(--theia-ui-font-color1);
-  
+
   /* Dialogs */
   --theia-ui-dialog-header-color: var(--theia-brand-color0);
   --theia-ui-dialog-header-font-color: var(--theia-ui-font-color1);


### PR DESCRIPTION
Fixes theia-ide/theia#3071

It is kind of a compromise between Chrome and Firefox. In Firefox the selection color is always a bit brighter.
Firefox:
<img width="285" alt="screen shot 2018-10-04 at 17 24 00" src="https://user-images.githubusercontent.com/28291421/46484697-91ff9e00-c7fa-11e8-85af-5ca0bd2e4c17.png">
Chrome:
<img width="251" alt="screen shot 2018-10-04 at 17 24 26" src="https://user-images.githubusercontent.com/28291421/46484716-99bf4280-c7fa-11e8-8fe0-c589668aa272.png">
