### PR TITLE
Fix plugin command label

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
@@ -28,7 +28,7 @@ export class PluginExtDeployCommandService implements QuickOpenModel {
 
     public static COMMAND: Command = {
         id: 'plugin-ext:deploy-plugin-id',
-        label: 'Plugin: Deploy a plugin\'s id'
+        label: 'Plugin: Deploy Plugin by Id'
     };
 
     @inject(QuickOpenService)


### PR DESCRIPTION
Fix the wording of the plugin command label to be more descriptive, and consistent with the rest of Theia.

Based on https://github.com/theia-ide/theia/pull/3185#discussion_r225453577

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
