### PR TITLE
GH-3333: Added toolbar support for the tab-bars.

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -61,6 +61,8 @@ import { AboutDialog, AboutDialogProps } from './about-dialog';
 import { EnvVariablesServer, envVariablesPath } from './../common/env-variables';
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { JsonSchemaStore } from './json-schema-store';
+import { TabBarToolbarRegistry, TabBarToolbarContribution, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
+import { WidgetTracker } from './widgets';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const themeService = ThemeService.get();
@@ -74,11 +76,28 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(ApplicationShellOptions).toConstantValue({});
     bind(ApplicationShell).toSelf().inSingletonScope();
+    bind(WidgetTracker).toService(ApplicationShell);
     bind(SidePanelHandlerFactory).toAutoFactory(SidePanelHandler);
     bind(SidePanelHandler).toSelf();
     bind(SplitPositionHandler).toSelf().inSingletonScope();
 
-    bind(DockPanelRendererFactory).toAutoFactory(DockPanelRenderer);
+    bindContributionProvider(bind, TabBarToolbarContribution);
+    bind(TabBarToolbarRegistry).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TabBarToolbarRegistry);
+    bind(TabBarToolbarFactory).toFactory(context => () => {
+        const { container } = context;
+        const commandRegistry = container.get(CommandRegistry);
+        const labelParser = container.get(LabelParser);
+        return new TabBarToolbar(commandRegistry, labelParser);
+    });
+
+    bind(DockPanelRendererFactory).toFactory(context => (widgetTracker: WidgetTracker) => {
+        const { container } = context;
+        const tabBarToolbarRegistry = container.get(TabBarToolbarRegistry);
+        const tabBarRendererFactory: () => TabBarRenderer = container.get(TabBarRendererFactory);
+        const tabBarToolbarFactory: () => TabBarToolbar = container.get(TabBarToolbarFactory);
+        return new DockPanelRenderer(tabBarRendererFactory, tabBarToolbarRegistry, widgetTracker, tabBarToolbarFactory);
+    });
     bind(DockPanelRenderer).toSelf();
     bind(TabBarRendererFactory).toFactory(context => () => {
         const contextMenuRenderer = context.container.get<ContextMenuRenderer>(ContextMenuRenderer);

--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -20,7 +20,7 @@ import { Widget, BaseWidget } from './widgets';
 import { WidgetOpenHandler, WidgetOpenerOptions } from './widget-open-handler';
 
 /**
- * `Navigatable` provides an access to an URI of an underyling instance of `Resource`.
+ * `Navigatable` provides an access to an URI of an underlying instance of `Resource`.
  */
 export interface Navigatable {
     /**
@@ -72,6 +72,7 @@ export interface NavigatableWidgetOptions {
 }
 export namespace NavigatableWidgetOptions {
     export function is(arg: Object | undefined): arg is NavigatableWidgetOptions {
+        // tslint:disable-next-line:no-any
         return !!arg && 'kind' in arg && (arg as any).kind === 'navigatable';
     }
 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.ts
@@ -1,0 +1,245 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable, named } from 'inversify';
+import { Widget, BaseWidget } from '../widgets';
+import { LabelParser, LabelIcon } from '../label-parser';
+import { ContributionProvider } from '../../common/contribution-provider';
+import { FrontendApplicationContribution } from '../frontend-application';
+import { Disposable, DisposableCollection } from '../../common/disposable';
+import { Command, CommandRegistry, CommandService } from '../../common/command';
+
+/**
+ * Factory for instantiating tab-bar toolbars.
+ */
+export const TabBarToolbarFactory = Symbol('TabBarToolbarFactory');
+export interface TabBarToolbarFactory {
+    (commandService: CommandService, labelParser: LabelParser): TabBarToolbar;
+}
+
+/**
+ * Tab-bar toolbar widget representing the active [tab-bar toolbar items](TabBarToolbarItem).
+ */
+export class TabBarToolbar extends BaseWidget {
+
+    protected readonly items: Map<TabBarToolbarItem, HTMLElement> = new Map();
+    protected readonly toDisposeOnUpdate: DisposableCollection = new DisposableCollection();
+
+    constructor(protected readonly commandService: CommandService, protected readonly labelParser: LabelParser) {
+        super();
+        this.toDispose.push(Disposable.create(() => this.removeItems()));
+        this.addClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR);
+        this.addClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR_HIDDEN);
+    }
+
+    updateItems(...items: TabBarToolbarItem[]): void {
+        const copy = items.slice().sort(TabBarToolbarItem.PRIORITY_COMPARATOR).reverse();
+        if (this.areSame(copy, Array.from(this.items.keys()))) {
+            return;
+        }
+        this.toDisposeOnUpdate.dispose();
+        this.removeItems();
+        this.createItems(...copy);
+    }
+
+    protected removeItems(): void {
+        for (const element of this.items.values()) {
+            const { parentElement } = element;
+            if (parentElement) {
+                parentElement.removeChild(element);
+            }
+        }
+        this.items.clear();
+    }
+
+    protected createItems(...items: TabBarToolbarItem[]): void {
+        for (const item of items) {
+            const itemContainer = document.createElement('div');
+            itemContainer.classList.add(TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM);
+            for (const labelPart of this.labelParser.parse(item.text)) {
+                const child = document.createElement('div');
+                const listener = () => this.commandService.executeCommand(item.command.id);
+                child.addEventListener('click', listener);
+                this.toDisposeOnUpdate.push(Disposable.create(() => itemContainer.removeEventListener('click', listener)));
+                if (typeof labelPart !== 'string' && LabelIcon.is(labelPart)) {
+                    const className = `fa fa-${labelPart.name}${labelPart.animation ? ' fa-' + labelPart.animation : ''}`;
+                    child.classList.add(...className.split(' '));
+                } else {
+                    child.innerText = labelPart;
+                }
+                if (item.tooltip) {
+                    child.title = item.tooltip;
+                }
+                itemContainer.appendChild(child);
+            }
+            this.node.appendChild(itemContainer);
+            this.items.set(item, itemContainer);
+        }
+        if (this.items.size === 0) {
+            this.addClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR_HIDDEN);
+        } else {
+            this.removeClass(TabBarToolbar.Styles.TAB_BAR_TOOLBAR_HIDDEN);
+        }
+    }
+
+    /**
+     * `true` if `left` and `right` contains the same items in the same order. Otherwise, `false`.
+     * We consider two items the same, if the IDs of the corresponding items are the same.
+     */
+    protected areSame(left: TabBarToolbarItem[], right: TabBarToolbarItem[]): boolean {
+        if (left.length === right.length) {
+            for (let i = 0; i < left.length; i++) {
+                if (left[0].id !== right[0].id) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+}
+
+export namespace TabBarToolbar {
+
+    export namespace Styles {
+
+        export const TAB_BAR_TOOLBAR = 'p-TabBar-toolbar';
+        export const TAB_BAR_TOOLBAR_ITEM = 'item';
+        export const TAB_BAR_TOOLBAR_HIDDEN = 'hidden';
+
+    }
+
+}
+
+/**
+ * Clients should implement this interface if they want to contribute to the tab-bar toolbar.
+ */
+export const TabBarToolbarContribution = Symbol('TabBarToolbarContribution');
+export interface TabBarToolbarContribution {
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void;
+
+}
+
+/**
+ * Representation of an item in the tab
+ */
+export interface TabBarToolbarItem {
+
+    /**
+     * The unique ID of the toolbar item.
+     */
+    readonly id: string;
+
+    /**
+     * The command to execute.
+     */
+    readonly command: Command;
+
+    /**
+     * Text of the item.
+     *
+     * Shamelessly copied and reused from `status-bar`:
+     *
+     * More details about the available `fontawesome` icons and CSS class names can be hound [here](http://fontawesome.io/icons/).
+     * To set a text with icon use the following pattern in text string:
+     * ```typescript
+     * $(fontawesomeClasssName)
+     * ```
+     *
+     * To use animated icons use the following pattern:
+     * ```typescript
+     * $(fontawesomeClassName~typeOfAnimation)
+     * ````
+     * The type of animation can be either `spin` or `pulse`.
+     * Look [here](http://fontawesome.io/examples/#animated) for more information to animated icons.
+     */
+    readonly text: string;
+
+    /**
+     * Function that evaluates to `true` if the toolbar item is visible for the given widget. Otherwise, `false`.
+     */
+    readonly isVisible: (widget: Widget) => boolean;
+
+    /**
+     * Priority among the items. Can be negative. The smaller the number the left-most the item will be placed in the toolbar. It is `0` by default.
+     */
+    readonly priority?: number;
+
+    /**
+     * Optional tooltip for the item.
+     */
+    readonly tooltip?: string;
+
+}
+
+export namespace TabBarToolbarItem {
+
+    /**
+     * Compares the items by `priority` in ascending. Undefined priorities will be treated as `0`.
+     */
+    export const PRIORITY_COMPARATOR = (left: TabBarToolbarItem, right: TabBarToolbarItem) => (left.priority || 0) - (right.priority || 0);
+
+}
+
+/**
+ * Main, shared registry for tab-bar toolbar items.
+ */
+@injectable()
+export class TabBarToolbarRegistry implements FrontendApplicationContribution {
+
+    protected items: Map<string, TabBarToolbarItem> = new Map();
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(ContributionProvider)
+    @named(TabBarToolbarContribution)
+    protected readonly contributionProvider: ContributionProvider<TabBarToolbarContribution>;
+
+    onStart(): void {
+        const contributions = this.contributionProvider.getContributions();
+        for (const contribution of contributions) {
+            contribution.registerToolbarItems(this);
+        }
+    }
+
+    /**
+     * Registers the given item. Throws an error, if the corresponding command cannot be found or an item has been already registered for the desired command.
+     *
+     * @param item the item to register.
+     */
+    registerItem(item: TabBarToolbarItem): void {
+        const { id } = item;
+        if (this.items.has(id)) {
+            throw new Error(`A toolbar item is already registered with the '${id}' ID.`);
+        }
+        this.items.set(id, item);
+    }
+
+    /**
+     * Returns an array of tab-bar toolbar items which are visible when the `widget` argument is the current one.
+     *
+     * By default returns with all items where the command is enabled and `item.isVisible` is `true`.
+     */
+    visibleItems(widget: Widget): TabBarToolbarItem[] {
+        return Array.from(this.items.values())
+            .filter(item => this.commandRegistry.isEnabled(item.id))
+            .filter(item => item.isVisible(widget));
+    }
+
+}

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -102,23 +102,23 @@
 | Perfect scrollbar
 |----------------------------------------------------------------------------*/
 
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x {
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x {
   height: var(--theia-private-horizontal-tab-scrollbar-rail-height);
   z-index: 1000;
 }
 
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x  >.ps__thumb-x {
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x  > .ps__thumb-x {
   height: var(--theia-private-horizontal-tab-scrollbar-height);
   bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
 }
 
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x:hover,
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x:focus {
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover,
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus {
   height: var(--theia-private-horizontal-tab-scrollbar-rail-height);
 }
 
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x:hover > .ps__thumb-x,
-.p-TabBar[data-orientation='horizontal'] > .ps__rail-x:focus > .ps__thumb-x {
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover > .ps__thumb-x,
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus > .ps__thumb-x {
   height: var(--theia-private-horizontal-tab-scrollbar-height);
   bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
 }
@@ -152,4 +152,36 @@
 .p-TabBar-tab.p-mod-drag-image > .p-TabBar-tabIcon {
   width: 15px;
   line-height: 1.7;
+}
+
+/*-----------------------------------------------------------------------------
+| Tab-bar toolbar
+|----------------------------------------------------------------------------*/
+
+.p-TabBar-toolbar {
+  z-index: 1001; /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
+  display: flex;
+  flex-direction: row-reverse;
+  flex-grow: 1;
+  padding: 4px;
+  margin-right: 4px;
+}
+
+.p-TabBar-toolbar.hidden {
+  display: none !important;
+}
+
+.p-TabBar-content-container {
+  display: flex;
+  background: var(--theia-layout-color0);
+}
+
+.p-TabBar-toolbar .item {
+  display: flex;
+  align-items: center;
+  margin-left: 8px; /* `padding` + `margin-right` from the container toolbar */
+}
+
+.p-TabBar-toolbar .item:hover {
+  cursor: pointer;
 }

--- a/packages/core/src/browser/widget-open-handler.ts
+++ b/packages/core/src/browser/widget-open-handler.ts
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-// tslint:disable:no-any
-
 import { inject, postConstruct, injectable } from 'inversify';
 import { Widget, FocusTracker } from '@phosphor/widgets';
 import URI from '../common/uri';

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -15,8 +15,9 @@
  ********************************************************************************/
 
 import { injectable, decorate, unmanaged } from 'inversify';
-import { Widget } from '@phosphor/widgets';
+import { Widget, FocusTracker } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
+import { Signal } from '@phosphor/signaling';
 import { Disposable, DisposableCollection, MaybePromise } from '../../common';
 import { KeyCode, KeysOrKeyCodes } from '../keys';
 
@@ -214,4 +215,38 @@ export function addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element
     return Disposable.create(() =>
         document.removeEventListener(type, documentListener)
     );
+}
+
+/**
+ * Tracks the current and active widgets in the application. Also provides access to the currently active and current widgets.
+ */
+export const WidgetTracker = Symbol('WidgetTracker');
+export interface WidgetTracker {
+
+    /**
+     * The current widget in the application shell. The current widget is the last widget that
+     * was active and not yet closed. See the remarks to `activeWidget` on what _active_ means.
+     */
+    currentWidget: Widget | undefined;
+
+    /**
+     * The active widget in the application shell. The active widget is the one that has focus
+     * (either the widget itself or any of its contents).
+     *
+     * _Note:_ Focus is taken by a widget through the `onActivateRequest` method. It is up to the
+     * widget implementation which DOM element will get the focus. The default implementation
+     * does not take any focus; in that case the widget is never returned by this property.
+     */
+    activeWidget: Widget | undefined;
+
+    /**
+     * A signal emitted whenever the `currentWidget` property is changed.
+     */
+    readonly currentChanged: Signal<object, FocusTracker.IChangedArgs<Widget>>;
+
+    /**
+     * A signal emitted whenever the `activeWidget` property is changed.
+     */
+    readonly activeChanged: Signal<object, FocusTracker.IChangedArgs<Widget>>;
+
 }

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -28,6 +28,7 @@
  */
 .p-TabBar.theia-app-centers {
     z-index: 0;
+    display: flex;
 }
 
 /*

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -19,6 +19,7 @@ import { Widget } from '@phosphor/widgets';
 import { FrontendApplicationContribution, WidgetOpenerOptions, NavigatableWidgetOpenHandler } from '@theia/core/lib/browser';
 import { EditorManager, TextEditor, EditorWidget, EditorContextMenu } from '@theia/editor/lib/browser';
 import { DisposableCollection, CommandContribution, CommandRegistry, Command, MenuContribution, MenuModelRegistry, CommandHandler, Disposable } from '@theia/core/lib/common';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import URI from '@theia/core/lib/common/uri';
 import { Position } from 'vscode-languageserver-types';
 import { PreviewWidget } from './preview-widget';
@@ -29,9 +30,12 @@ import { PreviewPreferences } from './preview-preferences';
 import debounce = require('lodash.debounce');
 
 export namespace PreviewCommands {
+    /**
+     * No `label`. Otherwise, it would show up in the `Command Palette` and we already have the `Preview` open handler.
+     * See in (`WorkspaceCommandContribution`)[https://bit.ly/2DncrSD].
+     */
     export const OPEN: Command = {
-        id: 'preview:open',
-        label: 'Open Preview'
+        id: 'preview:open'
     };
 }
 
@@ -40,7 +44,8 @@ export interface PreviewOpenerOptions extends WidgetOpenerOptions {
 }
 
 @injectable()
-export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWidget> implements CommandContribution, MenuContribution, FrontendApplicationContribution {
+// tslint:disable-next-line:max-line-length
+export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWidget> implements CommandContribution, MenuContribution, FrontendApplicationContribution, TabBarToolbarContribution {
 
     readonly id = PreviewUri.id;
     readonly label = 'Preview';
@@ -213,7 +218,17 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {
             commandId: PreviewCommands.OPEN.id,
-            label: PreviewCommands.OPEN.label,
+            label: 'Open Preview',
+        });
+    }
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: PreviewCommands.OPEN.id,
+            command: PreviewCommands.OPEN,
+            isVisible: (widget: Widget) => widget instanceof EditorWidget && this.canHandleEditorUri(),
+            text: '$(columns)',
+            tooltip: 'Open Preview to the Side'
         });
     }
 

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -194,12 +194,9 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         const mainTabBars = this.shell.mainAreaTabBars;
         const defaultTabBar = this.shell.getTabBarFor('main');
         if (mainTabBars.length > 1 && defaultTabBar) {
-            const currentTabArea = this.shell.currentTabArea;
-            const currentTabBar = (currentTabArea === 'main') ? this.shell.currentTabBar || defaultTabBar : defaultTabBar;
-            const currentIndex = mainTabBars.indexOf(currentTabBar);
-            const targetIndex = (mainTabBars.length === currentIndex + 1) ? currentIndex - 1 : currentIndex + 1;
-            const targetTabBar = mainTabBars[targetIndex];
-            const currentTitle = targetTabBar.currentTitle;
+            const currentTabBar = this.shell.currentTabBar || defaultTabBar;
+            const currentIndex = currentTabBar.currentIndex;
+            const currentTitle = currentTabBar.titles[currentIndex];
             if (currentTitle) {
                 return currentTitle.owner;
             }

--- a/packages/preview/src/browser/preview-frontend-module.ts
+++ b/packages/preview/src/browser/preview-frontend-module.ts
@@ -18,6 +18,7 @@ import { ContainerModule } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { CommandContribution, MenuContribution, bindContributionProvider, ResourceProvider } from '@theia/core/lib/common';
 import { OpenHandler, WidgetFactory, FrontendApplicationContribution, NavigatableWidgetOptions } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { PreviewContribution } from './preview-contribution';
 import { PreviewWidget, PreviewWidgetOptions } from './preview-widget';
 import { PreviewHandler, PreviewHandlerProvider } from './preview-handler';
@@ -50,7 +51,7 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(PreviewContribution).toSelf().inSingletonScope();
-    [CommandContribution, MenuContribution, OpenHandler, FrontendApplicationContribution].forEach(serviceIdentifier =>
+    [CommandContribution, MenuContribution, OpenHandler, FrontendApplicationContribution, TabBarToolbarContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(PreviewContribution)
     );
 });

--- a/packages/preview/src/browser/preview-preferences.ts
+++ b/packages/preview/src/browser/preview-preferences.ts
@@ -29,7 +29,7 @@ export const PreviewConfigSchema: PreferenceSchema = {
     'preview.openByDefault': {
       type: 'boolean',
       description: 'Open the preview instead of the editor by default.',
-      default: true
+      default: false
     }
   }
 };

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
-// Lint rules expected to be used in interactive editors.
 {
+  "//": [
+    "Lint rules expected to be used in interactive editors."
+  ],
   "extends": [
     "./configs/errors.tslint.json",
     "./configs/warnings.tslint.json"


### PR DESCRIPTION
 - It is supported only in the `main` and `bottom` panels.
 - From now on, `Preview` open in the `Code Editor` by default.
 - Removed the redundant `Open Preview` command.

Closes: #3333.
Closes: #3376.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->