### PR TITLE
debug hover in editor

### DIFF
--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -20,7 +20,8 @@
       "sourceMaps": true,
       "smartStep": true,
       "outputCapture": "std",
-      "internalConsoleOptions": "openOnSessionStart"
+      "internalConsoleOptions": "openOnSessionStart",
+      "openDebug": "openOnDebugBreak"
     }
   ]
 }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -81,7 +81,7 @@ export class BaseWidget extends Widget {
                 const container = await this.getScrollContainer();
                 container.style.overflow = 'hidden';
                 this.scrollBar = new PerfectScrollbar(container, this.scrollOptions);
-                this.toDispose.push(Disposable.create(async () => {
+                this.toDisposeOnDetach.push(Disposable.create(() => {
                     if (this.scrollBar) {
                         this.scrollBar.destroy();
                         this.scrollBar = undefined;

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -137,6 +137,10 @@ export namespace DebugCommands {
         id: 'debug.breakpoint.removeAll',
         label: 'Debug: Remove All Breakpoints'
     };
+    export const SHOW_HOVER = {
+        id: 'debug.editor.showHover',
+        label: 'Debug: Show Hover'
+    };
 
     export const RESTART_FRAME = {
         id: 'debug.frame.restart',
@@ -592,6 +596,10 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         registry.registerCommand(DebugCommands.REMOVE_ALL_BREAKPOINTS, {
             execute: () => this.breakpointManager.cleanAllMarkers(),
             isEnabled: () => !!this.breakpointManager.getUris().next().value
+        });
+        registry.registerCommand(DebugCommands.SHOW_HOVER, {
+            execute: () => this.editors.showHover(),
+            isEnabled: () => this.editors.canShowHover()
         });
 
         registry.registerCommand(DebugCommands.RESTART_FRAME, {

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -32,6 +32,7 @@ import { DebugEditorService } from './editor/debug-editor-service';
 import { DebugViewOptions } from './view/debug-view-model';
 import { DebugSessionWidget, DebugSessionWidgetFactory } from './view/debug-session-widget';
 import { InDebugModeContext } from './debug-keybinding-contexts';
+import { DebugEditorModelFactory, DebugEditorModel } from './editor/debug-editor-model';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bindContributionProvider(bind, DebugSessionContribution);
@@ -39,6 +40,9 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     bind(DebugSessionManager).toSelf().inSingletonScope();
 
     bind(BreakpointManager).toSelf().inSingletonScope();
+    bind(DebugEditorModelFactory).toDynamicValue(({ container }) => <DebugEditorModelFactory>(editor =>
+        DebugEditorModel.createModel(container, editor)
+    )).inSingletonScope();
     bind(DebugEditorService).toSelf().inSingletonScope();
 
     bind(DebugSessionWidgetFactory).toDynamicValue(({ container }) =>

--- a/packages/debug/src/browser/editor/debug-editor.ts
+++ b/packages/debug/src/browser/editor/debug-editor.ts
@@ -1,0 +1,17 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const DebugEditor = Symbol('DebugEditor');

--- a/packages/debug/src/browser/editor/debug-expression-provider.ts
+++ b/packages/debug/src/browser/editor/debug-expression-provider.ts
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation and others. All rights reserved.
+ *  Licensed under the MIT License. See https://github.com/Microsoft/vscode/blob/master/LICENSE.txt for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+
+/**
+ * TODO: introduce a new request to LSP to look up an expression range: https://github.com/Microsoft/language-server-protocol/issues/462
+ */
+@injectable()
+export class DebugExpressionProvider {
+    get(model: monaco.editor.IModel, selection: monaco.IRange): string {
+        const lineContent = model.getLineContent(selection.startLineNumber);
+        const { start, end } = this.getExactExpressionStartAndEnd(lineContent, selection.startColumn, selection.endColumn);
+        return lineContent.substring(start - 1, end);
+    }
+    protected getExactExpressionStartAndEnd(lineContent: string, looseStart: number, looseEnd: number): { start: number, end: number } {
+        let matchingExpression: string | undefined = undefined;
+        let startOffset = 0;
+
+        // Some example supported expressions: myVar.prop, a.b.c.d, myVar?.prop, myVar->prop, MyClass::StaticProp, *myVar
+        // Match any character except a set of characters which often break interesting sub-expressions
+        const expression = /([^()\[\]{}<>\s+\-/%~#^;=|,`!]|\->)+/g;
+        // tslint:disable-next-line
+        let result: RegExpExecArray | null = null;
+
+        // First find the full expression under the cursor
+        while (result = expression.exec(lineContent)) {
+            const start = result.index + 1;
+            const end = start + result[0].length;
+
+            if (start <= looseStart && end >= looseEnd) {
+                matchingExpression = result[0];
+                startOffset = start;
+                break;
+            }
+        }
+
+        // If there are non-word characters after the cursor, we want to truncate the expression then.
+        // For example in expression 'a.b.c.d', if the focus was under 'b', 'a.b' would be evaluated.
+        if (matchingExpression) {
+            const subExpression: RegExp = /\w+/g;
+            // tslint:disable-next-line
+            let subExpressionResult: RegExpExecArray | null = null;
+            while (subExpressionResult = subExpression.exec(matchingExpression)) {
+                const subEnd = subExpressionResult.index + 1 + startOffset + subExpressionResult[0].length;
+                if (subEnd >= looseEnd) {
+                    break;
+                }
+            }
+
+            if (subExpressionResult) {
+                matchingExpression = matchingExpression.substring(0, subExpression.lastIndex);
+            }
+        }
+
+        return matchingExpression ?
+            { start: startOffset, end: startOffset + matchingExpression.length - 1 } :
+            { start: 0, end: 0 };
+    }
+}

--- a/packages/debug/src/browser/editor/debug-hover-source.tsx
+++ b/packages/debug/src/browser/editor/debug-hover-source.tsx
@@ -1,0 +1,105 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as React from 'react';
+import { TreeSource, TreeElement } from '@theia/core/lib/browser/source-tree';
+import { ExpressionContainer, ExpressionItem, DebugVariable } from '../console/debug-console-items';
+import { DebugSessionManager } from '../debug-session-manager';
+import { injectable, inject } from 'inversify';
+
+@injectable()
+export class DebugHoverSource extends TreeSource {
+
+    @inject(DebugSessionManager)
+    protected readonly sessions: DebugSessionManager;
+
+    protected _expression: ExpressionItem | DebugVariable | undefined;
+    get expression(): ExpressionItem | DebugVariable | undefined {
+        return this._expression;
+    }
+
+    protected elements: TreeElement[] = [];
+    getElements(): IterableIterator<TreeElement> {
+        return this.elements.values();
+    }
+
+    protected renderTitle(element: ExpressionItem | DebugVariable): React.ReactNode {
+        return <div className='theia-debug-hover-title' title={element.value}>{element.value}</div>;
+    }
+
+    reset(): void {
+        this._expression = undefined;
+        this.elements = [];
+        this.fireDidChange();
+    }
+
+    async evaluate(expression: string): Promise<boolean> {
+        const evaluated = await this.doEvaluate(expression);
+        const elements = evaluated && await evaluated.getElements();
+        this._expression = evaluated;
+        this.elements = elements ? [...elements] : [];
+        this.fireDidChange();
+        return !!evaluated;
+    }
+    protected async doEvaluate(expression: string): Promise<ExpressionItem | DebugVariable | undefined> {
+        const { currentSession } = this.sessions;
+        if (!currentSession) {
+            return undefined;
+        }
+        if (currentSession.capabilities.supportsEvaluateForHovers) {
+            const item = new ExpressionItem(expression, currentSession);
+            await item.evaluate('hover');
+            return item.available && item || undefined;
+        }
+        return this.findVariable(expression.split('.').map(word => word.trim()).filter(word => !!word));
+    }
+    protected async findVariable(namesToFind: string[]): Promise<DebugVariable | undefined> {
+        const { currentFrame } = this.sessions;
+        if (!currentFrame) {
+            return undefined;
+        }
+        let variable: DebugVariable | undefined;
+        const scopes = await currentFrame.getScopes();
+        for (const scope of scopes) {
+            const found = await this.doFindVariable(scope, namesToFind);
+            if (!variable) {
+                variable = found;
+            } else if (found && found.value !== variable.value) {
+                // only show if all expressions found have the same value
+                return undefined;
+            }
+        }
+        return variable;
+    }
+    protected async doFindVariable(owner: ExpressionContainer, namesToFind: string[]): Promise<DebugVariable | undefined> {
+        const elements = await owner.getElements();
+        const variables: DebugVariable[] = [];
+        for (const element of elements) {
+            if (element instanceof DebugVariable && element.name === namesToFind[0]) {
+                variables.push(element);
+            }
+        }
+        if (variables.length !== 1) {
+            return undefined;
+        }
+        if (namesToFind.length === 1) {
+            return variables[0];
+        } else {
+            return this.doFindVariable(variables[0], namesToFind.slice(1));
+        }
+    }
+
+}

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -1,0 +1,215 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import debounce = require('lodash.debounce');
+
+import { Widget } from '@phosphor/widgets';
+import { Message } from '@phosphor/messaging';
+import { injectable, postConstruct, inject, Container, interfaces } from 'inversify';
+import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
+import { Key } from '@theia/core/lib/browser/keys';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { DebugSessionManager } from '../debug-session-manager';
+import { DebugEditor } from './debug-editor';
+import { DebugExpressionProvider } from './debug-expression-provider';
+import { DebugHoverSource } from './debug-hover-source';
+
+export interface ShowDebugHoverOptions {
+    selection: monaco.Range
+    /** default: false */
+    focus?: boolean
+    /** default: true */
+    immediate?: boolean
+}
+
+export interface HideDebugHoverOptions {
+    /** default: true */
+    immediate?: boolean
+}
+
+export function createDebugHoverWidgetContainer(parent: interfaces.Container, editor: monaco.editor.IStandaloneCodeEditor): Container {
+    const child = SourceTreeWidget.createContainer(parent, {
+        virtualized: false
+    });
+    child.bind(DebugEditor).toConstantValue(editor);
+    child.bind(DebugHoverSource).toSelf();
+    child.unbind(SourceTreeWidget);
+    child.bind(DebugExpressionProvider).toSelf();
+    child.bind(DebugHoverWidget).toSelf();
+    return child;
+}
+
+@injectable()
+export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.IContentWidget {
+
+    protected readonly toDispose = new DisposableCollection();
+
+    @inject(DebugEditor)
+    protected readonly editor: monaco.editor.IStandaloneCodeEditor;
+
+    @inject(DebugSessionManager)
+    protected readonly sessions: DebugSessionManager;
+
+    @inject(DebugHoverSource)
+    protected readonly hoverSource: DebugHoverSource;
+
+    @inject(DebugExpressionProvider)
+    protected readonly expressionProvider: DebugExpressionProvider;
+
+    allowEditorOverflow = true;
+
+    static ID = 'debug.editor.hover';
+    getId(): string {
+        return DebugHoverWidget.ID;
+    }
+
+    protected readonly domNode = document.createElement('div');
+    protected readonly titleNode = document.createElement('div');
+    protected readonly contentNode = document.createElement('div');
+    getDomNode(): HTMLElement {
+        return this.domNode;
+    }
+
+    @postConstruct()
+    protected init(): void {
+        super.init();
+        this.domNode.className = 'theia-debug-hover';
+        this.titleNode.className = 'theia-debug-hover-title';
+        this.domNode.appendChild(this.titleNode);
+        this.contentNode.className = 'theia-debug-hover-content';
+        this.domNode.appendChild(this.contentNode);
+
+        this.editor.addContentWidget(this);
+        this.source = this.hoverSource;
+        this.toDispose.pushAll([
+            this.hoverSource,
+            Disposable.create(() => this.editor.removeContentWidget(this)),
+            Disposable.create(() => this.hide()),
+            this.sessions.onDidChange(() => {
+                if (!this.isEditorFrame()) {
+                    this.hide();
+                }
+            })
+        ]);
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    show(options?: ShowDebugHoverOptions): void {
+        this.schedule(() => this.doShow(options), options && options.immediate);
+    }
+    hide(options?: HideDebugHoverOptions): void {
+        this.schedule(() => this.doHide(), options && options.immediate);
+    }
+    protected schedule(fn: () => void, immediate: boolean = true): void {
+        if (immediate) {
+            this.doSchedule.cancel();
+            fn();
+        } else {
+            this.doSchedule(fn);
+        }
+    }
+    protected readonly doSchedule = debounce((fn: () => void) => fn(), 300);
+
+    protected options: ShowDebugHoverOptions | undefined;
+    protected doHide(): void {
+        if (!this.isVisible) {
+            return;
+        }
+        if (this.domNode.contains(document.activeElement)) {
+            this.editor.focus();
+        }
+        if (this.isAttached) {
+            Widget.detach(this);
+        }
+        this.hoverSource.reset();
+        super.hide();
+        this.options = undefined;
+        this.editor.layoutContentWidget(this);
+    }
+    protected async doShow(options: ShowDebugHoverOptions | undefined = this.options): Promise<void> {
+        if (!this.isEditorFrame()) {
+            this.hide();
+            return;
+        }
+        if (!options) {
+            this.hide();
+            return;
+        }
+        if (this.options && this.options.selection.equalsRange(options.selection)) {
+            return;
+        }
+        if (!this.isAttached) {
+            Widget.attach(this, this.contentNode);
+        }
+        super.show();
+        this.options = options;
+        const expression = this.expressionProvider.get(this.editor.getModel(), options.selection);
+        if (!expression) {
+            this.hide();
+            return;
+        }
+        const toFocus = new DisposableCollection();
+        if (this.options.focus === true) {
+            toFocus.push(this.model.onNodeRefreshed(() => {
+                toFocus.dispose();
+                this.activate();
+            }));
+        }
+        if (!await this.hoverSource.evaluate(expression)) {
+            toFocus.dispose();
+            this.hide();
+            return;
+        }
+        this.editor.layoutContentWidget(this);
+    }
+    protected isEditorFrame(): boolean {
+        const { currentFrame } = this.sessions;
+        return !!currentFrame && !!currentFrame.source &&
+            this.editor.getModel().uri.toString() === currentFrame.source.uri.toString();
+    }
+
+    getPosition(): monaco.editor.IContentWidgetPosition {
+        if (!this.isVisible) {
+            return undefined!;
+        }
+        const position = this.options && this.options.selection.getStartPosition();
+        const word = position && this.editor.getModel().getWordAtPosition(position);
+        return position && word ? {
+            position: new monaco.Position(position.lineNumber, word.startColumn),
+            preference: [
+                monaco.editor.ContentWidgetPositionPreference.ABOVE,
+                monaco.editor.ContentWidgetPositionPreference.BELOW
+            ]
+        } : undefined!;
+    }
+
+    protected onUpdateRequest(msg: Message): void {
+        super.onUpdateRequest(msg);
+        const { expression } = this.hoverSource;
+        const value = expression && expression.value || '';
+        this.titleNode.textContent = value;
+        this.titleNode.title = value;
+    }
+
+    protected onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        this.addKeyListener(this.domNode, Key.ESCAPE, () => this.hide());
+    }
+
+}

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -271,3 +271,34 @@
 .breakpoints-activate {
 	background: var(--breakpoints-activate-url) center center no-repeat;
 }
+
+/** Hover */
+.theia-debug-hover {
+    display: flex;
+    flex-direction: column;
+    min-width: 324px;
+    min-height: 324px;
+    width: 324px;
+    height: 324px;
+    border: 1px solid var(--theia-layout-color4);
+    background: var(--theia-layout-color0);
+}
+
+.theia-debug-hover .theia-source-tree {
+    height: 100%;
+    width: 100%;
+}
+
+.theia-debug-hover-title {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding: var(--theia-ui-padding);
+    padding-left: calc(var(--theia-ui-padding)*2);
+    border-bottom: 1px solid var(--theia-layout-color4);
+}
+
+.theia-debug-hover-content {
+    display: flex;
+    flex: 1;
+}


### PR DESCRIPTION
![hover](https://user-images.githubusercontent.com/3082655/47657771-fb709380-db91-11e8-8d01-c76a2abfae08.gif)

Right now the expression detection is aligned with VS Code. It could be improved by a new LSP request: https://github.com/Microsoft/language-server-protocol/issues/462
