### PR TITLE
Remove empty css ruleset

### DIFF
--- a/packages/extension-manager/src/browser/style/extension-detail.css
+++ b/packages/extension-manager/src/browser/style/extension-detail.css
@@ -43,8 +43,6 @@
     margin-top: 0px;
 }
 
-.theia-extension-detail .extensionVersion {}
-
 .theia-extension-detail .extensionAuthor {
     border-right: var(--theia-ui-font-color1) 1px solid;
     padding-right: 10px;


### PR DESCRIPTION
Removed empty css ruleset based on `[css.lint.emptyRules]`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
