### PR TITLE
Fixed Git History related bug in electron.

### DIFF
--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -306,7 +306,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
 
     protected readonly handleScroll = (info: ScrollParams) => this.doHandleScroll(info);
     protected doHandleScroll(info: ScrollParams) {
-        this.node.scrollTo({ top: info.scrollTop });
+        this.node.scrollTop = info.scrollTop;
     }
 
     protected readonly loadMoreRows = (params: IndexRange) => this.doLoadMoreRows(params);


### PR DESCRIPTION
Electron does not know scrollTo method. Instead we set scrollTop value now.
Fixes #2855

