### PR TITLE
[callhierarchy] Add proposed LSP implementation

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-context.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-context.ts
@@ -52,9 +52,8 @@ export class CallHierarchyContext implements Disposable {
         return model;
     }
 
-    async getDefinitionLocation(location: Location): Promise<Location | undefined> {
-        const uri = location.uri;
-        const { line, character } = location.range.start;
+    async getDefinitionLocation(uri: string, position: Position): Promise<Location | undefined> {
+        const { line, character } = position;
 
         // Definition can be null
         // tslint:disable-next-line:no-null-keyword

--- a/packages/callhierarchy/src/browser/lsp-callhierarchy-service.ts
+++ b/packages/callhierarchy/src/browser/lsp-callhierarchy-service.ts
@@ -14,4 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export const CALLHIERARCHY_ID = 'callhierarchy';
+import { ILanguageClient } from '@theia/languages/lib/browser';
+import { CallsParams, CallsResult, CallsRequest } from '@theia/languages/lib/browser/calls/calls-protocol.proposed';
+import { CallHierarchyService } from './callhierarchy-service';
+
+export class LspCallHierarchyService implements CallHierarchyService {
+
+    constructor(public readonly languageId: string, protected readonly client: ILanguageClient) {}
+
+    async getCalls(params: CallsParams): Promise<CallsResult> {
+        const result = await this.client.sendRequest(CallsRequest.type, params);
+        return result;
+    }
+
+}

--- a/packages/callhierarchy/src/browser/style/index.css
+++ b/packages/callhierarchy/src/browser/style/index.css
@@ -46,6 +46,7 @@
 .theia-CallHierarchyTree .definitionNode .symbol {
     white-space: nowrap;
     overflow: hidden;
+    margin-left: 0px;
 }
 
 .theia-CallHierarchyTree .definitionNode .referenceCount {
@@ -63,4 +64,22 @@
 
 .call-hierarchy-tab-icon::before {
     content: "\f0ab"
+}
+
+.theia-CallHierarchyTree .definitionNode .rotation-incoming {
+    -webkit-transform: rotate(135deg);
+    -moz-transform: rotate(135deg);
+    -ms-transform: rotate(135deg);
+    -o-transform: rotate(135deg);
+    transform: rotate(135deg);
+    margin-left: 5px;
+}
+
+.theia-CallHierarchyTree .definitionNode .rotation-outgoing {
+    -webkit-transform: rotate(315deg);
+    -moz-transform: rotate(315deg);
+    -ms-transform: rotate(315deg);
+    -o-transform: rotate(315deg);
+    transform: rotate(315deg);
+    margin-left: 5px;
 }

--- a/packages/languages/src/browser/calls/calls-feature.proposed.ts
+++ b/packages/languages/src/browser/calls/calls-feature.proposed.ts
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { v4 } from 'uuid';
+import {
+    Disposable,
+    ILanguageClient,
+    DocumentSelector,
+    ClientCapabilities,
+    ServerCapabilities,
+    TextDocumentFeature,
+    TextDocumentRegistrationOptions
+} from '../language-client-services';
+import { CallsRequest, CallsClientCapabilities, CallsServerCapabilities } from './calls-protocol.proposed';
+
+export class CallsFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+
+    constructor(readonly client: ILanguageClient) {
+        super(client, CallsRequest.type);
+    }
+
+	fillClientCapabilities(capabilities: ClientCapabilities): void {
+		if (!!capabilities.textDocument) {
+			capabilities.textDocument = {};
+		}
+		const callsClientCapabilities = capabilities as CallsClientCapabilities;
+		callsClientCapabilities.textDocument!.calls = {
+			dynamicRegistration: true
+		};
+	}
+
+    initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+		const callsServerCapabilities = capabilities as CallsServerCapabilities;
+		if (!callsServerCapabilities.callsProvider) {
+			return;
+        }
+        if (callsServerCapabilities.callsProvider === true) {
+			if (!documentSelector) {
+				return;
+			}
+			this.register(this.messages, {
+				id: v4(),
+				registerOptions: Object.assign({}, { documentSelector: documentSelector })
+            });
+            // todo: register this languageId
+		} else {
+            const implCapabilities = callsServerCapabilities.callsProvider;
+			const id = typeof implCapabilities.id === 'string' && implCapabilities.id.length > 0 ? implCapabilities.id : v4();
+			const selector = implCapabilities.documentSelector || documentSelector;
+			if (selector) {
+				this.register(this.messages, {
+					id,
+					registerOptions: Object.assign({}, { documentSelector: selector })
+                });
+                // todo: register this languageId
+			}
+		}
+    }
+
+    dispose(): void {
+        // todo: unregister this languageId
+        super.dispose();
+    }
+
+    protected registerLanguageProvider(): Disposable {
+        return Disposable.create(() => {});
+    }
+
+}

--- a/packages/languages/src/browser/calls/calls-protocol.proposed.ts
+++ b/packages/languages/src/browser/calls/calls-protocol.proposed.ts
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { RequestType, RequestHandler } from 'vscode-jsonrpc';
+import { SymbolKind, Location, Range } from 'vscode-languageserver-types';
+import * as lsp from 'vscode-languageserver';
+
+export interface CallsClientCapabilities {
+    /**
+     * The text document client capabilities
+     */
+    textDocument?: {
+        /**
+         * Capabilities specific to the `textDocument/calls`
+         */
+        calls?: {
+            /**
+             * Whether implementation supports dynamic registration. If this is set to `true`
+             * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+             * return value for the corresponding server capability as well.
+             */
+            dynamicRegistration?: boolean;
+        };
+    }
+}
+
+export interface CallsServerCapabilities {
+    /**
+     * The server provides Call Hierarchy support.
+     */
+    callsProvider?: boolean | (lsp.TextDocumentRegistrationOptions & lsp.StaticRegistrationOptions);
+}
+
+/**
+ * A request to resolve all calls at a given text document position of a symbol definition or a call the same.
+ * The request's parameter is of type [CallsParams](#CallsParams), the response is of type [CallsResult](#CallsResult) or a
+ * Thenable that resolves to such.
+ */
+export namespace CallsRequest {
+    export const type = new RequestType<CallsParams, CallsResult, void, lsp.TextDocumentRegistrationOptions>('textDocument/calls');
+    export type HandlerSignature = RequestHandler<CallsParams, CallsResult | null, void>;
+}
+
+/**
+ * The parameters of a `textDocument/calls` request.
+ */
+export interface CallsParams extends lsp.TextDocumentPositionParams {
+    /**
+     * Outgoing direction for callees.
+     * The default is incoming for callers.
+     */
+    direction?: CallDirection;
+}
+
+/**
+ * Enum of call direction kinds
+ */
+export enum CallDirection {
+    /**
+     * Incoming calls aka. callers
+     */
+    Incoming = 'incoming',
+    /**
+     * Outgoing calls aka. callees
+     */
+    Outgoing = 'outgoing',
+}
+
+/**
+ * The result of a `textDocument/calls` request.
+ */
+export interface CallsResult {
+    /**
+     * The symbol of a definition for which the request was made.
+     *
+     * If no definition is found at a given text document position, the symbol is undefined.
+     */
+    symbol?: DefinitionSymbol;
+    /**
+     * List of calls.
+     */
+    calls: Call[];
+}
+
+/**
+ * Represents a directed call.
+ */
+export interface Call {
+    /**
+     * Actual location of a call to a definition.
+     */
+    location: Location;
+    /**
+     * Symbol refered to by this call. For outgoing calls this is a callee,
+     * otherwise a caller.
+     */
+    symbol: DefinitionSymbol;
+}
+
+export interface DefinitionSymbol {
+    /**
+     * The name of this symbol.
+     */
+    name: string;
+    /**
+     * More detail for this symbol, e.g the signature of a function.
+     */
+    detail?: string;
+    /**
+     * The kind of this symbol.
+     */
+    kind: SymbolKind;
+    /**
+     * The range enclosing this symbol not including leading/trailing whitespace but everything else
+     * like comments. This information is typically used to determine if the the clients cursor is
+     * inside the symbol to reveal in the symbol in the UI.
+     */
+    location: Location;
+    /**
+     * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+     * Must be contained by the the `range`.
+     */
+    selectionRange: Range;
+
+}

--- a/packages/languages/src/browser/language-client-factory.ts
+++ b/packages/languages/src/browser/language-client-factory.ts
@@ -23,6 +23,7 @@ import {
     ILanguageClient, LanguageClientOptions, MonacoLanguageClient,
     createConnection, LanguageContribution
 } from './language-client-services';
+import { CallsFeature } from './calls/calls-feature.proposed';
 
 @injectable()
 export class LanguageClientFactory {
@@ -64,7 +65,7 @@ export class LanguageClientFactory {
         let initializationFailedHandler = clientOptions.initializationFailedHandler;
         clientOptions.initializationFailedHandler = e => !!initializationFailedHandler && initializationFailedHandler(e);
         connection.onDispose(() => initializationFailedHandler = () => false);
-        return new MonacoLanguageClient({
+        const languageclient = new MonacoLanguageClient({
             id: contribution.id,
             name: contribution.name,
             clientOptions,
@@ -72,6 +73,8 @@ export class LanguageClientFactory {
                 get: async (errorHandler, closeHandler) => createConnection(connection, errorHandler, closeHandler)
             }
         });
+        languageclient.registerFeature(new CallsFeature(languageclient));
+        return languageclient;
     }
 
 }

--- a/packages/python/src/browser/python-callhierarchy-service.ts
+++ b/packages/python/src/browser/python-callhierarchy-service.ts
@@ -14,4 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export const CALLHIERARCHY_ID = 'callhierarchy';
+import { injectable } from 'inversify';
+import { AbstractDefaultCallHierarchyService } from '@theia/callhierarchy/lib/browser/default-callhierarchy-service';
+import { PYTHON_LANGUAGE_ID } from '../common';
+
+@injectable()
+export class PythonCallHierarchyService extends AbstractDefaultCallHierarchyService {
+
+    readonly languageId: string = PYTHON_LANGUAGE_ID;
+
+}

--- a/packages/python/src/browser/python-frontend-module.ts
+++ b/packages/python/src/browser/python-frontend-module.ts
@@ -19,10 +19,14 @@ import { LanguageClientContribution } from '@theia/languages/lib/browser';
 import { PythonClientContribution } from './python-client-contribution';
 import { PythonGrammarContribution } from './python-grammar-contribution';
 import { LanguageGrammarDefinitionContribution } from '@theia/monaco/lib/browser/textmate';
+import { CallHierarchyService } from '@theia/callhierarchy/lib/browser';
+import { PythonCallHierarchyService } from './python-callhierarchy-service';
 
 export default new ContainerModule(bind => {
     bind(PythonClientContribution).toSelf().inSingletonScope();
     bind(LanguageClientContribution).toDynamicValue(ctx => ctx.container.get(PythonClientContribution));
 
     bind(LanguageGrammarDefinitionContribution).to(PythonGrammarContribution).inSingletonScope();
+    bind(PythonCallHierarchyService).toSelf().inSingletonScope();
+    bind(CallHierarchyService).toService(PythonCallHierarchyService);
 });

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,7 +7,7 @@
     "@theia/core": "^0.3.15",
     "@theia/languages": "^0.3.15",
     "@theia/monaco": "^0.3.15",
-    "typescript-language-server": "^0.3.5"
+    "typescript-language-server": "dev"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9489,9 +9489,9 @@ typedoc@^0.8:
     typedoc-default-themes "^0.5.0"
     typescript "2.4.1"
 
-typescript-language-server@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.3.5.tgz#1d07237b014df40fdad1588a151c0190668db313"
+typescript-language-server@dev:
+  version "0.4.0-dev.9e83a6b"
+  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.4.0-dev.9e83a6b.tgz#c3a31134ade4fa1b1d9b72a25adf75930682da02"
   dependencies:
     command-exists "1.2.6"
     commander "^2.11.0"


### PR DESCRIPTION
also add generic implementation for python (to maintain the legacy)

<img width="1203" alt="screen shot 2018-10-18 at 10 47 20" src="https://user-images.githubusercontent.com/914497/47142548-6634eb80-d2c3-11e8-8dd8-ebef6ece0cb8.png">

related PR for the `typescript-language-server`: https://github.com/theia-ide/typescript-language-server/pull/85
related PR for the LSP extension: https://github.com/Microsoft/vscode-languageserver-node/pull/420