### PR TITLE
preferences for multi-root workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Breaking changes:
     - `debug.thread.next` renamed to `workbench.action.debug.stepOver`
     - `debug.stop` renamed to `workbench.action.debug.stop`
     - `debug.editor.showHover` renamed to `editor.debug.action.showDebugHover`
+- multi-root workspace support for preferences [#3247](https://github.com/theia-ide/theia/pull/3247)
+  - `PreferenceProvider` 
+    - is changed from a regular class to an abstract class.
+    - the `fireOnDidPreferencesChanged` function is deprecated. `emitPreferencesChangedEvent` function should be used instead. `fireOnDidPreferencesChanged` will be removed with the next major release.
+  - `PreferenceServiceImpl`
+    - `preferences` is deprecated. `getPreferences` function should be used instead. `preferences` will be removed with the next major release.
+  - having `properties` property defined in the `PreferenceSchema` object is now mandatory.
+  - `PreferenceProperty` is renamed to `PreferenceDataProperty`.
+  - `PreferenceSchemaProvider`
+    - the type of `combinedSchema` property is changed from `PreferenceSchema` to `PreferenceDataSchema`.
+    - the return type of `getCombinedSchema` function is changed from `PreferenceSchema` to `PreferenceDataSchema`.
+  - `affects` function is added to `PreferenceChangeEvent` and `PreferenceChange` interface.
+
 
 ## v0.3.19
 - [core] added `hostname` alias

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -193,6 +193,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(PreferenceProvider).toSelf().inSingletonScope().whenTargetNamed(PreferenceScope.User);
     bind(PreferenceProvider).toSelf().inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);
