### PR TITLE
Terminal Plugin API: by default, add a new line to the text being sent to the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.16
 - [plug-in] added `DocumentLinkProvider` Plug-in API
+- [plug-in] Terminal.sendText API adds a new line to the text being sent to the terminal if `addNewLine` parameter wasn't specified
 
 
 ## v0.3.15

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -79,7 +79,7 @@ export class TerminalExtImpl implements Terminal {
         this.termProcessId = this.proxy.$createTerminal(nameOrOptions);
     }
 
-    sendText(text: string, addNewLine?: boolean): void {
+    sendText(text: string, addNewLine: boolean = true): void {
         this.termProcessId.then(id => this.proxy.$sendText(id, text, addNewLine));
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2152,7 +2152,7 @@ declare module '@theia/plugin' {
         /**
          * Send text to the terminal.
          * @param text - text content.
-         * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line.
+         * @param addNewLine - in case true - apply new line after the text, otherwise don't apply new line. This defaults to `true`.
          */
         sendText(text: string, addNewLine?: boolean): void;
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

This PR makes the `Terminal.sendText` API consistent with VSCode. If it's called with omitted second parameter (`addNewLine`) then a new line will be added to the text being sent to the terminal since this is normally required to run a command in the terminal.

It's needed for https://github.com/eclipse/che/issues/10574