### PR TITLE
GH-3173: Replaced the file dialogs with the native ones in electron. 

### DIFF
--- a/dev-packages/application-package/package.json
+++ b/dev-packages/application-package/package.json
@@ -35,6 +35,7 @@
     "@types/write-json-file": "^2.2.1",
     "changes-stream": "^2.2.0",
     "fs-extra": "^4.0.2",
+    "is-electron": "^2.1.0",
     "request": "^2.82.0",
     "semver": "^5.4.1",
     "write-json-file": "^2.2.0"

--- a/dev-packages/application-package/src/environment.ts
+++ b/dev-packages/application-package/src/environment.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './file-dialog';
-export * from './file-dialog-container';
-export * from './file-dialog-tree-filters-renderer';
-export * from './file-dialog-service';
+const isElectronLib: () => boolean = require('is-electron');
+
+/**
+ * `true` if running in Electron. Otherwise, `false`. Can be called from both the `main` and the render process.
+ */
+export function isElectron(): boolean {
+    return isElectronLib();
+}
+
+/**
+ * `true` if running in Electron in development mode. Otherwise, `false`. Cannot be used from the browser.
+ */
+export function isElectronDevMode(): boolean {
+    return isElectron()
+        && typeof process !== 'undefined'
+        // `defaultApp` does not exist on the Node.js API, but on electron (`electron.d.ts`).
+        && ((process as any).defaultApp || /node_modules[/]electron[/]/.test(process.execPath)); // tslint:disable-line:no-any
+}

--- a/dev-packages/application-package/src/index.ts
+++ b/dev-packages/application-package/src/index.ts
@@ -18,3 +18,4 @@ export * from './npm-registry';
 export * from './extension-package';
 export * from './application-package';
 export * from './application-props';
+export * from './environment';

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -393,12 +393,6 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
         commandRegistry.registerCommand(CommonCommands.SAVE_ALL, {
             execute: () => this.shell.saveAll()
         });
-
-        commandRegistry.registerCommand(CommonCommands.QUIT, {
-            execute: () => {
-                /* FIXME implement QUIT of innermost command.  */
-            }
-        });
         commandRegistry.registerCommand(CommonCommands.ABOUT_COMMAND, {
             execute: () => this.openAbout()
         });
@@ -479,10 +473,6 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
             {
                 command: CommonCommands.SAVE_ALL.id,
                 keybinding: 'ctrlcmd+alt+s'
-            },
-            {
-                command: CommonCommands.QUIT.id,
-                keybinding: 'ctrlcmd+q'
             }
         );
     }

--- a/packages/core/src/browser/endpoint.spec.ts
+++ b/packages/core/src/browser/endpoint.spec.ts
@@ -94,7 +94,45 @@ describe('Endpoint', () => {
                     protocol: 'https:'
                 }, 'https://example.org/');
         });
+
+        it("should return with the 'options.httpScheme' if defined", () => {
+            expect(new Endpoint({ httpScheme: 'foo:' }, {
+                host: 'example.org',
+                pathname: '/',
+                search: '',
+                protocol: 'https:'
+            }).httpScheme).to.be.equal('foo:');
+        });
+
+        it('should return with the HTTP if the protocol is HTTP.', () => {
+            expect(new Endpoint({}, {
+                host: 'example.org',
+                pathname: '/',
+                search: '',
+                protocol: 'http:'
+            }).httpScheme).to.be.equal('http:');
+        });
+
+        it('should return with the HTTPS if the protocol is HTTPS.', () => {
+            expect(new Endpoint({}, {
+                host: 'example.org',
+                pathname: '/',
+                search: '',
+                protocol: 'https:'
+            }).httpScheme).to.be.equal('https:');
+        });
+
+        it('should return with the HTTP if the protocol is *not* HTTP or HTTPS.', () => {
+            expect(new Endpoint({}, {
+                host: 'example.org',
+                pathname: '/',
+                search: '',
+                protocol: 'file:'
+            }).httpScheme).to.be.equal('http:');
+        });
+
     });
