### PR TITLE
[debug] Show user-initiated debugger breaks (suspend)

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -238,7 +238,8 @@ export class BreakpointsManager implements FrontendApplicationContribution {
                 case 'exception':
                 case 'breakpoint':
                 case 'entry':
-                case 'step': {
+                case 'step':
+                case 'user request': {
                     const activeDebugSession = this.debugSessionManager.getActiveDebugSession();
                     if (activeDebugSession && activeDebugSession.sessionId === debugSession.sessionId) {
                         const args: DebugProtocol.StackTraceArguments = {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Split from https://github.com/theia-ide/theia/pull/3094

Support the `user-initiated` reason for debug stops when displaying breakpoints
