### PR TITLE
Fix no-any, and file-header in @theia/json

### DIFF
--- a/packages/json/src/browser/json-client-contribution.ts
+++ b/packages/json/src/browser/json-client-contribution.ts
@@ -123,5 +123,6 @@ interface SchemaData {
     description: string;
     fileMatch?: string[];
     url: string;
+    // tslint:disable-next-line:no-any
     schema: any;
 }

--- a/packages/json/src/browser/monaco.d.ts
+++ b/packages/json/src/browser/monaco.d.ts
@@ -1,1 +1,17 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
 /// <reference types='@theia/monaco/src/typings/monaco/index'/>


### PR DESCRIPTION
Fixed the tslint errors `no-any` and `file-header` in `@theia/json`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
