### PR TITLE
Replace toDynamicValue with toService when possible

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-container.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-container.ts
@@ -25,14 +25,14 @@ function createHierarchyTreeContainer(parent: interfaces.Container): Container {
 
     child.unbind(TreeImpl);
     child.bind(CallHierarchyTree).toSelf();
-    child.rebind(Tree).toDynamicValue(ctx => ctx.container.get(CallHierarchyTree));
+    child.rebind(Tree).toService(CallHierarchyTree);
 
     child.unbind(TreeModelImpl);
     child.bind(CallHierarchyTreeModel).toSelf();
-    child.rebind(TreeModel).toDynamicValue(ctx => ctx.container.get(CallHierarchyTreeModel));
+    child.rebind(TreeModel).toService(CallHierarchyTreeModel);
 
     child.bind(CallHierarchyTreeWidget).toSelf();
-    child.rebind(TreeWidget).toDynamicValue(ctx => ctx.container.get(CallHierarchyTreeWidget));
+    child.rebind(TreeWidget).toService(CallHierarchyTreeWidget);
 
     return child;
 }

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -106,14 +106,14 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bindContributionProvider(bind, OpenHandler);
     bind(DefaultOpenerService).toSelf().inSingletonScope();
-    bind(OpenerService).toDynamicValue(context => context.container.get(DefaultOpenerService));
+    bind(OpenerService).toService(DefaultOpenerService);
     bind(HttpOpenHandler).toSelf().inSingletonScope();
-    bind(OpenHandler).toDynamicValue(ctx => ctx.container.get(HttpOpenHandler)).inSingletonScope();
+    bind(OpenHandler).toService(HttpOpenHandler);
 
     bindContributionProvider(bind, WidgetFactory);
     bind(WidgetManager).toSelf().inSingletonScope();
     bind(ShellLayoutRestorer).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(ctx => ctx.container.get(ShellLayoutRestorer));
+    bind(CommandContribution).toService(ShellLayoutRestorer);
 
     bind(DefaultResourceProvider).toSelf().inSingletonScope();
     bind(ResourceProvider).toProvider(context =>
@@ -125,7 +125,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(SelectionService).toSelf().inSingletonScope();
     bind(CommandRegistry).toSelf().inSingletonScope();
-    bind(CommandService).toDynamicValue(context => context.container.get(CommandRegistry));
+    bind(CommandService).toService(CommandRegistry);
     bindContributionProvider(bind, CommandContribution);
     bind(QuickOpenContribution).to(CommandQuickOpenContribution);
 
@@ -141,7 +141,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(CommonFrontendContribution).toSelf().inSingletonScope();
     [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(CommonFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toService(CommonFrontendContribution)
     );
 
     bind(QuickOpenService).toSelf().inSingletonScope();
@@ -149,7 +149,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(QuickCommandService).toSelf().inSingletonScope();
     bind(QuickCommandFrontendContribution).toSelf().inSingletonScope();
     [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(QuickCommandFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toService(QuickCommandFrontendContribution)
     );
 
     bind(PrefixQuickOpenService).toSelf().inSingletonScope();
@@ -165,7 +165,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(StorageService).toService(LocalStorageService);
 
     bind(StatusBarImpl).toSelf().inSingletonScope();
-    bind(StatusBar).toDynamicValue(ctx => ctx.container.get(StatusBarImpl)).inSingletonScope();
+    bind(StatusBar).toService(StatusBarImpl);
     bind(LabelParser).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, LabelProviderContribution);
@@ -193,10 +193,10 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
         };
     });
     bind(FrontendConnectionStatusService).toSelf().inSingletonScope();
