### PR TITLE
Fix races in kill tests in task-server.slow-spec.ts

### DIFF
--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -178,36 +178,36 @@ describe('Task server / back-end', function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
         const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('shell'), wsRoot);
 
-        const p = new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
                 if (event.taskId === taskInfo.taskId && event.code === 0 && event.signal !== '0') {
                     toDispose.dispose();
                     resolve();
+                } else {
+                    reject();
                 }
             });
+
+            taskServer.kill(taskInfo.taskId);
         });
-
-        await taskServer.kill(taskInfo.taskId);
-
-        await p;
     });
 
     it('task using raw process can be killed', async function () {
         // const command = isWindows ? command_absolute_path_long_running_windows : command_absolute_path_long_running;
         const taskInfo: TaskInfo = await taskServer.run(createTaskConfigTaskLongRunning('process'), wsRoot);
 
-        const p = new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
                 if (event.taskId === taskInfo.taskId && event.code === null && event.signal === 'SIGTERM') {
                     toDispose.dispose();
                     resolve();
+                } else {
+                    reject();
                 }
             });
+
+            taskServer.kill(taskInfo.taskId);
         });
-
-        await taskServer.kill(taskInfo.taskId);
-
-        await p;
     });
 
     it('task using terminal process can handle command that does not exist', async function () {


### PR DESCRIPTION
The two tests modified in this patch are racy (I get some random
failures).  Depending on the timing, we can kill the process before we
have installed the "onTaskExit" handler.  This results in the handler
never being called, and the test fails after the 10s timeout.

This was found by working on Windows, but can easily be replicated
anywhere by calling taskWatcher.onTaskExit in a setTimeout(..., 2000) to
delay it on purpose.

To fix it, send the kill command only after we have installed the
handler.

Also, if the exit event we receive doesn't match what we expect, call
reject().  This makes the test fail quickly, rather than wait for the
timeout.

Change-Id: I7a91ec6744fda562cdb3676666e29b557f5dcd35
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
