### PR TITLE
Fix search-in-workspace widget error and notification message

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -21,6 +21,7 @@ import { CommandRegistry, MenuModelRegistry, SelectionService } from '@theia/cor
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import URI from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export namespace SearchInWorkspaceCommands {
     export const TOGGLE_SIW_WIDGET = {
@@ -42,6 +43,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
 
     @inject(SelectionService) protected readonly selectionService: SelectionService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     constructor() {
         super({
@@ -55,12 +57,13 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
-        await this.openView({activate: false});
+        await this.openView({ activate: false });
     }
 
     registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
         commands.registerCommand(SearchInWorkspaceCommands.OPEN_SIW_WIDGET, {
+            isEnabled: () => this.workspaceService.tryGetRoots().length > 0,
             execute: () => this.openView({
                 activate: true
             })

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -207,9 +207,11 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 }
                 this.refreshModelChildren();
             }
-        }, searchOptions);
+        }, searchOptions).catch(e => { return; });
         token.onCancellationRequested(() => {
-            this.searchService.cancel(searchId);
+            if (searchId) {
+                this.searchService.cancel(searchId);
+            }
         });
     }
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -21,6 +21,7 @@ import { SearchInWorkspaceOptions } from '../common/search-in-workspace-interfac
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Disposable } from '@theia/core/lib/common';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export interface SearchFieldState {
     className: string;
@@ -57,6 +58,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected resultContainer: HTMLElement;
 
     @inject(SearchInWorkspaceResultTreeWidget) protected readonly resultTreeWidget: SearchInWorkspaceResultTreeWidget;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     @postConstruct()
     init() {
@@ -234,7 +236,8 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     }
 
     protected renderControlButtons(): React.ReactNode {
-        const refreshButton = this.renderControlButton(`refresh${this.hasResults || this.searchTerm !== '' ? ' enabled' : ''}`, 'Refresh', this.refresh);
+        const refreshButton = this.renderControlButton(`refresh${(this.hasResults || this.searchTerm !== '') && this.workspaceService.tryGetRoots().length > 0
+            ? ' enabled' : ''}`, 'Refresh', this.refresh);
         const collapseAllButton = this.renderControlButton(`collapse-all${this.hasResults ? ' enabled' : ''}`, 'Collapse All', this.collapseAll);
         const clearButton = this.renderControlButton(`clear-all${this.hasResults ? ' enabled' : ''}`, 'Clear', this.clear);
         return <div className='controls button-container'>{refreshButton}{collapseAllButton}{clearButton}</div>;
@@ -276,6 +279,11 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     }
 
     protected renderNotification(): React.ReactNode {
+        if (this.workspaceService.tryGetRoots().length <= 0) {
+            return <div className='search-notification show'>
+                <div>Cannot search without an active workspace present.</div>
+            </div>;
+        }
         return <div
             className={`search-notification ${this.searchInWorkspaceOptions.maxResults && this.resultNumber >= this.searchInWorkspaceOptions.maxResults ? 'show' : ''}`}>
             <div>


### PR DESCRIPTION
Fixes #2287
Fixes #2297

- Catch error thrown when `search-in-workspace` widget is used to search a workspace without a workspace being present.
- Disable menu item `Search in Workspace` when no workspace is present.
- Display notification message in `search-in-workspace` widget when no workspace is present.

![selection_009](https://user-images.githubusercontent.com/40359487/47930496-85767000-dea2-11e8-8a17-e77b5e9e2044.png)


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
