### PR TITLE
[python] Fix line comments

### DIFF
--- a/packages/python/src/browser/python-grammar-contribution.ts
+++ b/packages/python/src/browser/python-grammar-contribution.ts
@@ -23,8 +23,7 @@ export class PythonGrammarContribution implements LanguageGrammarDefinitionContr
 
     readonly config: monaco.languages.LanguageConfiguration = {
         comments: {
-            lineComment: '//',
-            blockComment: ['/*', '*/'],
+            lineComment: '#'
         },
         brackets: [
             ['{', '}'],


### PR DESCRIPTION
Fixes comment setting in Python's language contribution.
Aligned with: https://www.python.org/dev/peps/pep-0008/#block-comments

Fixes theia-ide/theia#3168

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>