### PR TITLE
Add examples/*/test to tsconfig.json's include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -115,6 +115,7 @@
   },
   "include": [
     "dev-packages/*/src",
-    "packages/*/src"
+    "packages/*/src",
+    "examples/*/test"
   ]
 }


### PR DESCRIPTION
When editing files under examples/browser/test in Theia, we don't get
any tslint warnings.  Running tslint by hand on the project:

    $ tslint -p .

doesn't lint the files in there.  Adding the glob to `include` in
tsconfig.json makes tslint consider those files.

Change-Id: I0c2e96c87b6ba15b27853878e95e8b530a284c35
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
