### PR TITLE
Getting Started Extension and Widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
   - packages/extension-manager/node_modules
   - packages/file-search/node_modules
   - packages/filesystem/node_modules
+  - packages/getting-started/node_modules
   - packages/git/node_modules
   - packages/java/node_modules
   - packages/json/node_modules

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -14,6 +14,7 @@
     "@theia/extension-manager": "^0.3.16",
     "@theia/file-search": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
+    "@theia/getting-started": "^0.3.16",
     "@theia/git": "^0.3.16",
     "@theia/java": "^0.3.16",
     "@theia/json": "^0.3.16",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -17,6 +17,7 @@
     "@theia/extension-manager": "^0.3.16",
     "@theia/file-search": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
+    "@theia/getting-started": "^0.3.16",
     "@theia/git": "^0.3.16",
     "@theia/java": "^0.3.16",
     "@theia/json": "^0.3.16",

--- a/packages/getting-started/compile.tsconfig.json
+++ b/packages/getting-started/compile.tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/getting-started/package.json
+++ b/packages/getting-started/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@theia/getting-started",
+  "version": "0.3.16",
+  "description": "Theia - GettingStarted Extension",
+  "dependencies": {
+    "@theia/core": "^0.3.16",
+    "@theia/workspace": "^0.3.16",
+    "@theia/filesystem": "^0.3.16",
+    "@theia/keymaps": "^0.3.16"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/getting-started-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/theia-ide/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/theia-ide/theia/issues"
+  },
+  "homepage": "https://github.com/theia-ide/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "theiaext clean",
+    "build": "theiaext build",
+    "watch": "theiaext watch",
+    "test": "theiaext test",
+    "test:watch": "theiaext test:watch",
+    "docs": "theiaext docs"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "^0.3.16"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { CommandRegistry, MenuModelRegistry } from '@theia/core/lib/common';
+import { CommonMenus, AbstractViewContribution, FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
+import { GettingStartedWidget } from './getting-started-widget';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+export const GettingStartedCommand = {
+    id: GettingStartedWidget.ID,
+    label: GettingStartedWidget.LABEL
+};
+
+@injectable()
+export class GettingStartedContribution extends AbstractViewContribution<GettingStartedWidget> implements FrontendApplicationContribution {
+
+    @inject(FrontendApplicationStateService)
+    protected readonly stateService: FrontendApplicationStateService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    constructor() {
+        super({
+            widgetId: GettingStartedWidget.ID,
+            widgetName: GettingStartedWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'main',
+            }
+        });
+    }
+
+    async onStart(app: FrontendApplication): Promise<void> {
+        if (!this.workspaceService.opened) {
+            this.stateService.reachedState('ready').then(
+                a => this.openView({ reveal: true })
+            );
+        }
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(GettingStartedCommand, {
+            execute: () => this.openView({ reveal: true }),
+        });
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction(CommonMenus.HELP, {
+            commandId: GettingStartedCommand.id,
+            label: GettingStartedCommand.label,
+            order: 'a10'
+        });
+    }
+}

