### PR TITLE
Fix task exit messages and task/process API

### DIFF
--- a/packages/process/compile.tsconfig.json
+++ b/packages/process/compile.tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../configs/base.tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "strictFunctionTypes": true
   },
   "include": [
     "src"

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -19,7 +19,8 @@ import { ProcessManager } from './process-manager';
 import { ILogger, Emitter, Event } from '@theia/core/lib/common';
 
 export interface IProcessExitEvent {
-    readonly code: number,
+    // Exactly one of code and signal will be set.
+    readonly code?: number,
     readonly signal?: string
 }
 
@@ -88,8 +89,12 @@ export abstract class Process {
         return this.errorEmitter.event;
     }
 
-    protected emitOnExit(code: number, signal?: string) {
-        const exitEvent = { code, signal };
+    /**
+     * Emit the onExit event for this process.  Only one of code and signal
+     * should be defined.
+     */
+    protected emitOnExit(code?: number, signal?: string) {
+        const exitEvent: IProcessExitEvent = { code, signal };
         this.handleOnExit(exitEvent);
         this.exitEmitter.fire(exitEvent);
     }

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -90,21 +90,22 @@ describe('RawProcess', function () {
     it('test exit', async function () {
         const args = ['--version'];
         const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
-        const p = new Promise((resolve, reject) => {
+        const p = new Promise<number>((resolve, reject) => {
             rawProcess.onError(error => {
                 reject();
             });
 
             rawProcess.onExit(event => {
-                if (event.code > 0) {
+                if (event.code === undefined) {
                     reject();
-                } else {
-                    resolve();
                 }
+
+                resolve(event.code);
             });
         });
 
-        await p;
+        const exitCode = await p;
+        expect(exitCode).equal(0);
     });
 
     it('test pipe stdout stream', async function () {

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -103,7 +103,14 @@ export class RawProcess extends Process {
             }
 
             this.process.on('error', this.emitOnError.bind(this));
-            this.process.on('exit', this.emitOnExit.bind(this));
+            this.process.on('exit', (exitCode: number, signal: string) => {
+                // node's child_process exit sets the unused parameter to null,
+                // but we want it to be undefined instead.
+                this.emitOnExit(
+                    exitCode !== null ? exitCode : undefined,
+                    signal !== null ? signal : undefined,
+                );
+            });
 
             this.output = this.process.stdout;
             this.input = this.process.stdin;

--- a/packages/process/src/node/terminal-process.spec.ts
+++ b/packages/process/src/node/terminal-process.spec.ts
@@ -43,13 +43,22 @@ describe('TerminalProcess', function () {
             return expect(() => terminalProcessFactory({ command: '/non-existent' })).to.throw();
         } else {
             const terminalProcess = terminalProcessFactory({ command: '/non-existant' });
-            const p = new Promise(resolve => {
+            const p = new Promise<number>((resolve, reject) => {
+                terminalProcess.onError(error => {
+                    reject();
+                });
+
                 terminalProcess.onExit(event => {
-                    if (event.code > 0) { resolve(); }
+                    if (event.code === undefined) {
+                        reject();
+                    }
+
+                    resolve(event.code);
                 });
             });
 
-            await p;
+            const exitCode = await p;
+            expect(exitCode).equal(1);
         }
     });
 

--- a/packages/process/src/node/utils.ts
+++ b/packages/process/src/node/utils.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { isWindows } from '@theia/core';
+import * as os from 'os';
 const stringArgv = require('string-argv');
 
 /**
@@ -22,4 +24,40 @@ const stringArgv = require('string-argv');
  */
 export function parseArgs(line: string): string[] {
     return stringArgv(line);
+}
+
+// Polyfill for Object.entries, until we upgrade to ES2017.
+// tslint:disable-next-line:no-any
+function objectEntries(obj: any): any[] {
+    const props = Object.keys(obj);
+    const result = new Array(props.length);
+    for (let i = 0; i < props.length; i++) {
+        // tslint:disable-next-line:no-any
+        result[i] = [props[i], obj[props[i]]];
+    }
+
+    return result;
+}
+
+/**
+ * Convert a signal number to its short name (using the signal definitions of
+ * the current host).  Should never be called on Windows.  For Linux, this is
+ * only valid for the x86 and ARM architectures, since other architectures may
+ * use different numbers, see signal(7).
+ */
+export function signame(sig: number): string {
+    // We should never reach this on Windows, since signals are not a thing
+    // there.
+    if (isWindows) {
+        throw new Error('Trying to get a signal name on Windows.');
+    }
+
+    for (const entry of objectEntries(os.constants.signals)) {
+        if (entry[1] === sig) {
+            return entry[0];
+        }
+    }
+
+    // Don't know this signal?  Return the number as a string.
+    return sig.toString();
 }

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -65,7 +65,9 @@ export interface TaskServer extends JsonRpcServer<TaskClient> {
 export interface TaskExitedEvent {
     readonly taskId: number;
     readonly ctx?: string;
-    readonly code: number;
+
+    // Exactly one of code and signal will be set.
+    readonly code?: number;
     readonly signal?: string;
 }
 

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -26,6 +26,7 @@ import { FileUri } from '@theia/core/lib/node';
 import { terminalsPath } from '@theia/terminal/lib/common/terminal-protocol';
 import { expectThrowsAsync } from '@theia/core/lib/common/test/expect';
 import { TestWebSocketChannel } from '@theia/core/lib/node/messaging/test/test-web-socket-channel';
+import { expect } from 'chai';
 
 /**
  * Globals
@@ -178,36 +179,56 @@ describe('Task server / back-end', function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
         const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('shell'), wsRoot);
 
-        const p = new Promise((resolve, reject) => {
-            const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
-                if (event.taskId === taskInfo.taskId && event.code === 0 && event.signal !== '0') {
-                    toDispose.dispose();
-                    resolve();
+        const p = new Promise<string | number>((resolve, reject) => {
+            taskWatcher.onTaskExit((event: TaskExitedEvent) => {
+                if (isWindows) {
+                    if (event.taskId !== taskInfo.taskId || event.code === undefined) {
+                        reject();
+                    }
+                    resolve(event.code);
+                } else {
+                    if (event.taskId !== taskInfo.taskId || event.signal === undefined) {
+                        reject();
+                    }
+                    resolve(event.signal);
                 }
             });
+
+            taskServer.kill(taskInfo.taskId);
         });
 
-        await taskServer.kill(taskInfo.taskId);
-
-        await p;
+        // node-pty reports different things on Linux/macOS vs Windows when
+        // killing a process.  This is not ideal, but that's how things are
+        // currently.  Ideally, its behavior should be aligned as much as
+        // possible on what node's child_process module does.
+        const signalOrCode = await p;
+        if (isWindows) {
+            // On Windows, node-pty just reports an exit code of 0.
+            expect(signalOrCode).equals(0);
+        } else {
+            // On Linux/macOS, node-pty sends SIGHUP by default, for some reason.
+            expect(signalOrCode).equals('SIGHUP');
+        }
     });
 
     it('task using raw process can be killed', async function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
         const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('process'), wsRoot);
 
-        const p = new Promise((resolve, reject) => {
-            const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
-                if (event.taskId === taskInfo.taskId && event.code === null && event.signal === 'SIGTERM') {
-                    toDispose.dispose();
-                    resolve();
+        const p = new Promise<string>((resolve, reject) => {
+            taskWatcher.onTaskExit((event: TaskExitedEvent) => {
+                if (event.taskId !== taskInfo.taskId || event.signal === undefined) {
+                    reject();
                 }
+
+                resolve(event.signal);
             });
+
+            taskServer.kill(taskInfo.taskId);
         });
 
-        await taskServer.kill(taskInfo.taskId);
-
-        await p;
+        const signal = await p;
+        expect(signal).equals('SIGTERM');
     });
 
     it('task using terminal process can handle command that does not exist', async function () {

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -33,7 +33,9 @@ export namespace IBaseTerminalServer {
 
 export interface IBaseTerminalExitEvent {
     terminalId: number;
-    code: number;
+
+    // Exactly one of code and signal will be set.
+    code?: number;
     signal?: string;
 }
 


### PR DESCRIPTION
The original intention for this patch is this fix the message that
appears when tasks exit.  There are many inconsistencies:

task of type shell exits with exit code 0:
  Success - Task 2 has finished. exit code: 0, signal: undefined

task of type process exits with exit code 0:
  Success - Task 7 has finished. exit code: 0, signal: null

task of type shell exits with exit code 2:
  Error: Task 1 failed. Exit code: 2, signal: undefined

task of type process exits with exit code 2:
  Error: Task 8 failed. Exit code: 2, signal: null

task of type shell terminated by signal SIGUSR2:
  Interrupt received - Task 3 has finished. exit code: 0, signal: 12

task of type process terminated by signal SIGUSR2:
  Error: Task 5 failed. Exit code: null, signal: SIGUSR2

There are a some problems:

1. There is always either an exit code, either a signal, never both.  So
   we don't need to show both (the "undefined" or "null" are particularly
   annoying).
2. We should show signal names for all signals.  That signal name should
   be provided by the backend and not interpreted by the frontend,
   because they vary per OS.
3. Whether receiving a signal is an error is debatable, some signals can
   be expected.  Receiving a SIGSEGV is probably not, though.

There are a lot of inconsistencies with how node's child_process module
and the node-pty module report their exit events.  This patch tries to
normalize them so we get something predictable in the frontend.

End-to-end, I made the "code" value optional, so that when a signal is
reported, code will be undefined (compared to now where it will be 0).

Random notes:

- I found setting "strictFunctionTypes" in the compile.tsconfig.json was
  helpful for this, and it can only help in general, so I suggest we
  leave it.
- To use Object.entries, I had to change the lib we use to es2017.
  Since the version of typescript and node we use supports it, I don't see any
  downside.
- I removed the messages like "Interrupt received" in the messages.  I
  think they were a bit misleading.  If we want to have an "official"
  signal description, we should use the descriptions returned by
  strsignal(3).

Change-Id: I20d2dec8e131d95018cc6f1bf7bdf1876c662811
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