+
 });
 
 function expectWsUri(options: Endpoint.Options, mockLocation: Endpoint.Location, expectedUri: string) {

--- a/packages/core/src/browser/endpoint.ts
+++ b/packages/core/src/browser/endpoint.ts
@@ -80,7 +80,11 @@ export class Endpoint {
         return this.httpScheme === Endpoint.PROTO_HTTPS ? Endpoint.PROTO_WSS : Endpoint.PROTO_WS;
     }
 
-    protected get httpScheme() {
+    /**
+     * The HTTP/HTTPS scheme of the endpoint, or the user defined one.
+     * See: `Endpoint.Options.httpScheme`.
+     */
+    get httpScheme() {
         if (this.options.httpScheme) {
             return this.options.httpScheme;
         }

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -70,10 +70,11 @@ export interface TreeModel extends Tree, TreeSelectionService, TreeExpansionServ
     selectParent(): void;
 
     /**
-     * Navigates to the given node if it is defined.
-     * Navigation sets a node as a root node and expand it.
+     * Navigates to the given node if it is defined. This method accepts both the tree node and its ID as an argument.
+     * Navigation sets a node as a root node and expand it. Resolves to the node if the navigation was successful. Otherwise,
+     * resolves to `undefined`.
      */
-    navigateTo(node: Readonly<TreeNode> | undefined): Promise<void>;
+    navigateTo(nodeOrId: Readonly<TreeNode> | string | undefined): Promise<TreeNode | undefined>;
     /**
      * Tests whether it is possible to navigate forward.
      */
@@ -345,11 +346,16 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
         }
     }
 
-    async navigateTo(node: TreeNode | undefined): Promise<void> {
-        if (node) {
-            this.navigationService.push(node);
-            await this.doNavigate(node);
+    async navigateTo(nodeOrId: TreeNode | string | undefined): Promise<TreeNode | undefined> {
+        if (nodeOrId) {
+            const node = typeof nodeOrId === 'string' ? this.getNode(nodeOrId) : nodeOrId;
+            if (node) {
+                this.navigationService.push(node);
+                await this.doNavigate(node);
+                return node;
+            }
         }
+        return undefined;
     }
 
     canNavigateForward(): boolean {

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -34,3 +34,6 @@ export * from './message-service-protocol';
 export * from './selection';
 export * from './strings';
 export * from './application-error';
+
+import { isElectron, isElectronDevMode } from '@theia/application-package/lib/environment';
+export { isElectron, isElectronDevMode };

--- a/packages/core/src/common/os.ts
+++ b/packages/core/src/common/os.ts
@@ -36,3 +36,30 @@ export function cmd(command: string, ...args: string[]): CMD {
         isWindows ? ['/c', command, ...args] : args
     ];
 }
+
+export namespace OS {
+
+    /**
+     * Enumeration of the supported operating systems.
+     */
+    export enum Type {
+        Windows = 'Windows',
+        Linux = 'Linux',
+        OSX = 'OSX'
+    }
+
+    /**
+     * Returns with the type of the operating system. If it is neither [Windows](isWindows) nor [OS X](isOSX), then
+     * it always return with the `Linux` OS type.
+     */
+    export function type(): OS.Type {
+        if (isWindows) {
+            return Type.Windows;
+        }
+        if (isOSX) {
+            return Type.OSX;
+        }
+        return Type.Linux;
+    }
+
+}

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -141,7 +141,7 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
         registry.registerKeybindings(
             {
                 command: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
-                keybinding: 'ctrlcmd+shift+i'
+                keybinding: 'ctrlcmd+alt+i'
             },
             {
                 command: ElectronCommands.RELOAD.id,

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -37,6 +37,10 @@
     {
       "frontend": "lib/browser/download/file-download-frontend-module",
       "backend": "lib/node/download/file-download-backend-module"
+    },
+    {
+      "frontend": "lib/browser/file-dialog/file-dialog-module",
+      "frontendElectron": "lib/electron-browser/file-dialog/electron-file-dialog-module"
     }
   ],
   "keywords": [

--- a/packages/filesystem/src/browser/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog-service.ts
@@ -36,8 +36,8 @@ export class FileDialogService {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             const dialog = this.openFileDialogFactory(Object.assign(props, { title }));
-            dialog.model.navigateTo(rootNode);
-            return await dialog.open();
+            await dialog.model.navigateTo(rootNode);
+            return dialog.open();
         }
         return undefined;
     }
@@ -47,8 +47,8 @@ export class FileDialogService {
         const rootNode = await this.getRootNode(folder);
         if (rootNode) {
             const dialog = this.saveFileDialogFactory(Object.assign(props, { title }));
-            dialog.model.navigateTo(rootNode);
-            return await dialog.open();
+            await dialog.model.navigateTo(rootNode);
+            return dialog.open();
         }
         return undefined;
     }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog-module.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,15 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-/* note: this bogus test file is required so that
-   we are able to run mocha unit tests on this
-   package, without having any actual unit tests in it.
-   This way a coverage report will be generated,
-   showing 0% coverage, instead of no report.
-   This file can be removed once we have real unit
-   tests in place. */
+import { ContainerModule } from 'inversify';
+import { DefaultFileDialogService, FileDialogService } from './file-dialog-service';
 
-describe('workspace package', () => {
-
-    it('support code coverage statistics', () => true);
+export default new ContainerModule(bind => {
+    bind(DefaultFileDialogService).toSelf().inSingletonScope();
+    bind(FileDialogService).toService(DefaultFileDialogService);
 });

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -42,6 +42,7 @@ export const SAVE_DIALOG_CLASS = 'theia-SaveFileDialog';
 export const NAVIGATION_PANEL_CLASS = 'theia-NavigationPanel';
 export const NAVIGATION_BACK_CLASS = 'theia-NavigationBack';
 export const NAVIGATION_FORWARD_CLASS = 'theia-NavigationForward';
+export const NAVIGATION_HOME_CLASS = 'theia-NavigationHome';
 export const NAVIGATION_LOCATION_LIST_PANEL_CLASS = 'theia-LocationListPanel';
 
 export const FILTERS_PANEL_CLASS = 'theia-FiltersPanel';
@@ -109,6 +110,7 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
     protected readonly back: HTMLSpanElement;
     protected readonly forward: HTMLSpanElement;
+    protected readonly home: HTMLSpanElement;
     protected readonly locationListRenderer: LocationListRenderer;
     protected readonly treeFiltersRenderer: FileDialogTreeFiltersRenderer | undefined;
     protected readonly treePanel: Panel;
@@ -131,8 +133,13 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
         navigationPanel.appendChild(this.back = createIconButton('fa', 'fa-chevron-left'));
         this.back.classList.add(NAVIGATION_BACK_CLASS);
+        this.back.title = 'Navigate Back';
         navigationPanel.appendChild(this.forward = createIconButton('fa', 'fa-chevron-right'));
         this.forward.classList.add(NAVIGATION_FORWARD_CLASS);
+        this.forward.title = 'Navigate Forward';
+        navigationPanel.appendChild(this.home = createIconButton('fa', 'fa-home'));
+        this.home.classList.add(NAVIGATION_HOME_CLASS);
+        this.home.title = 'Go To Initial Location';
 
         this.locationListRenderer = this.createLocationListRenderer();
         this.locationListRenderer.host.classList.add(NAVIGATION_LOCATION_LIST_PANEL_CLASS);
@@ -161,6 +168,9 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
         super.onUpdateRequest(msg);
         setEnabled(this.back, this.model.canNavigateBackward());
         setEnabled(this.forward, this.model.canNavigateForward());
+        setEnabled(this.home, !!this.model.initialLocation
+            && !!this.model.location
+            && this.model.initialLocation.toString() !== this.model.location.toString());
         this.locationListRenderer.render();
 
         if (this.treeFiltersRenderer) {
@@ -203,6 +213,11 @@ export abstract class FileDialog<T> extends AbstractDialog<T> {
 
         this.addKeyListener(this.back, Key.ENTER, () => this.model.navigateBackward(), 'click');
         this.addKeyListener(this.forward, Key.ENTER, () => this.model.navigateForward(), 'click');
+        this.addKeyListener(this.home, Key.ENTER, () => {
+            if (this.model.initialLocation) {
+                this.model.location = this.model.initialLocation;
+            }
+        }, 'click');
         super.onAfterAttach(msg);
     }
 

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -25,7 +25,6 @@ import {
 import { FileResourceResolver } from './file-resource';
 import { bindFileSystemPreferences } from './filesystem-preferences';
 import { FileSystemWatcher } from './filesystem-watcher';
-import { FileDialogService } from './file-dialog-service';
 import { FileSystemFrontendContribution } from './filesystem-frontend-contribution';
 
 import '../../src/browser/style/index.css';
@@ -38,7 +37,7 @@ export default new ContainerModule(bind => {
     );
     bind(FileSystemWatcherServer).to(ReconnectingFileSystemWatcherServer);
     bind(FileSystemWatcher).toSelf().inSingletonScope();
-    bind(FileShouldOverwrite).toFunction(async function(file: FileStat, stat: FileStat): Promise<boolean> {
+    bind(FileShouldOverwrite).toFunction(async function (file: FileStat, stat: FileStat): Promise<boolean> {
         const dialog = new ConfirmDialog({
             title: `The file '${file.uri}' has been changed on the file system.`,
             msg: 'Do you want to overwrite the changes made on the file system?',
@@ -55,6 +54,5 @@ export default new ContainerModule(bind => {
     bind(FileResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toDynamicValue(ctx => ctx.container.get(FileResourceResolver));
 
-    bind(FileDialogService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).to(FileSystemFrontendContribution).inSingletonScope();
 });

--- a/packages/filesystem/src/browser/index.ts
+++ b/packages/filesystem/src/browser/index.ts
@@ -20,4 +20,3 @@ export * from './file-dialog';
 export * from './filesystem-preferences';
 export * from './filesystem-watcher';
 export * from './file-resource';
-export * from './file-dialog-service';

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -54,7 +54,8 @@
  */
 
 .dialogContent .theia-NavigationBack,
-.dialogContent .theia-NavigationForward {
+.dialogContent .theia-NavigationForward,
+.dialogContent .theia-NavigationHome {
     position: absolute;
     top: 0px;
     line-height: 23px;
@@ -63,17 +64,22 @@
 }
 
 .dialogContent .theia-NavigationBack:focus,
-.dialogContent .theia-NavigationForward:focus {
+.dialogContent .theia-NavigationForward:focus,
+.dialogContent .theia-NavigationHome:focus {
     outline: none;
     border: none;
     box-shadow: none;
 }
 
 .dialogContent .theia-NavigationBack {
-    left: 21px;
+    left: auto;
 }
 
 .dialogContent .theia-NavigationForward {
+    left: 21px;
+}
+
+.dialogContent .theia-NavigationHome {
     left: 41px;
 }
 

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -27,7 +27,7 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
      *
      * If the uri points to a folder it will contain one level of unresolved children.
      *
-     * Reject if a file for the given uri does not exist.
+     * `undefined` if a file for the given URI does not exist.
      */
     getFileStat(uri: string): Promise<FileStat | undefined>;
 
@@ -119,6 +119,45 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
      */
     getDrives(): Promise<string[]>;
 
+    /**
+     * Tests a user's permissions for the file or directory specified by URI.
+     * The mode argument is an optional integer that specifies the accessibility checks to be performed.
+     * Check `FileAccess.Constants` for possible values of mode.
+     * It is possible to create a mask consisting of the bitwise `OR` of two or more values (e.g. FileAccess.Constants.W_OK | FileAccess.Constants.R_OK).
+     * If `mode` is not defined, `FileAccess.Constants.F_OK` will be used instead.
+     */
+    access(uri: string, mode?: number): Promise<boolean>
+
+}
+
+export namespace FileAccess {
+
+    export namespace Constants {
+
+        /**
+         * Flag indicating that the file is visible to the calling process.
+         * This is useful for determining if a file exists, but says nothing about rwx permissions. Default if no mode is specified.
+         */
+        export const F_OK: number = 0;
+
+        /**
+         * Flag indicating that the file can be read by the calling process.
+         */
+        export const R_OK: number = 4;
+
+        /**
+         * Flag indicating that the file can be written by the calling process.
+         */
+        export const W_OK: number = 2;
+
+        /**
+         * Flag indicating that the file can be executed by the calling process.
+         * This has no effect on Windows (will behave like `FileAccess.F_OK`).
+         */
+        export const X_OK: number = 1;
+
+    }
+
 }
 
 export interface FileMoveOptions {
@@ -133,7 +172,7 @@ export interface FileDeleteOptions {
  * A callback type, called when we try to save a file but realize it has been
  * modified by somebody else since we have opened it.  `originalStat` is the
  * stat at the moment we opened the file, `currentStat` is the stat at the
- * moment we try to save it (after the externl modification).  The callback
+ * moment we try to save it (after the external modification).  The callback
  * should return true if we still want to save the file, false otherwise.
  */
 export const FileShouldOverwrite = Symbol('FileShouldOverwrite');
@@ -159,7 +198,7 @@ export interface FileSystemClient {
 export interface FileStat {
 
     /**
-     * The uri of the file.
+     * The URI of the file.
      */
     uri: string;
 
@@ -169,14 +208,13 @@ export interface FileStat {
     lastModification: number;
 
     /**
-     * The resource is a directory. Iff {{true}}
-     * {{encoding}} has no meaning.
+     * `true` if the resource is a directory. Otherwise, `false`.
      */
     isDirectory: boolean;
 
     /**
      * The children of the file stat.
-     * If it is undefined and isDirectory is true, then this file stat is unresolved.
+     * If it is `undefined` and `isDirectory` is `true`, then this file stat is unresolved.
      */
     children?: FileStat[];
 

--- a/packages/filesystem/src/common/test/mock-filesystem.ts
+++ b/packages/filesystem/src/common/test/mock-filesystem.ts
@@ -85,6 +85,10 @@ export class MockFilesystem implements FileSystem {
         return Promise.resolve(mockFileStat);
     }
 
+    async access(uri: string, mode?: number): Promise<boolean> {
+        return true;
+    }
+
     setClient(client: FileSystemClient) {
 
     }

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-module.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-module.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export namespace BackendProcess {
-    /* Running in electron or a childProcess.fork of electron */
-    export const electron = !!process.versions.electron || process.env.ELECTRON_RUN_AS_NODE;
-}
+import { ContainerModule } from 'inversify';
+import { FileDialogService } from '../../browser/file-dialog/file-dialog-service';
+import { ElectronFileDialogService } from './electron-file-dialog-service';
+
+export default new ContainerModule(bind => {
+    bind(ElectronFileDialogService).toSelf().inSingletonScope();
+    bind(FileDialogService).toService(ElectronFileDialogService);
+});

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -1,0 +1,177 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { remote, FileFilter, OpenDialogOptions, SaveDialogOptions } from 'electron';
+import URI from '@theia/core/lib/common/uri';
+import { isOSX } from '@theia/core/lib/common/os';
+import { MaybeArray } from '@theia/core/lib/common/types';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { FileStat } from '../../common';
+import { FileAccess } from '../../common/filesystem';
+import { DefaultFileDialogService, OpenFileDialogProps, SaveFileDialogProps } from '../../browser/file-dialog';
+
+//
+// We are OK to use this here because the electron backend and frontend are on the same host.
+// If required, we can move this single service (and its module) to a dedicated Theia extension,
+// and at packaging time, clients can decide whether they need the native or the browser-based
+// solution.
+//
+import { FileUri } from '@theia/core/lib/node/file-uri';
+
+@injectable()
+export class ElectronFileDialogService extends DefaultFileDialogService {
+
+    @inject(MessageService) protected readonly messageService: MessageService;
+
+    async showOpenDialog(props: OpenFileDialogProps & { canSelectMany: true }, folder?: FileStat): Promise<MaybeArray<URI> | undefined>;
+    async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<URI | undefined>;
+    async showOpenDialog(props: OpenFileDialogProps, folder?: FileStat): Promise<MaybeArray<URI> | undefined> {
+        const rootNode = await this.getRootNode(folder);
+        if (rootNode) {
+            return new Promise<MaybeArray<URI> | undefined>(resolve => {
+                remote.dialog.showOpenDialog(this.toOpenDialogOptions(rootNode.uri, props), (filePaths: string[] | undefined) => {
+                    if (!filePaths || filePaths.length === 0) {
+                        resolve(undefined);
+                        return;
+                    }
+                    const uris = filePaths.map(path => FileUri.create(path));
+                    if (this.canReadWrite(uris)) {
+                        resolve(uris.length === 1 ? uris[0] : uris);
+                    } else {
+                        resolve(undefined);
+                    }
+                });
+            });
+        }
+        return undefined;
+    }
+
+    async showSaveDialog(props: SaveFileDialogProps, folder?: FileStat): Promise<URI | undefined> {
+        const rootNode = await this.getRootNode(folder);
+        if (rootNode) {
+            return new Promise<URI | undefined>(resolve => {
+                remote.dialog.showSaveDialog(this.toSaveDialogOptions(rootNode.uri, props), (filename: string | undefined) => {
+                    if (!filename) {
+                        resolve(undefined);
+                        return;
+                    }
+                    const uri = FileUri.create(filename);
+                    if (this.canReadWrite(uri)) {
+                        resolve(uri);
+                    } else {
+                        resolve(undefined);
+                    }
+                });
+            });
+        }
+        return undefined;
+    }
+
+    protected async canReadWrite(uris: MaybeArray<URI>): Promise<boolean> {
+        for (const uri of uris) {
+            if (!(await this.fileSystem.access(uri.toString(), FileAccess.Constants.R_OK | FileAccess.Constants.W_OK))) {
+                this.messageService.error(`Cannot access resource at ${uri.path}.`);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected toDialogOptions(uri: URI, props: SaveFileDialogProps | OpenFileDialogProps, dialogTitle: string): electron.FileDialogProps {
+        const title = props.title || dialogTitle;
+        const defaultPath = FileUri.fsPath(uri);
+        const filters: FileFilter[] = [{ name: 'All Files', extensions: ['*'] }];
+        if (props.filters) {
+            filters.push(...Object.keys(props.filters).map(key => ({ name: key, extensions: props.filters![key] })));
+        }
+        return { title, defaultPath, filters };
+    }
+
+    protected toOpenDialogOptions(uri: URI, props: OpenFileDialogProps): OpenDialogOptions {
+        const properties: Array<'openFile' | 'openDirectory' | 'multiSelections'> = electron.dialog.toDialogProperties(props);
+        const buttonLabel = props.openLabel;
+        return { ...this.toDialogOptions(uri, props, 'Open'), properties, buttonLabel };
+    }
+
+    protected toSaveDialogOptions(uri: URI, props: SaveFileDialogProps): SaveDialogOptions {
+        const buttonLabel = props.saveLabel;
+        return { ...this.toDialogOptions(uri, props, 'Save'), buttonLabel };
+    }
+
+}
+
+export namespace electron {
+
+    /**
+     * Common "super" interface of the `electron.SaveDialogOptions` and `electron.OpenDialogOptions` types.
+     */
+    export interface FileDialogProps {
+
+        /**
+         * The dialog title.
+         */
+        readonly title?: string;
+
+        /**
+         * The default path, where the dialog opens. Requires an FS path.
+         */
+        readonly defaultPath?: string;
+
+        /**
+         * Resource filter.
+         */
+        readonly filters?: FileFilter[];
+
+    }
+
+    export namespace dialog {
+
+        /**
+         * Converts the Theia specific `OpenFileDialogProps` into an electron specific array.
+         *
+         * Note: On Windows and Linux an open dialog can not be both a file selector and a directory selector,
+         * so if you set properties to ['openFile', 'openDirectory'] on these platforms, a directory selector will be shown.
+         *
+         * See: https://github.com/electron/electron/issues/10252#issuecomment-322012159
+         */
+        export function toDialogProperties(props: OpenFileDialogProps): Array<'openFile' | 'openDirectory' | 'multiSelections'> {
+            if (!isOSX && props.canSelectFiles !== false && props.canSelectFolders === true) {
+                throw new Error(`Illegal props. Cannot have 'canSelectFiles' and 'canSelectFolders' at the same times. Props was: ${JSON.stringify(props)}.`);
+            }
+            const properties: Array<'openFile' | 'openDirectory' | 'multiSelections'> = [];
+            if (!isOSX) {
+                if (props.canSelectFiles !== false && props.canSelectFolders !== true) {
+                    properties.push('openFile');
+                }
+                if (props.canSelectFolders === true && props.canSelectFiles === false) {
+                    properties.push('openDirectory');
+                }
+            } else {
+                if (props.canSelectFiles !== false) {
+                    properties.push('openFile');
+                }
+                if (props.canSelectFolders === true) {
+                    properties.push('openDirectory');
+                }
+            }
+            if (props.canSelectMany === true) {
+                properties.push('multiSelections');
+            }
+            return properties;
+        }
+    }
+}

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -311,7 +311,7 @@ export class FileSystemNode implements FileSystem {
             throw FileSystemError.FileNotFound(uri);
         }
         if (stat.isDirectory) {
-            throw FileSystemError.FileIsDirectory(uri, '`Cannot get the encoding.');
+            throw FileSystemError.FileIsDirectory(uri, 'Cannot get the encoding.');
         }
         return this.options.encoding;
     }

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -25,7 +25,7 @@ import { injectable, inject, optional } from 'inversify';
 import { TextDocumentContentChangeEvent, TextDocument } from 'vscode-languageserver-types';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node/file-uri';
-import { FileStat, FileSystem, FileSystemClient, FileSystemError, FileMoveOptions, FileDeleteOptions } from '../common/filesystem';
+import { FileStat, FileSystem, FileSystemClient, FileSystemError, FileMoveOptions, FileDeleteOptions, FileAccess } from '../common/filesystem';
 
 @injectable()
 export class FileSystemNodeOptions {
@@ -368,6 +368,15 @@ export class FileSystemNode implements FileSystem {
 
     dispose(): void {
         // NOOP
+    }
+
+    async access(uri: string, mode: number = FileAccess.Constants.F_OK): Promise<boolean> {
+        try {
+            await fs.access(FileUri.fsPath(uri), mode);
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     protected async doGetStat(uri: URI, depth: number): Promise<FileStat | undefined> {

--- a/packages/json/src/browser/json-client-contribution.ts
+++ b/packages/json/src/browser/json-client-contribution.ts
@@ -28,6 +28,7 @@ import { ResourceProvider } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { JsonPreferences } from './json-preferences';
 import { JsonSchemaStore } from '@theia/core/lib/browser/json-schema-store';
+import { Endpoint } from '@theia/core/lib/browser';
 
 @injectable()
 export class JsonClientContribution extends BaseLanguageClientContribution {
@@ -102,13 +103,13 @@ export class JsonClientContribution extends BaseLanguageClientContribution {
     }
 
     protected async initializeJsonSchemaAssociations(): Promise<void> {
-        const url = `${window.location.protocol}//schemastore.azurewebsites.net/api/json/catalog.json`;
+        const url = `${new Endpoint().httpScheme}//schemastore.azurewebsites.net/api/json/catalog.json`;
         const response = await fetch(url);
         const schemas: SchemaData[] = (await response.json()).schemas!;
         for (const s of schemas) {
             if (s.fileMatch) {
                 this.jsonSchemaStore.registerSchema({
-                    fileMatch : s.fileMatch,
+                    fileMatch: s.fileMatch,
                     url: s.url
                 });
             }

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -181,9 +181,9 @@ export class FileNavigatorWidget extends FileTreeWidget {
      */
     protected renderOpenWorkspaceDiv(): React.ReactNode {
         return <div className='theia-navigator-container'>
-            You have not yet opened a workspace.
+            <div className='center'>You have not yet opened a workspace.</div>
             <div className='open-workspace-button-container'>
-                <button className='open-workspace-button' title='Select a directory as your workspace root' onClick={this.openWorkspace}>
+                <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openWorkspace}>
                     Open Workspace
                 </button>
             </div>

--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -26,6 +26,10 @@
     margin-top: 5px;
 }
 
+.theia-navigator-container .center {
+    text-align: center;
+}
+
 .p-Widget .open-workspace-button {
     border: 1px solid var(--theia-border-color1);
     color: var(--theia-ui-font-color1);

--- a/packages/workspace/src/browser/workspace-frontend-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.spec.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { OS } from '@theia/core/lib/common/os';
+import { OpenFileDialogProps } from '@theia/filesystem/lib/browser/file-dialog';
+import { WorkspaceFrontendContribution } from './workspace-frontend-contribution';
+import { WorkspaceCommands } from './workspace-commands';
+
+disableJSDOM();
+
+describe('workspace-frontend-contribution', () => {
+
+    describe('WorkspaceFrontendContribution', () => {
+
+        const title = WorkspaceCommands.OPEN_WORKSPACE.dialogLabel;
+        const filters = WorkspaceFrontendContribution.DEFAULT_FILE_FILTER;
+
+        before(() => disableJSDOM = enableJSDOM());
+        after(() => disableJSDOM());
+
+        ([
+
+            [OS.Type.Linux, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
+            [OS.Type.Linux, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
+            [OS.Type.Linux, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters }],
+            [OS.Type.Linux, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true }],
+
+            [OS.Type.Windows, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
+            [OS.Type.Windows, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
+            [OS.Type.Windows, 'electron', true, { title, canSelectFiles: true, canSelectFolders: false, filters }],
+            [OS.Type.Windows, 'electron', false, { title, canSelectFiles: false, canSelectFolders: true }],
+
+            [OS.Type.OSX, 'browser', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
+            [OS.Type.OSX, 'browser', false, { title, canSelectFiles: false, canSelectFolders: true }],
+            [OS.Type.OSX, 'electron', true, { title, canSelectFiles: true, canSelectFolders: true, filters }],
+            [OS.Type.OSX, 'electron', false, { title, canSelectFiles: true, canSelectFolders: true, filters }]
+
+        ] as [OS.Type, 'browser' | 'electron', boolean, OpenFileDialogProps][]).forEach(test => {
+            const [type, environment, supportMultiRootWorkspace, expected] = test;
+            const electron = environment === 'electron' ? true : false;
+            const os = (OS.Type as any)[type]; // tslint:disable-line:no-any
+            const actual = WorkspaceFrontendContribution.createOpenWorkspaceOpenFileDialogProps({
+                type,
+                electron,
+                supportMultiRootWorkspace
+            });
+            it(`createOpenWorkspaceOpenFileDialogProps - OS: ${os}, Environment: ${environment}, Multi-root workspace: ${supportMultiRootWorkspace ? 'yes' : 'no'}`, () => {
+                expect(actual).to.be.deep.equal(expected);
+            });
+        });
+
+    });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5071,6 +5071,11 @@ is-electron-renderer@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-electron-renderer/-/is-electron-renderer-2.0.1.tgz#a469d056f975697c58c98c6023eb0aa79af895a2"
 
+is-electron@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.1.0.tgz#37dd2e9e7167efa8bafce86c0c25762bc4b851fa"
+  integrity sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw==
+
 is-equal-shallow@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"


### PR DESCRIPTION
 - Got rid of the dummy `Quit` command in electron. Closes: #1331.
 - Fixed the `protocol` of the JSON scheme store URL. Closes: #3193.
 - Fixed the toggle issue with commands in electron. Closes: #2381.
 - Fixed the keybinding of the `Open Dev Tools` in electron.
 - Exposed an `access` file-system API.
 - Added `Home` button to the `File Dialog`. From now on, one can [go back to the initial location](https://github.com/theia-ide/theia/issues/3173#issuecomment-429877490).

Closes: #3173.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>