### PR TITLE
Fix no-any for @theia/callhierarchy

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -195,6 +195,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
         if ((oldState as any).root && (oldState as any).languageId) {
             // tslint:disable-next-line:no-any
             this.model.root = this.inflateFromStorage((oldState as any).root);
+            // tslint:disable-next-line:no-any
             this.model.initializeCallHierarchy((oldState as any).languageId, (this.model.root as DefinitionNode).definition.location);
         }
     }


### PR DESCRIPTION
Fixed the tslint error for `no-any` rule in the @theia/callhierarchy package

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
