### PR TITLE
Add error case tests for search-in-workspace test

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -16,11 +16,12 @@
 
 import { ILogger } from '@theia/core';
 import { RawProcess, RawProcessFactory, RawProcessOptions } from '@theia/process/lib/node';
-import { rgPath } from 'vscode-ripgrep';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import URI from '@theia/core/lib/common/uri';
 import { inject, injectable } from 'inversify';
 import { SearchInWorkspaceServer, SearchInWorkspaceOptions, SearchInWorkspaceResult, SearchInWorkspaceClient } from '../common/search-in-workspace-interface';
+
+export const RgPath = Symbol('RgPath');
 
 /**
  * Typing for ripgrep's arbitrary data object:
@@ -67,6 +68,9 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
     private nextSearchId: number = 0;
 
     private client: SearchInWorkspaceClient | undefined;
+
+    @inject(RgPath)
+    protected readonly rgPath: string;
 
     constructor(
         @inject(ILogger) protected readonly logger: ILogger,
@@ -126,7 +130,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
         }
 
         const processOptions: RawProcessOptions = {
-            command: rgPath,
+            command: this.rgPath,
             args: [...args, what].concat(rootUris.map(root => FileUri.fsPath(root)))
         };
         const process: RawProcess = this.rawProcessFactory(processOptions);

--- a/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
+++ b/packages/search-in-workspace/src/node/search-in-workspace-backend-module.ts
@@ -17,7 +17,8 @@
 import { ContainerModule } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core/lib/common';
 import { SearchInWorkspaceServer, SearchInWorkspaceClient } from '../common/search-in-workspace-interface';
-import { RipgrepSearchInWorkspaceServer } from './ripgrep-search-in-workspace-server';
+import { RipgrepSearchInWorkspaceServer, RgPath } from './ripgrep-search-in-workspace-server';
+import { rgPath } from 'vscode-ripgrep';
 
 export default new ContainerModule(bind => {
     bind(SearchInWorkspaceServer).to(RipgrepSearchInWorkspaceServer);
@@ -30,4 +31,5 @@ export default new ContainerModule(bind => {
                 return server;
             })
     );
+    bind(RgPath).toConstantValue(rgPath);
 });


### PR DESCRIPTION
Add tests for when the rg binary is not found and is not executable, to
make sure we handle that correctly.

When running the test case, I get a backtrace:

  ripgrep-search-in-workspace-server
TypeError: Cannot read property 'kill' of undefined
    at RawProcess.kill (/home/emaisin/src/theia/packages/process/src/node/raw-process.ts:103:26)
    at ProcessManager.unregister (/home/emaisin/src/theia/packages/process/src/node/process-manager.ts:62:21)
    at /home/emaisin/src/theia/packages/process/src/node/process-manager.ts:46:36
    at CallbackList.invoke (/home/emaisin/src/theia/packages/core/src/common/event.ts:107:39)
    at Emitter.fire (/home/emaisin/src/theia/packages/core/src/common/event.ts:199:36)
    at /home/emaisin/src/theia/packages/process/src/node/raw-process.ts:92:35
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
    ✓ fails gracefully when rg isn't executable

This is due to a latent bug in RawProcess, where if we try to execute a
non-executable file, the process property of the RawProcess is
undefined.  It doesn't make the test fail, however, and exists prior to
this patch, so I decided not to address it right now.

Change-Id: I19d95d9b003a48096c14a51dd81d8b9c48fdde59

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
