### PR TITLE
Fix crashes from the `git-history` and `git-commit-detail` widgets

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -32,7 +32,7 @@ export const GIT_DIFF = 'git-diff';
 @injectable()
 export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> implements StatefulWidget {
 
-    protected fileChangeNodes: GitFileChangeNode[];
+    protected fileChangeNodes: GitFileChangeNode[] = [];
     protected options: Git.Options.Diff;
 
     protected gitStatus?: WorkingDirectoryStatus;

--- a/packages/git/src/browser/history/git-commit-detail-widget.tsx
+++ b/packages/git/src/browser/history/git-commit-detail-widget.tsx
@@ -67,7 +67,7 @@ export class GitCommitDetailWidget extends GitDiffWidget {
         const mail = <div className='mail header-value noWrapInfo'>{`<${authorEMail}>`}</div>;
         const authorRow = <div className='header-row noWrapInfo'><div className='theia-header'>author: </div>{author}</div>;
         const mailRow = <div className='header-row noWrapInfo'><div className='theia-header'>e-mail: </div>{mail}</div>;
-        const authorDate = this.commitDetailOptions.authorDate;
+        const authorDate = new Date(this.commitDetailOptions.authorDate);
         const dateStr = authorDate.toLocaleDateString('en', {
             month: 'short',
             day: 'numeric',

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -327,14 +327,9 @@ export interface CommitIdentity {
     readonly email: string;
 
     /**
-     * The date of the commit.
+     * The date of the commit in ISO format.
      */
-    readonly timestamp: number;
-
-    /**
-     * The time-zone offset.
-     */
-    readonly tzOffset?: number;
+    readonly timestamp: string;
 
 }
 


### PR DESCRIPTION
Fixes #1770
Fixes #1754

- Fixes error thrown when attempting to perform `Date.toLocaleDateString` in the `git-commit-detail-widget`.
- Fixes error thrown when attempting to iterate over `fileChangeNodes` and it is `undefined`.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
