### PR TITLE
Adding the ability to pass arguments to task:run and openFile commands

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -21,6 +21,7 @@ import { MAIN_MENU_BAR, CommandContribution, Command, CommandRegistry, MenuContr
 import { FrontendApplication, FrontendApplicationContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskContribution, TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
+import { TaskService } from './task-service';
 
 export namespace TaskCommands {
     // Task menu
@@ -67,6 +68,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     @inject(TaskResolverRegistry)
     protected readonly taskResolverRegistry: TaskResolverRegistry;
 
+    @inject(TaskService)
+    protected readonly taskService: TaskService;
+
     onStart(): void {
         this.contributionProvider.getContributions().forEach(contrib => {
             if (contrib.registerResolvers) {
@@ -83,7 +87,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_RUN,
             {
                 isEnabled: () => true,
-                execute: () => this.quickOpenTask.open()
+                execute: (args: any[]) => {
+                    if (args) {
+                        const [type, label] = args;
+                        return this.taskService.run(type, label);
+                    }
+                    return this.quickOpenTask.open();
+                }
             }
         );
         registry.registerCommand(

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -42,7 +42,13 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(WorkspaceCommands.OPEN, {
             isEnabled: () => true,
-            execute: () => this.doOpen()
+            execute: (args: any[]) => {
+                if (args) {
+                    const [fileURI] = args;
+                    return this.workspaceService.open(fileURI);
+                }
+                return this.doOpen();
+            }
         });
         commands.registerCommand(WorkspaceCommands.OPEN_WORKSPACE, {
             isEnabled: () => true,


### PR DESCRIPTION
Adding the ability to pass arguments to task:run and openFile commands so they could be used from the command API without UI.