### PR TITLE
Improve prepare-travis for Windows

### DIFF
--- a/scripts/prepare-travis
+++ b/scripts/prepare-travis
@@ -23,13 +23,14 @@
 const fs = require('fs');
 const path = require('path');
 const child_process = require('child_process');
+const os = require('os');
 
 const directories = ['node_modules'];
 
 const workspaces = JSON.parse(JSON.parse(child_process.execSync('yarn workspaces info --json').toString()).data);
 for (const name in workspaces) {
     const workspace = workspaces[name];
-    const nodeModulesPath = path.join(workspace.location, 'node_modules');
+    const nodeModulesPath = [workspace.location, 'node_modules'].join('/');
     if (fs.existsSync(path.join(process.cwd(), nodeModulesPath))) {
         directories.push(nodeModulesPath);
     }
@@ -39,7 +40,7 @@ const travisPath = path.resolve(__dirname, '../.travis.yml');
 const content = fs.readFileSync(travisPath).toString();
 const startIndex = content.indexOf('# start_cache_directories') + '# start_cache_directories'.length;
 const endIndex = content.indexOf('# end_cache_directories');
-const result = content.substr(0, startIndex) +
-    directories.sort((d, d2) => d.localeCompare(d2)).map(d => `\n  - ${d}`).join('') +
-    '\n' + content.substr(endIndex);
+const result = content.substr(0, startIndex) + os.EOL +
+    directories.sort((d, d2) => d.localeCompare(d2)).map(d => `  - ${d}${os.EOL}`).join('') +
+    content.substr(endIndex);
 fs.writeFileSync(travisPath, result);


### PR DESCRIPTION
When running "yarn" on Windows, we get spurious diffs in .travis.yml.
The first reason is that since we use path.join, it replaces all / with
\.  Fix this by joining with '/' all the time.

Then, we get some git warnings about LF/CRLF.  The reason is that with
git on Windows, it's common to use core.autocrlf=true.  This means that
files are saved with \n end of lines in git objects, but those are
replaced with \r\n when checked out on Windows.  When we re-generate
.travis.yml on Windows, we currently, replace the \r\n (in the checked
out version of the file) with single \n.  Then, git warns us that our
file changed, but not really:

    $ git status .travis.yml
    ...
            modified:   .travis.yml
    ...
    $ git diff .travis.yml
    warning: LF will be replaced by CRLF in .travis.yml.
    The file will have its original line endings in your working directory.

Fix this by using platform-specific end of lines.  With this, running
"node scripts/prepare-travis" on a clean Theia repository results in no
changes to .travis.yml, on Linux or Windows.

Change-Id: I15e6e1ffed6be4aa3830c1c59167f7f9e91d50a3

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
