### PR TITLE
Include radix for safety whenever parseInt is used

### DIFF
--- a/packages/debug-nodejs/src/node/debug-nodejs.ts
+++ b/packages/debug-nodejs/src/node/debug-nodejs.ts
@@ -71,14 +71,14 @@ export class NodeJsDebugAdapterContribution implements DebugAdapterContribution 
         config.protocol = DEFAULT_PROTOCOL;
         config.port = DEFAULT_INSPECTOR_PORT;
 
-        const pidToDebug = Number.parseInt(config.processId);
+        const pidToDebug = Number.parseInt(config.processId, 10);
 
         const tasks: [{ pid: number, cmd: string }] = await psList();
         const taskToDebug = tasks.find(task => task.pid === pidToDebug);
         if (taskToDebug) {
             const matches = DEBUG_PORT_PATTERN.exec(taskToDebug.cmd);
             if (matches && matches.length === 3) {
-                config.port = parseInt(matches[2]);
+                config.port = parseInt(matches[2], 10);
                 config.protocol = matches[1] === 'debug' ? 'legacy' : 'inspector';
             }
         }

--- a/packages/git/src/browser/dirty-diff/content-lines.ts
+++ b/packages/git/src/browser/dirty-diff/content-lines.ts
@@ -92,7 +92,7 @@ export namespace ContentLines {
                         };
                 }
                 // tslint:disable-next-line:no-any
-                const index = Number.parseInt(p as any);
+                const index = Number.parseInt(p as any, 10);
                 if (Number.isInteger(index)) {
                     if (index >= 0 && index < target.length) {
                         const value = target.getLineContent(index);

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -135,7 +135,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
         let matchedElement: HTMLElement | undefined;
         for (let i = 0; i < markedElements.length; i++) {
             const element = markedElements[i];
-            const line = Number.parseInt(element.getAttribute('data-line') || '0');
+            const line = Number.parseInt(element.getAttribute('data-line') || '0', 10);
             if (line > sourceLine) {
                 break;
             }
@@ -201,7 +201,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
 
     protected getLineNumberFromAttribute(element: HTMLElement): number | undefined {
         const attribute = element.getAttribute('data-line');
-        return attribute ? Number.parseInt(attribute) : undefined;
+        return attribute ? Number.parseInt(attribute, 10) : undefined;
     }
 
     protected engine: markdownit.MarkdownIt | undefined;

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -198,7 +198,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             throw new Error(`Unexpected format for --theia-code-font-size (${fontSizeStr})`);
         }
 
-        const fontSize = Number.parseInt(fontSizeMatch[1]);
+        const fontSize = Number.parseInt(fontSizeMatch[1], 10);
 
         /* xterm.js expects #XXX of #XXXXXX for colors.  */
         const colorRe = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;


### PR DESCRIPTION
Added base10 radix for instances of `parseInt` to avoid confusion, warnings and guarantee a predictable behaviour.

https://palantir.github.io/tslint/rules/radix/

```
Always specify this parameter to eliminate reader confusion 
and to guarantee predictable behavior. Different implementations 
produce different results when a radix is not specified, usually 
defaulting the value to 10.
```
Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
