### PR TITLE
Fix loading a plugin that contributes a language with configuration options provided in a JSON file with comments

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -16,7 +16,8 @@
     "decompress": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "ps-tree": "1.1.0",
-    "vscode-uri": "^1.0.1"
+    "vscode-uri": "^1.0.1",
+    "jsonc-parser": "^2.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -41,6 +41,7 @@ import * as path from 'path';
 import { isObject } from 'util';
 import { GrammarsReader } from './grammars-reader';
 import { CharacterPair } from '../../../api/plugin-api';
+import * as jsoncparser from 'jsonc-parser';
 
 @injectable()
 export class TheiaPluginScanner implements PluginScanner {
@@ -208,7 +209,8 @@ export class TheiaPluginScanner implements PluginScanner {
         if (rawLang.configuration) {
             const conf = fs.readFileSync(path.resolve(pluginPath, rawLang.configuration), 'utf8');
             if (conf) {
-                const rawConfiguration: PluginPackageLanguageContributionConfiguration = JSON.parse(conf);
+                const strippedContent = jsoncparser.stripComments(conf);
+                const rawConfiguration: PluginPackageLanguageContributionConfiguration = jsoncparser.parse(strippedContent);
 
                 const configuration: LanguageConfiguration = {
                     brackets: rawConfiguration.brackets,


### PR DESCRIPTION
This PR replaces using JSON parser by JSONC parser for reading the configuration options of the contributed language.

In my case I want to load [VSCode Kubernetes plugin](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) which contributes [`helm` language](https://github.com/Azure/vscode-kubernetes-tools/blob/master/package.json#L967) with configuration options provided in [a file in JSONC format](https://github.com/Azure/vscode-kubernetes-tools/blob/master/language-configuration.json).
Theia cannot load the plugin due to the following parsing error:
```shell
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /tmp/vscode-unpacked/vscode-kubernetes-tools-0.1.14.vsix
root INFO accepting packagejson with engines { vscode: '^1.23.0' }
root ERROR Uncaught Exception:  SyntaxError: Unexpected token / in JSON at position 28
root ERROR SyntaxError: Unexpected token / in JSON at position 28
    at JSON.parse (<anonymous>)
    at VsCodePluginScanner.TheiaPluginScanner.readLanguage (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/scanners/scanner-theia.js:181:45)
    at /home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/scanners/scanner-theia.js:165:68
    at Array.map (<anonymous>)
    at VsCodePluginScanner.TheiaPluginScanner.readLanguages (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/scanners/scanner-theia.js:165:29)
    at VsCodePluginScanner.TheiaPluginScanner.readContributions (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/scanners/scanner-theia.js:84:34)
    at VsCodePluginScanner.getModel (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext-vscode/lib/node/scanner-vscode.js:66:35)
    at MetadataScanner.getPluginMetadata (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/metadata-scanner.js:45:28)
    at HostedPluginReader.getPluginMetadata (/home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/plugin-reader.js:61:43)
    at /home/artem/projects/github/theia-ide/theia/packages/plugin-ext/lib/hosted/node/plugin-service.js:117:47
root INFO [hosted-plugin: 25971] PLUGIN_HOST(25971) starting instance
```

It's needed for https://github.com/eclipse/che/issues/10574