### PR TITLE
Open keymaps.json as a split panel from keybindings-widget

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -373,6 +373,6 @@ export class KeybindingWidget extends ReactWidget {
         return property.replace(new RegExp(this.regexp), '$1');
     }
 
-    protected openKeybindings = () => this.keymapsService.open();
+    protected openKeybindings = () => this.keymapsService.open(this);
 
 }

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -17,7 +17,7 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { ResourceProvider, Resource, MessageService } from '@theia/core/lib/common';
-import { KeybindingRegistry, KeybindingScope, OpenerService, open, Keybinding } from '@theia/core/lib/browser';
+import { Keybinding, KeybindingRegistry, KeybindingScope, OpenerService, open, WidgetOpenerOptions, Widget } from '@theia/core/lib/browser';
 import { UserStorageUri } from '@theia/userstorage/lib/browser';
 import { KeymapsParser } from './keymaps-parser';
 import * as jsoncparser from 'jsonc-parser';
@@ -76,8 +76,12 @@ export class KeymapsService {
         }
     }
 
-    open(): void {
-        open(this.opener, this.resource.uri);
+    open(ref?: Widget): void {
+        const options: WidgetOpenerOptions = {
+            widgetOptions: ref ? { area: 'main', mode: 'split-right', ref } : { area: 'main' },
+            mode: 'activate'
+        };
+        open(this.opener, this.resource.uri, options);
     }
 
     async setKeybinding(keybindingJson: KeybindingJson): Promise<void> {


### PR DESCRIPTION
When opening the `keymaps.json` file from the `keybindings-widget`, instead of opening in a new tab, open it instead as a split panel to make it easier for users to view their changes.

![selection_090](https://user-images.githubusercontent.com/40359487/46738567-8aae1980-cc6c-11e8-921a-44ca62254577.png)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
