### PR TITLE
Call super constructor in 'MonacoEditorService' 

### DIFF
--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -42,6 +42,10 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
     @inject(EditorManager)
     protected readonly editors: EditorManager;
 
+    constructor() {
+        super(monaco.services.StaticServices.standaloneThemeService.get());
+    }
+
     getActiveCodeEditor(): ICodeEditor | undefined {
         const editor = MonacoEditor.getActive(this.editors);
         return editor && editor.getControl();

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -325,6 +325,7 @@ declare module monaco.keybindings {
 declare module monaco.services {
 
     export abstract class CodeEditorServiceImpl implements monaco.editor.ICodeEditorService {
+        constructor(themeService: IStandaloneThemeService);
         abstract getActiveCodeEditor(): monaco.editor.ICodeEditor | undefined;
         abstract openCodeEditor(input: monaco.editor.IResourceInput, source?: monaco.editor.ICodeEditor,
             sideBySide?: boolean): monaco.Promise<monaco.editor.CommonCodeEditor | undefined>;


### PR DESCRIPTION
`MonacoEditorService` extends `monaco.services.CodeEditorServiceImpl` which has constructor which accept `ThemeService`: [source](https://github.com/Microsoft/vscode/blob/master/src/vs/editor/browser/services/codeEditorServiceImpl.ts#L24). 
This pull request add call of that constructor and pass `IStandaloneThemeService` as his argument.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
