### PR TITLE
[debug] Minor debug fixes

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -238,7 +238,8 @@ export class BreakpointsManager implements FrontendApplicationContribution {
                 case 'exception':
                 case 'breakpoint':
                 case 'entry':
-                case 'step': {
+                case 'step':
+                case 'user request': {
                     const activeDebugSession = this.debugSessionManager.getActiveDebugSession();
                     if (activeDebugSession && activeDebugSession.sessionId === debugSession.sessionId) {
                         const args: DebugProtocol.StackTraceArguments = {

--- a/packages/debug/src/browser/debug-command.ts
+++ b/packages/debug/src/browser/debug-command.ts
@@ -261,6 +261,10 @@ export class DebugCommandHandlers implements MenuContribution, CommandContributi
             execute: () => {
                 const debugSession = this.debugSessionManager.getActiveDebugSession();
                 if (debugSession) {
+                    const threadId = this.getSelectedThreadId(debugSession.sessionId);
+                    if (threadId) {
+                        debugSession.resume({ threadId });
+                    }
                     debugSession.resumeAll();
                 }
             },
@@ -281,6 +285,10 @@ export class DebugCommandHandlers implements MenuContribution, CommandContributi
             execute: () => {
                 const debugSession = this.debugSessionManager.getActiveDebugSession();
                 if (debugSession) {
+                    const threadId = this.getSelectedThreadId(debugSession.sessionId);
+                    if (threadId) {
+                        debugSession.pause({ threadId });
+                    }
                     debugSession.pauseAll();
                 }
             },

--- a/packages/debug/src/common/debug-common.ts
+++ b/packages/debug/src/common/debug-common.ts
@@ -263,6 +263,7 @@ export class DebugSessionStateAccumulator implements DebugSessionState {
 
         this.allThreadsContinued = body.allThreadsContinued;
         if (this.allThreadsContinued) {
+            this.allThreadsStopped = false;
             this.stoppedThreadIds.clear();
         } else {
             this.stoppedThreadIds.delete(body.threadId);
@@ -273,6 +274,9 @@ export class DebugSessionStateAccumulator implements DebugSessionState {
         const body = event.body;
 
         this.allThreadsStopped = body.allThreadsStopped;
+        if (this.allThreadsStopped) {
+            this.allThreadsContinued = false;
+        }
         if (body.threadId) {
             this.stoppedThreadIds.add(body.threadId);
         }


### PR DESCRIPTION
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

This PR fixes a few minor debug issues:

- Debug `pauseAll()` and `resumeAll()` don't always find threads. Also pause/resume the current known thread
- Support the `user-initiated` reason for debug stops when displaying breakpoints
- Fix debug toolbar resume/suspend button states by resetting the `allTheadXXX` flags