### PR TITLE
Fixed GitHistory when opened via view menu

### DIFF
--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -121,9 +121,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
 
     protected async addCommits(options?: Git.Options.Log): Promise<void> {
         let repository: Repository | undefined;
-        if (options && options.uri) {
-            repository = this.repositoryProvider.findRepository(new URI(options.uri));
-        }
+        repository = this.repositoryProvider.findRepositoryOrSelected(options);
         let resolver: () => void;
         this.errorMessage = undefined;
         this.cancelIndicator.cancel();
@@ -177,6 +175,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         } else {
             setTimeout(() => {
                 this.commits = [];
+                this.errorMessage = <React.Fragment>There is no repository selected in this workspace.</React.Fragment>;
                 resolver();
             });
         }


### PR DESCRIPTION
Use `repositoryProvider.findRepositoryOrSelected` instead of `repositoryProvider.findRepository` in `addCommits` so that we load commits from selected repository in case we don't set uri in options.

Fixes #3197 
