### PR TITLE
[lsp] handle reconnection & init errors gracefully

### DIFF
--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -47,9 +47,7 @@ export class WebSocketConnectionProvider {
         const socket = this.createWebSocket(url);
         socket.onerror = console.error;
         socket.onclose = ({ code, reason }) => {
-            const channels = [...this.channels.values()];
-            this.channels.clear();
-            for (const channel of channels) {
+            for (const channel of [...this.channels.values()]) {
                 channel.close(code, reason);
             }
         };
@@ -110,10 +108,13 @@ export class WebSocketConnectionProvider {
         const channel = this.createChannel(id);
         this.channels.set(id, channel);
         channel.onClose(() => {
-            this.channels.delete(channel.id);
-            const { reconnecting } = { reconnecting: true, ...options };
-            if (reconnecting) {
-                this.openChannel(path, handler, options);
+            if (this.channels.delete(channel.id)) {
+                const { reconnecting } = { reconnecting: true, ...options };
+                if (reconnecting) {
+                    this.openChannel(path, handler, options);
+                }
+            } else {
+                console.error('The ws channel does not exist', channel.id);
             }
         });
         channel.onOpen(() => handler(channel));

--- a/packages/core/src/common/messaging/web-socket-channel.ts
+++ b/packages/core/src/common/messaging/web-socket-channel.ts
@@ -110,8 +110,17 @@ export class WebSocketChannel implements IWebSocket {
         this.toDispose.push(Disposable.create(() => this.fireError = () => { }));
     }
 
+    protected closing = false;
     protected fireClose(code: number, reason: string): void {
-        this.closeEmitter.fire([code, reason]);
+        if (this.closing) {
+            return;
+        }
+        this.closing = true;
+        try {
+            this.closeEmitter.fire([code, reason]);
+        } finally {
+            this.closing = false;
+        }
         this.dispose();
     }
     onClose(cb: (code: number, reason: string) => void): Disposable {

--- a/packages/editor/src/browser/semantic-highlight/semantic-highlighting-service.ts
+++ b/packages/editor/src/browser/semantic-highlight/semantic-highlighting-service.ts
@@ -46,9 +46,7 @@ export class SemanticHighlightingService implements Disposable {
         if (scopes && scopes.length > 0) {
             this.logger.info(`Registering scopes for language: ${languageId}.`);
             if (this.scopes.has(languageId)) {
-                const error = new Error(`The scopes are already registered for language: ${languageId}.`);
-                this.logger.error(error.message);
-                throw error;
+                this.logger.warn(`The scopes are already registered for language: ${languageId}.`);
             }
             this.scopes.set(languageId, scopes.map(scope => scope.slice(0)));
             this.logger.info(`The scopes have been successfully registered for ${languageId}.`);
@@ -61,9 +59,7 @@ export class SemanticHighlightingService implements Disposable {
     protected unregister(languageId: string): void {
         this.logger.info(`Unregistering scopes for language: ${languageId}.`);
         if (!this.scopes.has(languageId)) {
-            const error = new Error(`No scopes were registered for language: ${languageId}.`);
-            this.logger.error(error.message);
-            throw error;
+            this.logger.warn(`No scopes were registered for language: ${languageId}.`);
         }
         this.scopes.delete(languageId);
         this.logger.info(`The scopes have been successfully unregistered for ${languageId}.`);

--- a/packages/languages/src/browser/language-client-contribution.ts
+++ b/packages/languages/src/browser/language-client-contribution.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+// tslint:disable:no-any
+
 import { injectable, inject } from 'inversify';
 import { MessageService, CommandRegistry } from '@theia/core';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common';
@@ -23,15 +25,19 @@ import {
     DocumentSelector, TextDocument, FileSystemWatcher,
     Workspace, Languages, State
 } from './language-client-services';
-import { MessageConnection } from 'vscode-jsonrpc';
+import { MessageConnection, ResponseError } from 'vscode-jsonrpc';
 import { LanguageClientFactory } from './language-client-factory';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { InitializeParams } from 'monaco-languageclient';
 
 export const LanguageClientContribution = Symbol('LanguageClientContribution');
 export interface LanguageClientContribution extends LanguageContribution {
+    readonly running: boolean;
     readonly languageClient: Promise<ILanguageClient>;
     waitForActivation(app: FrontendApplication): Promise<void>;
     activate(app: FrontendApplication): Disposable;
+    deactivate(): void;
+    restart(): void;
 }
 
 @injectable()
@@ -88,12 +94,19 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         return this.workspace.ready;
     }
 
+    protected readonly toDeactivate = new DisposableCollection();
     activate(): Disposable {
+        if (this.toDeactivate.disposed) {
+            this.doActivate(this.toDeactivate);
+        }
+        return this.toDeactivate;
+    }
+    deactivate(): void {
+        this.toDeactivate.dispose();
+    }
+    protected doActivate(toDeactivate: DisposableCollection): void {
         const options: WebSocketOptions = {};
-        const toDeactivate = new DisposableCollection();
-        toDeactivate.push(Disposable.create(() => {
-            options.reconnecting = false;
-        }));
+        toDeactivate.push(Disposable.create(() => options.reconnecting = false));
         this.connectionProvider.listen({
             path: LanguageContribution.getPath(this),
             onConnection: messageConnection => {
@@ -101,27 +114,23 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
                     messageConnection.dispose();
                     return;
                 }
-                toDeactivate.push(messageConnection);
-
                 const languageClient = this.createLanguageClient(messageConnection);
                 this.onWillStart(languageClient);
-                languageClient.start();
-                this.toRestart.push(Disposable.create(async () => {
-                    await languageClient.onReady();
-                    languageClient.stop();
-                }));
+                toDeactivate.pushAll([
+                    messageConnection,
+                    this.toRestart.push(Disposable.create(async () => {
+                        await languageClient.onReady();
+                        languageClient.stop();
+                    })),
+                    languageClient.start()
+                ]);
             }
         }, options);
-
-        this.registerRestartCommand();
-        toDeactivate.push(Disposable.create(() => this.unregisterRestartCommand()));
-
-        return toDeactivate;
     }
 
     protected state: State | undefined;
     get running(): boolean {
-        return this.state === State.Running;
+        return !this.toDeactivate.disposed && this.state === State.Running;
     }
 
     protected readonly toRestart = new DisposableCollection();
@@ -158,14 +167,20 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         return {
             documentSelector,
             synchronize: { fileEvents, configurationSection },
-            initializationFailedHandler: err => {
-                const detail = err instanceof Error ? `: ${err.message}` : '.';
-                this.messageService.error(`Failed to start ${this.name} language server${detail}`);
-                return false;
-            },
+            initializationFailedHandler: err => this.handleInitializationFailed(err),
             diagnosticCollectionName: id,
             initializationOptions
         };
+    }
+    protected handleInitializationFailed(err: ResponseError<InitializeParams> | Error | any): boolean {
+        this.deactivate();
+        const detail = err instanceof Error ? `: ${err.message}` : '.';
+        this.messageService.error(`Failed to start ${this.name} language server${detail}`, 'Retry').then(result => {
+            if (result) {
+                this.activate();
+            }
+        });
+        return false;
     }
 
     // tslint:disable-next-line:no-any
@@ -232,34 +247,4 @@ export abstract class BaseLanguageClientContribution implements LanguageClientCo
         });
     }
 
-    /**
-     * Return the id of the "restart" command for this language client.
-     */
-    private restartCommandId(): string {
-        return `languages.${this.id}.restart`;
-    }
-
-    /**
-     * Register a command that lets the user restart the language server this
-     * client is connected to.
-     */
-    protected registerRestartCommand(): void {
-        this.registry.registerCommand(
-            {
-                id: this.restartCommandId(),
-                label: `${this.name}: Restart Language Server`,
-            },
-            {
-                execute: () => this.restart(),
-                isEnabled: () => this.running,
-                isVisible: () => this.running,
-            });
-    }
-
-    /**
-     * Unregister the command registered by `registerRestartCommand`.
-     */
-    protected unregisterRestartCommand(): void {
-        this.registry.unregisterCommand(this.restartCommandId());
-    }
 }

--- a/packages/languages/src/browser/languages-frontend-module.ts
+++ b/packages/languages/src/browser/languages-frontend-module.ts
@@ -32,7 +32,9 @@ export default new ContainerModule(bind => {
     bind(LanguageClientFactory).toSelf().inSingletonScope();
 
     bindContributionProvider(bind, LanguageClientContribution);
-    bind(FrontendApplicationContribution).to(LanguagesFrontendContribution);
+    bind(LanguagesFrontendContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(LanguagesFrontendContribution);
+    bind(CommandContribution).toService(LanguagesFrontendContribution);
 
     bind(WorkspaceSymbolCommand).toSelf().inSingletonScope();
     for (const identifier of [CommandContribution, KeybindingContribution, QuickOpenContribution]) {


### PR DESCRIPTION
- fixes #2750: on the initialization error the server should be stopped, a user should be prompted to retry with a notification. There is also a command to start a language server if it is not running.
- fixes #2995, fixes #1684: commands should be properly disposed when a language server is stopped
- fixes #3224: ~not sure whether this issue still exists. I've only tested connection and initialization issues. The situation when a server goes completely down does not happen often in practice.~ - turned out to be the worst bug with a cycle between closing old channel and opening a new one, leading to a lot of duplicate channels
- closes #2419: one can activate/deactivate language contributions programmatically
