### PR TITLE
Display 'No Recent Workspaces' label in getting-started widget

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -134,14 +134,14 @@ export class GettingStartedWidget extends ReactWidget {
                 </span>
             </div>
         );
-        const more = (paths.length > this.recentLimit) ? <div className='gs-action-contaienr'>
+        const more = (paths.length > this.recentLimit) ? <div className='gs-action-container'>
             <a href='#' onClick={this.doOpenRecentWorkspace}>More...</a>
         </div> : <div />;
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className='fa fa-clock-o'></i>Recent Workspaces
-                    </h3>
-            {content}
+            </h3>
+            {(items.length > 0) ? content : <p className='gs-no-recent'>No Recent Workspaces</p>}
             {more}
         </div>;
     }
@@ -182,7 +182,9 @@ export class GettingStartedWidget extends ReactWidget {
     protected renderVersion(): React.ReactNode {
         return <div className='gs-section'>
             <div className='gs-action-container'>
-                <p className='gs-sub-header gs-version' > {this.applicationInfo ? 'Version ' + this.applicationInfo.version : ''}</p>
+                <p className='gs-sub-header gs-version' >
+                    {this.applicationInfo ? 'Version ' + this.applicationInfo.version : ''}
+                </p>
             </div>
         </div>;
     }

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -30,12 +30,12 @@ html, body {
 
 .gs-action-container {
     line-height: 20px;
-    color: var(--theia-ui-font-color1);
+    color: var(--theia-ui-font-color0);
 }
 
 .gs-action-details {
     padding-left: 5px;
-    color: var(--theia-ui-font-color2);
+    color: var(--theia-ui-font-color1);
 }
 
 .gs-container {
@@ -43,17 +43,21 @@ html, body {
 }
 
 .gs-header h1 {
-    color: var(--theia-ui-font-color1);
+    color: var(--theia-ui-font-color0);
     flex: 1;
     font-weight: 600;
     text-transform: uppercase;
 }
 
 .gs-hr {
-    background-color: var(--theia-border-color1); 
-    height: 1px; 
+    background-color: var(--theia-border-color1);
+    height: 1px;
     border: 0;
     margin: 0px;
+}
+
+.gs-no-recent {
+    color: var(--theia-ui-font-color1);
 }
 
 .gs-section a {
@@ -69,7 +73,7 @@ html, body {
 }
 
 .gs-section-header {
-    color: var(--theia-ui-font-color1);
+    color: var(--theia-ui-font-color0);
     font-size: var(--theia-ui-font-size2);
     font-weight: 600;
     margin-bottom: 5px;
@@ -80,7 +84,7 @@ html, body {
 }
 
 .gs-sub-header {
-    color: var(--theia-ui-font-color2);
+    color: var(--theia-ui-font-color1);
     text-transform: capitalize;
-    font-weight: 200;
+    font-weight: 400;
 }


### PR DESCRIPTION
- Display the label 'No Recent Workspaces' if there aren't any recent workspaces present
- Fix some UI styling issues present in dark vs light themes
- Fix className typo

<img width="1155" alt="screen shot 2018-10-30 at 9 27 47 pm" src="https://user-images.githubusercontent.com/40359487/47760580-5b973080-dc8b-11e8-928b-645248a338c3.png">

<img width="938" alt="screen shot 2018-10-30 at 9 36 12 pm" src="https://user-images.githubusercontent.com/40359487/47760683-dfe9b380-dc8b-11e8-8ee5-99c11d890d04.png">



Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
