### PR TITLE
Fix 'Close Workspace'

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -275,7 +275,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             msg: 'Do you really want to close the workspace?'
         });
         if (await dialog.open()) {
-            this.workspaceService.close();
+            await this.workspaceService.close();
         }
     }
 

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -318,11 +318,11 @@ export class WorkspaceService implements FrontendApplicationContribution {
     /**
      * Clears current workspace root.
      */
-    close(): void {
+    async close(): Promise<void> {
         this._workspace = undefined;
         this._roots.length = 0;
 
-        this.server.setMostRecentlyUsedWorkspace('');
+        await this.server.setMostRecentlyUsedWorkspace('');
         this.reloadWindow();
     }
 


### PR DESCRIPTION
Fixes #2662

- Fixed issue with the command `Close Workspace` which did not work on all browsers
- Since the function `setMostRecentlyUsedWorkspace` returns a Promise, it was necessary to `await` until the data is saved in `recentWorkspace.json` before reloading Theia

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