-    bind(ConnectionStatusService).toDynamicValue(ctx => ctx.container.get(FrontendConnectionStatusService)).inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(FrontendConnectionStatusService)).inSingletonScope();
+    bind(ConnectionStatusService).toService(FrontendConnectionStatusService);
+    bind(FrontendApplicationContribution).toService(FrontendConnectionStatusService);
     bind(ApplicationConnectionStatusContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(ApplicationConnectionStatusContribution)).inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ApplicationConnectionStatusContribution);
 
     bind(ApplicationServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -58,7 +58,7 @@ before(async () => {
 
         bind(TestContribution).toSelf().inSingletonScope();
         [CommandContribution, KeybindingContribution].forEach(serviceIdentifier =>
-            bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(TestContribution)).inSingletonScope()
+            bind(serviceIdentifier).toService(TestContribution)
         );
 
         bind(KeybindingContext).toConstantValue({
@@ -69,8 +69,8 @@ before(async () => {
         });
 
         bind(StatusBarImpl).toSelf().inSingletonScope();
-        bind(StatusBar).toDynamicValue(ctx => ctx.container.get(StatusBarImpl)).inSingletonScope();
-        bind(CommandService).toDynamicValue(context => context.container.get(CommandRegistry));
+        bind(StatusBar).toService(StatusBarImpl);
+        bind(CommandService).toService(CommandRegistry);
         bind(LabelParser).toSelf().inSingletonScope();
         bind(FrontendApplicationStateService).toSelf().inSingletonScope();
     });

--- a/packages/core/src/browser/tree/tree-container.ts
+++ b/packages/core/src/browser/tree/tree-container.ts
@@ -33,18 +33,18 @@ export function createTreeContainer(parent: interfaces.Container, props?: Partia
     child.parent = parent;
 
     child.bind(TreeImpl).toSelf();
-    child.bind(Tree).toDynamicValue(ctx => ctx.container.get(TreeImpl));
+    child.bind(Tree).toService(TreeImpl);
 
     child.bind(TreeSelectionServiceImpl).toSelf();
-    child.bind(TreeSelectionService).toDynamicValue(ctx => ctx.container.get(TreeSelectionServiceImpl));
+    child.bind(TreeSelectionService).toService(TreeSelectionServiceImpl);
 
     child.bind(TreeExpansionServiceImpl).toSelf();
-    child.bind(TreeExpansionService).toDynamicValue(ctx => ctx.container.get(TreeExpansionServiceImpl));
+    child.bind(TreeExpansionService).toService(TreeExpansionServiceImpl);
 
     child.bind(TreeNavigationService).toSelf();
 
     child.bind(TreeModelImpl).toSelf();
-    child.bind(TreeModel).toDynamicValue(ctx => ctx.container.get(TreeModelImpl));
+    child.bind(TreeModel).toService(TreeModelImpl);
 
     child.bind(TreeWidget).toSelf();
     child.bind(TreeProps).toConstantValue({

--- a/packages/core/src/electron-browser/menu/electron-menu-module.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-module.ts
@@ -31,6 +31,6 @@ export default new ContainerModule(bind => {
 
     bind(ElectronMenuContribution).toSelf().inSingletonScope();
     for (const serviceIdentifier of [FrontendApplicationContribution, KeybindingContribution, CommandContribution, MenuContribution]) {
-        bind(serviceIdentifier).toDynamicValue(ctx => ctx.container.get(ElectronMenuContribution)).inSingletonScope();
+        bind(serviceIdentifier).toService(ElectronMenuContribution);
     }
 });

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -31,7 +31,7 @@ decorate(injectable(), ApplicationPackage);
 export function bindServerProcess(bind: interfaces.Bind, masterFactory: RemoteMasterProcessFactory): void {
     bind(RemoteMasterProcessFactory).toConstantValue(masterFactory);
     bind(ServerProcess).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(ServerProcess)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(ServerProcess);
 }
 
 export const backendApplicationModule = new ContainerModule(bind => {

--- a/packages/core/src/node/logger-backend-module.ts
+++ b/packages/core/src/node/logger-backend-module.ts
@@ -30,7 +30,7 @@ export function bindLogger(bind: interfaces.Bind): void {
     bind(LoggerWatcher).toSelf().inSingletonScope();
     bind(ILoggerServer).to(ConsoleLoggerServer).inSingletonScope();
     bind(LogLevelCliContribution).toSelf().inSingletonScope();
-    bind(CliContribution).toDynamicValue(ctx => ctx.container.get(LogLevelCliContribution));
+    bind(CliContribution).toService(LogLevelCliContribution);
     bind(LoggerFactory).toFactory(ctx =>
         (name: string) => {
             const child = new Container({ defaultScope: 'Singleton' });

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -34,11 +34,11 @@ import { TaskContribution } from '@theia/task/lib/browser/task-contribution';
 export default new ContainerModule(bind => {
     bind(CommandContribution).to(CppCommandContribution).inSingletonScope();
     bind(CppKeybindingContext).toSelf().inSingletonScope();
-    bind(KeybindingContext).toDynamicValue(context => context.container.get(CppKeybindingContext));
+    bind(KeybindingContext).toService(CppKeybindingContext);
     bind(KeybindingContribution).to(CppKeybindingContribution).inSingletonScope();
 
     bind(CppLanguageClientContribution).toSelf().inSingletonScope();
-    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppLanguageClientContribution));
+    bind(LanguageClientContribution).toService(CppLanguageClientContribution);
 
     bind(CppTaskProvider).toSelf().inSingletonScope();
     bind(CppBuildConfigurationManager).to(CppBuildConfigurationManagerImpl).inSingletonScope();

--- a/packages/extension-manager/src/browser/extension-frontend-module.ts
+++ b/packages/extension-manager/src/browser/extension-frontend-module.ts
@@ -44,8 +44,8 @@ export default new ContainerModule(bind => {
     }));
 
     bind(ExtensionWidgetFactory).toSelf().inSingletonScope();
-    bind(WidgetFactory).toDynamicValue(ctx => ctx.container.get(ExtensionWidgetFactory)).inSingletonScope();
+    bind(WidgetFactory).toService(ExtensionWidgetFactory);
 
     bind(ExtensionOpenHandler).toSelf().inSingletonScope();
-    bind(OpenHandler).toDynamicValue(ctx => ctx.container.get(ExtensionOpenHandler)).inSingletonScope();
+    bind(OpenHandler).toService(ExtensionOpenHandler);
 });

--- a/packages/extension-manager/src/node/extension-backend-module.ts
+++ b/packages/extension-manager/src/node/extension-backend-module.ts
@@ -31,7 +31,7 @@ export function bindNodeExtensionServer(bind: interfaces.Bind, args?: Applicatio
         bind(ApplicationProjectOptions).toConstantValue(args);
     } else {
         bind(ApplicationProjectCliContribution).toSelf().inSingletonScope();
-        bind(CliContribution).toDynamicValue(ctx => ctx.container.get(ApplicationProjectCliContribution)).inSingletonScope();
+        bind(CliContribution).toService(ApplicationProjectCliContribution);
         bind(NpmClientOptions).toDynamicValue(ctx =>
             ctx.container.get(ApplicationProjectCliContribution).args
         ).inSingletonScope();
@@ -44,9 +44,7 @@ export function bindNodeExtensionServer(bind: interfaces.Bind, args?: Applicatio
 
     bind(ExtensionKeywords).toConstantValue([extensionKeyword]);
     bind(NodeExtensionServer).toSelf().inSingletonScope();
-    bind(ExtensionServer).toDynamicValue(ctx =>
-        ctx.container.get(NodeExtensionServer)
-    ).inSingletonScope();
+    bind(ExtensionServer).toService(NodeExtensionServer);
 }
 
 export default new ContainerModule(bind => {

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-container.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-container.ts
@@ -27,7 +27,7 @@ export function createFileDialogContainer(parent: interfaces.Container): Contain
 
     child.unbind(FileTreeModel);
     child.bind(FileDialogModel).toSelf();
-    child.rebind(TreeModel).toDynamicValue(ctx => ctx.container.get(FileDialogModel));
+    child.rebind(TreeModel).toService(FileDialogModel);
 
     child.unbind(FileTreeWidget);
     child.bind(FileDialogWidget).toSelf();

--- a/packages/filesystem/src/browser/file-tree/file-tree-container.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-container.ts
@@ -25,11 +25,11 @@ export function createFileTreeContainer(parent: interfaces.Container): Container
 
     child.unbind(TreeImpl);
     child.bind(FileTree).toSelf();
-    child.rebind(Tree).toDynamicValue(ctx => ctx.container.get(FileTree));
+    child.rebind(Tree).toService(FileTree);
 
     child.unbind(TreeModelImpl);
     child.bind(FileTreeModel).toSelf();
-    child.rebind(TreeModel).toDynamicValue(ctx => ctx.container.get(FileTreeModel));
+    child.rebind(TreeModel).toService(FileTreeModel);
 
     child.unbind(TreeWidget);
     child.bind(FileTreeWidget).toSelf();

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -52,7 +52,7 @@ export default new ContainerModule(bind => {
     ).inSingletonScope();
 
     bind(FileResourceResolver).toSelf().inSingletonScope();
-    bind(ResourceResolver).toDynamicValue(ctx => ctx.container.get(FileResourceResolver));
+    bind(ResourceResolver).toService(FileResourceResolver);
 
     bind(FrontendApplicationContribution).to(FileSystemFrontendContribution).inSingletonScope();
 });

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -25,7 +25,7 @@ import { NsfwFileSystemWatcherServer } from './nsfw-watcher/nsfw-filesystem-watc
 
 export function bindFileSystem(bind: interfaces.Bind): void {
     bind(FileSystemNode).toSelf().inSingletonScope();
-    bind(FileSystem).toDynamicValue(ctx => ctx.container.get(FileSystemNode)).inSingletonScope();
+    bind(FileSystem).toService(FileSystemNode);
 }
 
 export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
@@ -39,9 +39,7 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
         });
     } else {
         bind(FileSystemWatcherServerClient).toSelf();
-        bind(FileSystemWatcherServer).toDynamicValue(ctx =>
-            ctx.container.get(FileSystemWatcherServerClient)
-        );
+        bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
     }
 }
 

--- a/packages/git/src/browser/history/git-history-frontend-module.ts
+++ b/packages/git/src/browser/history/git-history-frontend-module.ts
@@ -46,7 +46,7 @@ export function bindGitHistoryModule(bind: interfaces.Bind) {
     }));
 
     bind(GitCommitDetailOpenHandler).toSelf();
-    bind(OpenHandler).toDynamicValue(ctx => ctx.container.get(GitCommitDetailOpenHandler));
+    bind(OpenHandler).toService(GitCommitDetailOpenHandler);
 
     bindViewContribution(bind, GitHistoryContribution);
 

--- a/packages/git/src/node/git-backend-module.ts
+++ b/packages/git/src/node/git-backend-module.ts
@@ -71,7 +71,7 @@ export function bindGit(bind: interfaces.Bind, bindingOptions: GitBindingOptions
 
 export function bindRepositoryWatcher(bind: interfaces.Bind): void {
     bind(DugiteGitWatcherServer).toSelf();
-    bind(GitWatcherServer).toDynamicValue(context => context.container.get(DugiteGitWatcherServer));
+    bind(GitWatcherServer).toService(DugiteGitWatcherServer);
 }
 
 export default new ContainerModule(bind => {

--- a/packages/java/src/browser/java-frontend-module.ts
+++ b/packages/java/src/browser/java-frontend-module.ts
@@ -32,17 +32,17 @@ import './monaco-contribution';
 
 export default new ContainerModule(bind => {
     bind(JavaCommandContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(ctx => ctx.container.get(JavaCommandContribution)).inSingletonScope();
-    bind(KeybindingContribution).toDynamicValue(ctx => ctx.container.get(JavaCommandContribution)).inSingletonScope();
-    bind(MenuContribution).toDynamicValue(ctx => ctx.container.get(JavaCommandContribution)).inSingletonScope();
+    bind(CommandContribution).toService(JavaCommandContribution);
+    bind(KeybindingContribution).toService(JavaCommandContribution);
+    bind(MenuContribution).toService(JavaCommandContribution);
 
     bind(JavaClientContribution).toSelf().inSingletonScope();
-    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(JavaClientContribution));
+    bind(LanguageClientContribution).toService(JavaClientContribution);
 
     bind(KeybindingContext).to(JavaEditorTextFocusContext).inSingletonScope();
 
     bind(JavaResourceResolver).toSelf().inSingletonScope();
-    bind(ResourceResolver).toDynamicValue(ctx => ctx.container.get(JavaResourceResolver));
+    bind(ResourceResolver).toService(JavaResourceResolver);
 
     bind(LabelProviderContribution).to(JavaLabelProviderContribution).inSingletonScope();
 

--- a/packages/languages/src/browser/languages-frontend-module.ts
+++ b/packages/languages/src/browser/languages-frontend-module.ts
@@ -42,6 +42,6 @@ export default new ContainerModule(bind => {
     }
 
     bind(LanguageClientProviderImpl).toSelf().inSingletonScope();
-    bind(LanguageClientProvider).toDynamicValue(ctx => ctx.container.get(LanguageClientProviderImpl)).inSingletonScope();
+    bind(LanguageClientProvider).toService(LanguageClientProviderImpl);
 
 });

--- a/packages/markers/src/browser/problem/problem-container.ts
+++ b/packages/markers/src/browser/problem/problem-container.ts
@@ -35,14 +35,14 @@ export function createProblemTreeContainer(parent: interfaces.Container): Contai
 
     child.unbind(TreeImpl);
     child.bind(ProblemTree).toSelf();
-    child.rebind(Tree).toDynamicValue(ctx => ctx.container.get(ProblemTree));
+    child.rebind(Tree).toService(ProblemTree);
 
     child.unbind(TreeWidget);
     child.bind(ProblemWidget).toSelf();
 
     child.unbind(TreeModelImpl);
     child.bind(ProblemTreeModel).toSelf();
-    child.rebind(TreeModel).toDynamicValue(ctx => ctx.container.get(ProblemTreeModel));
+    child.rebind(TreeModel).toService(ProblemTreeModel);
 
     child.rebind(TreeProps).toConstantValue(PROBLEM_TREE_PROPS);
     child.bind(MarkerOptions).toConstantValue(PROBLEM_OPTIONS);

--- a/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflicts-frontend-module.ts
@@ -34,6 +34,6 @@ export default new ContainerModule(bind => {
     bind(MergeConflictsFrontendContribution).toSelf().inSingletonScope();
     bind(MergeConflictsProvider).toSelf().inSingletonScope();
     [CommandContribution, FrontendApplicationContribution].forEach(serviceIdentifier =>
-        bind(serviceIdentifier).toDynamicValue(c => c.container.get(MergeConflictsFrontendContribution)).inSingletonScope()
+        bind(serviceIdentifier).toService(MergeConflictsFrontendContribution)
     );
 });

--- a/packages/messages/src/node/messages-backend-module.ts
+++ b/packages/messages/src/node/messages-backend-module.ts
@@ -20,7 +20,7 @@ import { ConnectionHandler, JsonRpcConnectionHandler, MessageClient, Dispatching
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(DispatchingMessageClient).toSelf().inSingletonScope();
-    rebind(MessageClient).toDynamicValue(ctx => ctx.container.get(DispatchingMessageClient)).inSingletonScope();
+    rebind(MessageClient).toService(DispatchingMessageClient);
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler<MessageClient>(messageServicePath, client => {
             const dispatching = ctx.container.get<DispatchingMessageClient>(DispatchingMessageClient);

--- a/packages/mini-browser/src/node/mini-browser-backend-module.ts
+++ b/packages/mini-browser/src/node/mini-browser-backend-module.ts
@@ -24,7 +24,7 @@ import { MiniBrowserEndpoint, MiniBrowserEndpointHandler, HtmlHandler, ImageHand
 export default new ContainerModule(bind => {
     bind(MiniBrowserEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(MiniBrowserEndpoint);
-    bind(MiniBrowserService).toDynamicValue(context => context.container.get(MiniBrowserEndpoint));
+    bind(MiniBrowserService).toService(MiniBrowserEndpoint);
     bind(ConnectionHandler).toDynamicValue(context => new JsonRpcConnectionHandler(MiniBrowserServicePath, () => context.container.get(MiniBrowserService))).inSingletonScope();
     bindContributionProvider(bind, MiniBrowserEndpointHandler);
     bind(MiniBrowserEndpointHandler).to(HtmlHandler).inSingletonScope();

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -81,7 +81,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     );
 
     bind(MonacoOutlineContribution).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(MonacoOutlineContribution));
+    bind(FrontendApplicationContribution).toService(MonacoOutlineContribution);
 
     bind(MonacoStatusBarContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(MonacoStatusBarContribution);
@@ -93,9 +93,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(StrictEditorTextFocusContext).to(MonacoStrictEditorTextFocusContext).inSingletonScope();
 
     bind(MonacoQuickOpenService).toSelf().inSingletonScope();
-    rebind(QuickOpenService).toDynamicValue(ctx =>
-        ctx.container.get(MonacoQuickOpenService)
-    ).inSingletonScope();
+    rebind(QuickOpenService).toService(MonacoQuickOpenService);
 
     MonacoTextmateModuleBinder(bind, unbind, isBound, rebind);
 

--- a/packages/navigator/src/browser/navigator-container.ts
+++ b/packages/navigator/src/browser/navigator-container.ts
@@ -36,11 +36,11 @@ export function createFileNavigatorContainer(parent: interfaces.Container): Cont
 
     child.unbind(FileTree);
     child.bind(FileNavigatorTree).toSelf();
-    child.rebind(Tree).toDynamicValue(ctx => ctx.container.get(FileNavigatorTree));
+    child.rebind(Tree).toService(FileNavigatorTree);
 
     child.unbind(FileTreeModel);
     child.bind(FileNavigatorModel).toSelf();
-    child.rebind(TreeModel).toDynamicValue(ctx => ctx.container.get(FileNavigatorModel));
+    child.rebind(TreeModel).toService(FileNavigatorModel);
 
     child.unbind(FileTreeWidget);
     child.bind(FileNavigatorWidget).toSelf();
@@ -48,7 +48,7 @@ export function createFileNavigatorContainer(parent: interfaces.Container): Cont
     child.rebind(TreeProps).toConstantValue(FILE_NAVIGATOR_PROPS);
 
     child.bind(NavigatorDecoratorService).toSelf().inSingletonScope();
-    child.rebind(TreeDecoratorService).toDynamicValue(ctx => ctx.container.get(NavigatorDecoratorService)).inSingletonScope();
+    child.rebind(TreeDecoratorService).toService(NavigatorDecoratorService);
     bindContributionProvider(child, NavigatorTreeDecorator);
 
     return child;

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -35,7 +35,7 @@ export default new ContainerModule(bind => {
     );
 
     bind(OutlineViewService).toSelf().inSingletonScope();
-    bind(WidgetFactory).toDynamicValue(context => context.container.get(OutlineViewService));
+    bind(WidgetFactory).toService(OutlineViewService);
 
     bindViewContribution(bind, OutlineViewContribution);
     bind(FrontendApplicationContribution).toService(OutlineViewContribution);

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -39,7 +39,7 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
 
     bind(HostedPluginProcess).toSelf().inSingletonScope();
 
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(HostedPluginReader)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(HostedPluginReader);
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler<HostedPluginClient>(hostedServicePath, client => {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -58,7 +58,7 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();
 
     bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
-    bind(CommandContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));
+    bind(CommandContribution).toService(PluginApiFrontendContribution);
 
     bind(TextEditorService).to(TextEditorServiceImpl).inSingletonScope();
     bind(EditorModelService).to(EditorModelServiceImpl).inSingletonScope();

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -32,11 +32,11 @@ import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
 
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(PluginApiContribution)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(PluginApiContribution);
 
     bind(PluginDeployer).to(PluginDeployerImpl).inSingletonScope();
     bind(PluginDeployerContribution).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(PluginDeployerContribution)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(PluginDeployerContribution);
 
     bind(PluginDeployerResolver).to(LocalDirectoryPluginDeployerResolver).inSingletonScope();
     bind(PluginDeployerResolver).to(GithubPluginDeployerResolver).inSingletonScope();

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -81,9 +81,7 @@ before(async () => {
     });
     testContainer.bind(PreferenceServiceImpl).toSelf().inSingletonScope();
 
-    testContainer.bind(PreferenceService).toDynamicValue(ctx =>
-        ctx.container.get(PreferenceServiceImpl)
-    ).inSingletonScope();
+    testContainer.bind(PreferenceService).toService(PreferenceServiceImpl);
 
     testContainer.bind(FileSystemPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);

--- a/packages/preferences/src/browser/preference-tree-container.ts
+++ b/packages/preferences/src/browser/preference-tree-container.ts
@@ -31,7 +31,7 @@ export function createPreferencesTreeWidget(parent: interfaces.Container): Prefe
 
     child.bind(PreferencesTreeWidget).toSelf();
     child.rebind(TreeProps).toConstantValue({ ...defaultTreeProps, search: true });
-    child.rebind(TreeWidget).toDynamicValue(ctx => ctx.container.get(PreferencesTreeWidget));
+    child.rebind(TreeWidget).toService(PreferencesTreeWidget);
 
     bindPreferencesDecorator(child);
 
@@ -41,5 +41,5 @@ export function createPreferencesTreeWidget(parent: interfaces.Container): Prefe
 function bindPreferencesDecorator(parent: interfaces.Container): void {
     parent.bind(PreferencesDecorator).toSelf().inSingletonScope();
     parent.bind(PreferencesDecoratorService).toSelf().inSingletonScope();
-    parent.rebind(TreeDecoratorService).toDynamicValue(ctx => ctx.container.get(PreferencesDecoratorService)).inSingletonScope();
+    parent.rebind(TreeDecoratorService).toService(PreferencesDecoratorService);
 }

--- a/packages/process/src/node/process-backend-module.ts
+++ b/packages/process/src/node/process-backend-module.ts
@@ -25,7 +25,7 @@ import { MultiRingBuffer, MultiRingBufferOptions } from './multi-ring-buffer';
 export default new ContainerModule(bind => {
     bind(RawProcess).toSelf().inTransientScope();
     bind(ProcessManager).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(ProcessManager)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(ProcessManager);
     bind(ILogger).toDynamicValue(ctx => {
         const parentLogger = ctx.container.get<ILogger>(ILogger);
         return parentLogger.child('process');

--- a/packages/python/src/browser/python-frontend-module.ts
+++ b/packages/python/src/browser/python-frontend-module.ts
@@ -22,7 +22,7 @@ import { LanguageGrammarDefinitionContribution } from '@theia/monaco/lib/browser
 
 export default new ContainerModule(bind => {
     bind(PythonClientContribution).toSelf().inSingletonScope();
-    bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(PythonClientContribution));
+    bind(LanguageClientContribution).toService(PythonClientContribution);
 
     bind(LanguageGrammarDefinitionContribution).to(PythonGrammarContribution).inSingletonScope();
 });

--- a/packages/task/src/node/task-backend-module.ts
+++ b/packages/task/src/node/task-backend-module.ts
@@ -29,7 +29,7 @@ import { TaskClient, TaskServer, taskPath } from '../common/task-protocol';
 export default new ContainerModule(bind => {
 
     bind(TaskManager).toSelf().inSingletonScope();
-    bind(BackendApplicationContribution).toDynamicValue(ctx => ctx.container.get(TaskManager)).inSingletonScope();
+    bind(BackendApplicationContribution).toService(TaskManager);
     bind(TaskServer).to(TaskServerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler<TaskClient>(taskPath, client => {

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -46,7 +46,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WorkspaceService).toSelf().inSingletonScope();
     bind(IWorkspaceService).toService(WorkspaceService);
-    bind(FrontendApplicationContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceService));
+    bind(FrontendApplicationContribution).toService(WorkspaceService);
     bind(WorkspaceServer).toDynamicValue(ctx => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
         return provider.createProxy<WorkspaceServer>(workspacePath);
@@ -54,9 +54,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
 
     bind(WorkspaceFrontendContribution).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, KeybindingContribution, MenuContribution]) {
-        bind(identifier).toDynamicValue(ctx =>
-            ctx.container.get(WorkspaceFrontendContribution)
-        ).inSingletonScope();
+        bind(identifier).toService(WorkspaceFrontendContribution);
     }
 
     bind(OpenFileDialogFactory).toFactory(ctx =>

--- a/packages/workspace/src/node/workspace-backend-module.ts
+++ b/packages/workspace/src/node/workspace-backend-module.ts
@@ -22,11 +22,9 @@ import { CliContribution } from '@theia/core/lib/node/cli';
 
 export default new ContainerModule(bind => {
     bind(WorkspaceCliContribution).toSelf().inSingletonScope();
-    bind(CliContribution).toDynamicValue(ctx => ctx.container.get(WorkspaceCliContribution));
+    bind(CliContribution).toService(WorkspaceCliContribution);
     bind(DefaultWorkspaceServer).toSelf().inSingletonScope();
-    bind(WorkspaceServer).toDynamicValue(ctx =>
-        ctx.container.get(DefaultWorkspaceServer)
-    ).inSingletonScope();
+    bind(WorkspaceServer).toService(DefaultWorkspaceServer);
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(workspacePath, () =>


### PR DESCRIPTION
When we have a binding in the form

    bind(OpenerService).toDynamicValue(context => context.container.get(DefaultOpenerService));

we prefer the equivalent form

    bind(OpenerService).toService(DefaultOpenerService);

This patch changes all instances I could find.  It was mostly generated
using sed, and a few more instances were adjusted by hand.

Change-Id: I82493bd8f4631fd8271bf1919c09ce5e2bcc5ea6
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
