### PR TITLE
Add context to keymaps.json when editing through the keybindings-widget

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -272,17 +272,18 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected editKeybinding(item: KeybindingItem): void {
-        const rawCommand = this.getRawValue(item.command);
-        const rawId = this.getRawValue(item.id);
-        const rawKeybinding = (item.keybinding) ? this.getRawValue(item.keybinding) : '';
+        const command = this.getRawValue(item.command);
+        const id = this.getRawValue(item.id);
+        const keybinding = (item.keybinding) ? this.getRawValue(item.keybinding) : '';
+        const context = (item.context) ? this.getRawValue(item.context) : '';
         const dialog = new SingleTextInputDialog({
-            title: `Edit Keybinding For ${rawCommand}`,
-            initialValue: rawKeybinding,
-            validate: keybinding => this.validateKeybinding(rawCommand, rawKeybinding, keybinding),
+            title: `Edit Keybinding For ${command}`,
+            initialValue: keybinding,
+            validate: newKeybinding => this.validateKeybinding(command, keybinding, newKeybinding),
         });
-        dialog.open().then(async keybinding => {
-            if (keybinding) {
-                await this.keymapsService.setKeybinding(rawId, keybinding);
+        dialog.open().then(async newKeybinding => {
+            if (newKeybinding) {
+                await this.keymapsService.setKeybinding({ 'command': id, 'keybinding': newKeybinding, 'context': context });
             }
         });
     }

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -26,6 +26,7 @@ import { Emitter } from '@theia/core/lib/common/';
 export interface KeybindingJson {
     command: string,
     keybinding: string,
+    context: string,
 }
 
 @injectable()
@@ -79,7 +80,7 @@ export class KeymapsService {
         open(this.opener, this.resource.uri);
     }
 
-    async setKeybinding(command: string, keybinding: string): Promise<void> {
+    async setKeybinding(keybindingJson: KeybindingJson): Promise<void> {
         if (!this.resource.saveContents) {
             return;
         }
@@ -87,13 +88,13 @@ export class KeymapsService {
         const keybindings: KeybindingJson[] = content ? jsoncparser.parse(content) : [];
         let updated = false;
         for (let i = 0; i < keybindings.length; i++) {
-            if (keybindings[i].command === command) {
+            if (keybindings[i].command === keybindingJson.command) {
                 updated = true;
-                keybindings[i].keybinding = keybinding;
+                keybindings[i].keybinding = keybindingJson.keybinding;
             }
         }
         if (!updated) {
-            const item: KeybindingJson = { 'command': command, 'keybinding': keybinding };
+            const item: KeybindingJson = { ...keybindingJson };
             keybindings.push(item);
         }
         await this.resource.saveContents(JSON.stringify(keybindings, undefined, 4));


### PR DESCRIPTION
Include the `context` field in `keymaps.json` when edited through the `keybindings-widget`.
Addresses an issue where if a keybinding already contains a context and is then edited, it loses it's context from the `keybindings-widget` table.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
