### PR TITLE
[plug-in] Add languages.registerCodeLensProvider API mock

### DIFF
--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -292,6 +292,13 @@ export class LanguagesExtImpl implements LanguagesExt {
     }
     // ### Code Actions Provider end
 
+    // ### Code Lens Provider begin
+    registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider): theia.Disposable {
+        // FIXME: to implement
+        return new Disposable(() => { });
+    }
+    // ### Code Lens Provider end
+
     // ### Code Reference Provider begin
     registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider): theia.Disposable {
         // FIXME: to implement

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -361,6 +361,9 @@ export function createAPIFactory(
             registerCodeActionsProvider(selector: theia.DocumentSelector, provider: theia.CodeActionProvider, metadata?: theia.CodeActionProviderMetadata): theia.Disposable {
                 return languagesExt.registerCodeActionsProvider(selector, provider, metadata);
             },
+            registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider): theia.Disposable {
+                return languagesExt.registerCodeLensProvider(selector, provider);
+            },
             registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider): theia.Disposable {
                 return languagesExt.registerReferenceProvider(selector, provider);
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4318,6 +4318,37 @@ declare module '@theia/plugin' {
     }
 
     /**
+	 * A code lens provider adds [commands](#Command) to source text. The commands will be shown
+	 * as dedicated horizontal lines in between the source text.
+	 */
+    export interface CodeLensProvider {
+        /**
+        * An optional event to signal that the code lenses from this provider have changed.
+        */
+        onDidChangeCodeLenses?: Event<void>;
+        /**
+        * Compute a list of [lenses](#CodeLens). This call should return as fast as possible and if
+        * computing the commands is expensive implementors should only return code lens objects with the
+        * range set and implement [resolve](#CodeLensProvider.resolveCodeLens).
+        *
+        * @param document The document in which the command was invoked.
+        * @param token A cancellation token.
+        * @return An array of code lenses or a thenable that resolves to such. The lack of a result can be
+        * signaled by returning `undefined`, `null`, or an empty array.
+        */
+        provideCodeLenses(document: TextDocument, token: CancellationToken): ProviderResult<CodeLens[]>;
+        /**
+        * This function will be called for each visible code lens, usually when scrolling and after
+        * calls to [compute](#CodeLensProvider.provideCodeLenses)-lenses.
+        *
+        * @param codeLens code lens that must be resolved.
+        * @param token A cancellation token.
+        * @return The given, resolved code lens or thenable that resolves to such.
+        */
+        resolveCodeLens?(codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>;
+    }
+
+    /**
      * Kind of a code action.
      *
      * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
@@ -4778,6 +4809,19 @@ declare module '@theia/plugin' {
         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
         */
         export function registerCodeActionsProvider(selector: DocumentSelector, provider: CodeActionProvider, metadata?: CodeActionProviderMetadata): Disposable;
+
+        /**
+         * Register a code lens provider.
+         *
+         * Multiple providers can be registered for a language. In that case providers are asked in
+         * parallel and the results are merged. A failing provider (rejected promise or exception) will
+         * not cause a failure of the whole operation.
+         *
+         * @param selector A selector that defines the documents this provider is applicable to.
+         * @param provider A code lens provider.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
+        export function registerCodeLensProvider(selector: DocumentSelector, provider: CodeLensProvider): Disposable;
 
         /**
          * Register a formatting provider that works on type. The provider is active when the user enables the setting `editor.formatOnType`.


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

The PR mocks `languages.registerCodeLensProvider` API call to eliminate error
```
TypeError: vscode.languages.registerCodeLensProvider is not a function
```
when using a plug-in which makes such API call.

It's needed for https://github.com/eclipse/che/issues/10574