### PR TITLE
Fixed shell script syntax highlighting

### DIFF
--- a/packages/textmate-grammars/src/browser/shell.ts
+++ b/packages/textmate-grammars/src/browser/shell.ts
@@ -21,7 +21,7 @@ import { injectable } from 'inversify';
 export class ShellContribution implements LanguageGrammarDefinitionContribution {
 
     readonly id = 'shell';
-    readonly scopeName = 'source.sh';
+    readonly scopeName = 'source.shell';
 
     registerTextmateLanguage(registry: TextmateRegistry) {
         monaco.languages.register({


### PR DESCRIPTION
The scope name in LanguageGrammarDefinitionContribution for shell scripts was not the same as used in language data file. So there were no syntax colouring.