### PR TITLE
Fix no-any no-return-await for @theia/debug

### DIFF
--- a/packages/debug/src/node/debug-model.ts
+++ b/packages/debug/src/node/debug-model.ts
@@ -65,6 +65,7 @@ export interface DebugAdapterExecutable {
      * the parameters contain a command and arguments. For instance:
      * {'program' : 'COMMAND_TO_LAUNCH_DEBUG_ADAPTER', args : [ { 'arg1', 'arg2' } ] }
      */
+    // tslint:disable-next-line:no-any
     [key: string]: any;
 }
 

--- a/packages/debug/src/node/debug-service-impl.ts
+++ b/packages/debug/src/node/debug-service-impl.ts
@@ -214,7 +214,7 @@ export class DebugServiceImpl implements DebugService, MessagingService.Contribu
     }
 
     async provideDebugConfigurations(debugType: string): Promise<DebugConfiguration[]> {
-        return await this.registry.provideDebugConfigurations(debugType);
+        return this.registry.provideDebugConfigurations(debugType);
     }
 
     getSchemaAttributes(debugType: string): Promise<IJSONSchema[]> {
@@ -222,7 +222,7 @@ export class DebugServiceImpl implements DebugService, MessagingService.Contribu
     }
 
     async resolveDebugConfiguration(config: DebugConfiguration): Promise<DebugConfiguration> {
-        return await this.registry.resolveDebugConfiguration(config);
+        return this.registry.resolveDebugConfiguration(config);
     }
 
     async create(config: DebugConfiguration): Promise<string> {


### PR DESCRIPTION
Fixed the tslint errors from `no-any` and `no-return-await` rules in the `@theia/debug package`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
