### PR TITLE
Pinning inversify to 4.13.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "file-icons-js": "^1.0.3",
     "font-awesome": "^4.7.0",
     "fuzzy": "^0.1.3",
-    "inversify": "^4.2.0",
+    "inversify": "4.13.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "perfect-scrollbar": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4977,9 +4977,10 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^4.2.0:
+inversify@4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-4.13.0.tgz#0ab40570bfa4474b04d5b919bbab3a4f682a72f5"
+  integrity sha512-O5d8y7gKtyRwrvTLZzYET3kdFjqUy58sGpBYMARF13mzqDobpfBXVOPLH7HmnD2VR6Q+1HzZtslGvsdQfeb0SA==
 
 invert-kv@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is a mitigation for #3204, until a proper fix is made
to make Theia compatible with inversify 4.14.0+.

ATM this bug prevents some Theia applications from working
as they should. e.g. our various docker images from repo
theia-ide/theia-apps fail at statup with this exception in
the F-E:

contribution-provider.ts:67 Uncaught (in promise) TypeError: e is not a function
    at Object.t.bindContributionProvider (contribution-provider.ts:67)
    at p (navigator-container.ts:52)
    at Object.t.createFileNavigatorWidget (navigator-container.ts:58)
    at e.dynamicValue (navigator-frontend-module.ts:38)
    at resolver.js:63
    at c (resolver.js:10)
    at resolver.js:63
    at Object.t.resolve (resolver.js:96)
    at container.js:319
    at e._get (container.js:310)

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
