### PR TITLE
[plug-in] Add debug.registerDebugConfigurationProvider API mock

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -382,6 +382,13 @@ export function createAPIFactory(
             }
         };
 
+        const debug: typeof theia.debug = {
+            registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider): theia.Disposable {
+                // FIXME: to implement
+                return new Disposable(() => { });
+            }
+        };
+
         return <typeof theia>{
             version: require('../../package.json').version,
             commands,
@@ -390,6 +397,7 @@ export function createAPIFactory(
             env,
             languages,
             plugins,
+            debug,
             // Types
             StatusBarAlignment: StatusBarAlignment,
             Disposable: Disposable,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4886,4 +4886,69 @@ declare module '@theia/plugin' {
         provideHover(document: TextDocument, position: Position, token: CancellationToken | undefined): ProviderResult<Hover>;
     }
 
+    /**
+	 * Configuration for a debug session.
+	 */
+	export interface DebugConfiguration {
+		/**
+		 * The type of the debug session.
+		 */
+		type: string;
+ 		/**
+		 * The name of the debug session.
+		 */
+		name: string;
+ 		/**
+		 * The request type of the debug session.
+		 */
+		request: string;
+ 		/**
+		 * Additional debug type specific properties.
+		 */
+		[key: string]: any;
+	}
+ 	/**
+	 * A debug configuration provider allows to add the initial debug configurations to a newly created launch.json
+	 * and to resolve a launch configuration before it is used to start a new debug session.
+	 * A debug configuration provider is registered via #debug.registerDebugConfigurationProvider.
+	 */
+	export interface DebugConfigurationProvider {
+		/**
+		 * Provides initial [debug configuration](#DebugConfiguration). If more than one debug configuration provider is
+		 * registered for the same type, debug configurations are concatenated in arbitrary order.
+		 *
+		 * @param folder The workspace folder for which the configurations are used or undefined for a folderless setup.
+		 * @param token A cancellation token.
+		 * @return An array of [debug configurations](#DebugConfiguration).
+		 */
+		provideDebugConfigurations?(folder: WorkspaceFolder | undefined, token?: CancellationToken): ProviderResult<DebugConfiguration[]>;
+ 		/**
+		 * Resolves a [debug configuration](#DebugConfiguration) by filling in missing values or by adding/changing/removing attributes.
+		 * If more than one debug configuration provider is registered for the same type, the resolveDebugConfiguration calls are chained
+		 * in arbitrary order and the initial debug configuration is piped through the chain.
+		 * Returning the value 'undefined' prevents the debug session from starting.
+		 * Returning the value 'null' prevents the debug session from starting and opens the underlying debug configuration instead.
+		 *
+		 * @param folder The workspace folder from which the configuration originates from or undefined for a folderless setup.
+		 * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
+		 * @param token A cancellation token.
+		 * @return The resolved debug configuration or undefined or null.
+		 */
+		resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>;
+    }
+    
+	/**
+	 * Namespace for debug functionality.
+	 */
+	export namespace debug {
+ 		/**
+		 * Register a [debug configuration provider](#DebugConfigurationProvider) for a specific debug type.
+		 * More than one provider can be registered for the same type.
+		 *
+		 * @param type The debug type for which the provider is registered.
+		 * @param provider The [debug configuration provider](#DebugConfigurationProvider) to register.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+		export function registerDebugConfigurationProvider(debugType: string, provider: DebugConfigurationProvider): Disposable;
+    }
 }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

The PR mocks `debug.registerDebugConfigurationProvider` API call to eliminate error
```
TypeError: vscode.debug.registerDebugConfigurationProvider is not a function
```
when using a plug-in which makes such API call.

It's needed for https://github.com/eclipse/che/issues/10574