--- a/packages/getting-started/src/browser/getting-started-frontend-module.ts
+++ b/packages/getting-started/src/browser/getting-started-frontend-module.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { GettingStartedContribution } from './getting-started-contribution';
+import { ContainerModule } from 'inversify';
+import { GettingStartedWidget } from './getting-started-widget';
+import { WidgetFactory, FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
+
+import '../../src/browser/style/index.css';
+
+export default new ContainerModule(bind => {
+    bindViewContribution(bind, GettingStartedContribution);
+    bind(FrontendApplicationContribution).toService(GettingStartedContribution);
+    bind(GettingStartedWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(context => ({
+        id: GettingStartedWidget.ID,
+        createWidget: () => context.container.get<GettingStartedWidget>(GettingStartedWidget),
+    })).inSingletonScope();
+});

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -1,0 +1,206 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from 'react';
+import URI from '@theia/core/lib/common/uri';
+import { injectable, inject, postConstruct } from 'inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandRegistry } from '@theia/core/lib/common';
+import { WorkspaceCommands, WorkspaceService } from '@theia/workspace/lib/browser';
+import { FileStat, FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { FileSystemUtils } from '@theia/filesystem/lib/common/filesystem-utils';
+import { KeymapsCommands } from '@theia/keymaps/lib/browser';
+import { CommonCommands } from '@theia/core/lib/browser';
+import { ApplicationInfo, ApplicationServer } from '@theia/core/lib/common/application-protocol';
+
+@injectable()
+export class GettingStartedWidget extends ReactWidget {
+
+    static readonly ID = 'getting.started.widget';
+    static readonly LABEL = 'Getting Started';
+
+    protected applicationInfo: ApplicationInfo | undefined;
+
+    protected stat: FileStat | undefined;
+    protected home: string | undefined;
+
+    protected readonly recentLimit = 5;
+    protected recentWorkspaces: string[] = [];
+
+    protected readonly documentationUrl = 'https://www.theia-ide.org/doc/';
+    protected readonly extensionUrl = 'https://www.theia-ide.org/doc/Authoring_Extensions.html';
+    protected readonly pluginUrl = 'https://www.theia-ide.org/doc/Authoring_Plugins.html';
+
+    @inject(ApplicationServer)
+    protected readonly appServer: ApplicationServer;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.id = GettingStartedWidget.ID;
+        this.title.label = GettingStartedWidget.LABEL;
+        this.title.caption = GettingStartedWidget.LABEL;
+        this.title.closable = true;
+
+        this.applicationInfo = await this.appServer.getApplicationInfo();
+        this.recentWorkspaces = await this.workspaceService.recentWorkspaces();
+        this.stat = await this.fileSystem.getCurrentUserHome();
+        this.home = (this.stat) ? new URI(this.stat.uri).withoutScheme().toString() : undefined;
+        this.update();
+    }
+
+    protected render(): React.ReactNode {
+        return <div className='gs-container'>
+            {this.renderHeader()}
+            <hr className='gs-hr' />
+            <div className='flex-grid'>
+                <div className='col'>
+                    {this.renderOpen()}
+                </div>
+            </div>
+            <div className='flex-grid'>
+                <div className='col'>
+                    {this.renderRecentWorkspaces()}
+                </div>
+            </div>
+            <div className='flex-grid'>
+                <div className='col'>
+                    {this.renderSettings()}
+                </div>
+            </div>
+            <div className='flex-grid'>
+                <div className='col'>
+                    {this.renderHelp()}
+                </div>
+            </div>
+            <div className='flex-grid'>
+                <div className='col'>
+                    {this.renderVersion()}
+                </div>
+            </div>
+        </div>;
+    }
+
+    protected renderHeader(): React.ReactNode {
+        return <div className='gs-header'>
+            <h1>Theia <span className='gs-sub-header'>Getting Started</span></h1>
+        </div>;
+    }
+
+    protected renderOpen(): React.ReactNode {
+        return <div className='gs-section'>
+            <h3 className='gs-section-header'>
+                <i className='fa fa-folder-open'></i>
+                Open
+            </h3>
+            <div className='gs-action-container'>
+                <a href='#' onClick={this.doOpen}>Open</a>
+            </div>
+            <div className='gs-action-container'>
+                <a href='#' onClick={this.doOpenWorkspace}>Open Workspace</a>
+            </div>
+        </div>;
+    }
+
+    protected renderRecentWorkspaces(): React.ReactNode {
+        const items = this.recentWorkspaces;
+        const paths = this.buildPaths(items);
+        const content = paths.slice(0, this.recentLimit).map((item, index) =>
+            <div className='gs-action-container' key={index}>
+                <a href='#' onClick={a => this.open(new URI(items[index]))}>{new URI(items[index]).path.base}</a>
+                <span className='gs-action-details'>
+                    {item}
+                </span>
+            </div>
+        );
+        const more = (paths.length > this.recentLimit) ? <div className='gs-action-contaienr'>
+            <a href='#' onClick={this.doOpenRecentWorkspace}>More...</a>
+        </div> : <div />;
+        return <div className='gs-section'>
+            <h3 className='gs-section-header'>
+                <i className='fa fa-clock-o'></i>Recent Workspaces
+                    </h3>
+            {content}
+            {more}
+        </div>;
+    }
+
+    protected renderSettings(): React.ReactNode {
+        return <div className='gs-section'>
+            <h3 className='gs-section-header'>
+                <i className='fa fa-cog'></i>
+                Settings
+            </h3>
+            <div className='gs-action-container'>
+                <a href='#' onClick={this.doOpenPreferences}>Open Preferences</a>
+            </div>
+            <div className='gs-action-container'>
+                <a href='#' onClick={this.doOpenKeyboardShortcuts}>Open Keyboard Shortcuts</a>
+            </div>
+        </div>;
+    }
+
+    protected renderHelp(): React.ReactNode {
+        return <div className='gs-section'>
+            <h3 className='gs-section-header'>
+                <i className='fa fa-question-circle'></i>
+                Help
+            </h3>
+            <div className='gs-action-container'>
+                <a href={this.documentationUrl} target='_blank'>Documentation</a>
+            </div>
+            <div className='gs-action-container'>
+                <a href={this.extensionUrl} target='_blank'>Building a New Extension</a>
+            </div>
+            <div className='gs-action-container'>
+                <a href={this.pluginUrl} target='_blank'>Building a New Plugin</a>
+            </div>
+        </div>;
+    }
+
+    protected renderVersion(): React.ReactNode {
+        return <div className='gs-section'>
+            <div className='gs-action-container'>
+                <p className='gs-sub-header gs-version' > {this.applicationInfo ? 'Version ' + this.applicationInfo.version : ''}</p>
+            </div>
+        </div>;
+    }
+
+    protected buildPaths(workspaces: string[]): string[] {
+        const paths: string[] = [];
+        workspaces.forEach(workspace => {
+            const uri = new URI(workspace);
+            const path = (this.home) ? FileSystemUtils.tildifyPath(uri.path.toString(), this.home) : uri.path.toString();
+            paths.push(path);
+        });
+        return paths;
+    }
+
+    protected doOpen = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN.id);
+    protected doOpenWorkspace = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_WORKSPACE.id);
+    protected doOpenRecentWorkspace = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_RECENT_WORKSPACE.id);
+    protected doOpenPreferences = () => this.commandRegistry.executeCommand(CommonCommands.OPEN_PREFERENCES.id);
+    protected doOpenKeyboardShortcuts = () => this.commandRegistry.executeCommand(KeymapsCommands.OPEN_KEYMAPS.id);
+    protected open = (workspace: URI) => this.workspaceService.open(workspace);
+}

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -1,0 +1,86 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+html, body {
+    font-family: var(--theia-ui-font-family);
+}
+
+.col {
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+}
+
+.flex-grid {
+    display: flex;
+}
+
+.gs-action-container {
+    line-height: 20px;
+    color: var(--theia-ui-font-color1);
+}
+
+.gs-action-details {
+    padding-left: 5px;
+    color: var(--theia-ui-font-color2);
+}
+
+.gs-container {
+    padding: 20px;
+}
+
+.gs-header h1 {
+    color: var(--theia-ui-font-color1);
+    flex: 1;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.gs-hr {
+    background-color: var(--theia-border-color1); 
+    height: 1px; 
+    border: 0;
+    margin: 0px;
+}
+
+.gs-section a {
+    border: none;
+    color: var(--theia-accent-color1);
+    font-weight: 500;
+    outline: 0;
+    text-decoration: none;
+}
+
+.gs-section a:hover {
+    text-decoration: underline;
+}
+
+.gs-section-header {
+    color: var(--theia-ui-font-color1);
+    font-size: var(--theia-ui-font-size2);
+    font-weight: 600;
+    margin-bottom: 5px;
+}
+
+.gs-section-header i {
+    padding-right: 5px;
+}
+
+.gs-sub-header {
+    color: var(--theia-ui-font-color2);
+    text-transform: capitalize;
+    font-weight: 200;
+}

--- a/packages/getting-started/src/package.spec.ts
+++ b/packages/getting-started/src/package.spec.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe('getting-started package', () => {
+
+    it('support code coverage statistics', () => true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -102,6 +102,9 @@
       ],
       "@theia/console/lib/*": [
         "packages/console/src/*"
+      ],
+      "@theia/getting-started/lib/*": [
+        "packages/getting-started/src/*"
       ]
     },
     "plugins": [


### PR DESCRIPTION
`getting-started` widget:
* used to display open commands (open, open workspace), list and open recent workspaces, settings, and help documentation
* only gets displayed on startup when there is no workspace present
* included command and menu items to trigger opening the widget as well if needed

![selection_094](https://user-images.githubusercontent.com/40359487/46874487-42772e80-ce07-11e8-8cc3-110797ce8a18.png)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
