### PR TITLE
keep status of focus on the right pref editor

### DIFF
--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -173,8 +173,8 @@ export class PreferencesContainer extends SplitPanel implements ApplicationShell
     }
 
     protected onActivateRequest(msg: Message): void {
-        if (this.treeWidget) {
-            this.treeWidget.activate();
+        if (this.currentEditor) {
+            this.currentEditor.activate();
         }
         super.onActivateRequest(msg);
     }


### PR DESCRIPTION
- when the preference widget gets re-activated, the pref editor loses focus. This change keeps the status of focus on the preference editor that used to have the focus.
- fixed #3230

Signed-off-by: elaihau <liang.huang@ericsson.com>

