### PR TITLE
prompt if user has no access to workspace file

### DIFF
--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -46,6 +46,7 @@ import { MockWorkspaceServer } from '@theia/workspace/lib/common/test/mock-works
 import { MockWindowService } from '@theia/core/lib/browser/window/test/mock-window-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { WorkspacePreferences, createWorkspacePreferences } from '@theia/workspace/lib/browser/workspace-preferences';
+import { MessageService, MessageClient } from '@theia/core/lib/common';
 import * as sinon from 'sinon';
 import URI from '@theia/core/lib/common/uri';
 
@@ -132,6 +133,9 @@ before(async () => {
 
     /* Logger mock */
     testContainer.bind(ILogger).to(MockLogger);
+
+    testContainer.bind(MessageClient).toSelf().inSingletonScope();
+    testContainer.bind(MessageService).toSelf().inSingletonScope();
 });
 
 describe('Preference Service', function () {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -21,7 +21,7 @@ import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
 import { MenuContribution, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
-import { FileSystem, FileStat } from '@theia/filesystem/lib/common/filesystem';
+import { FileAccess, FileSystem, FileStat } from '@theia/filesystem/lib/common';
 import { FileDialogService } from '@theia/filesystem/lib/browser';
 import { SingleTextInputDialog, ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { OpenerService, OpenHandler, open, FrontendApplication } from '@theia/core/lib/browser';
@@ -361,6 +361,11 @@ export class WorkspaceCommandContribution implements CommandContribution {
 
     protected async addFolderToWorkspace(uri: URI | undefined): Promise<void> {
         if (uri) {
+            const uriStr = uri.toString();
+            const canRead = await this.fileSystem.access(uriStr, FileAccess.Constants.R_OK);
+            if (!canRead) {
+                this.messageService.error(`Access denied: Failed to read data from ${uriStr}.`, { timeout: 0 });
+            }
             const stat = await this.fileSystem.getFileStat(uri.toString());
             if (stat && stat.isDirectory) {
                 await this.workspaceService.addRoot(uri);


### PR DESCRIPTION
Theia silently fails when user 
- adds/removes roots to/from a workspace
- "saves workspace as"
while s/he doesn't have access to the workspace file.

With this change the user would see an error message populated in the aforementioned situations.

Signed-off-by: elaihau <liang.huang@ericsson.com>
