### PR TITLE
Specify target as a CLI argument

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -27,6 +27,9 @@ const argv = yargs.option('mode', {
     description: 'Split frontend modules into separate chunks. By default enabled in the dev mode and disabled in the prod mode.',
     type: 'boolean',
     default: undefined
+}).option('app-target', {
+    description: 'The target application type. Overrides ["theia.target"] in the application\'s package.json.',
+    choices: ['browser', 'electron'],
 }).argv;
 const mode: 'development' | 'production' = argv.mode;
 const splitFrontend: boolean = argv['split-frontend'] === undefined ? mode === 'development' : argv['split-frontend'];

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -29,12 +29,12 @@ export class ApplicationPackageOptions {
     readonly log?: ApplicationLog;
     readonly error?: ApplicationLog;
     readonly registry?: NpmRegistry;
+    readonly appTarget?: ApplicationProps.Target;
 }
 
 export type ApplicationModuleResolver = (modulePath: string) => string;
 
 export class ApplicationPackage {
-
     readonly projectPath: string;
     readonly log: ApplicationLog;
     readonly error: ApplicationLog;
@@ -67,6 +67,11 @@ export class ApplicationPackage {
             return this._props;
         }
         const theia = this.pck.theia || {};
+
+        if (this.options.appTarget) {
+            theia.target = this.options.appTarget;
+        }
+
         return this._props = { ...ApplicationProps.DEFAULT, ...theia };
     }
 

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -53,7 +53,8 @@ function rebuildCommand(command: string, target: ApplicationProps.Target): yargs
 
 (function () {
     const projectPath = process.cwd();
-    const manager = new ApplicationPackageManager({ projectPath });
+    const appTarget: ApplicationProps.Target = yargs.argv['app-target'];
+    const manager = new ApplicationPackageManager({ projectPath, appTarget });
     const target = manager.pck.target;
 
     yargs


### PR DESCRIPTION
Addresses [3217](https://github.com/theia-ide/theia/issues/3217)

Added an `--app-target` argument the the Theia CLI. This is an optional argument that will override the value of `theia.target` from the `package.json` in the ApplicationPackage.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
