### PR TITLE
Fix the label for 'Toggle Blame Annotations'

### DIFF
--- a/packages/git/src/browser/blame/blame-contribution.ts
+++ b/packages/git/src/browser/blame/blame-contribution.ts
@@ -138,7 +138,6 @@ export class BlameContribution implements CommandContribution, KeybindingContrib
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EDITOR_CONTEXT_MENU_GIT, {
             commandId: BlameCommands.TOGGLE_GIT_ANNOTATIONS.id,
-            label: BlameCommands.TOGGLE_GIT_ANNOTATIONS.label!.slice('Git: '.length)
         });
     }
 


### PR DESCRIPTION
- Due to recent updates of #3313 it is no longer necessary to splice the label since it causes the display name to be truncated.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
