### PR TITLE
[output] Fix double scrollbar appearing in output panel

### DIFF
--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -14,15 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-#outputView {
+ #outputView {
 	font-size: var(--theia-ui-font-size1);
-    padding: 6px;
     color: var(--theia-ui-font-color1);
 }
 
 #outputView #outputContents {
     overflow: auto;
     height: inherit;
+    padding: 6px;
+    box-sizing: border-box;
 }
 
 #outputView #outputChannelList {
@@ -44,6 +45,7 @@
     background-repeat: no-repeat;
     padding-left: 3px;
     padding-right: 15px;
+    margin: 6px;
 }
 
 .output-tab-icon::before {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

From @micque01

Hovering over the output panel shows two scrollbars overlaying each other (One for the containing div and one for the output contents).

The padding was pushing the containing div to be larger than the window, so a scrollbar was being shown.

This PR fixes this to only show one scrollbar.

Before:
![scrollbar-before](https://user-images.githubusercontent.com/61341/46750166-10a78000-ccc0-11e8-9ca6-0f75e6d5e449.png)

After:
![scrollbar-after](https://user-images.githubusercontent.com/61341/46750187-19985180-ccc0-11e8-8e86-ea71c998e6dc.png)

