### PR TITLE
Automatically add "restart" commands for language servers

### DIFF
--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -112,6 +112,10 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                 }));
             }
         }, options);
+
+        this.registerRestartCommand();
+        toDeactivate.push(Disposable.create(() => this.unregisterRestartCommand()));
+
         return toDeactivate;
     }
 
@@ -228,4 +232,34 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         });
     }
 
+    /**
+     * Return the id of the "restart" command for this language client.
+     */
+    private restartCommandId(): string {
+        return `languages.${this.id}.restart`;
+    }
+
+    /**
+     * Register a command that lets the user restart the language server this
+     * client is connected to.
+     */
+    protected registerRestartCommand(): void {
+        this.registry.registerCommand(
+            {
+                id: this.restartCommandId(),
+                label: `${this.name}: Restart Language Server`,
+            },
+            {
+                execute: () => this.restart(),
+                isEnabled: () => this.running,
+                isVisible: () => this.running,
+            });
+    }
+
+    /**
+     * Unregister the command registered by `registerRestartCommand`.
+     */
+    protected unregisterRestartCommand(): void {
+        this.registry.unregisterCommand(this.restartCommandId());
+    }
 }

--- a/packages/typescript/src/browser/typescript-frontend-contribution.ts
+++ b/packages/typescript/src/browser/typescript-frontend-contribution.ts
@@ -40,10 +40,6 @@ export namespace TypeScriptCommands {
         label: 'TypeScript: Open Server Log',
         id: 'typescript.server.openLog'
     };
-    export const restartServer: Command = {
-        label: 'TypeScript: Restart Server',
-        id: 'typescript.server.restart'
-    };
 }
 
 @injectable()
@@ -82,11 +78,6 @@ export class TypeScriptFrontendContribution implements CommandContribution, Menu
             execute: () => this.openServerLog(),
             isEnabled: () => !!this.clientContribution.logFileUri,
             isVisible: () => !!this.clientContribution.logFileUri
-        });
-        commands.registerCommand(TypeScriptCommands.restartServer, {
-            execute: () => this.clientContribution.restart(),
-            isEnabled: () => this.clientContribution.running,
-            isVisible: () => this.clientContribution.running
         });
     }
 


### PR DESCRIPTION
It is quite common (though not desirable) to have to restart a language
server, because it misbehaves or doesn't pick up new settings
properly.  This patch registers Theia commands for each started language
server.

Change-Id: I567e6e9851ef1b68198d0ac9b25aa9926213d6f9
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
