### PR TITLE
changed tab header tooltips of preference editors

### DIFF
--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -22,7 +22,7 @@ import { bindViewContribution, WidgetFactory, FrontendApplicationContribution } 
 import { PreferencesContribution } from './preferences-contribution';
 import { createPreferencesTreeWidget } from './preference-tree-container';
 import { PreferencesMenuFactory } from './preferences-menu-factory';
-import { PreferencesContainer, PreferencesTreeWidget } from './preferences-tree-widget';
+import { PreferencesContainer, PreferencesEditorsContainer, PreferencesTreeWidget } from './preferences-tree-widget';
 import { PreferencesFrontendApplicationContribution } from './preferences-frontend-application-contribution';
 
 import './monaco-contribution';
@@ -45,6 +45,12 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
         id: PreferencesTreeWidget.ID,
         createWidget: () => createPreferencesTreeWidget(container)
     })).inSingletonScope();
+
+    bind(PreferencesEditorsContainer).toSelf();
+    bind(WidgetFactory).toDynamicValue(({ container }) => ({
+        id: PreferencesEditorsContainer.ID,
+        createWidget: () => container.get(PreferencesEditorsContainer)
+    }));
 
     bind(PreferencesMenuFactory).toSelf();
     bind(FrontendApplicationContribution).to(PreferencesFrontendApplicationContribution).inSingletonScope();

--- a/packages/preferences/src/browser/user-preference-provider.ts
+++ b/packages/preferences/src/browser/user-preference-provider.ts
@@ -17,8 +17,9 @@
 import { injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { AbstractResourcePreferenceProvider } from './abstract-resource-preference-provider';
+import { UserStorageUri } from '@theia/userstorage/lib/browser';
 
-export const USER_PREFERENCE_URI = new URI().withScheme('user_storage').withPath('settings.json');
+export const USER_PREFERENCE_URI = new URI().withScheme(UserStorageUri.SCHEME).withPath('settings.json');
 @injectable()
 export class UserPreferenceProvider extends AbstractResourcePreferenceProvider {
 

--- a/packages/userstorage/src/browser/user-storage-service-filesystem.ts
+++ b/packages/userstorage/src/browser/user-storage-service-filesystem.ts
@@ -22,7 +22,7 @@ import { FileSystem } from '@theia/filesystem/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { UserStorageUri } from './user-storage-uri';
 
-const THEIA_USER_STORAGE_FOLDER = '.theia';
+export const THEIA_USER_STORAGE_FOLDER = '.theia';
 
 @injectable()
 export class UserStorageServiceFilesystemImpl implements UserStorageService {


### PR DESCRIPTION
- made PreferencesEditorsContainer in the preferences package injectable
- with this change, tab header tooltips of preference editors contain more context info of paths
- added tooltip to the preference widget
- resolved #3166

Signed-off-by: elaihau <liang.huang@ericsson.com>

