### PR TITLE
Extract interface from CppBuildConfigurationManager

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations-ui.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations-ui.ts
@@ -21,7 +21,7 @@ import { QuickOpenModel, QuickOpenItem, QuickOpenMode, } from '@theia/core/lib/b
 import { FileSystem, FileSystemUtils } from '@theia/filesystem/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { PreferenceScope, PreferenceService } from '@theia/preferences/lib/browser';
-import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
+import { CppBuildConfigurationManager, CppBuildConfiguration, CPP_BUILD_CONFIGURATIONS_PREFERENCE_KEY } from './cpp-build-configurations';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { CommonCommands } from '@theia/core/lib/browser';
 
@@ -130,7 +130,7 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
         const configs = this.cppBuildConfigurations.getConfigs();
         const newConfigs = configs.slice(0);
         newConfigs.push({ name: '', directory: '' });
-        await this.preferenceService.set(this.cppBuildConfigurations.BUILD_CONFIGURATIONS_PREFERENCE_KEY, newConfigs, PreferenceScope.Workspace);
+        await this.preferenceService.set(CPP_BUILD_CONFIGURATIONS_PREFERENCE_KEY, newConfigs, PreferenceScope.Workspace);
     }
 
 }

--- a/packages/cpp/src/browser/cpp-build-configurations.spec.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.spec.ts
@@ -20,7 +20,7 @@ import { FileSystem } from '@theia/filesystem/lib/common';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
 import { MockStorageService } from '@theia/core/lib/browser/test/mock-storage-service';
 import sinon = require('sinon');
-import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
+import { CppBuildConfigurationManager, CppBuildConfiguration, CppBuildConfigurationManagerImpl } from './cpp-build-configurations';
 import { FileSystemNode } from '@theia/filesystem/lib/node/node-filesystem';
 import { bindCppPreferences } from './cpp-preferences';
 import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
@@ -30,7 +30,7 @@ let container: Container;
 
 beforeEach(function() {
     const m = new ContainerModule(bind => {
-        bind(CppBuildConfigurationManager).toSelf().inSingletonScope();
+        bind(CppBuildConfigurationManager).to(CppBuildConfigurationManagerImpl).inSingletonScope();
         bind(StorageService).to(MockStorageService).inSingletonScope();
         bind(FileSystem).to(FileSystemNode).inSingletonScope();
         bindCppPreferences(bind);

--- a/packages/cpp/src/browser/cpp-frontend-module.ts
+++ b/packages/cpp/src/browser/cpp-frontend-module.ts
@@ -24,7 +24,7 @@ import { CppLanguageClientContribution } from './cpp-language-client-contributio
 import { CppKeybindingContribution, CppKeybindingContext } from './cpp-keybinding';
 import { bindCppPreferences } from './cpp-preferences';
 import { CppBuildConfigurationsContributions, CppBuildConfigurationChanger } from './cpp-build-configurations-ui';
-import { CppBuildConfigurationManager } from './cpp-build-configurations';
+import { CppBuildConfigurationManager, CppBuildConfigurationManagerImpl } from './cpp-build-configurations';
 import { LanguageGrammarDefinitionContribution } from '@theia/monaco/lib/browser/textmate';
 import { CppGrammarContribution } from './cpp-grammar-contribution';
 import { CppBuildConfigurationsStatusBarElement } from './cpp-build-configurations-statusbar-element';
@@ -38,7 +38,7 @@ export default new ContainerModule(bind => {
     bind(CppLanguageClientContribution).toSelf().inSingletonScope();
     bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(CppLanguageClientContribution));
 
-    bind(CppBuildConfigurationManager).toSelf().inSingletonScope();
+    bind(CppBuildConfigurationManager).to(CppBuildConfigurationManagerImpl).inSingletonScope();
     bind(CppBuildConfigurationChanger).toSelf().inSingletonScope();
     bind(CppBuildConfigurationsContributions).toSelf().inSingletonScope();
     bind(CommandContribution).to(CppBuildConfigurationsContributions).inSingletonScope();


### PR DESCRIPTION
... so it's easier to mock when testing something that depends on it.

Change-Id: I599957845abd557f17b30c39c346e08e70f72629
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
