### PR TITLE
Disable tslint indent rule for json-schema.ts

### DIFF
--- a/packages/core/src/common/json-schema.ts
+++ b/packages/core/src/common/json-schema.ts
@@ -21,6 +21,9 @@
 
 // copied from https://github.com/Microsoft/vscode/blob/d4edb9abcc261846cabee6702715fe2914ae42cb/src/vs/base/common/jsonSchema.ts
 
+// Keep tab indent for easier comparison with the original file.
+/* tslint:disable:indent */
+
 /**
  * extended JSON schema
  */


### PR DESCRIPTION
This file uses tabs instead of 4 spaces, which our tslint.json file
specifies.  Since this file was copied from the vscode repo, I chose to
leave the tabs there and just disable the rule for this file.  This will
make it easier to diff it with the original file, in case we need to
update it.

Change-Id: Idc7536e5e80be4d7e0d32b529a442d99365f7a19
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
