### PR TITLE
Fix boundary check for editor selection range

### DIFF
--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -122,10 +122,10 @@ export class EditorManager extends NavigatableWidgetOpenHandler<EditorWidget> {
 
     protected getSelection(selection: RecursivePartial<Range>): Range | Position | undefined {
         const { start, end } = selection;
-        if (start && start.line !== undefined && start.line >= 0 &&
-            start.character !== undefined && start.character >= 0) {
-            if (end && end.line !== undefined && end.line >= 0 &&
-                end.character !== undefined && end.character >= 0) {
+        if (start && start.line !== undefined && start.line >= -1 &&
+            start.character !== undefined && start.character >= -1) {
+            if (end && end.line !== undefined && end.line >= -1 &&
+                end.character !== undefined && end.character >= -1) {
                 return selection as Range;
             }
             return start as Position;


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR modifies the range boundaries to ensure editor selections are successful for ranges with `column 0` or `line 0`.

The [monaco-languageclient](https://github.com/TypeFox/monaco-languageclient/blob/60fd01d96e9b670df72b0abd0b15fb66b521b411/src/monaco-converter.ts#L879) always adds `+1` to every line and column being selected, but is 0-based.

To counter this, it seems [decrements have been made elsewhere](https://github.com/theia-ide/theia/blob/master/packages/debug/src/browser/debug-utils.ts#L40).

This leads to the possibility of lines or columns being `-1`. However, a selection check exists which only goes down to 0. It doesn't any more. I can't help feeling this whole +1/-1 scenario is a tad messy 😄 
