### PR TITLE
Cache busting

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -32,7 +32,7 @@ export class FrontendGenerator extends AbstractGenerator {
 <html>
 
 <head>${this.compileIndexHead(frontendModules)}
-  <script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
+  <script type="text/javascript" src="./bundle.js?_=${Date.now()}" charset="utf-8"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This is very useful specially for theia that are hosted and uses cdn such as cloudflare.

Cache busting makes sure that the cdn will use the latest built `bundle.js` and not the one from it's cache.


Signed-off-by: Uni Sayo <unibtc@gmail.com>