### PR TITLE
Fix double scrollbar appearing in output panel

### DIFF
--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -16,13 +16,14 @@
 
 #outputView {
 	font-size: var(--theia-ui-font-size1);
-    padding: 6px;
     color: var(--theia-ui-font-color1);
 }
 
 #outputView #outputContents {
     overflow: auto;
     height: inherit;
+    padding: 6px;
+    box-sizing: border-box;
 }
 
 #outputView #outputChannelList {
@@ -44,6 +45,7 @@
     background-repeat: no-repeat;
     padding-left: 3px;
     padding-right: 15px;
+    margin: 6px;
 }
 
 .output-tab-icon::before {


### PR DESCRIPTION
Signed-off-by: Michael Quested <michael.quested@arm.com>

Hovering over the output panel shows two scrollbars overlaying each other (One for the containing div and one for the output contents).

The padding was pushing the containing div to be larger than the window, so a scrollbar was being shown.

This PR fixes this to only show one scrollbar.
