### PR TITLE
GH-3268: Disabled the icons in the main menu. They're unsupported.

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -100,7 +100,6 @@ export class ElectronMainMenuFactory {
                 items.push({
                     id: menu.id,
                     label: menu.label,
-                    icon: menu.icon,
                     type: this.commandRegistry.getToggledHandler(commandId) ? 'checkbox' : 'normal',
                     checked: this.commandRegistry.isToggled(commandId),
                     enabled: true, // https://github.com/theia-ide/theia/issues/446


### PR DESCRIPTION
We cannot use the CSS class name of the `font-awesome` icons.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

