### PR TITLE
Set vscode preference for keeping final newlines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
     "[json]": {
         "editor.tabSize": 2
     },
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "files.insertFinalNewline": true
 }


### PR DESCRIPTION
We already have this in our .editorconfig file:

    insert_final_newline = true

But this only works in vscode if you have the editorconfig extension,
which is not the case of everybody.  This patch adds the
vscode-specific preference, for convenience.

Change-Id: I07a5b310c7a06450c36b567b9687f592c4813f5f
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
