### PR TITLE
[Git] History and Diff don't depend on selected repository anymore

### DIFF
--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -28,6 +28,7 @@ import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import URI from '@theia/core/lib/common/uri';
 import { GIT_RESOURCE_SCHEME } from '../git-resource';
 import { Git } from '../../common';
+import { GitRepositoryProvider } from '../git-repository-provider';
 
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
@@ -46,7 +47,8 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         @inject(GitQuickOpenService) protected readonly quickOpenService: GitQuickOpenService,
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
         @inject(OpenerService) protected openerService: OpenerService,
-        @inject(MessageService) protected readonly notifications: MessageService
+        @inject(MessageService) protected readonly notifications: MessageService,
+        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider
     ) {
         super({
             widgetId: GIT_DIFF,
@@ -80,18 +82,18 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
                         if (fileStat) {
                             if (fileStat.isDirectory) {
                                 this.showWidget(options);
-                            }
-                        } else {
-                            const fromURI = fileUri.withScheme(GIT_RESOURCE_SCHEME).withQuery(fromRevision);
-                            const toURI = fileUri;
-                            const diffUri = DiffUris.encode(fromURI, toURI, fileUri.displayName);
-                            if (diffUri) {
-                                open(this.openerService, diffUri).catch(e => {
-                                    this.notifications.error(e.message);
-                                });
+                            } else {
+                                const fromURI = fileUri.withScheme(GIT_RESOURCE_SCHEME).withQuery(fromRevision);
+                                const toURI = fileUri;
+                                const diffUri = DiffUris.encode(fromURI, toURI, fileUri.displayName);
+                                if (diffUri) {
+                                    open(this.openerService, diffUri).catch(e => {
+                                        this.notifications.error(e.message);
+                                    });
+                                }
                             }
                         }
-                    });
+                    }, this.repositoryProvider.findRepository(fileUri));
             }
         }));
     }

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -72,7 +72,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
 
     async setContent(options: Git.Options.Diff) {
         this.options = options;
-        const repository = this.repositoryProvider.selectedRepository;
+        const repository = this.repositoryProvider.findRepositoryOrSelected(options);
         if (repository) {
             const fileChanges: GitFileChange[] = await this.git.diff(repository, {
                 range: options.range,
@@ -128,6 +128,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
 
     protected renderDiffListHeader(): React.ReactNode {
         return this.doRenderDiffListHeader(
+            this.renderRepositoryHeader(),
             this.renderPathHeader(),
             this.renderRevisionHeader(),
             this.renderToolbar()
@@ -138,15 +139,11 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         return <div className='diff-header'>{...children}</div>;
     }
 
-    protected renderHeaderRow({ name, value, classNames }: { name: string, value: React.ReactNode, classNames?: string[] }): React.ReactNode {
-        if (value === null) {
-            return null;
+    protected renderRepositoryHeader(): React.ReactNode {
+        if (this.options && this.options.uri) {
+            return this.renderHeaderRow({ name: 'repository', value: this.getRepositoryLabel(this.options.uri) });
         }
-        const className = ['header-row', ...(classNames || [])].join(' ');
-        return <div key={name} className={className}>
-            <div className='theia-header'>{name}</div>
-            <div className='header-value'>{value}</div>
-        </div>;
+        return undefined;
     }
 
     protected renderPathHeader(): React.ReactNode {
@@ -160,6 +157,8 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
             const path = this.relativePath(this.options.uri);
             if (path.length > 0) {
                 return '/' + path;
+            } else {
+                return this.labelProvider.getLongName(new URI(this.options.uri));
             }
         }
         return null;

--- a/packages/git/src/browser/git-navigable-list-widget.tsx
+++ b/packages/git/src/browser/git-navigable-list-widget.tsx
@@ -23,6 +23,7 @@ import { Message } from '@phosphor/messaging';
 import { ElementExt } from '@phosphor/domutils';
 import { inject, injectable } from 'inversify';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import * as React from 'react';
 
 @injectable()
 export abstract class GitNavigableListWidget<T extends { selected?: boolean }> extends ReactWidget {
@@ -75,12 +76,18 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
 
     protected relativePath(uri: URI | string): string {
         const parsedUri = typeof uri === 'string' ? new URI(uri) : uri;
-        const repo = this.repositoryProvider.selectedRepository;
+        const repo = this.repositoryProvider.findRepository(parsedUri);
         if (repo) {
             return Repository.relativePath(repo, parsedUri).toString();
         } else {
             return this.labelProvider.getLongName(parsedUri);
         }
+    }
+
+    protected getRepositoryLabel(uri: string): string | undefined {
+        const repository = this.repositoryProvider.findRepository(new URI(uri));
+        const isSelectedRepo = this.repositoryProvider.selectedRepository && repository && this.repositoryProvider.selectedRepository.localUri === repository.localUri;
+        return repository && !isSelectedRepo ? this.labelProvider.getLongName(new URI(repository.localUri)) : undefined;
     }
 
     protected computeCaption(fileChange: GitFileChange): string {
@@ -89,6 +96,17 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
             result = `${this.relativePath(fileChange.oldUri)} -> ${result}`;
         }
         return result;
+    }
+
+    protected renderHeaderRow({ name, value, classNames }: { name: string, value: React.ReactNode, classNames?: string[] }): React.ReactNode {
+        if (!value) {
+            return;
+        }
+        const className = ['header-row', ...(classNames || [])].join(' ');
+        return <div key={name} className={className}>
+            <div className='theia-header'>{name}</div>
+            <div className='header-value'>{value}</div>
+        </div>;
     }
 
     protected addGitListNavigationKeyListeners(container: HTMLElement) {

--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -200,10 +200,10 @@ export class GitQuickOpenService {
         }
     }
 
-    async chooseTagsAndBranches(execFunc: (branchName: string, currentBranchName: string) => void): Promise<void> {
-        const repository = this.getRepository();
+    async chooseTagsAndBranches(execFunc: (branchName: string, currentBranchName: string) => void, repo?: Repository): Promise<void> {
+        const repository = repo || this.getRepository();
         if (repository) {
-            const [branches, tags, currentBranch] = await Promise.all([this.getBranches(), this.getTags(), this.getCurrentBranch()]);
+            const [branches, tags, currentBranch] = await Promise.all([this.getBranches(repository), this.getTags(repository), this.getCurrentBranch(repository)]);
             const execute = async (item: GitQuickOpenItem<Branch | Tag>) => {
                 execFunc(item.ref.name, currentBranch ? currentBranch.name : '');
             };
@@ -283,8 +283,8 @@ export class GitQuickOpenService {
         }
     }
 
-    private async getTags(): Promise<Tag[]> {
-        const repository = this.getRepository();
+    private async getTags(repo?: Repository): Promise<Tag[]> {
+        const repository = repo || this.getRepository();
         if (repository) {
             const result = await this.git.exec(repository, ['tag', '--sort=-creatordate']);
             return result.stdout.trim().split('\n').map(tag => ({ name: tag }));
@@ -292,8 +292,8 @@ export class GitQuickOpenService {
         return [];
     }
 
-    private async getBranches(): Promise<Branch[]> {
-        const repository = this.getRepository();
+    private async getBranches(repo?: Repository): Promise<Branch[]> {
+        const repository = repo || this.getRepository();
         if (!repository) {
             return [];
         }
@@ -309,8 +309,8 @@ export class GitQuickOpenService {
         }
     }
 
-    private async getCurrentBranch(): Promise<Branch | undefined> {
-        const repository = this.getRepository();
+    private async getCurrentBranch(repo?: Repository): Promise<Branch | undefined> {
+        const repository = repo || this.getRepository();
         if (!repository) {
             return undefined;
         }

--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -200,8 +200,7 @@ export class GitQuickOpenService {
         }
     }
 
-    async chooseTagsAndBranches(execFunc: (branchName: string, currentBranchName: string) => void, repo?: Repository): Promise<void> {
-        const repository = repo || this.getRepository();
+    async chooseTagsAndBranches(execFunc: (branchName: string, currentBranchName: string) => void, repository: Repository | undefined = this.getRepository()): Promise<void> {
         if (repository) {
             const [branches, tags, currentBranch] = await Promise.all([this.getBranches(repository), this.getTags(repository), this.getCurrentBranch(repository)]);
             const execute = async (item: GitQuickOpenItem<Branch | Tag>) => {
@@ -283,17 +282,15 @@ export class GitQuickOpenService {
         }
     }
 
-    private async getTags(repo?: Repository): Promise<Tag[]> {
-        const repository = repo || this.getRepository();
+    private async getTags(repository: Repository | undefined = this.getRepository()): Promise<Tag[]> {
         if (repository) {
             const result = await this.git.exec(repository, ['tag', '--sort=-creatordate']);
-            return result.stdout.trim().split('\n').map(tag => ({ name: tag }));
+            return result.stdout !== '' ? result.stdout.trim().split('\n').map(tag => ({ name: tag })) : [];
         }
         return [];
     }
 
-    private async getBranches(repo?: Repository): Promise<Branch[]> {
-        const repository = repo || this.getRepository();
+    private async getBranches(repository: Repository | undefined = this.getRepository()): Promise<Branch[]> {
         if (!repository) {
             return [];
         }
@@ -309,8 +306,7 @@ export class GitQuickOpenService {
         }
     }
 
-    private async getCurrentBranch(repo?: Repository): Promise<Branch | undefined> {
-        const repository = repo || this.getRepository();
+    private async getCurrentBranch(repository: Repository | undefined = this.getRepository()): Promise<Branch | undefined> {
         if (!repository) {
             return undefined;
         }

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -89,8 +89,26 @@ export class GitRepositoryProvider {
     }
 
     findRepository(uri: URI): Repository | undefined {
-        const reposSorted = this._allRepositories ? this._allRepositories.sort((ra: Repository, rb: Repository) => rb.localUri.length - ra.localUri.length) : [];
+        const reposSorted = this._allRepositories ? this._allRepositories.sort(Repository.sortComparator) : [];
         return reposSorted.find(repo => new URI(repo.localUri).isEqualOrParent(uri));
+    }
+
+    findRepositoryOrSelected(arg: URI | string | { uri?: string | URI } | undefined): Repository | undefined {
+        let uri: URI | string | undefined;
+        if (arg) {
+            if (arg instanceof URI || typeof arg === 'string') {
+                uri = arg;
+            } else if (typeof arg === 'object' && 'uri' in arg && arg.uri) {
+                uri = arg.uri;
+            }
+            if (uri) {
+                if (typeof uri === 'string') {
+                    uri = new URI(uri);
+                }
+                return this.findRepository(uri);
+            }
+        }
+        return this.selectedRepository;
     }
 
     async refresh(options?: GitRefreshOptions): Promise<void> {

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -20,6 +20,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
 import { Event, Emitter } from '@theia/core';
 import { LocalStorageService } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
 
 export interface GitRefreshOptions {
     readonly maxCount: number
@@ -85,6 +86,11 @@ export class GitRepositoryProvider {
      */
     get allRepositories(): Repository[] {
         return this._allRepositories || [];
+    }
+
+    findRepository(uri: URI): Repository | undefined {
+        const reposSorted = this._allRepositories ? this._allRepositories.sort((ra: Repository, rb: Repository) => rb.localUri.length - ra.localUri.length) : [];
+        return reposSorted.find(repo => new URI(repo.localUri).isEqualOrParent(uri));
     }
 
     async refresh(options?: GitRefreshOptions): Promise<void> {

--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -91,14 +91,7 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(GitHistoryCommands.OPEN_FILE_HISTORY, this.newUriAwareCommandHandler({
             execute: async uri => this.showWidget(uri.toString()),
-            isEnabled: (uri: URI) => {
-                for (const repo of this.repositoryProvider.allRepositories) {
-                    if (new URI(repo.localUri).isEqualOrParent(uri)) {
-                        return true;
-                    }
-                }
-                return false;
-            }
+            isEnabled: (uri: URI) => !!this.repositoryProvider.findRepository(uri)
         }));
         commands.registerCommand(GitHistoryCommands.OPEN_BRANCH_HISTORY, {
             execute: () => this.showWidget(undefined)

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -23,7 +23,7 @@ import { AutoSizer, List, ListRowRenderer, ListRowProps, InfiniteLoader, IndexRa
 import { GIT_RESOURCE_SCHEME } from '../git-resource';
 import URI from '@theia/core/lib/common/uri';
 import { GIT_HISTORY, GIT_HISTORY_MAX_COUNT } from './git-history-contribution';
-import { GitFileStatus, Git, GitFileChange } from '../../common';
+import { GitFileStatus, Git, GitFileChange, Repository } from '../../common';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { GitDiffContribution } from '../diff/git-diff-contribution';
 import { GitAvatarService } from './git-avatar-service';
@@ -120,7 +120,10 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
     }
 
     protected async addCommits(options?: Git.Options.Log): Promise<void> {
-        const repository = this.repositoryProvider.selectedRepository;
+        let repository: Repository | undefined;
+        if (options && options.uri) {
+            repository = this.repositoryProvider.findRepository(new URI(options.uri));
+        }
         let resolver: () => void;
         this.errorMessage = undefined;
         this.cancelIndicator.cancel();
@@ -163,7 +166,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                         });
                     }
                     this.commits.push(...commits);
-                } else if (options && options.uri) {
+                } else if (options && options.uri && repository) {
                     const pathIsUnderVersionControl = await this.git.lsFiles(repository, options.uri, { errorUnmatch: true });
                     if (!pathIsUnderVersionControl) {
                         const relPath = this.relativePath(options.uri);

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -169,8 +169,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                 } else if (options && options.uri && repository) {
                     const pathIsUnderVersionControl = await this.git.lsFiles(repository, options.uri, { errorUnmatch: true });
                     if (!pathIsUnderVersionControl) {
-                        const relPath = this.relativePath(options.uri);
-                        this.errorMessage = <React.Fragment><i>/{decodeURIComponent(relPath)}</i> is not under version control.</React.Fragment>;
+                        this.errorMessage = <React.Fragment>It is not under version control.</React.Fragment>;
                     }
                 }
                 resolver();
@@ -252,7 +251,9 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
             reason = this.errorMessage;
             if (this.options.uri) {
                 const relPath = this.relativePath(this.options.uri);
-                path = <React.Fragment> for <i>/{decodeURIComponent(relPath)}</i></React.Fragment>;
+                const repo = this.repositoryProvider.findRepository(new URI(this.options.uri));
+                const repoName = repo ? ` in ${new URI(repo.localUri).displayName}` : '';
+                path = <React.Fragment> for <i>/{decodeURIComponent(relPath)}</i>{repoName}</React.Fragment>;
             }
             content = <div className='message-container'>
                 <div className='no-history-message'>
@@ -275,16 +276,10 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
             const path = this.relativePath(this.options.uri);
             return <div className='diff-header'>
                 {
-                    path.length > 0 ?
-                        <div className='header-row'>
-                            <div className='theia-header'>
-                                path:
-                                </div>
-                            <div className='header-value'>
-                                {'/' + path}
-                            </div>
-                        </div>
-                        : ''
+                    this.renderHeaderRow({ name: 'repository', value: this.getRepositoryLabel(this.options.uri) })
+                }
+                {
+                    this.renderHeaderRow({ name: 'path', value: path })
                 }
                 <div className='theia-header'>
                     Commits

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -188,6 +188,7 @@ export namespace Repository {
         const repositoryUri = new URI(Repository.is(repository) ? repository.localUri : repository);
         return new Path(uri.toString().substr(repositoryUri.toString().length + 1));
     }
+    export const sortComparator = (ra: Repository, rb: Repository) => rb.localUri.length - ra.localUri.length;
 }
 
 /**

--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -550,7 +550,8 @@ export class DugiteGit implements Git {
         const args = ['diff', '--name-status', '-C', '-M', '-z'];
         args.push(this.mapRange((options || {}).range));
         if (options && options.uri) {
-            args.push(...['--', Path.relative(this.getFsPath(repository), this.getFsPath(options.uri))]);
+            const relativePath = Path.relative(this.getFsPath(repository), this.getFsPath(options.uri));
+            args.push(...['--', relativePath !== '' ? relativePath : '.']);
         }
         const result = await this.exec(repository, args);
         return this.nameStatusParser.parse(repository.localUri, result.stdout.trim());


### PR DESCRIPTION
Git diff and history views are now independent of the currently selected repository. So, if we have multible repositories we can open the history or a diff list for every repository without changing the actual selected one.

Fixes #1404
Fixes #1364