### PR TITLE
[plug-in] allow to specify timeout for plug-in debugger. Set it to be 30s

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -171,6 +171,7 @@ export class HostedPluginManagerClient {
         const configuration = {
             type: 'node',
             request: 'attach',
+            timeout: 30000,
             name: 'Hosted Plugin'
         } as DebugConfiguration;
         const session = await this.debugService.create(configuration);


### PR DESCRIPTION
Fix #3118 : Debug nodejs allow to specify timeout, increase the value

Change-Id: I13cf9d9f6c62a7b44eee4f99f1508e4d58769d60
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
