### PR TITLE
Rename 'Open New Terminal' command/menu item to 'New Terminal'

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -42,7 +42,7 @@ const NAVIGATOR_CONTEXT_MENU_NEW = ['navigator-context-menu', '4_new'];
 export namespace TerminalCommands {
     export const NEW: Command = {
         id: 'terminal:new',
-        label: 'Open New Terminal'
+        label: 'New Terminal'
     };
     export const TERMINAL_CLEAR: Command = {
         id: 'terminal:clear',


### PR DESCRIPTION
Fixes #2609

- Renamed `Open New Terminal` command/menu item to `New Terminal`
- Change made since the command `New Terminal` is self-explanatory on its own, and it currently is displayed within the `New` menu items category

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
