### PR TITLE
Dispose onDidChangeKeymaps() for the the keyboard-shortcuts widget

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -82,10 +82,10 @@ export class KeybindingWidget extends ReactWidget {
     protected init(): void {
         this.items = this.getItems();
         if (this.keymapsService.onDidChangeKeymaps) {
-            this.keymapsService.onDidChangeKeymaps(() => {
+            this.toDispose.push(this.keymapsService.onDidChangeKeymaps(() => {
                 this.doSearchKeybindings();
                 this.update();
-            });
+            }));
         }
     }
 


### PR DESCRIPTION
Make sure to handle disposing the `onDidChangeKeymaps` event to avoid memory leaks

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
