### PR TITLE
Fix for 2859

### DIFF
--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -26,7 +26,6 @@ import { CliContribution } from '@theia/core/lib/node/cli';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { MessageService, ILogger } from '@theia/core';
 import { WorkspaceServer } from '../common';
-import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class WorkspaceCliContribution implements CliContribution {
@@ -124,11 +123,7 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
     }
 
     private workspaceStillExist(wspath: string): boolean {
-        const uri = new URI(wspath);
-        if (fs.pathExistsSync(uri.path.toString())) {
-            return true;
-        }
-        return false;
+        return fs.pathExistsSync(FileUri.fsPath(wspath));
     }
 
     protected async getWorkspaceURIFromCli(): Promise<string | undefined> {


### PR DESCRIPTION
This is a fix for [2859](https://github.com/theia-ide/theia/issues/2859). The problem is that a lot of the `fs` methods don't recognize Windows absolute paths if they have leading slashes. The previous code was converting Windows paths from file URIs to a format `fs.pathExistsSync()` didn't recognize. For example `file:///c:/Users/me/` became `/c:/Users/me/`. `fs.existsSync()` recognizes URLs if you construct them with the URL constructor. This may be a fix you would want to make in other parts of Theia where you are trying to use file URIs with `fs` methods.