### PR TITLE
Display problem marker error codes if applicable

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -107,6 +107,9 @@ export class ProblemWidget extends TreeWidget {
                     {'[' + problemMarker.owner + ']'}
                 </div>
                 <div className='message'>{problemMarker.data.message}
+                    {
+                        (problemMarker.data.code) ? <span className='code'>{'[' + problemMarker.data.code + ']'}</span> : ''
+                    }
                     <span className='position'>
                         {'(' + (problemMarker.data.range.start.line + 1) + ', ' + (problemMarker.data.range.start.character + 1) + ')'}
                     </span>
@@ -136,7 +139,7 @@ export class ProblemWidget extends TreeWidget {
 
 }
 
-export class ProblemMarkerRemoveButton extends React.Component<{model: ProblemTreeModel, node: TreeNode}> {
+export class ProblemMarkerRemoveButton extends React.Component<{ model: ProblemTreeModel, node: TreeNode }> {
 
     render(): React.ReactNode {
         return <span className='remove-node' onClick={this.remove}></span>;

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -66,11 +66,13 @@
 }
 
 .theia-marker-container .markerNode .position,
-.theia-marker-container .markerNode .owner {
+.theia-marker-container .markerNode .owner,
+.theia-marker-container .markerNode .code {
     color: var(--theia-ui-font-color2);
 }
 
-.theia-marker-container .markerNode .position {
+.theia-marker-container .markerNode .position,
+.theia-marker-container .markerNode .code {
     margin-left: 5px;
 }
 


### PR DESCRIPTION
If applicable, add error codes when displaying problem markers in the `problems-widget`

<img width="676" alt="screen shot 2018-10-10 at 8 33 37 pm" src="https://user-images.githubusercontent.com/40359487/46773528-d643e000-cccb-11e8-907c-0b92e23cd7ae.png">

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
