### PR TITLE
Add process dependency to file-search

### DIFF
--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.3.16",
     "@theia/editor": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
+    "@theia/process": "^0.3.16",
     "@theia/workspace": "^0.3.16",
     "fuzzy": "^0.1.3",
     "vscode-ripgrep": "^1.0.1"


### PR DESCRIPTION
file-search uses process, but doesn't have it in its dependency list.

Change-Id: I98cfec9880321573b69805ef3565b157fa2f2dc6
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
