### PR TITLE
dugite-git.spec.ts: Increase timeout for 'log' suite

### DIFF
--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -763,7 +763,9 @@ describe('git', async function () {
 
 });
 
-describe('log', () => {
+describe('log', function () {
+
+    this.timeout(10000);
 
     async function testLogFromRepoRoot(testLocalGit: string) {
         const savedValue = process.env.USE_LOCAL_GIT;


### PR DESCRIPTION
Some git tests often fail on AppVeyor.  For example:

    @theia/git:   1) log should not fail with local git when executed from the repository root:
    @theia/git:      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

The 'git' suite, higher in the same file, already has a
this.timeout(10000).  I think that the test that fails here would pass
if we gave it a bit more time (since it works intermittently).  So this
patch sets the timeout to 10000ms for the 'log' suite as well.

Change-Id: I0f676313f12066c69df5cd3bef1d0bcd18e1d004
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
