### PR TITLE
plugin-hosted: fix loading sequence of plugin API initialisation

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -69,8 +69,8 @@ export class HostedPluginSupport {
             if (frontend) {
                 const worker = new PluginWorker();
                 const hostedExtManager = worker.rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
-                hostedExtManager.$init({ plugins: pluginsMetadata });
                 setUpPluginApi(worker.rpc, container);
+                hostedExtManager.$init({ plugins: pluginsMetadata });
             }
 
             if (backend) {
@@ -78,8 +78,8 @@ export class HostedPluginSupport {
                 pluginsMetadata.forEach(pluginMetadata => {
                     const rpc = this.createServerRpc(pluginMetadata);
                     const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
-                    hostedExtManager.$init({ plugins: [pluginMetadata] });
                     setUpPluginApi(rpc, container);
+                    hostedExtManager.$init({ plugins: [pluginMetadata] });
                 });
             }
         });


### PR DESCRIPTION
Writing a backend plugin and using `theia.env.getQueryParameter` is failing because of loading sequence of plugin API initialisation.
With this code sample https://github.com/AndrienkoAleksandr/testQuery/blob/master/src/testQuery-backend-plugin.ts#L9, and passing parameter to the Theia url is failling logging the query parameters passed.
This PR is fixing it.