### PR TITLE
Improve output widget readability

### DIFF
--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -100,16 +100,22 @@ export class OutputWidget extends ReactWidget {
     protected renderLines(): React.ReactNode[] {
         let id = 0;
         const result = [];
+
+        const style: React.CSSProperties = {
+            whiteSpace: 'pre',
+            fontFamily: 'monospace',
+        };
+
         if (this.selectedChannel) {
             for (const text of this.selectedChannel.getLines()) {
-                const lines = text.split(/([\n\r]+)/);
+                const lines = text.split(/[\n\r]+/);
                 for (const line of lines) {
-                    result.push(<div key={id++}>{line}</div>);
+                    result.push(<div style={style} key={id++}>{line}</div>);
                 }
             }
         }
         if (result.length === 0) {
-            result.push(<div key={id++}>{'<no output yet>'}</div>);
+            result.push(<div style={style} key={id++}>{'<no output yet>'}</div>);
         }
         return result;
     }


### PR DESCRIPTION
Because the output view uses renders text as HTML inside a simple div,
any leading whitespace is ignored and any repeated whitespace appears as
just one.  This makes formatted output from tools very difficult to
read.

This patch makes it so whitespaces are rendered by the browser (using
the "white-space: pre" css property).

It also makes the font monospace, since the text we find in the output
widget is most likely to be more readable when using a fixed-width font
(the language server output, for example).

Change-Id: I62b30d5a27222cb0cf851962c5a7aaea2c533ad5
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
