### PR TITLE
Add HOME environment variable for the child process where a plug-in is running

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -112,6 +112,8 @@ export class HostedPluginProcess implements ServerPluginRunner {
         // create env and add PATH to it so any executable from root process is available
         const env = createIpcEnv();
         env.PATH = process.env.PATH;
+        // add HOME to env since some plug-ins need to read files from user's home dir
+        env.HOME = process.env.HOME;
 
         const forkOptions: cp.ForkOptions = {
             silent: true,


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

This PR sets the `HOME` environment variable for a child process where a plug-in is running.
Some plug-ins read this variable but it's `undefined`.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

It's needed for https://github.com/eclipse/che/issues/10574