### PR TITLE
[outline] Use the `DocumentSymbol.detail` not just only the `Document…

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -91,6 +91,7 @@
 .theia-TreeNodeSegment {
     flex-grow: 0;
     user-select: none;
+    white-space: nowrap;
 }
 
 .theia-TreeNodeSegmentGrow {

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -50,6 +50,8 @@ decorate(injectable(), ProtocolToMonacoConverter);
 import '../../src/browser/style/index.css';
 import '../../src/browser/style/symbol-sprite.svg';
 import '../../src/browser/style/symbol-icons.css';
+import { MonacoOutlineDecorator } from './monaco-outline-decorator';
+import { OutlineTreeDecorator } from '@theia/outline-view/lib/browser/outline-decorator-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplicationContribution).to(MonacoFrontendApplicationContribution).inSingletonScope();
@@ -98,4 +100,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(MonacoSemanticHighlightingService).toSelf().inSingletonScope();
     rebind(SemanticHighlightingService).to(MonacoSemanticHighlightingService).inSingletonScope();
+
+    bind(MonacoOutlineDecorator).toSelf().inSingletonScope();
+    bind(OutlineTreeDecorator).toService(MonacoOutlineDecorator);
 });

--- a/packages/monaco/src/browser/monaco-outline-contribution.ts
+++ b/packages/monaco/src/browser/monaco-outline-contribution.ts
@@ -280,6 +280,7 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
             id,
             iconClass: SymbolKind[symbol.kind].toString().toLowerCase(),
             name: this.getName(symbol),
+            detail: this.getDetail(symbol),
             parent,
             uri,
             range: this.getNameRange(symbol),
@@ -296,7 +297,11 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
     }
 
     protected getName(symbol: DocumentSymbol): string {
-        return symbol.name + (symbol.detail || '');
+        return symbol.name;
+    }
+
+    protected getDetail(symbol: DocumentSymbol): string {
+        return symbol.detail;
     }
 
     protected createId(name: string, ids: Map<string, number>): string {
@@ -342,6 +347,7 @@ export interface MonacoOutlineSymbolInformationNode extends OutlineSymbolInforma
     uri: URI;
     range: Range;
     fullRange: Range;
+    detail?: string;
     parent: MonacoOutlineSymbolInformationNode | undefined;
     children: MonacoOutlineSymbolInformationNode[];
 }

--- a/packages/monaco/src/browser/monaco-outline-decorator.ts
+++ b/packages/monaco/src/browser/monaco-outline-decorator.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (C) 2018 RedHat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { Tree } from '@theia/core/lib/browser/tree/tree';
+import { DepthFirstTreeIterator } from '@theia/core/lib/browser/tree/tree-iterator';
+import { TreeDecorator, TreeDecoration } from '@theia/core/lib/browser/tree/tree-decorator';
+import { MonacoOutlineSymbolInformationNode} from './monaco-outline-contribution';
+
+@injectable()
+export class MonacoOutlineDecorator implements TreeDecorator {
+
+    readonly id = 'theia-monaco-outline-decorator';
+
+    protected readonly emitter = new Emitter<(tree: Tree) => Map<string, TreeDecoration.Data>>();
+
+    async decorations(tree: Tree): Promise<Map<string, TreeDecoration.Data>> {
+        return this.collectDecorations(tree);
+    }
+
+    get onDidChangeDecorations(): Event<(tree: Tree) => Map<string, TreeDecoration.Data>> {
+        return this.emitter.event;
+    }
+
+    protected collectDecorations(tree: Tree): Map<string, TreeDecoration.Data> {
+      const result = new Map();
+        if (tree.root === undefined) {
+            return result;
+        }
+
+        for (const treeNode of new DepthFirstTreeIterator(tree.root)) {
+            if (MonacoOutlineSymbolInformationNode.is(treeNode) && treeNode.detail) {
+                result.set(treeNode.id, this.toDecoration(treeNode));
+            }
+        }
+
+        return result;
+    }
+
+    protected toDecoration(node: MonacoOutlineSymbolInformationNode): TreeDecoration.Data {
+        const captionSuffixes: TreeDecoration.CaptionAffix[] = [{
+                data: (node.detail || ''),
+                fontData: {
+                    color: 'var(--theia-ui-font-color2)',
+                }
+            }];
+
+        return {
+                captionSuffixes
+            };
+    }
+}

--- a/packages/outline-view/src/browser/outline-decorator-service.ts
+++ b/packages/outline-view/src/browser/outline-decorator-service.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2018 Redhat, Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { TreeDecorator, AbstractTreeDecoratorService } from '@theia/core/lib/browser/tree/tree-decorator';
+
+/**
+ * Symbol for all decorators that would like to contribute into the outline.
+ */
+export const OutlineTreeDecorator = Symbol('OutlineTreeDecorator');
+
+/**
+ * Decorator service for the outline.
+ */
+@injectable()
+export class OutlineDecoratorService extends AbstractTreeDecoratorService {
+
+    constructor(@inject(ContributionProvider) @named(OutlineTreeDecorator) protected readonly contributions: ContributionProvider<TreeDecorator>) {
+        super(contributions.getContributions());
+    }
+
+}

--- a/packages/outline-view/src/browser/outline-view-frontend-module.ts
+++ b/packages/outline-view/src/browser/outline-view-frontend-module.ts
@@ -24,10 +24,13 @@ import {
     TreeWidget,
     bindViewContribution,
     TreeProps,
-    defaultTreeProps
+    defaultTreeProps,
+    TreeDecoratorService
 } from '@theia/core/lib/browser';
 import { OutlineViewWidgetFactory, OutlineViewWidget } from './outline-view-widget';
 import '../../src/browser/styles/index.css';
+import { bindContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { OutlineDecoratorService, OutlineTreeDecorator } from './outline-decorator-service';
 
 export default new ContainerModule(bind => {
     bind(OutlineViewWidgetFactory).toFactory(ctx =>
@@ -48,6 +51,10 @@ function createOutlineViewWidget(parent: interfaces.Container): OutlineViewWidge
 
     child.unbind(TreeWidget);
     child.bind(OutlineViewWidget).toSelf();
+
+    child.bind(OutlineDecoratorService).toSelf().inSingletonScope();
+    child.rebind(TreeDecoratorService).toDynamicValue(ctx => ctx.container.get(OutlineDecoratorService)).inSingletonScope();
+    bindContributionProvider(child, OutlineTreeDecorator);
 
     return child.get(OutlineViewWidget);
 }


### PR DESCRIPTION
…Symbol.name` #2894

This fix:
- adds the decorator service to the outline
- adds the tree node decorator to the monaco editor in order to decorate nodes using DocumentSymbo's detail property

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

![t2894](https://user-images.githubusercontent.com/620781/48619402-abb90700-e99c-11e8-9138-cd91f0c3fa69.png)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

[outline] Outline is added with a possibility to decorate the text of the tree elements.
