### PR TITLE
Fix copy pasto (resolver -> provider)

### DIFF
--- a/packages/task/src/browser/task-contribution.ts
+++ b/packages/task/src/browser/task-contribution.ts
@@ -70,8 +70,8 @@ export class TaskProviderRegistry {
     }
 
     /** Registers the given Task Provider to return Task Configurations of the specified type. */
-    register(type: string, resolver: TaskProvider): Disposable {
-        this.providers.set(type, resolver);
+    register(type: string, provider: TaskProvider): Disposable {
+        this.providers.set(type, provider);
         return {
             dispose: () => this.providers.delete(type)
         };


### PR DESCRIPTION
The variable name should be provider instead of resolver, this seems to
have been copied from the similar code just above.

Change-Id: I3470df77663bfd440dc1e61f9c81eb060e7602de
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
