### PR TITLE
[notifications] Remove message from visible array on timeout

### DIFF
--- a/packages/messages/src/browser/notifications-message-client.ts
+++ b/packages/messages/src/browser/notifications-message-client.ts
@@ -44,7 +44,7 @@ export class NotificationsMessageClient extends MessageClient {
             this.showToast(message, a => {
                 this.visibleMessages.delete(key);
                 resolve(a);
-            });
+            }, () => this.visibleMessages.delete(key));
         });
     }
 
@@ -52,7 +52,7 @@ export class NotificationsMessageClient extends MessageClient {
         return `${m.type}-${m.text}-${m.actions ? m.actions.join('|') : '|'}`;
     }
 
-    protected showToast(message: Message, onCloseFn: (action: string | undefined) => void): void {
+    protected showToast(message: Message, onCloseFn: (action: string | undefined) => void, timeoutFn?: () => void): void {
         const icon = this.iconFor(message.type);
         const text = message.text;
         const actions = (message.actions || []).map(action => <NotificationAction>{
@@ -73,7 +73,8 @@ export class NotificationsMessageClient extends MessageClient {
             icon,
             text,
             actions,
-            timeout
+            timeout,
+            timeoutFn
         });
     }
 

--- a/packages/messages/src/browser/notifications.ts
+++ b/packages/messages/src/browser/notifications.ts
@@ -30,6 +30,7 @@ export interface NotificationProperties {
     text: string;
     actions?: NotificationAction[];
     timeout: number | undefined;
+    timeoutFn?: () => void;
 }
 
 export interface Notification {
@@ -71,6 +72,9 @@ export class Notifications {
         text.innerText = properties.text;
         const close = () => {
             element.remove();
+            if (properties.timeoutFn) {
+                properties.timeoutFn();
+            }
         };
         const handler = <Notification>{ element, properties };
         const buttons = element.appendChild(document.createElement('div'));


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

With reference to https://github.com/theia-ide/theia/pull/2768 and https://github.com/theia-ide/theia/pull/2850, messages only get removed from the array of visible messages when the user clicks the `close` button. This means the same message will never re-appear during a Theia session (which I assume isn't the desired outcome).

This PR ensures messages are removed from the visible messages array when the message times out and is hidden.

@AlexTugarev 
