### PR TITLE
Moving openfile command with args to the right command.

### DIFF
--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
 import { QuickFileOpenService, quickFileOpen } from './quick-file-open';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { KeybindingRegistry, KeybindingContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
@@ -27,7 +28,13 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {
-            execute: () => this.quickFileOpenService.open(),
+            execute: (args: any[]) => {
+                if (args) {
+                    const [fileURI] = args;
+                    return this.quickFileOpenService.openFile(new URI(fileURI));
+                }
+                return this.quickFileOpenService.open();
+            },
             isEnabled: () => this.quickFileOpenService.isEnabled()
         });
     }

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -187,9 +187,13 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
             if (mode !== QuickOpenMode.OPEN) {
                 return false;
             }
-            this.openerService.getOpener(uri).then(opener => opener.open(uri));
+            this.openFile(uri);
             return true;
         };
+    }
+
+    openFile(uri: URI) {
+        this.openerService.getOpener(uri).then(opener => opener.open(uri));
     }
 
     private async toItem(uriOrString: URI | string, group?: string) {

--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -43,14 +43,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         commands.registerCommand(WorkspaceCommands.OPEN, {
             isEnabled: () => isOSX || !this.isElectron(),
             isVisible: () => isOSX || !this.isElectron(),
-            // tslint:disable-next-line:no-any
-            execute: (args: any[]) => {
-                if (args) {
-                    const [fileURI] = args;
-                    return this.workspaceService.open(fileURI);
-                }
-                return this.doOpen();
-            }
+            execute: () => this.doOpen()
         });
         // Visible/enabled only on Windows/Linux in electron.
         commands.registerCommand(WorkspaceCommands.OPEN_FILE, {


### PR DESCRIPTION
With this PR, from a plug-in we can do:

```
   theia.commands.executeCommand('file-search.openFile', 'file:///projects/theia/README.md')
```
and it will open the file.