+    bind(PreferenceProvider).toSelf().inSingletonScope().whenTargetNamed(PreferenceScope.Folder);
     bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => {
         if (scope === PreferenceScope.Default) {
             return ctx.container.get(PreferenceSchemaProvider);

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -15,9 +15,10 @@
  ********************************************************************************/
 
 import * as Ajv from 'ajv';
-import { inject, injectable, named, interfaces, postConstruct } from 'inversify';
+import { inject, injectable, interfaces, named, postConstruct } from 'inversify';
 import { ContributionProvider, bindContributionProvider } from '../../common';
-import { PreferenceProvider } from './preference-provider';
+import { PreferenceScope } from './preference-service';
+import { PreferenceProvider, PreferenceProviderPriority, PreferenceProviderDataChange } from './preference-provider';
 
 // tslint:disable:no-any
 
@@ -26,30 +27,62 @@ export interface PreferenceContribution {
     readonly schema: PreferenceSchema;
 }
 
-export const PreferenceSchema = Symbol('PreferenceSchema');
-
 export interface PreferenceSchema {
-    [name: string]: Object,
+    [name: string]: any,
+    scope?: 'application' | 'window' | 'resource' | PreferenceScope,
     properties: {
-        [name: string]: PreferenceProperty
+        [name: string]: PreferenceSchemaProperty
+    }
+}
+export namespace PreferenceSchema {
+    export function getDefaultScope(schema: PreferenceSchema): PreferenceScope {
+        let defaultScope: PreferenceScope = PreferenceScope.Workspace;
+        if (!PreferenceScope.is(schema.scope)) {
+            defaultScope = PreferenceScope.fromString(<string>schema.scope) || PreferenceScope.Workspace;
+        } else {
+            defaultScope = schema.scope;
+        }
+        return defaultScope;
+    }
+}
+
+export interface PreferenceDataSchema {
+    [name: string]: any,
+    scope?: PreferenceScope,
+    properties: {
+        [name: string]: PreferenceDataProperty
     }
 }
 
 export interface PreferenceItem {
     type?: JsonType | JsonType[];
     minimum?: number;
-    // tslint:disable-next-line:no-any
     default?: any;
     enum?: string[];
     items?: PreferenceItem;
     properties?: { [name: string]: PreferenceItem };
     additionalProperties?: object;
-    // tslint:disable-next-line:no-any
     [name: string]: any;
 }
 
-export interface PreferenceProperty extends PreferenceItem {
+export interface PreferenceSchemaProperty extends PreferenceItem {
     description: string;
+    scope?: 'application' | 'window' | 'resource' | PreferenceScope;
+}
+
+export interface PreferenceDataProperty extends PreferenceItem {
+    description: string;
+    scope?: PreferenceScope;
+}
+export namespace PreferenceDataProperty {
+    export function fromPreferenceSchemaProperty(schemaProps: PreferenceSchemaProperty, defaultScope: PreferenceScope = PreferenceScope.Workspace): PreferenceDataProperty {
+        if (!schemaProps.scope) {
+            schemaProps.scope = defaultScope;
+        } else if (typeof schemaProps.scope === 'string') {
+            return Object.assign(schemaProps, { scope: PreferenceScope.fromString(schemaProps.scope) || defaultScope });
+        }
+        return <PreferenceDataProperty>schemaProps;
+    }
 }
 
 export type JsonType = 'string' | 'array' | 'number' | 'integer' | 'object' | 'boolean' | 'null';
@@ -62,8 +95,8 @@ export function bindPreferenceSchemaProvider(bind: interfaces.Bind): void {
 @injectable()
 export class PreferenceSchemaProvider extends PreferenceProvider {
 
-    protected readonly combinedSchema: PreferenceSchema = { properties: {} };
     protected readonly preferences: { [name: string]: any } = {};
+    protected readonly combinedSchema: PreferenceDataSchema = { properties: {} };
     protected validateFunction: Ajv.ValidateFunction;
 
     @inject(ContributionProvider) @named(PreferenceContribution)
@@ -74,21 +107,23 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         this.preferenceContributions.getContributions().forEach(contrib => {
             this.doSetSchema(contrib.schema);
         });
+        this.combinedSchema.additionalProperties = false;
         this.updateValidate();
         this._ready.resolve();
     }
 
     protected doSetSchema(schema: PreferenceSchema): void {
+        const defaultScope = PreferenceSchema.getDefaultScope(schema);
         const props: string[] = [];
-        for (const property in schema.properties) {
+        for (const property of Object.keys(schema.properties)) {
+            const schemaProps = schema.properties[property];
             if (this.combinedSchema.properties[property]) {
                 console.error('Preference name collision detected in the schema for property: ' + property);
             } else {
-                this.combinedSchema.properties[property] = schema.properties[property];
+                this.combinedSchema.properties[property] = PreferenceDataProperty.fromPreferenceSchemaProperty(schemaProps, defaultScope);
                 props.push(property);
             }
         }
-        // tslint:disable-next-line:forin
         for (const property of props) {
             this.preferences[property] = this.combinedSchema.properties[property].default;
         }
@@ -102,22 +137,40 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         return this.validateFunction({ [name]: value }) as boolean;
     }
 
-    getCombinedSchema(): PreferenceSchema {
+    getCombinedSchema(): PreferenceDataSchema {
         return this.combinedSchema;
+    }
+
+    setSchema(schema: PreferenceSchema): void {
+        this.doSetSchema(schema);
+        this.updateValidate();
+        const changes: PreferenceProviderDataChange[] = [];
+        for (const property of Object.keys(schema.properties)) {
+            const schemaProps = schema.properties[property];
+            changes.push({
+                preferenceName: property, newValue: schemaProps.default, oldValue: undefined, scope: this.getScope(), domain: this.getDomain()
+            });
+        }
+        this.emitPreferencesChangedEvent(changes);
     }
 
     getPreferences(): { [name: string]: any } {
         return this.preferences;
     }
 
-    setSchema(schema: PreferenceSchema): void {
-        this.doSetSchema(schema);
-        this.updateValidate();
-        this.fireOnDidPreferencesChanged();
-    }
-
     async setPreference(): Promise<void> {
         throw new Error('Unsupported');
     }
 
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        return { priority: PreferenceProviderPriority.Default, provider: this };
+    }
+
+    isValidInScope(prefName: string, scope: PreferenceScope): boolean {
+        const schemaProps = this.combinedSchema.properties[prefName];
+        if (schemaProps) {
+            return schemaProps.scope! >= scope;
+        }
+        return false;
+    }
 }

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -19,11 +19,33 @@
 import { injectable } from 'inversify';
 import { Disposable, DisposableCollection, Emitter, Event } from '../../common';
 import { Deferred } from '../../common/promise-util';
+import { PreferenceScope } from './preference-service';
+
+export namespace PreferenceProviderPriority {
+    export const NA = -1;
+    export const Default = 0;
+    export const User = 1;
+    export const Workspace = 2;
+    export const Folder = 3;
+}
+
+export interface PreferenceProviderDataChange {
+    readonly preferenceName: string;
+    readonly newValue?: any;
+    readonly oldValue?: any;
+    readonly scope: PreferenceScope;
+    readonly domain: string[];
+}
+
+export interface PreferenceProviderDataChanges {
+    [preferenceName: string]: PreferenceProviderDataChange
+}
 
 @injectable()
-export class PreferenceProvider implements Disposable {
-    protected readonly onDidPreferencesChangedEmitter = new Emitter<void>();
-    readonly onDidPreferencesChanged: Event<void> = this.onDidPreferencesChangedEmitter.event;
+export abstract class PreferenceProvider implements Disposable {
+
+    protected readonly onDidPreferencesChangedEmitter = new Emitter<PreferenceProviderDataChanges | undefined>();
+    readonly onDidPreferencesChanged: Event<PreferenceProviderDataChanges | undefined> = this.onDidPreferencesChangedEmitter.event;
 
     protected readonly toDispose = new DisposableCollection();
 
@@ -41,20 +63,57 @@ export class PreferenceProvider implements Disposable {
         this.toDispose.dispose();
     }
 
+    /**
+     * Informs the listeners that one or more preferences of this provider are changed.
+     * The listeners are able to find what was changed from the emitted event.
+     */
+    protected emitPreferencesChangedEvent(changes: PreferenceProviderDataChanges | PreferenceProviderDataChange[]): void {
+        if (Array.isArray(changes)) {
+            const prefChanges: PreferenceProviderDataChanges = {};
+            for (const change of changes) {
+                prefChanges[change.preferenceName] = change;
+            }
+            this.onDidPreferencesChangedEmitter.fire(prefChanges);
+        } else {
+            this.onDidPreferencesChangedEmitter.fire(changes);
+        }
+    }
+
+    /**
+     * Informs the listeners that one or more preferences of this provider are changed.
+     * @deprecated Use emitPreferencesChangedEvent instead.
+     */
     protected fireOnDidPreferencesChanged(): void {
         this.onDidPreferencesChangedEmitter.fire(undefined);
     }
 
-    getPreferences(): { [p: string]: any } {
-        return [];
+    get<T>(preferenceName: string, resourceUri?: string): T | undefined {
+        const value = this.getPreferences(resourceUri)[preferenceName];
+        if (value !== undefined && value !== null) {
+            return value;
+        }
     }
 
-    setPreference(key: string, value: any): Promise<void> {
-        return Promise.resolve();
-    }
+    // tslint:disable-next-line:no-any
+    abstract getPreferences(resourceUri?: string): { [p: string]: any };
+
+    // tslint:disable-next-line:no-any
+    abstract setPreference(key: string, value: any, resourceUri?: string): Promise<void>;
 
     /** See `_ready`.  */
     get ready() {
         return this._ready.promise;
+    }
+
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        return { priority: PreferenceProviderPriority.NA, provider: this };
+    }
+
+    getDomain(): string[] {
+        return [];
+    }
+
+    protected getScope() {
+        return PreferenceScope.Default;
     }
 }

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -16,36 +16,109 @@
 
 // tslint:disable:no-any
 
-import { JSONExt } from '@phosphor/coreutils';
 import { injectable, inject, postConstruct } from 'inversify';
+import { JSONExt } from '@phosphor/coreutils';
 import { FrontendApplicationContribution } from '../../browser';
 import { Event, Emitter, DisposableCollection, Disposable, deepFreeze } from '../../common';
 import { Deferred } from '../../common/promise-util';
-import { PreferenceProvider } from './preference-provider';
+import { PreferenceProvider, PreferenceProviderDataChange, PreferenceProviderDataChanges } from './preference-provider';
 import { PreferenceSchemaProvider } from './preference-contribution';
+import URI from '../../common/uri';
 
 export enum PreferenceScope {
     Default,
     User,
-    Workspace
+    Workspace,
+    Folder
 }
 
 export namespace PreferenceScope {
+    export function is(scope: any): scope is PreferenceScope {
+        return typeof scope === 'number' && getScopes().findIndex(s => s === scope) >= 0;
+    }
+
     export function getScopes(): PreferenceScope[] {
         return Object.keys(PreferenceScope)
             .filter(k => typeof PreferenceScope[k as any] === 'string')
             .map(v => <PreferenceScope>Number(v));
     }
-}
 
-export interface PreferenceChangedEvent {
-    changes: PreferenceChange[]
+    export function getReversedScopes(): PreferenceScope[] {
+        return getScopes().reverse();
+    }
+
+    export function getScopeNames(scope?: PreferenceScope): string[] {
+        const names: string[] = [];
+        const allNames = Object.keys(PreferenceScope)
+            .filter(k => typeof PreferenceScope[k as any] === 'number');
+        if (scope) {
+            for (const name of allNames) {
+                if ((<any>PreferenceScope)[name] <= scope) {
+                    names.push(name);
+                }
+            }
+        }
+        return names;
+    }
+
+    export function fromString(strScope: string): PreferenceScope | undefined {
+        switch (strScope) {
+            case 'application':
+                return PreferenceScope.User;
+            case 'window':
+                return PreferenceScope.Workspace;
+            case 'resource':
+                return PreferenceScope.Folder;
+        }
+    }
 }
 
 export interface PreferenceChange {
     readonly preferenceName: string;
     readonly newValue?: any;
     readonly oldValue?: any;
+    affects(resourceUri?: string): boolean;
+}
+
+export class PreferenceChangeImpl implements PreferenceChange {
+    constructor(
+        private change: PreferenceProviderDataChange,
+        private providers: Map<PreferenceScope, PreferenceProvider>
+    ) { }
+
+    get preferenceName() {
+        return this.change.preferenceName;
+    }
+    get newValue() {
+        return this.change.newValue;
+    }
+    get oldValue() {
+        return this.change.oldValue;
+    }
+
+    affects(resourceUri?: string): boolean {
+        if (this.change.domain && resourceUri &&
+            this.change.domain.length !== 0 &&
+            this.change.domain.map(uriStr => new URI(uriStr))
+                .every(folderUri => folderUri.path.relativity(new URI(resourceUri).path) < 0)
+        ) {
+            return false;
+        }
+        for (const [scope, provider] of this.providers.entries()) {
+            if (!resourceUri && scope === PreferenceScope.Folder) {
+                continue;
+            }
+            const providerInfo = provider.canProvide(this.preferenceName, resourceUri);
+            const priority = providerInfo.priority;
+            if (priority >= 0 && scope > this.change.scope) {
+                return false;
+            }
+            if (scope === this.change.scope && this.change.domain.some(d => providerInfo.provider.getDomain().findIndex(pd => pd === d) < 0)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 
 export interface PreferenceChanges {
@@ -57,8 +130,9 @@ export interface PreferenceService extends Disposable {
     readonly ready: Promise<void>;
     get<T>(preferenceName: string): T | undefined;
     get<T>(preferenceName: string, defaultValue: T): T;
-    get<T>(preferenceName: string, defaultValue?: T): T | undefined;
-    set(preferenceName: string, value: any, scope?: PreferenceScope): Promise<void>;
+    get<T>(preferenceName: string, defaultValue: T, resourceUri: string): T;
+    get<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): T | undefined;
+    set(preferenceName: string, value: any, scope?: PreferenceScope, resourceUri?: string): Promise<void>;
     onPreferenceChanged: Event<PreferenceChange>;
 }
 
@@ -67,12 +141,10 @@ export interface PreferenceService extends Disposable {
  * It allows to load them lazilly after DI is configured.
  */
 export const PreferenceProviderProvider = Symbol('PreferenceProviderProvider');
-export type PreferenceProviderProvider = (scope: PreferenceScope) => PreferenceProvider;
+export type PreferenceProviderProvider = (scope: PreferenceScope, uri?: URI) => PreferenceProvider;
 
 @injectable()
 export class PreferenceServiceImpl implements PreferenceService, FrontendApplicationContribution {
-
-    protected preferences: { [key: string]: any } = {};
 
     protected readonly onPreferenceChangedEmitter = new Emitter<PreferenceChange>();
     readonly onPreferenceChanged = this.onPreferenceChangedEmitter.event;
@@ -89,12 +161,17 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     protected readonly providerProvider: PreferenceProviderProvider;
 
     protected readonly providers: PreferenceProvider[] = [];
+    protected providersMap: Map<PreferenceScope, PreferenceProvider> = new Map();
+
+    /**
+     * @deprecated Use getPreferences() instead
+     */
+    protected preferences: { [key: string]: any } = {};
 
     @postConstruct()
     protected init(): void {
         this.toDispose.push(Disposable.create(() => this._ready.reject()));
-        this.providers.push(this.schema);
-        this.preferences = this.parsePreferences();
+        this.doSetProvider(PreferenceScope.Default, this.schema);
     }
 
     dispose(): void {
@@ -109,119 +186,158 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     initialize(): void {
         this.initializeProviders();
     }
-    protected async initializeProviders(): Promise<void> {
+
+    protected initializeProviders(): void {
         try {
-            const providers = this.createProviders();
-            this.toDispose.pushAll(providers);
-            await Promise.all(providers.map(p => p.ready));
+            this.createProviders();
             if (this.toDispose.disposed) {
                 return;
             }
-            this.providers.push(...providers);
-            for (const provider of providers) {
-                provider.onDidPreferencesChanged(_ => this.reconcilePreferences());
+            for (const provider of this.providersMap.values()) {
+                this.toDispose.push(provider.onDidPreferencesChanged(changes =>
+                    this.reconcilePreferences(changes)
+                ));
             }
-            this.reconcilePreferences();
-            this._ready.resolve();
+            Promise.all(this.providers.map(p => p.ready)).then(() => this._ready.resolve());
         } catch (e) {
             this._ready.reject(e);
         }
     }
+
     protected createProviders(): PreferenceProvider[] {
-        return [
-            this.providerProvider(PreferenceScope.User),
-            this.providerProvider(PreferenceScope.Workspace)
-        ];
+        const providers: PreferenceProvider[] = [];
+        PreferenceScope.getScopes().forEach(scope => {
+            const p = this.doCreateProvider(scope);
+            if (p) {
+                providers.push(p);
+            }
+        });
+        return providers;
     }
 
-    protected reconcilePreferences(): void {
-        const changes: PreferenceChanges = {};
-        const deleted = new Set(Object.keys(this.preferences));
-        const preferences = this.parsePreferences();
-        // tslint:disable-next-line:forin
-        for (const preferenceName in preferences) {
-            deleted.delete(preferenceName);
-            const oldValue = this.preferences[preferenceName];
-            const newValue = preferences[preferenceName];
-            if (oldValue !== undefined) {
-                if (!JSONExt.deepEqual(oldValue, newValue)) {
-                    changes[preferenceName] = { preferenceName, newValue, oldValue };
-                    this.preferences[preferenceName] = deepFreeze(newValue);
+    protected reconcilePreferences(changes?: PreferenceProviderDataChanges): void {
+        const changesToEmit: PreferenceChanges = {};
+        if (changes) {
+            for (const prefName of Object.keys(changes)) {
+                const change = changes[prefName];
+                if (this.schema.isValidInScope(prefName, PreferenceScope.Folder)) {
+                    const toEmit = new PreferenceChangeImpl(change, this.providersMap);
+                    changesToEmit[prefName] = toEmit;
+                    continue;
                 }
-            } else {
-                changes[preferenceName] = { preferenceName, newValue };
-                this.preferences[preferenceName] = deepFreeze(newValue);
-            }
-        }
-        for (const preferenceName of deleted) {
-            const oldValue = this.preferences[preferenceName];
-            changes[preferenceName] = { preferenceName, oldValue };
-            this.preferences[preferenceName] = undefined;
-        }
-        this.onPreferencesChangedEmitter.fire(changes);
-        // tslint:disable-next-line:forin
-        for (const preferenceName in changes) {
-            this.onPreferenceChangedEmitter.fire(changes[preferenceName]);
-        }
-    }
-    protected parsePreferences(): { [name: string]: any } {
-        const result: { [name: string]: any } = {};
-        for (const provider of this.providers) {
-            const preferences = provider.getPreferences();
-            // tslint:disable-next-line:forin
-            for (const preferenceName in preferences) {
-                if (this.schema.validate(preferenceName, preferences[preferenceName])) {
-                    result[preferenceName] = preferences[preferenceName];
+                for (const s of PreferenceScope.getReversedScopes()) {
+                    if (this.schema.isValidInScope(prefName, s)) {
+                        const p = this.providersMap.get(s);
+                        if (p) {
+                            const value = p.get(prefName);
+                            if (s > change.scope && value !== undefined && value !== null) {
+                                // preference defined in a more specific scope
+                                break;
+                            } else if (s === change.scope) {
+                                const toEmit = new PreferenceChangeImpl(change, this.providersMap);
+                                changesToEmit[prefName] = toEmit;
+                            }
+                        }
+                    }
                 }
             }
+        } else { // go through providers for the Default, User, and Workspace Scopes to find delta
+            const newPrefs = this.getPreferences();
+            const oldPrefs = this.preferences;
+            for (const preferenceName of Object.keys(newPrefs)) {
+                const newValue = newPrefs[preferenceName];
+                const oldValue = oldPrefs[preferenceName];
+                if (newValue === undefined && oldValue !== newValue
+                    || oldValue === undefined && newValue !== oldValue // JSONExt.deepEqual() does not support handling `undefined`
+                    || !JSONExt.deepEqual(oldValue, newValue)) {
+                    const toEmit = new PreferenceChangeImpl({
+                        newValue, oldValue, preferenceName, scope: PreferenceScope.Workspace, domain: []
+                    }, this.providersMap);
+                    changesToEmit[preferenceName] = toEmit;
+                }
+            }
+            this.preferences = newPrefs;
         }
-        return result;
+
+        // emit the changes
+        const changedPreferenceNames = Object.keys(changesToEmit);
+        if (changedPreferenceNames.length > 0) {
+            this.onPreferencesChangedEmitter.fire(changesToEmit);
+        }
+        changedPreferenceNames.forEach(preferenceName => this.onPreferenceChangedEmitter.fire(changesToEmit[preferenceName]));
     }
 
-    getPreferences(): { [key: string]: Object | undefined } {
-        return this.preferences;
+    protected doCreateProvider(scope: PreferenceScope): PreferenceProvider | undefined {
+        if (!this.providersMap.has(scope)) {
+            const provider = this.providerProvider(scope);
+            this.doSetProvider(scope, provider);
+            return provider;
+        }
+        return this.providersMap.get(scope);
     }
 
-    has(preferenceName: string): boolean {
-        return this.preferences[preferenceName] !== undefined;
+    private doSetProvider(scope: PreferenceScope, provider: PreferenceProvider): void {
+        this.providersMap.set(scope, provider);
+        this.providers.push(provider);
+        this.toDispose.push(provider);
+    }
+
+    getPreferences(resourceUri?: string): { [key: string]: any } {
+        const prefs: { [key: string]: any } = {};
+        Object.keys(this.schema.getCombinedSchema().properties).forEach(p => {
+            prefs[p] = resourceUri ? this.get(p, undefined, resourceUri) : this.get(p, undefined);
+        });
+        return prefs;
+    }
+
+    has(preferenceName: string, resourceUri?: string): boolean {
+        return resourceUri ? this.get(preferenceName, undefined, resourceUri) !== undefined : this.get(preferenceName, undefined) !== undefined;
     }
 
     get<T>(preferenceName: string): T | undefined;
     get<T>(preferenceName: string, defaultValue: T): T;
-    get<T>(preferenceName: string, defaultValue?: T): T | undefined {
-        const value = this.preferences[preferenceName];
-        return value !== null && value !== undefined ? value : defaultValue;
+    get<T>(preferenceName: string, defaultValue: T, resourceUri: string): T;
+    get<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): T | undefined {
+        for (const s of PreferenceScope.getReversedScopes()) {
+            if (this.schema.isValidInScope(preferenceName, s)) {
+                const p = this.providersMap.get(s);
+                if (p && p.canProvide(preferenceName, resourceUri).priority >= 0) {
+                    const value = p.get<T>(preferenceName, resourceUri);
+                    const ret = value !== null && value !== undefined ? value : defaultValue;
+                    return deepFreeze(ret);
+                }
+            }
+        }
     }
 
-    set(preferenceName: string, value: any, scope: PreferenceScope = PreferenceScope.User): Promise<void> {
-        return this.providerProvider(scope).setPreference(preferenceName, value);
+    set(preferenceName: string, value: any, scope: PreferenceScope = PreferenceScope.User, resourceUri?: string): Promise<void> {
+        return this.providerProvider(scope).setPreference(preferenceName, value, resourceUri);
     }
 
     getBoolean(preferenceName: string): boolean | undefined;
     getBoolean(preferenceName: string, defaultValue: boolean): boolean;
-    getBoolean(preferenceName: string, defaultValue?: boolean): boolean | undefined {
-        const value = this.preferences[preferenceName];
+    getBoolean(preferenceName: string, defaultValue: boolean, resourceUri: string): boolean;
+    getBoolean(preferenceName: string, defaultValue?: boolean, resourceUri?: string): boolean | undefined {
+        const value = resourceUri ? this.get(preferenceName, defaultValue, resourceUri) : this.get(preferenceName, defaultValue);
         return value !== null && value !== undefined ? !!value : defaultValue;
     }
 
     getString(preferenceName: string): string | undefined;
     getString(preferenceName: string, defaultValue: string): string;
-    getString(preferenceName: string, defaultValue?: string): string | undefined {
-        const value = this.preferences[preferenceName];
+    getString(preferenceName: string, defaultValue: string, resourceUri: string): string;
+    getString(preferenceName: string, defaultValue?: string, resourceUri?: string): string | undefined {
+        const value = resourceUri ? this.get(preferenceName, defaultValue, resourceUri) : this.get(preferenceName, defaultValue);
         if (value === null || value === undefined) {
             return defaultValue;
-        }
-        if (typeof value === 'string') {
-            return value;
         }
         return value.toString();
     }
 
     getNumber(preferenceName: string): number | undefined;
     getNumber(preferenceName: string, defaultValue: number): number;
-    getNumber(preferenceName: string, defaultValue?: number): number | undefined {
-        const value = this.preferences[preferenceName];
-
+    getNumber(preferenceName: string, defaultValue: number, resourceUri: string): number;
+    getNumber(preferenceName: string, defaultValue?: number, resourceUri?: string): number | undefined {
+        const value = resourceUri ? this.get(preferenceName, defaultValue, resourceUri) : this.get(preferenceName, defaultValue);
         if (value === null || value === undefined) {
             return defaultValue;
         }
@@ -231,4 +347,45 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
         return Number(value);
     }
 
+    protected inpsectInScope<T>(preferenceName: string, scope: PreferenceScope, resourceUri?: string): T | undefined {
+        const val = this.inspect<T>(preferenceName, resourceUri);
+        if (val) {
+            switch (scope) {
+                case PreferenceScope.Default:
+                    return val.defaultValue;
+                case PreferenceScope.User:
+                    return val.globalValue;
+                case PreferenceScope.Workspace:
+                    return val.workspaceValue;
+                case PreferenceScope.Folder:
+                    return val.workspaceFolderValue;
+            }
+        }
+    }
+
+    inspect<T>(preferenceName: string, resourceUri?: string): {
+        preferenceName: string,
+        defaultValue: T | undefined,
+        globalValue: T | undefined, // User Preference
+        workspaceValue: T | undefined, // Workspace Preference
+        workspaceFolderValue: T | undefined // Folder Preference
+    } | undefined {
+        const schemaProps = this.schema.getCombinedSchema().properties[preferenceName];
+        if (schemaProps) {
+            const defaultValue = schemaProps.default;
+            const userProvider = this.providersMap.get(PreferenceScope.User);
+            const globalValue = userProvider && userProvider.canProvide(preferenceName, resourceUri).priority >= 0
+                ? userProvider.get<T>(preferenceName, resourceUri) : undefined;
+
+            const workspaceProvider = this.providersMap.get(PreferenceScope.Workspace);
+            const workspaceValue = workspaceProvider && workspaceProvider.canProvide(preferenceName, resourceUri).priority >= 0
+                ? workspaceProvider.get<T>(preferenceName, resourceUri) : undefined;
+
+            const folderProvider = this.providersMap.get(PreferenceScope.Folder);
+            const workspaceFolderValue = folderProvider && folderProvider.canProvide(preferenceName, resourceUri).priority >= 0
+                ? folderProvider.get<T>(preferenceName, resourceUri) : undefined;
+
+            return { preferenceName, defaultValue, globalValue, workspaceValue, workspaceFolderValue };
+        }
+    }
 }

--- a/packages/core/src/browser/preferences/test/index.ts
+++ b/packages/core/src/browser/preferences/test/index.ts
@@ -16,3 +16,4 @@
 
 export * from './mock-preference-service';
 export * from './mock-preference-proxy';
+export * from './mock-preference-provider';

--- a/packages/core/src/browser/preferences/test/mock-preference-provider.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-provider.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Ericsson and others.
+ * Copyright (C) 2019 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,21 +15,24 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { PreferenceService, PreferenceChange } from '../';
-import { Emitter, Event } from '../../../common';
+import { PreferenceProvider, PreferenceProviderPriority } from '../';
 
 @injectable()
-export class MockPreferenceService implements PreferenceService {
-    constructor() { }
-    dispose() { }
-    get<T>(preferenceName: string): T | undefined;
-    get<T>(preferenceName: string, defaultValue: T): T;
-    get<T>(preferenceName: string, defaultValue: T, resourceUri: string): T;
-    get<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): T | undefined {
-        return undefined;
+export class MockPreferenceProvider extends PreferenceProvider {
+    // tslint:disable-next-line:no-any
+    readonly prefs: { [p: string]: any } = {};
+
+    getPreferences() {
+        return this.prefs;
     }
     // tslint:disable-next-line:no-any
-    set(preferenceName: string, value: any): Promise<void> { return Promise.resolve(); }
-    ready: Promise<void> = Promise.resolve();
-    readonly onPreferenceChanged: Event<PreferenceChange> = new Emitter<PreferenceChange>().event;
+    setPreference(key: string, value: any, resourceUri?: string): Promise<void> {
+        return Promise.resolve();
+    }
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        if (this.prefs[preferenceName] === undefined) {
+            return { priority: PreferenceProviderPriority.NA, provider: this };
+        }
+        return { priority: PreferenceProviderPriority.User, provider: this };
+    }
 }

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -73,6 +73,22 @@
   display: inline-block;
 }
 
+.p-TabBar-tab-secondary-label {
+  color: var(--theia-brand-color2);
+  cursor: pointer;
+  font-size: var(--theia-ui-font-size0);
+  margin-left: 5px;
+  text-decoration-line: underline;
+
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--theia-ui-font-color1) 50%), linear-gradient(135deg, var(--theia-ui-font-color1) 50%, transparent 50%);
+  background-position: calc(100% - 6px) 8px, calc(100% - 2px) 8px, 100% 0;
+  background-size: 4px 5px;
+  background-repeat: no-repeat;
+  padding: 2px 14px 0 0;
+}
+
 .p-TabBar .p-TabBar-tabIcon {
   width: 15px;
   line-height: 1.7;

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -166,4 +166,15 @@ export class Path {
         return !!this.relative(path);
     }
 
+    relativity(path: Path): number {
+        const relative = this.relative(path);
+        if (relative) {
+            const relativeStr = relative.toString();
+            if (relativeStr === '') {
+                return 0;
+            }
+            return relativeStr.split(Path.separator).length;
+        }
+        return -1;
+    }
 }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -27,6 +27,7 @@ import { isOSX } from '@theia/core/lib/common/os';
 
 export const editorPreferenceSchema: PreferenceSchema = {
     'type': 'object',
+    'scope': 'resource',
     'properties': {
         'editor.tabSize': {
             'type': 'number',

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -35,13 +35,14 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
                 '**/.git/objects/**': true,
                 '**/.git/subtree-cache/**': true,
                 '**/node_modules/**': true
-            }
+            },
+            'scope': 'resource'
         }
     }
 };
 
 export interface FileSystemConfiguration {
-    'files.watcherExclude': { [globPattern: string]: boolean }
+    'files.watcherExclude': { [globPattern: string]: boolean };
 }
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');

--- a/packages/filesystem/src/browser/filesystem-watcher.ts
+++ b/packages/filesystem/src/browser/filesystem-watcher.ts
@@ -146,7 +146,7 @@ export class FileSystemWatcher implements Disposable {
      * Return a disposable to stop file watching under the given uri.
      */
     watchFileChanges(uri: URI): Promise<Disposable> {
-        return this.createWatchOptions()
+        return this.createWatchOptions(uri.toString())
             .then(options =>
                 this.server.watchFileChanges(uri.toString(), options)
             )
@@ -167,16 +167,15 @@ export class FileSystemWatcher implements Disposable {
             });
     }
 
-    protected createWatchOptions(): Promise<WatchOptions> {
-        return this.getIgnored().then(ignored => ({
+    protected createWatchOptions(uri: string): Promise<WatchOptions> {
+        return this.getIgnored(uri).then(ignored => ({
             ignored
         }));
     }
 
-    protected getIgnored(): Promise<string[]> {
-        const patterns = this.preferences['files.watcherExclude'];
-
-        return Promise.resolve(Object.keys(patterns).filter(pattern => patterns[pattern]));
+    protected async getIgnored(uri: string): Promise<string[]> {
+        const patterns = this.preferences.get('files.watcherExclude', undefined, uri);
+        return Object.keys(patterns).filter(pattern => patterns[pattern]);
     }
 
     protected fireDidMove(sourceUri: string, targetUri: string): void {

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -57,12 +57,13 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
     }
 
     protected async loadModel(uri: URI): Promise<MonacoEditorModel> {
+        const uriStr = uri.toString();
         await this.editorPreferences.ready;
         const resource = await this.resourceProvider(uri);
         const model = await (new MonacoEditorModel(resource, this.m2p, this.p2m).load());
-        model.autoSave = this.editorPreferences['editor.autoSave'];
-        model.autoSaveDelay = this.editorPreferences['editor.autoSaveDelay'];
-        model.textEditorModel.updateOptions(this.getModelOptions());
+        model.autoSave = this.editorPreferences.get('editor.autoSave', undefined, uriStr);
+        model.autoSaveDelay = this.editorPreferences.get('editor.autoSaveDelay', undefined, uriStr);
+        model.textEditorModel.updateOptions(this.getModelOptions(uriStr));
         const disposable = this.editorPreferences.onPreferenceChanged(change => this.updateModel(model, change));
         model.onDispose(() => disposable.dispose());
         return model;
@@ -77,10 +78,10 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
 
     protected updateModel(model: MonacoEditorModel, change: EditorPreferenceChange): void {
         if (change.preferenceName === 'editor.autoSave') {
-            model.autoSave = this.editorPreferences['editor.autoSave'];
+            model.autoSave = this.editorPreferences.get('editor.autoSave', undefined, model.uri);
         }
         if (change.preferenceName === 'editor.autoSaveDelay') {
-            model.autoSaveDelay = this.editorPreferences['editor.autoSaveDelay'];
+            model.autoSaveDelay = this.editorPreferences.get('editor.autoSaveDelay', undefined, model.uri);
         }
         const modelOption = this.modelOptions[change.preferenceName];
         if (modelOption) {
@@ -91,10 +92,10 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
         }
     }
 
-    protected getModelOptions(): monaco.editor.ITextModelUpdateOptions {
+    protected getModelOptions(uri: string): monaco.editor.ITextModelUpdateOptions {
         return {
-            tabSize: this.editorPreferences['editor.tabSize'],
-            insertSpaces: this.editorPreferences['editor.insertSpaces']
+            tabSize: this.editorPreferences.get('editor.tabSize', undefined, uri),
+            insertSpaces: this.editorPreferences.get('editor.insertSpaces', undefined, uri)
         };
     }
 

--- a/packages/navigator/src/browser/navigator-filter.ts
+++ b/packages/navigator/src/browser/navigator-filter.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import { Minimatch } from 'minimatch';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { Event, Emitter } from '@theia/core/lib/common/event';
@@ -28,16 +28,20 @@ import { FileNavigatorPreferences, FileNavigatorConfiguration } from './navigato
 @injectable()
 export class FileNavigatorFilter {
 
-    protected readonly emitter: Emitter<void>;
+    protected readonly emitter: Emitter<void> = new Emitter<void>();
 
     protected filterPredicate: FileNavigatorFilter.Predicate;
 
     protected showHiddenFiles: boolean;
 
-    constructor(@inject(FileNavigatorPreferences) protected readonly preferences: FileNavigatorPreferences) {
-        this.emitter = new Emitter<void>();
+    constructor(
+        @inject(FileNavigatorPreferences) protected readonly preferences: FileNavigatorPreferences
+    ) { }
+
+    @postConstruct()
+    protected async init(): Promise<void> {
         this.filterPredicate = this.createFilterPredicate(this.preferences['navigator.exclude']);
-        preferences.onPreferenceChanged(this.onPreferenceChanged.bind(this));
+        this.preferences.onPreferenceChanged(this.onPreferenceChanged.bind(this));
     }
 
     async filter<T extends { id: string }>(items: MaybePromise<T[]>): Promise<T[]> {

--- a/packages/plugin-ext/src/main/browser/preference-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/preference-registry-main.ts
@@ -18,7 +18,6 @@ import {
     PreferenceService,
     PreferenceServiceImpl,
     PreferenceScope,
-    PreferenceChange,
     PreferenceProviderProvider
 } from '@theia/core/lib/browser/preferences';
 import { interfaces } from 'inversify';
@@ -52,12 +51,7 @@ export class PreferenceRegistryMainImpl implements PreferenceRegistryMain {
 
         preferenceServiceImpl.onPreferenceChanged(e => {
             const data = getPreferences(this.preferenceProviderProvider);
-            const eventData: PreferenceChange = {
-                preferenceName: e.preferenceName,
-                newValue: e.newValue,
-                oldValue: e.oldValue
-            };
-            this.proxy.$acceptConfigurationChanged(data, eventData);
+            this.proxy.$acceptConfigurationChanged(data, Object.assign({}, e));
         });
     }
 

--- a/packages/preferences/README.md
+++ b/packages/preferences/README.md
@@ -1,6 +1,15 @@
 # Theia - Preferences Extension
 
-This package includes preferences implementation for the preferences api defined in `@theia/core`. This provides two preference providers, one for the user home directory, and one for the workspace, which has precedence over the previous one. To set preferences, create or edit a `settings.json` under the `.theia` folder located either in the user home, or the root of the workspace.
+This package includes preferences implementation for the preferences api defined in `@theia/core`, which provides four preference providers:
+- Default Preference, which serves as default values of preferences,
+- User Preference for the user home directory, which has precedence over the default values,
+- Workspace Preference for the workspace, which has precedence over User Preference, and
+- Folder Preference for the root folder, which has precedence over the Workspace Preference
+
+To set
+- User Preferences: Create or edit a `settings.json` under the `.theia` folder located either in the user home.
+- Workspace Preference: If one folder is opened as the workspace, create or edit a `settings.json` under the root of the workspace. If a multi-root workspace is opened, create or edit the "settings" property in the workspace file.
+- Folder Preferences: Create or edit a `settings.json` under any of the root folders.
 
 Example of a `settings.json` below:
 
@@ -11,6 +20,27 @@ Example of a `settings.json` below:
     // Tab width in the editor
 	"editor.tabSize": 4,
 	"files.watcherExclude": "path/to/file"
+}
+```
+
+Example of a workspace file below:
+
+```typescript
+{
+   "folders": [
+      {
+         "path": "file:///home/username/helloworld"
+	  },
+	  {
+         "path": "file:///home/username/dev/byeworld"
+      }
+   ],
+   "settings": {
+      // Enable/Disable the line numbers in the monaco editor
+	  "editor.lineNumbers": "off",
+      // Tab width in the editor
+	  "editor.tabSize": 4,
+   }
 }
 ```
 

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.19",
     "@theia/editor": "^0.3.19",
     "@theia/filesystem": "^0.3.19",
+    "@theia/json": "^0.3.19",
     "@theia/monaco": "^0.3.19",
     "@theia/userstorage": "^0.3.19",
     "@theia/workspace": "^0.3.19",

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -1,0 +1,73 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { PreferenceScope, PreferenceProvider, PreferenceProviderPriority } from '@theia/core/lib/browser';
+import { AbstractResourcePreferenceProvider } from './abstract-resource-preference-provider';
+import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
+
+export const FolderPreferenceProviderFactory = Symbol('FolderPreferenceProviderFactory');
+export interface FolderPreferenceProviderFactory {
+    (options: FolderPreferenceProviderOptions): FolderPreferenceProvider;
+}
+
+export const FolderPreferenceProviderOptions = Symbol('FolderPreferenceProviderOptions');
+export interface FolderPreferenceProviderOptions {
+    folder: FileStat;
+}
+
+@injectable()
+export class FolderPreferenceProvider extends AbstractResourcePreferenceProvider {
+
+    private folderUri: URI | undefined;
+
+    constructor(
+        @inject(FolderPreferenceProviderOptions) protected readonly options: FolderPreferenceProviderOptions,
+        @inject(FileSystem) protected readonly fileSystem: FileSystem
+    ) {
+        super();
+    }
+
+    get uri(): URI | undefined {
+        return this.folderUri;
+    }
+
+    async getUri(): Promise<URI | undefined> {
+        this.folderUri = new URI(this.options.folder.uri);
+        if (await this.fileSystem.exists(this.folderUri.toString())) {
+            const uri = this.folderUri.resolve('.theia').resolve('settings.json');
+            return uri;
+        }
+    }
+
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        const value = this.get(preferenceName);
+        if (value === undefined || value === null || !resourceUri || !this.folderUri) {
+            return super.canProvide(preferenceName, resourceUri);
+        }
+        const uri = new URI(resourceUri);
+        return { priority: PreferenceProviderPriority.Folder + this.folderUri.path.relativity(uri.path), provider: this };
+    }
+
+    protected getScope() {
+        return PreferenceScope.Folder;
+    }
+
+    getDomain(): string[] {
+        return this.folderUri ? [this.folderUri.toString()] : [];
+    }
+}

--- a/packages/preferences/src/browser/folders-preferences-provider.ts
+++ b/packages/preferences/src/browser/folders-preferences-provider.ts
@@ -1,0 +1,137 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import { PreferenceProvider } from '@theia/core/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { FolderPreferenceProvider, FolderPreferenceProviderFactory } from './folder-preference-provider';
+import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
+import URI from '@theia/core/lib/common/uri';
+
+@injectable()
+export class FoldersPreferencesProvider extends PreferenceProvider {
+
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(FolderPreferenceProviderFactory) protected readonly folderPreferenceProviderFactory: FolderPreferenceProviderFactory;
+
+    private providers: FolderPreferenceProvider[] = [];
+
+    @postConstruct()
+    protected async init(): Promise<void> {
+        await this.workspaceService.roots;
+        if (this.workspaceService.saved) {
+            for (const root of this.workspaceService.tryGetRoots()) {
+                if (await this.fileSystem.exists(root.uri)) {
+                    const provider = this.createFolderPreferenceProvider(root);
+                    this.providers.push(provider);
+                }
+            }
+        }
+
+        // Try to read the initial content of the preferences.  The provider
+        // becomes ready even if we fail reading the preferences, so we don't
+        // hang the preference service.
+        Promise.all(this.providers.map(p => p.ready))
+            .then(() => this._ready.resolve())
+            .catch(() => this._ready.resolve());
+
+        this.workspaceService.onWorkspaceChanged(roots => {
+            for (const root of roots) {
+                if (!this.existsProvider(root.uri)) {
+                    const provider = this.createFolderPreferenceProvider(root);
+                    if (!this.existsProvider(root.uri)) {
+                        this.providers.push(provider);
+                    } else {
+                        provider.dispose();
+                    }
+                }
+            }
+
+            const numProviders = this.providers.length;
+            for (let ind = numProviders - 1; ind >= 0; ind--) {
+                const provider = this.providers[ind];
+                if (roots.findIndex(r => !!provider.uri && r.uri === provider.uri.toString()) < 0) {
+                    this.providers.splice(ind, 1);
+                    provider.dispose();
+                }
+            }
+        });
+    }
+
+    private existsProvider(folderUri: string): boolean {
+        return this.providers.findIndex(p => !!p.uri && p.uri.toString() === folderUri) >= 0;
+    }
+
+    // tslint:disable-next-line:no-any
+    getPreferences(resourceUri?: string): { [p: string]: any } {
+        const numProviders = this.providers.length;
+        if (resourceUri && numProviders > 0) {
+            const provider = this.getProvider(resourceUri);
+            if (provider) {
+                return provider.getPreferences();
+            }
+        }
+        return {};
+    }
+
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        if (resourceUri && this.providers.length > 0) {
+            const provider = this.getProvider(resourceUri);
+            if (provider) {
+                return { priority: provider.canProvide(preferenceName, resourceUri).priority, provider };
+            }
+        }
+        return super.canProvide(preferenceName, resourceUri);
+    }
+
+    protected getProvider(resourceUri: string): PreferenceProvider | undefined {
+        let provider: PreferenceProvider | undefined;
+        let relativity = Number.MAX_SAFE_INTEGER;
+        for (const p of this.providers) {
+            if (p.uri) {
+                const providerRelativity = p.uri.path.relativity(new URI(resourceUri).path);
+                if (providerRelativity >= 0 && providerRelativity <= relativity) {
+                    relativity = providerRelativity;
+                    provider = p;
+                }
+            }
+        }
+        return provider;
+    }
+
+    protected createFolderPreferenceProvider(folder: FileStat): FolderPreferenceProvider {
+        const provider = this.folderPreferenceProviderFactory({ folder });
+        this.toDispose.push(provider);
+        this.toDispose.push(provider.onDidPreferencesChanged(change => this.onDidPreferencesChangedEmitter.fire(change)));
+        return provider;
+    }
+
+    // tslint:disable-next-line:no-any
+    async setPreference(key: string, value: any, resourceUri?: string): Promise<void> {
+        if (resourceUri) {
+            for (const provider of this.providers) {
+                const providerResourceUri = await provider.getUri();
+                if (providerResourceUri && providerResourceUri.toString() === resourceUri) {
+                    return provider.setPreference(key, value);
+                }
+            }
+            console.error(`FoldersPreferencesProvider did not find the provider for ${resourceUri} to update the preference ${key}`);
+        } else {
+            console.error('FoldersPreferencesProvider requires resource URI to update preferences');
+        }
+    }
+}

--- a/packages/preferences/src/browser/index.ts
+++ b/packages/preferences/src/browser/index.ts
@@ -18,3 +18,5 @@ export * from '@theia/core/lib/browser/preferences';
 export * from './abstract-resource-preference-provider';
 export * from './user-preference-provider';
 export * from './workspace-preference-provider';
+export * from './folders-preferences-provider';
+export * from './folder-preference-provider';

--- a/packages/preferences/src/browser/preference-editor-widget.ts
+++ b/packages/preferences/src/browser/preference-editor-widget.ts
@@ -1,0 +1,141 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Title } from '@phosphor/widgets';
+import { AttachedProperty } from '@phosphor/properties';
+import { DockPanel, Menu, TabBar, Widget } from '@phosphor/widgets';
+import { CommandRegistry } from '@phosphor/commands';
+import { VirtualElement, h } from '@phosphor/virtualdom';
+import { PreferenceScope } from '@theia/core/lib/browser';
+import { EditorWidget } from '@theia/editor/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import URI from '@theia/core/lib/common/uri';
+import { FileAccess, FileSystem } from '@theia/filesystem/lib/common';
+
+export class PreferencesEditorWidgetTitle extends Title<PreferencesEditorWidget> {
+    clickableText?: string;
+    clickableTextTooltip?: string;
+    clickableTextCallback?: (value: string) => void;
+}
+
+export class PreferencesEditorWidget extends EditorWidget {
+    scope: PreferenceScope | undefined;
+
+    get title(): PreferencesEditorWidgetTitle {
+        return new AttachedProperty<PreferencesEditorWidget, PreferencesEditorWidgetTitle>({
+            name: 'title',
+            create: owner => new PreferencesEditorWidgetTitle({ owner }),
+        }).get(this);
+    }
+}
+
+export class PreferenceEditorTabHeaderRenderer extends TabBar.Renderer {
+
+    constructor(
+        private readonly workspaceService: WorkspaceService,
+        private readonly fileSystem: FileSystem
+    ) {
+        super();
+    }
+
+    renderTab(data: TabBar.IRenderData<PreferencesEditorWidget>): VirtualElement {
+        const title = data.title;
+        const key = this.createTabKey(data);
+        const style = this.createTabStyle(data);
+        const className = this.createTabClass(data);
+        return h.li({
+            key, className, title: title.caption, style
+        },
+            this.renderIcon(data),
+            this.renderLabel(data),
+            this.renderCloseIcon(data)
+        );
+    }
+
+    renderLabel(data: TabBar.IRenderData<PreferencesEditorWidget>): VirtualElement {
+        const clickableTitle = data.title.owner.title;
+        if (clickableTitle.clickableText) {
+            return h.div(
+                h.span({ className: 'p-TabBar-tabLabel' }, data.title.label),
+                h.span({
+                    className: 'p-TabBar-tabLabel p-TabBar-tab-secondary-label',
+                    title: clickableTitle.clickableTextTooltip,
+                    onclick: event => {
+                        const editorUri = data.title.owner.editor.uri;
+                        this.refreshContextMenu(editorUri.parent.parent.toString(), clickableTitle.clickableTextCallback || (() => { }))
+                            .then(menu => menu.open(event.x, event.y));
+                    }
+                }, clickableTitle.clickableText)
+            );
+        }
+        return super.renderLabel(data);
+    }
+
+    protected async refreshContextMenu(activeMenuId: string, menuItemAction: (value: string) => void): Promise<Menu> {
+        const commands = new CommandRegistry();
+        const menu = new Menu({ commands });
+        const roots = this.workspaceService.tryGetRoots().map(r => r.uri);
+        for (const root of roots) {
+            if (await this.canAccessSettings(root)) {
+                const commandId = `switch_folder_pref_editor_to_${root}`;
+                if (!commands.hasCommand(commandId)) {
+                    const rootUri = new URI(root);
+                    const isActive = rootUri.toString() === activeMenuId;
+                    commands.addCommand(commandId, {
+                        label: rootUri.displayName,
+                        iconClass: isActive ? 'fa fa-check' : '',
+                        execute: () => {
+                            if (!isActive) {
+                                menuItemAction(root);
+                            }
+                        }
+                    });
+                }
+
+                menu.addItem({
+                    type: 'command',
+                    command: commandId
+                });
+            }
+        }
+        return menu;
+    }
+
+    private async canAccessSettings(folderUriStr: string): Promise<boolean> {
+        const folderUri = new URI(folderUriStr);
+        const settingsUriStr = folderUri.resolve('.theia').resolve('settings.json').toString();
+        if (await this.fileSystem.exists(settingsUriStr)) {
+            return this.fileSystem.access(settingsUriStr, FileAccess.Constants.R_OK);
+        }
+        return this.fileSystem.access(folderUriStr, FileAccess.Constants.W_OK);
+    }
+}
+
+export class PreferenceEditorContainerTabBarRenderer extends DockPanel.Renderer {
+
+    constructor(
+        private readonly workspaceService: WorkspaceService,
+        private readonly fileSystem: FileSystem
+    ) {
+        super();
+    }
+
+    createTabBar(): TabBar<Widget> {
+        const bar = new TabBar({ renderer: new PreferenceEditorTabHeaderRenderer(this.workspaceService, this.fileSystem) });
+        bar.addClass('p-DockPanel-tabBar');
+        return bar;
+    }
+}

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ContainerModule, interfaces, } from 'inversify';
+import { Container, ContainerModule, interfaces } from 'inversify';
 import { PreferenceProvider, PreferenceScope } from '@theia/core/lib/browser/preferences';
 import { UserPreferenceProvider } from './user-preference-provider';
 import { WorkspacePreferenceProvider } from './workspace-preference-provider';
@@ -22,8 +22,10 @@ import { bindViewContribution, WidgetFactory, FrontendApplicationContribution } 
 import { PreferencesContribution } from './preferences-contribution';
 import { createPreferencesTreeWidget } from './preference-tree-container';
 import { PreferencesMenuFactory } from './preferences-menu-factory';
-import { PreferencesContainer, PreferencesEditorsContainer, PreferencesTreeWidget } from './preferences-tree-widget';
 import { PreferencesFrontendApplicationContribution } from './preferences-frontend-application-contribution';
+import { PreferencesContainer, PreferencesTreeWidget, PreferencesEditorsContainer } from './preferences-tree-widget';
+import { FoldersPreferencesProvider } from './folders-preferences-provider';
+import { FolderPreferenceProvider, FolderPreferenceProviderFactory, FolderPreferenceProviderOptions } from './folder-preference-provider';
 
 import './preferences-monaco-contribution';
 
@@ -32,6 +34,16 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
 
     bind(PreferenceProvider).to(UserPreferenceProvider).inSingletonScope().whenTargetNamed(PreferenceScope.User);
     bind(PreferenceProvider).to(WorkspacePreferenceProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);
+    bind(PreferenceProvider).to(FoldersPreferencesProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Folder);
+    bind(FolderPreferenceProvider).toSelf().inTransientScope();
+    bind(FolderPreferenceProviderFactory).toFactory(ctx =>
+        (options: FolderPreferenceProviderOptions) => {
+            const child = new Container({ defaultScope: 'Transient' });
+            child.parent = ctx.container;
+            child.bind(FolderPreferenceProviderOptions).toConstantValue(options);
+            return child.get(FolderPreferenceProvider);
+        }
+    );
 
     bindViewContribution(bind, PreferencesContribution);
 

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+// tslint:disable:no-any
 // tslint:disable:no-unused-expression
 
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
@@ -26,8 +27,8 @@ import * as fs from 'fs-extra';
 import * as temp from 'temp';
 import { Emitter } from '@theia/core/lib/common';
 import {
-    PreferenceService, PreferenceScope,
-    PreferenceProviderProvider, PreferenceServiceImpl, PreferenceProvider, bindPreferenceSchemaProvider
+    PreferenceService, PreferenceScope, PreferenceProviderDataChanges,
+    PreferenceSchemaProvider, PreferenceProviderProvider, PreferenceServiceImpl, bindPreferenceSchemaProvider
 } from '@theia/core/lib/browser/preferences';
 import { FileSystem, FileShouldOverwrite, FileStat } from '@theia/filesystem/lib/common/';
 import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watcher';
@@ -36,9 +37,12 @@ import { FileSystemPreferences, createFileSystemPreferences } from '@theia/files
 import { ILogger, MessageService, MessageClient } from '@theia/core';
 import { UserPreferenceProvider } from './user-preference-provider';
 import { WorkspacePreferenceProvider } from './workspace-preference-provider';
+import { FoldersPreferencesProvider, } from './folders-preferences-provider';
+import { FolderPreferenceProvider, FolderPreferenceProviderFactory, FolderPreferenceProviderOptions } from './folder-preference-provider';
 import { ResourceProvider } from '@theia/core/lib/common/resource';
 import { WorkspaceServer } from '@theia/workspace/lib/common/';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { MockPreferenceProvider } from '@theia/core/lib/browser/preferences/test';
 import { MockFilesystem, MockFilesystemWatcherServer } from '@theia/filesystem/lib/common/test';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { MockResourceProvider } from '@theia/core/lib/common/test/mock-resource-provider';
@@ -55,11 +59,11 @@ disableJSDOM();
 const expect = chai.expect;
 let testContainer: Container;
 
-let prefService: PreferenceService;
 const tempPath = temp.track().openSync().path;
 
-const mockUserPreferenceEmitter = new Emitter<void>();
-const mockWorkspacePreferenceEmitter = new Emitter<void>();
+const mockUserPreferenceEmitter = new Emitter<PreferenceProviderDataChanges>();
+const mockWorkspacePreferenceEmitter = new Emitter<PreferenceProviderDataChanges>();
+const mockFolderPreferenceEmitter = new Emitter<PreferenceProviderDataChanges>();
 
 function testContainerSetup() {
     testContainer = new Container();
@@ -67,18 +71,42 @@ function testContainerSetup() {
 
     testContainer.bind(UserPreferenceProvider).toSelf().inSingletonScope();
     testContainer.bind(WorkspacePreferenceProvider).toSelf().inSingletonScope();
+    testContainer.bind(FoldersPreferencesProvider).toSelf().inSingletonScope();
+
+    testContainer.bind(FolderPreferenceProvider).toSelf().inSingletonScope();
+    testContainer.bind(FolderPreferenceProviderOptions).toConstantValue({ folder: <FileStat>{ uri: 'file:///home/oneFile', isDirectory: true, lastModification: 0 } });
+    testContainer.bind(FolderPreferenceProviderFactory).toFactory(ctx =>
+        (options: FolderPreferenceProviderOptions) => {
+            const child = new Container({ defaultScope: 'Transient' });
+            child.parent = ctx.container;
+            child.bind(FolderPreferenceProviderOptions).toConstantValue(options);
+            return child.get(FolderPreferenceProvider);
+        }
+    );
 
     testContainer.bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => {
-        const userProvider = ctx.container.get(UserPreferenceProvider);
-        const workspaceProvider = ctx.container.get(WorkspacePreferenceProvider);
-
-        sinon.stub(userProvider, 'onDidPreferencesChanged').get(() =>
-            mockUserPreferenceEmitter.event
-        );
-        sinon.stub(workspaceProvider, 'onDidPreferencesChanged').get(() =>
-            mockWorkspacePreferenceEmitter.event
-        );
-        return scope === PreferenceScope.User ? userProvider : workspaceProvider;
+        switch (scope) {
+            case PreferenceScope.User:
+                const userProvider = ctx.container.get(UserPreferenceProvider);
+                sinon.stub(userProvider, 'onDidPreferencesChanged').get(() =>
+                    mockUserPreferenceEmitter.event
+                );
+                return userProvider;
+            case PreferenceScope.Workspace:
+                const workspaceProvider = ctx.container.get(WorkspacePreferenceProvider);
+                sinon.stub(workspaceProvider, 'onDidPreferencesChanged').get(() =>
+                    mockWorkspacePreferenceEmitter.event
+                );
+                return workspaceProvider;
+            case PreferenceScope.Folder:
+                const folderProvider = ctx.container.get(FoldersPreferencesProvider);
+                sinon.stub(folderProvider, 'onDidPreferencesChanged').get(() =>
+                    mockFolderPreferenceEmitter.event
+                );
+                return folderProvider;
+            default:
+                return ctx.container.get(PreferenceSchemaProvider);
+        }
     });
     testContainer.bind(PreferenceServiceImpl).toSelf().inSingletonScope();
 
@@ -137,7 +165,10 @@ function testContainerSetup() {
     testContainer.bind(MessageClient).toSelf().inSingletonScope();
 }
 
-describe('Preference Service', function () {
+describe('Preference Service', () => {
+    let prefService: PreferenceService;
+    let prefSchema: PreferenceSchemaProvider;
+    const stubs: sinon.SinonStub[] = [];
 
     before(() => {
         disableJSDOM = enableJSDOM();
@@ -152,6 +183,7 @@ describe('Preference Service', function () {
     });
 
     beforeEach(() => {
+        prefSchema = testContainer.get(PreferenceSchemaProvider);
         prefService = testContainer.get<PreferenceService>(PreferenceService);
         const impl = testContainer.get(PreferenceServiceImpl);
         impl.initialize();
@@ -159,146 +191,160 @@ describe('Preference Service', function () {
 
     afterEach(() => {
         prefService.dispose();
+        stubs.forEach(s => s.restore());
+        stubs.length = 0;
     });
 
-    it('Should get notified if a provider gets a change', function (done) {
-
-        const prefValue = true;
-        prefService.onPreferenceChanged(pref => {
-            try {
-                expect(pref.preferenceName).eq('testPref');
-            } catch (e) {
-                stubGet.restore();
-                done(e);
-                return;
-            }
-            expect(pref.newValue).eq(prefValue);
-            stubGet.restore();
-            done();
-        });
-
+    it('should get notified if a provider emits a change', done => {
         const userProvider = testContainer.get(UserPreferenceProvider);
-        const stubGet = sinon.stub(userProvider, 'getPreferences').returns({
-            'testPref': prefValue
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
+            testPref: 'oldVal'
+        }));
+        prefService.onPreferenceChanged(pref => {
+            if (pref) {
+                expect(pref.preferenceName).eq('testPref');
+                expect(pref.newValue).eq('newVal');
+                return done();
+            }
+            return done(new Error('onPreferenceChanged() fails to return any preference change infomation'));
         });
-
-        mockUserPreferenceEmitter.fire(undefined);
-
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        mockUserPreferenceEmitter.fire({
+            testPref: {
+                preferenceName: 'testPref',
+                newValue: 'newVal',
+                oldValue: 'oldVal',
+                scope: PreferenceScope.User,
+                domain: []
+            }
+        });
     }).timeout(2000);
 
-    it('Should return the preference from the more specific scope (user > workspace)', () => {
+    it('should return the preference from the more specific scope (user > workspace)', () => {
         const userProvider = testContainer.get(UserPreferenceProvider);
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
-        const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
             'test.number': 1
-        });
-        const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
+        }));
+        stubs.push(sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
             'test.number': 0
-        });
-        mockUserPreferenceEmitter.fire(undefined);
-
-        let value = prefService.get('test.boolean');
-        expect(value).to.be.false;
-
-        value = prefService.get('test.number');
-        expect(value).equals(0);
-
-        [stubUser, stubWorkspace].forEach(stub => {
-            stub.restore();
-        });
+        }));
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(prefService.get('test.boolean')).to.be.false;
+        expect(prefService.get('test.number')).equals(0);
     });
 
-    it('Should return the preference from the less specific scope if the value is removed from the more specific one', () => {
+    it('should return the preference from the more specific scope (folders > workspace)', () => {
         const userProvider = testContainer.get(UserPreferenceProvider);
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
-        const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
+        const foldersProvider = testContainer.get(FoldersPreferencesProvider);
+        const oneFolderProvider = testContainer.get(FolderPreferenceProvider);
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
+            'test.string': 'userValue',
+            'test.number': 1
+        }));
+        stubs.push(sinon.stub(workspaceProvider, 'getPreferences').returns({
+            'test.string': 'wsValue',
+            'test.number': 0
+        }));
+        stubs.push(sinon.stub(foldersProvider, 'canProvide').returns({ priority: 10, provider: oneFolderProvider }));
+        stubs.push(sinon.stub(foldersProvider, 'getPreferences').returns({
+            'test.string': 'folderValue',
+            'test.number': 20
+        }));
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(prefService.get('test.string')).equals('folderValue');
+        expect(prefService.get('test.number')).equals(20);
+    });
+
+    it('should return the preference from the less specific scope if the value is removed from the more specific one', () => {
+        const userProvider = testContainer.get(UserPreferenceProvider);
+        const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
             'test.number': 1
-        });
+        }));
         const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
             'test.number': 0
         });
-        mockUserPreferenceEmitter.fire(undefined);
-
-        let value = prefService.get('test.boolean');
-        expect(value).to.be.false;
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(prefService.get('test.boolean')).to.be.false;
 
         stubWorkspace.restore();
-        mockUserPreferenceEmitter.fire(undefined);
-
-        value = prefService.get('test.boolean');
-        expect(value).to.be.true;
-
-        stubUser.restore();
+        stubs.push(sinon.stub(workspaceProvider, 'getPreferences').returns({}));
+        expect(prefService.get('test.boolean')).to.be.true;
     });
 
-    it('Should throw a TypeError if the preference (reference object) is modified', () => {
+    it('should throw a TypeError if the preference (reference object) is modified', () => {
         const userProvider = testContainer.get(UserPreferenceProvider);
-        const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
             'test.immutable': [
                 'test', 'test', 'test'
             ]
-        });
-        mockUserPreferenceEmitter.fire(undefined);
-
+        }));
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
         const immutablePref: string[] | undefined = prefService.get('test.immutable');
         expect(immutablePref).to.not.be.undefined;
         if (immutablePref !== undefined) {
-            expect(() => {
-                immutablePref.push('fails');
-            }).to.throw(TypeError);
+            expect(() => immutablePref.push('fails')).to.throw(TypeError);
         }
-        stubUser.restore();
     });
 
-    it('Should still report the more specific preference even though the less specific one changed', () => {
+    it('should still report the more specific preference even though the less specific one changed', () => {
         const userProvider = testContainer.get(UserPreferenceProvider);
         const workspaceProvider = testContainer.get(WorkspacePreferenceProvider);
-        let stubUser = sinon.stub(userProvider, 'getPreferences').returns({
+        const stubUser = sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
             'test.number': 1
         });
-        const stubWorkspace = sinon.stub(workspaceProvider, 'getPreferences').returns({
+        stubs.push(sinon.stub(workspaceProvider, 'getPreferences').returns({
             'test.boolean': false,
             'test.number': 0
+        }));
+        mockUserPreferenceEmitter.fire({
+            'test.number': {
+                preferenceName: 'test.number',
+                newValue: 2,
+                scope: PreferenceScope.User,
+                domain: []
+            }
         });
-        mockUserPreferenceEmitter.fire(undefined);
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(prefService.get('test.number')).equals(0);
 
-        let value = prefService.get('test.number');
-        expect(value).equals(0);
         stubUser.restore();
-
-        stubUser = sinon.stub(userProvider, 'getPreferences').returns({
+        stubs.push(sinon.stub(userProvider, 'getPreferences').returns({
             'test.boolean': true,
             'test.number': 4
+        }));
+        mockUserPreferenceEmitter.fire({
+            'test.number': {
+                preferenceName: 'test.number',
+                newValue: 4,
+                scope: PreferenceScope.User,
+                domain: []
+            }
         });
-        mockUserPreferenceEmitter.fire(undefined);
-
-        value = prefService.get('test.number');
-        expect(value).equals(0);
-
-        [stubUser, stubWorkspace].forEach(stub => {
-            stub.restore();
-        });
+        expect(prefService.get('test.number')).equals(0);
     });
 
-    it('Should store preference when settings file is empty', async () => {
+    it('should store preference when settings file is empty', async () => {
         const settings = '{\n   "key": "value"\n}';
         await prefService.set('key', 'value', PreferenceScope.User);
         expect(fs.readFileSync(tempPath).toString()).equals(settings);
     });
 
-    it('Should store preference when settings file is not empty', async () => {
+    it('should store preference when settings file is not empty', async () => {
         const settings = '{\n   "key": "value",\n   "newKey": "newValue"\n}';
         fs.writeFileSync(tempPath, '{\n   "key": "value"\n}');
         await prefService.set('newKey', 'newValue', PreferenceScope.User);
         expect(fs.readFileSync(tempPath).toString()).equals(settings);
     });
 
-    it('Should override existing preference', async () => {
+    it('should override existing preference', async () => {
         const settings = '{\n   "key": "newValue"\n}';
         fs.writeFileSync(tempPath, '{\n   "key": "oldValue"\n}');
         await prefService.set('key', 'newValue', PreferenceScope.User);
@@ -306,39 +352,70 @@ describe('Preference Service', function () {
     });
 
     /**
+     * A slow provider that becomes ready after 1 second.
+     */
+    class SlowProvider extends MockPreferenceProvider {
+        constructor() {
+            super();
+            setTimeout(() => {
+                this.prefs['mypref'] = 2;
+                this._ready.resolve();
+            }, 1000);
+        }
+    }
+    /**
+     * Default provider that becomes ready after constructor gets called
+     */
+    class MockDefaultProvider extends MockPreferenceProvider {
+        constructor() {
+            super();
+            this.prefs['mypref'] = 5;
+            this._ready.resolve();
+        }
+    }
+
+    /**
      * Make sure that the preference service is ready only once the providers
      * are ready to provide preferences.
      */
-    it('Should be ready only when all providers are ready', async () => {
-        /**
-         * A slow provider that becomes ready after 1 second.
-         */
-        class SlowProvider extends PreferenceProvider {
-            // tslint:disable-next-line:no-any
-            readonly prefs: { [p: string]: any } = {};
-
-            constructor() {
-                super();
-                setTimeout(() => {
-                    this.prefs['mypref'] = 2;
-                    this._ready.resolve();
-                }, 1000);
-            }
-
-            getPreferences() {
-                return this.prefs;
-            }
-        }
-
+    it('should be ready only when all providers are ready', async () => {
         const container = new Container();
         bindPreferenceSchemaProvider(container.bind.bind(container));
-        container.bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => new SlowProvider());
+        container.bind(ILogger).to(MockLogger);
+        container.bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => {
+            if (scope === PreferenceScope.User) {
+                return new MockDefaultProvider();
+            }
+            return new SlowProvider();
+        });
         container.bind(PreferenceServiceImpl).toSelf().inSingletonScope();
 
         const service = container.get<PreferenceServiceImpl>(PreferenceServiceImpl);
         service.initialize();
+        prefSchema = container.get(PreferenceSchemaProvider);
         await service.ready;
-        const n = service.getNumber('mypref');
-        expect(n).to.equal(2);
+        stubs.push(sinon.stub(PreferenceServiceImpl, <any>'doSetProvider').callsFake(() => { }));
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(service.get('mypref')).to.equal(2);
+    });
+
+    it('should answer queries before all providers are ready', async () => {
+        const container = new Container();
+        bindPreferenceSchemaProvider(container.bind.bind(container));
+        container.bind(ILogger).to(MockLogger);
+        container.bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => {
+            if (scope === PreferenceScope.User) {
+                return new MockDefaultProvider();
+            }
+            return new SlowProvider();
+        });
+        container.bind(PreferenceServiceImpl).toSelf().inSingletonScope();
+
+        const service = container.get<PreferenceServiceImpl>(PreferenceServiceImpl);
+        service.initialize();
+        prefSchema = container.get(PreferenceSchemaProvider);
+        stubs.push(sinon.stub(PreferenceServiceImpl, <any>'doSetProvider').callsFake(() => { }));
+        stubs.push(sinon.stub(prefSchema, 'isValidInScope').returns(true));
+        expect(service.get('mypref')).to.equal(5);
     });
 });

--- a/packages/preferences/src/browser/preferences-frontend-application-contribution.ts
+++ b/packages/preferences/src/browser/preferences-frontend-application-contribution.ts
@@ -29,17 +29,15 @@ export class PreferencesFrontendApplicationContribution implements FrontendAppli
     @inject(InMemoryResources) inmemoryResources: InMemoryResources;
 
     onStart() {
-        this.schemaProvider.ready.then(async () => {
-            const serializeSchema = () => JSON.stringify(this.schemaProvider.getCombinedSchema());
-            const uri = new URI('vscode://schemas/settings/user');
-            this.inmemoryResources.add(uri, serializeSchema());
-            this.jsonSchemaStore.registerSchema({
-                fileMatch: ['.theia/settings.json', USER_PREFERENCE_URI.toString()],
-                url: uri.toString()
-            });
-            this.schemaProvider.onDidPreferencesChanged(() =>
-                this.inmemoryResources.update(uri, serializeSchema())
-            );
+        const serializeSchema = () => JSON.stringify(this.schemaProvider.getCombinedSchema());
+        const uri = new URI('vscode://schemas/settings/user');
+        this.inmemoryResources.add(uri, serializeSchema());
+        this.jsonSchemaStore.registerSchema({
+            fileMatch: ['.theia/settings.json', USER_PREFERENCE_URI.toString()],
+            url: uri.toString()
         });
+        this.schemaProvider.onDidPreferencesChanged(() =>
+            this.inmemoryResources.update(uri, serializeSchema())
+        );
     }
 }

--- a/packages/preferences/src/browser/preferences-menu-factory.ts
+++ b/packages/preferences/src/browser/preferences-menu-factory.ts
@@ -17,34 +17,34 @@
 import { injectable } from 'inversify';
 import { Menu } from '@phosphor/widgets';
 import { CommandRegistry } from '@phosphor/commands';
-import { PreferenceProperty } from '@theia/core/lib/browser';
 import { escapeInvisibleChars, unescapeInvisibleChars } from '@theia/core/lib/common/strings';
+import { PreferenceDataProperty } from '@theia/core/lib/browser';
 
 @injectable()
 export class PreferencesMenuFactory {
 
     // tslint:disable-next-line:no-any
-    createPreferenceContextMenu(id: string, savedPreference: any, property: PreferenceProperty, execute: (property: string, value: any) => void): Menu {
+    createPreferenceContextMenu(id: string, savedPreference: any, property: PreferenceDataProperty, execute: (property: string, value: any) => void): Menu {
         const commands = new CommandRegistry();
         const menu = new Menu({ commands });
         if (property) {
             const enumConst = property.enum;
             if (enumConst) {
                 enumConst.map(escapeInvisibleChars)
-                .forEach(enumValue => {
-                    const commandId = id + '-' + enumValue;
-                    if (!commands.hasCommand(commandId)) {
-                        commands.addCommand(commandId, {
-                            label: enumValue,
-                            iconClass: escapeInvisibleChars(savedPreference) === enumValue || !savedPreference && property.default === enumValue ? 'fa fa-check' : '',
-                            execute: () => execute(id, unescapeInvisibleChars(enumValue))
-                        });
-                        menu.addItem({
-                            type: 'command',
-                            command: commandId
-                        });
-                    }
-                });
+                    .forEach(enumValue => {
+                        const commandId = id + '-' + enumValue;
+                        if (!commands.hasCommand(commandId)) {
+                            commands.addCommand(commandId, {
+                                label: enumValue,
+                                iconClass: escapeInvisibleChars(savedPreference) === enumValue || !savedPreference && property.default === enumValue ? 'fa fa-check' : '',
+                                execute: () => execute(id, unescapeInvisibleChars(enumValue))
+                            });
+                            menu.addItem({
+                                type: 'command',
+                                command: commandId
+                            });
+                        }
+                    });
             } else if (property.type && property.type === 'boolean') {
                 const commandTrue = id + '-true';
                 commands.addCommand(commandTrue, {

--- a/packages/preferences/src/browser/user-preference-provider.ts
+++ b/packages/preferences/src/browser/user-preference-provider.ts
@@ -18,6 +18,7 @@ import { injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { AbstractResourcePreferenceProvider } from './abstract-resource-preference-provider';
 import { UserStorageUri } from '@theia/userstorage/lib/browser';
+import { PreferenceScope, PreferenceProvider, PreferenceProviderPriority } from '@theia/core/lib/browser';
 
 export const USER_PREFERENCE_URI = new URI().withScheme(UserStorageUri.SCHEME).withPath('settings.json');
 @injectable()
@@ -27,4 +28,15 @@ export class UserPreferenceProvider extends AbstractResourcePreferenceProvider {
         return USER_PREFERENCE_URI;
     }
 
+    canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
+        const value = this.get(preferenceName);
+        if (value === undefined || value === null) {
+            return super.canProvide(preferenceName, resourceUri);
+        }
+        return { priority: PreferenceProviderPriority.User, provider: this };
+    }
+
+    protected getScope() {
+        return PreferenceScope.User;
+    }
 }


### PR DESCRIPTION
With changes in 543b119, URIs of root folders in a multi-root workspace are stored in a file with the extension of "theia-workspace", while the workspace preferences are in the ".theia/settings.json" under the first root.

In this pull request, workspace preferences are stored
- in the workspace file under the "settings" property, if a workspace file exists, or
- in the ".theia/settings.json" if the workspace data is not saved in a workspace file.

Also, this change supports
- having 4 levels of preferences (from highest priority to the lowest): FolderPreference, WorkspacePreference, UserPreference, and DefaultPreference, with
- an updated preference editor that supports viewing & editing the FolderPreferences, WorkspacePreferences, and UserPreferneces.

Signed-off-by: elaihau <liang.huang@ericsson.com>

