### PR TITLE
Create terminal main-menu item

### DIFF
--- a/examples/browser/test/top-panel/top-panel.ts
+++ b/examples/browser/test/top-panel/top-panel.ts
@@ -25,8 +25,8 @@ export class TopPanel {
     }
 
     openNewTerminal() {
-        this.clickMenuTab('File');
-        this.clickSubMenu('Open New Terminal');
+        this.clickMenuTab('Terminal');
+        this.clickSubMenu('New Terminal');
     }
 
     toggleCallHierarchyView() {

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -46,11 +46,12 @@ export namespace CommonMenus {
     export const EDIT_CLIPBOARD = [...EDIT, '2_clipboard'];
     export const EDIT_FIND = [...EDIT, '3_find'];
 
-    export const VIEW = [...MAIN_MENU_BAR, '3_view'];
+    export const VIEW = [...MAIN_MENU_BAR, '4_view'];
     export const VIEW_VIEWS = [...VIEW, '1_views'];
     export const VIEW_LAYOUT = [...VIEW, '2_layout'];
 
-    export const HELP = [...MAIN_MENU_BAR, '4_help'];
+    // last menu item
+    export const HELP = [...MAIN_MENU_BAR, '9_help'];
 
 }
 

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -44,7 +44,7 @@ import { DebugEditorService } from './editor/debug-editor-service';
 import { DebugConsoleContribution } from './console/debug-console-contribution';
 
 export namespace DebugMenus {
-    export const DEBUG = [...MAIN_MENU_BAR, '4_debug'];
+    export const DEBUG = [...MAIN_MENU_BAR, '6_debug'];
     export const DEBUG_CONTROLS = [...DEBUG, 'a_controls'];
     export const DEBUG_CONFIGURATION = [...DEBUG, 'b_configuration'];
     export const DEBUG_THREADS = [...DEBUG, 'c_threads'];

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -32,7 +32,7 @@ export namespace EditorMainMenu {
     /**
      * The main `Go` menu item.
      */
-    export const GO = [...MAIN_MENU_BAR, '4_go'];
+    export const GO = [...MAIN_MENU_BAR, '5_go'];
 
     /**
      * Navigation menu group in the `Go` menu.

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -17,31 +17,25 @@
 import { inject, injectable, named } from 'inversify';
 import { ILogger, ContributionProvider } from '@theia/core/lib/common';
 import { QuickOpenTask } from './quick-open-task';
-import { MAIN_MENU_BAR, CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
+import { CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import { FrontendApplication, FrontendApplicationContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskContribution, TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
 import { TaskService } from './task-service';
+import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 
 export namespace TaskCommands {
-    // Task menu
-    export const TASK_MENU = [...MAIN_MENU_BAR, '3_task'];
-    export const TASK_MENU_RUN = [...TASK_MENU, '1_run'];
-    export const TASK_MENU_LABEL = 'Task';
-
-    // run task group
-    export const TASK = [...MAIN_MENU_BAR, '3_task'];
-    export const RUN_GROUP = [...TASK, '1_run'];
-
-    // run task command
+    const TASK_CATEGORY = 'Task';
     export const TASK_RUN: Command = {
         id: 'task:run',
-        label: 'Tasks: Run...'
+        category: TASK_CATEGORY,
+        label: 'Run Task...'
     };
 
     export const TASK_ATTACH: Command = {
         id: 'task:attach',
-        label: 'Tasks: Attach...'
+        category: TASK_CATEGORY,
+        label: 'Attach Task...'
     };
 }
 
@@ -107,17 +101,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     }
 
     registerMenus(menus: MenuModelRegistry): void {
-        // Explicitly register the Task Submenu
-        menus.registerSubmenu(TaskCommands.TASK_MENU, TaskCommands.TASK_MENU_LABEL);
-        menus.registerMenuAction(TaskCommands.RUN_GROUP, {
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
             commandId: TaskCommands.TASK_RUN.id,
-            label: TaskCommands.TASK_RUN.label ? TaskCommands.TASK_RUN.label.slice('Tasks: '.length) : TaskCommands.TASK_RUN.label,
             order: '0'
         });
 
-        menus.registerMenuAction(TaskCommands.RUN_GROUP, {
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
             commandId: TaskCommands.TASK_ATTACH.id,
-            label: TaskCommands.TASK_ATTACH.label ? TaskCommands.TASK_ATTACH.label.slice('Tasks: '.length) : TaskCommands.TASK_ATTACH.label,
             order: '1'
         });
     }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -25,7 +25,7 @@ import {
     SelectionService
 } from '@theia/core/lib/common';
 import {
-    CommonMenus, ApplicationShell, KeybindingContribution, KeyCode, Key,
+    ApplicationShell, KeybindingContribution, KeyCode, Key,
     KeyModifier, KeybindingRegistry
 } from '@theia/core/lib/browser';
 import { WidgetManager } from '@theia/core/lib/browser';
@@ -36,8 +36,14 @@ import { TerminalWidgetOptions, TerminalWidget } from './base/terminal-widget';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import URI from '@theia/core/lib/common/uri';
+import { MAIN_MENU_BAR } from '@theia/core';
 
-const NAVIGATOR_CONTEXT_MENU_NEW = ['navigator-context-menu', '4_new'];
+export namespace TerminalMenus {
+    export const TERMINAL = [...MAIN_MENU_BAR, '7_terminal'];
+    export const TERMINAL_NEW = [...TERMINAL, '1_terminal'];
+    export const TERMINAL_TASKS = [...TERMINAL, '2_terminal'];
+    export const TERMINAL_NAVIGATOR_CONTEXT_MENU = ['navigator-context-menu', '4_new'];
+}
 
 export namespace TerminalCommands {
     const TERMINAL_CATEGORY = 'Terminal';
@@ -105,10 +111,13 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     }
 
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerMenuAction(CommonMenus.FILE_NEW, {
-            commandId: TerminalCommands.NEW.id
+        menus.registerSubmenu(TerminalMenus.TERMINAL, 'Terminal');
+        menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
+            commandId: TerminalCommands.NEW.id,
+            label: 'New Terminal',
+            order: '0'
         });
-        menus.registerMenuAction(NAVIGATOR_CONTEXT_MENU_NEW, {
+        menus.registerMenuAction(TerminalMenus.TERMINAL_NAVIGATOR_CONTEXT_MENU, {
             commandId: TerminalCommands.TERMINAL_CONTEXT.id
         });
     }


### PR DESCRIPTION
Fixes #3356 
Fixes #2609 

- Created new `Terminal` main menu item which encompasses both terminal and task commands
- Remove `Task` menu and instead placed the items under the new `Terminal` main-menu in their own separated category

<div align="center">
<img width="354" alt="screen shot 2018-10-31 at 2 23 47 pm" src="https://user-images.githubusercontent.com/40359487/47810088-d0647c00-dd18-11e8-81f7-6d554ac5b1c8.png">
</div>

- Fixed the ordering of the main-menu items to align with `vscode`

<div align="center">
<img width="579" alt="screen shot 2018-10-31 at 2 36 17 pm" src="https://user-images.githubusercontent.com/40359487/47810708-5f25c880-dd1a-11e8-8067-77dac68d63c9.png">
</div>

---

**Reasons for Change**
- Make the `Terminal` and its commands more discoverable for end-users
- Group related items together
- Align with vscode
- Easier to add more commands to both `Terminal`& `Tasks`

**What is not included in the change**
- Adding the `Terminal` menu item in the `View` main-menu

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
