### PR TITLE
[commands] prefix commands for easier categorising and searching 

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -56,9 +56,13 @@ export namespace CommonMenus {
 
 export namespace CommonCommands {
 
+    const FILE_CATEGORY = 'File';
+    const VIEW_CATEGORY = 'View';
+
     export const OPEN: Command = {
         id: 'core.open',
-        label: 'Open'
+        category: FILE_CATEGORY,
+        label: 'Open',
     };
 
     export const CUT: Command = {
@@ -94,53 +98,65 @@ export namespace CommonCommands {
 
     export const NEXT_TAB: Command = {
         id: 'core.nextTab',
+        category: VIEW_CATEGORY,
         label: 'Switch to Next Tab'
     };
     export const PREVIOUS_TAB: Command = {
         id: 'core.previousTab',
+        category: VIEW_CATEGORY,
         label: 'Switch to Previous Tab'
     };
     export const CLOSE_TAB: Command = {
         id: 'core.close.tab',
+        category: VIEW_CATEGORY,
         label: 'Close Tab'
     };
     export const CLOSE_OTHER_TABS: Command = {
         id: 'core.close.other.tabs',
+        category: VIEW_CATEGORY,
         label: 'Close Other Tabs'
     };
     export const CLOSE_RIGHT_TABS: Command = {
         id: 'core.close.right.tabs',
+        category: VIEW_CATEGORY,
         label: 'Close Tabs to the Right'
     };
     export const CLOSE_ALL_TABS: Command = {
         id: 'core.close.all.tabs',
+        category: VIEW_CATEGORY,
         label: 'Close All Tabs'
     };
     export const COLLAPSE_PANEL: Command = {
         id: 'core.collapse.tab',
+        category: VIEW_CATEGORY,
         label: 'Collapse Side Panel'
     };
     export const COLLAPSE_ALL_PANELS: Command = {
         id: 'core.collapse.all.tabs',
+        category: VIEW_CATEGORY,
         label: 'Collapse All Side Panels'
     };
     export const TOGGLE_BOTTOM_PANEL: Command = {
         id: 'core.toggle.bottom.panel',
+        category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     };
 
     export const SAVE: Command = {
         id: 'core.save',
-        label: 'Save'
+        category: FILE_CATEGORY,
+        label: 'Save',
     };
     export const SAVE_ALL: Command = {
         id: 'core.saveAll',
-        label: 'Save All'
+        category: FILE_CATEGORY,
+        label: 'Save All',
     };
 
     export const AUTO_SAVE: Command = {
         id: 'textEditor.commands.autosave',
-        label: 'Auto Save'
+        category: FILE_CATEGORY,
+        label: 'Auto Save',
     };
 
     export const QUIT: Command = {
@@ -155,7 +171,8 @@ export namespace CommonCommands {
 
     export const OPEN_PREFERENCES: Command = {
         id: 'preferences:open',
-        label: 'Open Preferences'
+        category: 'Settings',
+        label: 'Open Preferences',
     };
 
 }

--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -40,7 +40,7 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
     init(): void {
         // let's compute the items here to do it in the context of the currently activeElement
         this.items = [];
-        const filteredAndSortedCommands = this.commands.commands.filter(a => a.label).sort((a, b) => a.label!.localeCompare(b.label!));
+        const filteredAndSortedCommands = this.commands.commands.filter(a => a.label).sort((a, b) => Command.compareCommands(a, b));
         for (const command of filteredAndSortedCommands) {
             if (command.label) {
                 this.items.push(new CommandQuickOpenItem(command, this.commands, this.keybindings));
@@ -59,6 +59,7 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
     getOptions(): QuickOpenOptions {
         return { fuzzyMatchLabel: true };
     }
+
 }
 
 export class CommandQuickOpenItem extends QuickOpenItem {
@@ -77,7 +78,9 @@ export class CommandQuickOpenItem extends QuickOpenItem {
     }
 
     getLabel(): string {
-        return this.command.label!;
+        return (this.command.category)
+            ? `${this.command.category}: ` + this.command.label!
+            : this.command.label!;
     }
 
     isHidden(): boolean {

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -65,6 +65,7 @@ export class ShellLayoutRestorer implements CommandContribution {
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand({
             id: 'reset.layout',
+            category: 'View',
             label: 'Reset Workbench Layout'
         }, {
                 execute: async () => {

--- a/packages/core/src/browser/theming.ts
+++ b/packages/core/src/browser/theming.ts
@@ -132,6 +132,7 @@ export class ThemeService {
 export class ThemingCommandContribution implements CommandContribution, MenuContribution, CommandHandler, Command, QuickOpenModel {
 
     id = 'change_theme';
+    category = 'Settings';
     label = 'Change Color Theme';
     private resetTo: string | undefined;
 

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -36,12 +36,27 @@ export interface Command {
      * An icon class of this command.
      */
     iconClass?: string;
+    /**
+     * A category of this command.
+     */
+    category?: string;
 }
 
 export namespace Command {
     /* Determine whether object is a Command */
     export function is(arg: Command | any): arg is Command {
         return !!arg && arg === Object(arg) && 'id' in arg;
+    }
+
+    /** Comparator function for when sorting commands */
+    export function compareCommands(a: Command, b: Command): number {
+        if (a.label && b.label) {
+            const aCommand = (a.category) ? a.category + a.label : a.label;
+            const bCommand = (b.category) ? b.category + b.label : b.label;
+            return (aCommand).localeCompare(bCommand);
+        } else {
+            return 0;
+        }
     }
 }
 

--- a/packages/cpp/src/browser/cpp-build-configurations-ui.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations-ui.ts
@@ -141,7 +141,8 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
  */
 export const CPP_CHANGE_BUILD_CONFIGURATION: Command = {
     id: 'cpp.change-build-configuration',
-    label: 'C/C++: Change Build Configuration'
+    category: 'C/C++',
+    label: 'Change Build Configuration'
 };
 
 @injectable()

--- a/packages/cpp/src/browser/cpp-commands.ts
+++ b/packages/cpp/src/browser/cpp-commands.ts
@@ -27,12 +27,15 @@ import { HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 import { ExecuteCommandRequest, ExecuteCommandParams } from 'vscode-languageserver-protocol';
 import { CppPreferences } from './cpp-preferences';
 
+const CPP_CATEGORY = 'C/C++';
+
 /**
  * Switch between source/header file
  */
 export const SWITCH_SOURCE_HEADER: Command = {
     id: 'switch_source_header',
-    label: 'C/C++: Switch Between Source/Header File',
+    category: CPP_CATEGORY,
+    label: 'Switch Between Source/Header File',
 };
 
 /**
@@ -44,22 +47,26 @@ export const SHOW_CLANGD_REFERENCES: Command = {
 
 export const DUMP_INCLUSIONS: Command = {
     id: 'clangd.dumpinclusions',
-    label: 'C/C++: Dump File Inclusions (Debug)'
+    category: CPP_CATEGORY,
+    label: 'Dump File Inclusions (Debug)',
 };
 
 export const DUMP_INCLUDED_BY: Command = {
     id: 'clangd.dumpincludedby',
-    label: 'C/C++: Dump Files Including this File (Debug)'
+    category: CPP_CATEGORY,
+    label: 'Dump Files Including this File (Debug)',
 };
 
 export const REINDEX: Command = {
     id: 'clangd.reindex',
-    label: 'C/C++: Reindex Workspace (Debug)'
+    category: CPP_CATEGORY,
+    label: 'Reindex Workspace (Debug)',
 };
 
 export const PRINT_STATS: Command = {
     id: 'clangd.printstats',
-    label: 'C/C++: Print Index Statistics (Debug)'
+    category: CPP_CATEGORY,
+    label: 'Print Index Statistics (Debug)',
 };
 
 export const FILE_OPEN_PATH = (path: string): Command => <Command>{

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -53,115 +53,140 @@ export namespace DebugMenus {
 }
 
 export namespace DebugCommands {
-    export const START = {
+
+    const DEBUG_CATEGORY = 'Debug';
+
+    export const START: Command = {
         id: 'debug.start',
-        label: 'Debug: Start Debugging',
+        category: DEBUG_CATEGORY,
+        label: 'Start Debugging',
         iconClass: 'fa fa-play'
     };
-    export const START_NO_DEBUG = {
+    export const START_NO_DEBUG: Command = {
         id: 'debug.start.noDebug',
         label: 'Debug: Start Without Debugging'
     };
-    export const STOP = {
+    export const STOP: Command = {
         id: 'debug.stop',
-        label: 'Debug: Stop Debugging',
+        category: DEBUG_CATEGORY,
+        label: 'Stop Debugging',
         iconClass: 'fa fa-stop'
     };
-    export const RESTART = {
+    export const RESTART: Command = {
         id: 'debug.restart',
-        label: 'Debug: Restart Debugging'
+        category: DEBUG_CATEGORY,
+        label: 'Restart Debugging',
     };
 
-    export const OPEN_CONFIGURATION = {
+    export const OPEN_CONFIGURATION: Command = {
         id: 'debug.configuration.open',
-        label: 'Debug: Open Configuration'
+        category: DEBUG_CATEGORY,
+        label: 'Open Configuration',
     };
-    export const ADD_CONFIGURATION = {
+    export const ADD_CONFIGURATION: Command = {
         id: 'debug.configuration.add',
-        label: 'Debug: Add Configuration...'
+        category: DEBUG_CATEGORY,
+        label: 'Add Configuration...',
     };
 
-    export const STEP_OVER = {
+    export const STEP_OVER: Command = {
         id: 'debug.thread.next',
-        label: 'Debug: Step Over',
+        category: DEBUG_CATEGORY,
+        label: 'Step Over',
         iconClass: 'fa fa-arrow-right'
     };
-    export const STEP_INTO = {
+    export const STEP_INTO: Command = {
         id: 'debug.thread.stepin',
-        label: 'Debug: Step Into',
+        category: DEBUG_CATEGORY,
+        label: 'Step Into',
         iconClass: 'fa fa-arrow-down'
     };
-    export const STEP_OUT = {
+    export const STEP_OUT: Command = {
         id: 'debug.thread.stepout',
-        label: 'Debug: Step Out',
+        category: DEBUG_CATEGORY,
+        label: 'Step Out',
         iconClass: 'fa fa-arrow-up'
     };
-    export const CONTINUE = {
+    export const CONTINUE: Command = {
         id: 'debug.thread.continue',
-        label: 'Debug: Continue',
+        category: DEBUG_CATEGORY,
+        label: 'Continue',
         iconClass: 'fa fa-play-circle'
     };
-    export const PAUSE = {
+    export const PAUSE: Command = {
         id: 'debug.thread.pause',
-        label: 'Debug: Pause',
+        category: DEBUG_CATEGORY,
+        label: 'Pause',
         iconClass: 'fa fa-pause'
     };
-    export const CONTINUE_ALL = {
+    export const CONTINUE_ALL: Command = {
         id: 'debug.thread.continue.all',
-        label: 'Debug: Continue All',
+        category: DEBUG_CATEGORY,
+        label: 'Continue All',
         iconClass: 'fa fa-play-circle'
     };
-    export const PAUSE_ALL = {
+    export const PAUSE_ALL: Command = {
         id: 'debug.thread.pause.all',
-        label: 'Debug: Pause All',
+        category: DEBUG_CATEGORY,
+        label: 'Pause All',
         iconClass: 'fa fa-pause'
     };
 
-    export const TOGGLE_BREAKPOINT = {
+    export const TOGGLE_BREAKPOINT: Command = {
         id: 'debug.breakpoint.toggle',
-        label: 'Debug: Toggle Breakpoint'
+        category: DEBUG_CATEGORY,
+        label: 'Toggle Breakpoint',
     };
-    export const ENABLE_ALL_BREAKPOINTS = {
+    export const ENABLE_ALL_BREAKPOINTS: Command = {
         id: 'debug.breakpoint.enableAll',
-        label: 'Debug: Enable All Breakpoints'
+        category: DEBUG_CATEGORY,
+        label: 'Enable All Breakpoints',
     };
-    export const DISABLE_ALL_BREAKPOINTS = {
+    export const DISABLE_ALL_BREAKPOINTS: Command = {
         id: 'debug.breakpoint.disableAll',
-        label: 'Debug: Disable All Breakpoints'
+        category: DEBUG_CATEGORY,
+        label: 'Disable All Breakpoints',
     };
-    export const REMOVE_BREAKPOINT = {
+    export const REMOVE_BREAKPOINT: Command = {
         id: 'debug.breakpoint.remove',
-        label: 'Debug: Remove Breakpoint'
+        category: DEBUG_CATEGORY,
+        label: 'Remove Breakpoint',
     };
-    export const REMOVE_ALL_BREAKPOINTS = {
+    export const REMOVE_ALL_BREAKPOINTS: Command = {
         id: 'debug.breakpoint.removeAll',
-        label: 'Debug: Remove All Breakpoints'
+        category: DEBUG_CATEGORY,
+        label: 'Remove All Breakpoints',
     };
     export const SHOW_HOVER = {
         id: 'debug.editor.showHover',
         label: 'Debug: Show Hover'
     };
 
-    export const RESTART_FRAME = {
+    export const RESTART_FRAME: Command = {
         id: 'debug.frame.restart',
-        label: 'Debug: Restart Frame'
+        category: DEBUG_CATEGORY,
+        label: 'Restart Frame',
     };
-    export const COPY_CALL_STACK = {
+    export const COPY_CALL_STACK: Command = {
         id: 'debug.callStack.copy',
-        label: 'Debug: Copy Call Stack'
+        category: DEBUG_CATEGORY,
+        label: 'Copy Call Stack',
     };
 
-    export const SET_VARIABLE_VALUE = {
+    export const SET_VARIABLE_VALUE: Command = {
         id: 'debug.variable.setValue',
-        label: 'Debug: Set Value'
+        category: DEBUG_CATEGORY,
+        label: 'Set Value',
     };
-    export const COPY_VAIRABLE_VALUE = {
+    export const COPY_VAIRABLE_VALUE: Command = {
         id: 'debug.variable.copyValue',
-        label: 'Debug: Copy Value'
+        category: DEBUG_CATEGORY,
+        label: 'Copy Value',
     };
-    export const COPY_VAIRABLE_AS_EXPRESSION = {
+    export const COPY_VAIRABLE_AS_EXPRESSION: Command = {
         id: 'debug.variable.copyAsExpression',
-        label: 'Debug: Copy As Expression'
+        category: DEBUG_CATEGORY,
+        label: 'Copy As Expression',
     };
 }
 export namespace DebugThreadContextCommands {

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -23,6 +23,8 @@ import { EditorManager } from './editor-manager';
 
 export namespace EditorCommands {
 
+    const EDITOR_CATEGORY = 'Editor';
+
     /**
      * Show editor references
      */
@@ -37,14 +39,17 @@ export namespace EditorCommands {
     };
     export const INDENT_USING_SPACES: Command = {
         id: 'textEditor.commands.indentUsingSpaces',
+        category: EDITOR_CATEGORY,
         label: 'Indent Using Spaces'
     };
     export const INDENT_USING_TABS: Command = {
         id: 'textEditor.commands.indentUsingTabs',
+        category: EDITOR_CATEGORY,
         label: 'Indent Using Tabs'
     };
     export const CHANGE_LANGUAGE: Command = {
         id: 'textEditor.change.language',
+        category: EDITOR_CATEGORY,
         label: 'Change Language Mode'
     };
 
@@ -53,6 +58,7 @@ export namespace EditorCommands {
      */
     export const GO_BACK: Command = {
         id: 'textEditor.commands.go.back',
+        category: EDITOR_CATEGORY,
         label: 'Go Back'
     };
     /**
@@ -60,6 +66,7 @@ export namespace EditorCommands {
      */
     export const GO_FORWARD: Command = {
         id: 'textEditor.commands.go.forward',
+        category: EDITOR_CATEGORY,
         label: 'Go Forward'
     };
     /**
@@ -67,6 +74,7 @@ export namespace EditorCommands {
      */
     export const GO_LAST_EDIT: Command = {
         id: 'textEditor.commands.go.lastEdit',
+        category: EDITOR_CATEGORY,
         label: 'Go to Last Edit Location'
     };
 }

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -31,6 +31,7 @@ import * as fuzzy from 'fuzzy';
 
 export const quickFileOpen: Command = {
     id: 'file-search.openFile',
+    category: 'File',
     label: 'Open File...'
 };
 

--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -28,7 +28,8 @@ import debounce = require('lodash.debounce');
 export namespace BlameCommands {
     export const TOGGLE_GIT_ANNOTATIONS: Command = {
         id: 'git.editor.toggle.annotations',
-        label: 'Git: Toggle Blame Annotations'
+        category: 'Git',
+        label: 'Toggle Blame Annotations'
     };
     export const CLEAR_GIT_ANNOTATIONS: Command = {
         id: 'git.editor.clear.annotations'

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -33,7 +33,8 @@ import { GitRepositoryProvider } from '../git-repository-provider';
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
         id: 'git-diff:open-file-diff',
-        label: 'Diff: Compare With...'
+        category: 'Git Diff',
+        label: 'Compare With...'
     };
 }
 

--- a/packages/java/src/browser/java-commands.ts
+++ b/packages/java/src/browser/java-commands.ts
@@ -42,8 +42,9 @@ export const APPLY_WORKSPACE_EDIT: Command = {
  * Organize Imports
  */
 export const JAVA_ORGANIZE_IMPORTS: Command = {
-    label: 'Java: Organize Imports',
-    id: 'java.edit.organizeImports'
+    id: 'java.edit.organizeImports',
+    category: 'Java',
+    label: 'Organize Imports',
 };
 
 @injectable()

--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -30,7 +30,8 @@ import { KeybindingWidget } from './keybindings-widget';
 export namespace KeymapsCommands {
     export const OPEN_KEYMAPS: Command = {
         id: 'keymaps:open',
-        label: 'Open Keyboard Shortcuts'
+        category: 'Settings',
+        label: 'Open Keyboard Shortcuts',
     };
 }
 

--- a/packages/merge-conflicts/src/browser/merge-conflict.ts
+++ b/packages/merge-conflicts/src/browser/merge-conflict.ts
@@ -35,16 +35,20 @@ export interface MergeConflictCommandArgument {
 }
 
 export namespace MergeConflictsCommands {
+    const MERGE_CONFLIC_PREFIX = 'Merge Conflict';
     export const AcceptCurrent: Command = {
         id: 'merge-conflicts:accept.current',
-        label: 'Merge Conflict: Accept Current Change'
+        category: MERGE_CONFLIC_PREFIX,
+        label: 'Accept Current Change'
     };
     export const AcceptIncoming: Command = {
         id: 'merge-conflicts:accept.incoming',
-        label: 'Merge Conflict: Accept Incoming Change'
+        category: MERGE_CONFLIC_PREFIX,
+        label: 'Accept Incoming Change'
     };
     export const AcceptBoth: Command = {
         id: 'merge-conflicts:accept.both',
-        label: 'Merge Conflict: Accept Both Changes'
+        category: MERGE_CONFLIC_PREFIX,
+        label: 'Accept Both Changes'
     };
 }

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -31,27 +31,33 @@ import { HostedPluginPreferences } from './hosted-plugin-preferences';
  * Commands to control Hosted plugin instances.
  */
 export namespace HostedPluginCommands {
+    const HOSTED_PLUGIN_CATEGORY = 'Hosted Plugin';
     export const START: Command = {
         id: 'hosted-plugin:start',
-        label: 'Hosted Plugin: Start Instance'
+        category: HOSTED_PLUGIN_CATEGORY,
+        label: 'Start Instance'
     };
 
     export const DEBUG: Command = {
         id: 'hosted-plugin:debug',
-        label: 'Hosted Plugin: Debug Instance'
+        category: HOSTED_PLUGIN_CATEGORY,
+        label: 'Debug Instance'
     };
 
     export const STOP: Command = {
         id: 'hosted-plugin:stop',
-        label: 'Hosted Plugin: Stop Instance'
+        category: HOSTED_PLUGIN_CATEGORY,
+        label: 'Stop Instance'
     };
     export const RESTART: Command = {
         id: 'hosted-plugin:restart',
-        label: 'Hosted Plugin: Restart Instance'
+        category: HOSTED_PLUGIN_CATEGORY,
+        label: 'Restart Instance'
     };
     export const SELECT_PATH: Command = {
         id: 'hosted-plugin:select-path',
-        label: 'Hosted Plugin: Select Path'
+        category: HOSTED_PLUGIN_CATEGORY,
+        label: 'Select Path'
     };
 }
 

--- a/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
@@ -28,7 +28,9 @@ export class PluginExtDeployCommandService implements QuickOpenModel {
 
     public static COMMAND: Command = {
         id: 'plugin-ext:deploy-plugin-id',
-        label: 'Plugin: Deploy Plugin by Id'
+        category: 'Plugin',
+        label: 'Deploy Plugin by Id',
+
     };
 
     @inject(QuickOpenService)

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -17,22 +17,25 @@
 import { AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenus, FrontendApplication, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { injectable, inject } from 'inversify';
-import { CommandRegistry, MenuModelRegistry, SelectionService } from '@theia/core';
+import { CommandRegistry, MenuModelRegistry, SelectionService, Command } from '@theia/core';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import URI from '@theia/core/lib/common/uri';
 
 export namespace SearchInWorkspaceCommands {
+    const SEARCH_CATEGORY = 'Search';
     export const TOGGLE_SIW_WIDGET = {
         id: 'search-in-workspace.toggle'
     };
-    export const OPEN_SIW_WIDGET = {
+    export const OPEN_SIW_WIDGET: Command = {
         id: 'search-in-workspace.open',
-        label: 'Search in Workspace'
+        category: SEARCH_CATEGORY,
+        label: 'Find in Files'
 
     };
-    export const FIND_IN_FOLDER = {
+    export const FIND_IN_FOLDER: Command = {
         id: 'search-in-workspace.in-folder',
+        category: SEARCH_CATEGORY,
         label: 'Find in Folder...'
     };
 }
@@ -55,7 +58,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
-        await this.openView({activate: false});
+        await this.openView({ activate: false });
     }
 
     registerCommands(commands: CommandRegistry): void {

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -40,16 +40,20 @@ import URI from '@theia/core/lib/common/uri';
 const NAVIGATOR_CONTEXT_MENU_NEW = ['navigator-context-menu', '4_new'];
 
 export namespace TerminalCommands {
+    const TERMINAL_CATEGORY = 'Terminal';
     export const NEW: Command = {
         id: 'terminal:new',
+        category: TERMINAL_CATEGORY,
         label: 'Open New Terminal'
     };
     export const TERMINAL_CLEAR: Command = {
         id: 'terminal:clear',
-        label: 'Terminal: Clear'
+        category: TERMINAL_CATEGORY,
+        label: 'Clear Terminal'
     };
     export const TERMINAL_CONTEXT: Command = {
         id: 'terminal:context',
+        category: TERMINAL_CATEGORY,
         label: 'Open in Terminal'
     };
 }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -34,18 +34,24 @@ import { WorkspaceDeleteHandler } from './workspace-delete-handler';
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
 export namespace WorkspaceCommands {
+
+    const WORKSPACE_CATEGORY = 'Workspace';
+    const FILE_CATEGORY = 'File';
+
     // On Linux and Windows, both files and folders cannot be opened at the same time in electron.
     // `OPEN_FILE` and `OPEN_FOLDER` must be available only on Linux and Windows in electron.
     // `OPEN` must *not* be available on Windows and Linux in electron.
     // VS Code does the same. See: https://github.com/theia-ide/theia/pull/3202#issuecomment-430585357
     export const OPEN: Command & { dialogLabel: string } = {
         id: 'workspace:open',
+        category: FILE_CATEGORY,
         label: 'Open...',
         dialogLabel: 'Open'
     };
     // No `label`. Otherwise, it shows up in the `Command Palette`.
     export const OPEN_FILE: Command & { dialogLabel: string } = {
         id: 'workspace:openFile',
+        category: FILE_CATEGORY,
         dialogLabel: 'Open File'
     };
     export const OPEN_FOLDER: Command & { dialogLabel: string } = {
@@ -54,56 +60,69 @@ export namespace WorkspaceCommands {
     };
     export const OPEN_WORKSPACE: Command & { dialogLabel: string } = {
         id: 'workspace:openWorkspace',
+        category: FILE_CATEGORY,
         label: 'Open Workspace...',
         dialogLabel: 'Open Workspace'
     };
     export const OPEN_RECENT_WORKSPACE: Command = {
         id: 'workspace:openRecent',
+        category: FILE_CATEGORY,
         label: 'Open Recent Workspace...'
     };
     export const CLOSE: Command = {
         id: 'workspace:close',
+        category: WORKSPACE_CATEGORY,
         label: 'Close Workspace'
     };
     export const NEW_FILE: Command = {
         id: 'file.newFile',
+        category: FILE_CATEGORY,
         label: 'New File'
     };
     export const NEW_FOLDER: Command = {
         id: 'file.newFolder',
+        category: FILE_CATEGORY,
         label: 'New Folder'
     };
     export const FILE_OPEN_WITH = (opener: OpenHandler): Command => ({
         id: `file.openWith.${opener.id}`,
+        category: FILE_CATEGORY,
         label: opener.label,
         iconClass: opener.iconClass
     });
     export const FILE_RENAME: Command = {
         id: 'file.rename',
+        category: FILE_CATEGORY,
         label: 'Rename'
     };
     export const FILE_DELETE: Command = {
         id: 'file.delete',
+        category: FILE_CATEGORY,
         label: 'Delete'
     };
     export const FILE_DUPLICATE: Command = {
         id: 'file.duplicate',
+        category: FILE_CATEGORY,
         label: 'Duplicate'
     };
     export const FILE_COMPARE: Command = {
         id: 'file.compare',
+        category: FILE_CATEGORY,
         label: 'Compare with Each Other'
     };
     export const ADD_FOLDER: Command = {
         id: 'workspace:addFolder',
+        category: WORKSPACE_CATEGORY,
         label: 'Add Folder to Workspace...'
     };
     export const REMOVE_FOLDER: Command = {
         id: 'workspace:removeFolder',
+        category: WORKSPACE_CATEGORY,
         label: 'Remove Folder from Workspace'
     };
     export const SAVE_WORKSPACE_AS: Command = {
         id: 'workspace:saveAs',
+        category: WORKSPACE_CATEGORY,
         label: 'Save Workspace As...'
     };
 }


### PR DESCRIPTION
**Prefixed** commands in order to categorise and search commands through the `quick open command palette` more easily. 

Based on discussions from https://github.com/theia-ide/theia/issues/3287#issuecomment-433639535

**Examples:**
<img width="1198" alt="screen shot 2018-10-29 at 3 12 23 pm" src="https://user-images.githubusercontent.com/40359487/47674184-21476980-db8d-11e8-974b-d6a5621e9a73.png">
<img width="1198" alt="screen shot 2018-10-29 at 3 13 32 pm" src="https://user-images.githubusercontent.com/40359487/47674230-391eed80-db8d-11e8-9169-b66d332efad2.png">



<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
