### PR TITLE
Add command to clear local storage

### DIFF
--- a/packages/core/src/browser/storage-service.ts
+++ b/packages/core/src/browser/storage-service.ts
@@ -34,6 +34,7 @@ export interface StorageService {
      */
     getData<T>(key: string, defaultValue: T): Promise<T>;
     getData<T>(key: string): Promise<T | undefined>;
+
 }
 
 interface LocalStorage {
@@ -115,7 +116,7 @@ export class LocalStorageService implements StorageService {
         }
     }
 
-    private clearStorage(): void {
+    clearStorage(): void {
         this.storage.clear();
     }
 


### PR DESCRIPTION
Added command to clear local storage by first prompting for a confirmation to reduce accidental triggering.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
