### PR TITLE
Added GitHistory command to editor context menu.

### DIFF
--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -24,6 +24,7 @@ import { GitHistoryWidget } from './git-history-widget';
 import { Git } from '../../common';
 import { GitRepositoryTracker } from '../git-repository-tracker';
 import { GitRepositoryProvider } from '../git-repository-provider';
+import { EDITOR_CONTEXT_MENU_GIT } from '../git-view-contribution';
 
 export namespace GitHistoryCommands {
     export const OPEN_FILE_HISTORY: Command = {
@@ -84,7 +85,9 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
         menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '5_history'], {
             commandId: GitHistoryCommands.OPEN_FILE_HISTORY.id
         });
-
+        menus.registerMenuAction(EDITOR_CONTEXT_MENU_GIT, {
+            commandId: GitHistoryCommands.OPEN_FILE_HISTORY.id
+        });
         super.registerMenus(menus);
     }
 


### PR DESCRIPTION
Now it is possible to open the git history directly from editor widget. 

Fixes theia-ide/theia#2767

