### PR TITLE
[core] Add shortcuts for browser tab switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## v0.3.17
 - [plug-in] added `languages.registerCodeLensProvider` Plug-in API
+- [core] `ctrl+alt+a` and `ctrl+alt+d` to switch tabs left/right
 
 
 ## v0.3.16
 - [plug-in] added `DocumentLinkProvider` Plug-in API
 - [plug-in] Terminal.sendText API adds a new line to the text being sent to the terminal if `addNewLine` parameter wasn't specified
-- Reverted [cpp] Add debugging for C/C++ programs. This feature will come back in its own cpp-specific repo 
+- Reverted [cpp] Add debugging for C/C++ programs. This feature will come back in its own cpp-specific repo
 - [core] Add methods to unregister menus, commands and keybindings
 - [terminal] Add 'open in terminal' to navigator
 - [markers] Added ability to remove markers
@@ -20,7 +21,7 @@
 ## v0.3.15
 - [plug-in] added `menus` contribution point
 - [cpp] Add debugging for C/C++ programs
-- View Keybindings Widget - used to view and search keybindings 
+- View Keybindings Widget - used to view and search keybindings
 - multi-root workspace support, vsCode compatibility
 - Add TCL grammar file
 - [debug] resolve variables in configurations
@@ -30,7 +31,7 @@
 
 ## v0.3.13
 - [cpp] Add a status bar button to select an active cpp build configuration
-- Recently opened workspaces history 
+- Recently opened workspaces history
 - [git/blame] convert to toggle command
 - [cpp] Watch changes to compile_commands.json
 - [ts] one ls for all js related languages

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -436,6 +436,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
             });
         }
         registry.registerKeybindings(
+            // Edition
             {
                 command: CommonCommands.UNDO.id,
                 keybinding: 'ctrlcmd+z'
@@ -452,13 +453,22 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 command: CommonCommands.REPLACE.id,
                 keybinding: 'ctrlcmd+alt+f'
             },
+            // Tabs
             {
                 command: CommonCommands.NEXT_TAB.id,
                 keybinding: 'ctrlcmd+tab'
             },
             {
+                command: CommonCommands.NEXT_TAB.id,
+                keybinding: 'ctrlcmd+alt+d'
+            },
+            {
                 command: CommonCommands.PREVIOUS_TAB.id,
                 keybinding: 'ctrlcmd+shift+tab'
+            },
+            {
+                command: CommonCommands.PREVIOUS_TAB.id,
+                keybinding: 'ctrlcmd+alt+a'
             },
             {
                 command: CommonCommands.CLOSE_TAB.id,
@@ -472,6 +482,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 command: CommonCommands.CLOSE_ALL_TABS.id,
                 keybinding: 'alt+shift+w'
             },
+            // Panels
             {
                 command: CommonCommands.COLLAPSE_PANEL.id,
                 keybinding: 'alt+c'
@@ -484,6 +495,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
                 command: CommonCommands.COLLAPSE_ALL_PANELS.id,
                 keybinding: 'alt+shift+c',
             },
+            // Saving
             {
                 command: CommonCommands.SAVE.id,
                 keybinding: 'ctrlcmd+s'


### PR DESCRIPTION
Before, it was set to just `ctrl+tab`, but this doesn't work in browsers.
Add `ctrl+alt+a` and `ctrl+alt+d` in order to switch between tabs.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
