### PR TITLE
Removed inline styles for navigator

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -838,10 +838,6 @@ export namespace TreeWidget {
                 scrollToIndex={scrollToRow}
                 onScroll={handleScroll}
                 tabIndex={-1}
-                style={{
-                    overflowY: 'visible',
-                    overflowX: 'visible'
-                }}
             />;
         }
         protected renderTreeRow: ListRowRenderer = ({ key, index, style }) => {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

As part of #2724, some inline styles were introduced into the navigator layout.

We extend the navigator to add our own toolbox and these CSS changes have affected the layout of our modified navigator.  Removing the styles again fixes our layout issue.

We have tested Theia to confirm removing these styles doesn't break the navigator layout in the electron nor browser versions (chrome and firefox) and the original bug hasn't been re-introduced.

@jbicker Were these styles introduced to support the bug fix?

![screen shot 2018-10-04 at 17 58 03](https://user-images.githubusercontent.com/61341/46491461-b2335b00-c802-11e8-9f05-e04a37d3031b.png)

cc @bogthe
