### PR TITLE
Register Text Document Content Provider plugin API

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -73,7 +73,7 @@ export class QuickInputService {
             options,
             {
                 prefix: options.value,
-                placeholder: options.placeHolder,
+                placeholder: options.placeHolder ? options.placeHolder : '',
                 onClose: () => inputItem.resolve(undefined)
             });
         this.quickOpenService.internalOpen(this.opts);

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -318,11 +318,14 @@ export interface WorkspaceMain {
     $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<theia.WorkspaceFolder | undefined>;
     $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes: string | false,
         maxResults: number | undefined, token: theia.CancellationToken): PromiseLike<UriComponents[]>;
-
+    $registerTextDocumentContentProvider(scheme: string): Promise<void>;
+    $unregisterTextDocumentContentProvider(scheme: string): void;
+    $onTextDocumentContentChange(uri: string, content: string): void;
 }
 
 export interface WorkspaceExt {
     $onWorkspaceFoldersChanged(event: theia.WorkspaceFoldersChangeEvent): void;
+    $provideTextDocumentContent(uri: string): Promise<string | undefined>;
 }
 
 export interface DialogsMain {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -42,6 +42,7 @@ import { UntitledResourceResolver } from './editor/untitled-resource';
 import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginContributionHandler } from './plugin-contribution-handler';
 import { ViewRegistry } from './view/view-registry';
+import { TextContentResourceResolver } from './workspace-main';
 
 export default new ContainerModule(bind => {
     bindHostedPluginPreferences(bind);
@@ -94,4 +95,7 @@ export default new ContainerModule(bind => {
     bind(MenusContributionPointHandler).toSelf().inSingletonScope();
 
     bind(PluginContributionHandler).toSelf().inSingletonScope();
+
+    bind(TextContentResourceResolver).toSelf().inSingletonScope();
+    bind(ResourceResolver).toService(TextContentResourceResolver);
 });

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as theia from '@theia/plugin';
-import { interfaces } from 'inversify';
+import { interfaces, injectable } from 'inversify';
 import { WorkspaceExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain } from '../../api/plugin-api';
 import { RPCProtocol } from '../../api/rpc-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -26,6 +26,9 @@ import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/br
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
 import { FileStat } from '@theia/filesystem/lib/common';
 import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
+import URI from '@theia/core/lib/common/uri';
+import { Resource } from '@theia/core/lib/common/resource';
+import { Emitter, Event, Disposable, ResourceResolver } from '@theia/core';
 
 export class WorkspaceMainImpl implements WorkspaceMain {
 
@@ -37,11 +40,14 @@ export class WorkspaceMainImpl implements WorkspaceMain {
 
     private roots: FileStat[];
 
+    private resourceResolver: TextContentResourceResolver;
+
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WORKSPACE_EXT);
         this.quickOpenService = container.get(MonacoQuickOpenService);
         const workspaceService = container.get(WorkspaceService);
         this.fileSearchService = container.get(FileSearchService);
+        this.resourceResolver = container.get(TextContentResourceResolver);
 
         workspaceService.roots.then(roots => {
             this.roots = roots;
@@ -131,15 +137,15 @@ export class WorkspaceMainImpl implements WorkspaceMain {
     }
 
     $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes?: string | false,
-                     maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
+        maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
         const uris: UriComponents[] = new Array();
         let j = 0;
         const promises: Promise<any>[] = new Array();
         for (const root of this.roots) {
-            promises[j++] = this.fileSearchService.find(includePattern, {rootUri: root.uri}).then(value => {
+            promises[j++] = this.fileSearchService.find(includePattern, { rootUri: root.uri }).then(value => {
                 const paths: string[] = new Array();
                 let i = 0;
-                value.forEach( item => {
+                value.forEach(item => {
                     let path: string;
                     path = root.uri.endsWith('/') ? root.uri + item : root.uri + '/' + item;
                     paths[i++] = path;
@@ -153,6 +159,126 @@ export class WorkspaceMainImpl implements WorkspaceMain {
                 uris[i++] = Uri.parse(path);
             });
             return Promise.resolve(uris);
-            });
+        });
     }
+
+    async $registerTextDocumentContentProvider(scheme: string): Promise<void> {
+        return this.resourceResolver.registerContentProvider(scheme, this.proxy);
+    }
+
+    $unregisterTextDocumentContentProvider(scheme: string): void {
+        this.resourceResolver.unregisterContentProvider(scheme);
+    }
+
+    $onTextDocumentContentChange(uri: string, content: string): void {
+        this.resourceResolver.onContentChange(uri, content);
+    }
+
+}
+
+/**
+ * Text content provider for resources with custom scheme.
+ */
+export interface TextContentResourceProvider {
+
+    /**
+     * Provides resource for given URI
+     */
+    provideResource(uri: URI): Resource;
+
+}
+
+@injectable()
+export class TextContentResourceResolver implements ResourceResolver {
+
+    // Resource providers for different schemes
+    private providers = new Map<string, TextContentResourceProvider>();
+
+    // Opened resources
+    private resources = new Map<string, TextContentResource>();
+
+    async resolve(uri: URI): Promise<Resource> {
+        const provider = this.providers.get(uri.scheme);
+        if (provider) {
+            return provider.provideResource(uri);
+        }
+
+        throw new Error(`Unable to find Text Content Resource Provider for scheme '${uri.scheme}'`);
+    }
+
+    async registerContentProvider(scheme: string, proxy: WorkspaceExt): Promise<void> {
+        if (this.providers.has(scheme)) {
+            throw new Error(`Text Content Resource Provider for scheme '${scheme}' is already registered`);
+        }
+
+        const instance = this;
+        this.providers.set(scheme, {
+            provideResource: (uri: URI): Resource => {
+                let resource = instance.resources.get(uri.toString());
+                if (resource) {
+                    return resource;
+                }
+
+                resource = new TextContentResource(uri, proxy, {
+                    dispose() {
+                        instance.resources.delete(uri.toString());
+                    }
+                });
+
+                instance.resources.set(uri.toString(), resource);
+                return resource;
+            }
+        });
+    }
+
+    unregisterContentProvider(scheme: string): void {
+        if (!this.providers.delete(scheme)) {
+            throw new Error(`Text Content Resource Provider for scheme '${scheme}' has not been registered`);
+        }
+    }
+
+    onContentChange(uri: string, content: string): void {
+        const resource = this.resources.get(uri);
+        if (resource) {
+            resource.setContent(content);
+        }
+    }
+
+}
+
+export class TextContentResource implements Resource {
+
+    private onDidChangeContentsEmmiter: Emitter<void> = new Emitter<void>();
+    readonly onDidChangeContents: Event<void> = this.onDidChangeContentsEmmiter.event;
+
+    // cached content
+    cache: string | undefined;
+
+    constructor(public uri: URI, private proxy: WorkspaceExt, protected disposable: Disposable) {
+    }
+
+    async readContents(options?: { encoding?: string }): Promise<string> {
+        if (this.cache) {
+            const content = this.cache;
+            this.cache = undefined;
+            return content;
+        } else {
+            const content = await this.proxy.$provideTextDocumentContent(this.uri.toString());
+            if (content) {
+                return content;
+            }
+        }
+
+        return Promise.reject(`Unable to get content for '${this.uri.toString()}'`);
+    }
+
+    dispose() {
+        this.disposable.dispose();
+    }
+
+    setContent(content: string) {
+        this.cache = content;
+        this.onDidChangeContentsEmmiter.fire(undefined);
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -29,6 +29,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
     }
+
     registerCommand(command: theia.Command, handler?: Handler): Disposable {
         if (this.commands.has(command.id)) {
             throw new Error(`Command ${command.id} already exist`);
@@ -68,7 +69,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     }
 
     // tslint:disable-next-line:no-any
-    executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
+    executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined> {
         if (this.commands.has(id)) {
             return this.executeLocalCommand(id, args);
         } else {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -112,7 +112,13 @@ export class QuickOpenExtImpl implements QuickOpenExt {
     showInput(options?: InputBoxOptions, token: CancellationToken = CancellationToken.None): PromiseLike<string | undefined> {
         this.validateInputHandler = options && options.validateInput;
 
-        const promise = this.proxy.$input(options!, typeof this.validateInputHandler === 'function');
+        if (!options) {
+            options = {
+                placeHolder: ''
+            };
+        }
+
+        const promise = this.proxy.$input(options, typeof this.validateInputHandler === 'function');
         return hookCancellationToken(token, promise);
     }
 

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -261,7 +261,8 @@ class TreeViewExtImpl<T> extends Disposable {
             const treeItem = await this.treeDataProvider.getTreeItem(cachedElement);
 
             if (treeItem.command) {
-                this.commandRegistry.executeCommand(treeItem.command.id, treeItem.command.arguments);
+                this.commandRegistry.executeCommand(treeItem.command.id, treeItem.command.arguments ?
+                    treeItem.command.arguments : []);
             }
         }
     }

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -14,12 +14,26 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFolderPickOptions, GlobPattern, FileSystemWatcher } from '@theia/plugin';
+import {
+    WorkspaceFolder,
+    WorkspaceFoldersChangeEvent,
+    WorkspaceFolderPickOptions,
+    GlobPattern,
+    FileSystemWatcher,
+    TextDocumentContentProvider,
+    Disposable
+} from '@theia/plugin';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
-import { WorkspaceExt, WorkspaceFolderPickOptionsMain, WorkspaceMain, PLUGIN_RPC_CONTEXT as Ext } from '../api/plugin-api';
+import {
+    WorkspaceExt,
+    WorkspaceFolderPickOptionsMain,
+    WorkspaceMain,
+    PLUGIN_RPC_CONTEXT as Ext
+} from '../api/plugin-api';
 import { Path } from '@theia/core/lib/common/path';
 import { RPCProtocol } from '../api/rpc-protocol';
+import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import URI from 'vscode-uri';
 
 export class WorkspaceExtImpl implements WorkspaceExt {
@@ -31,7 +45,9 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
     private folders: WorkspaceFolder[] | undefined;
 
-    constructor(rpc: RPCProtocol) {
+    private documentContentProviders = new Map<string, TextDocumentContentProvider>();
+
+    constructor(rpc: RPCProtocol, private editorsAndDocuments: EditorsAndDocumentsExtImpl) {
         this.proxy = rpc.getProxy(Ext.WORKSPACE_MAIN);
     }
 
@@ -66,7 +82,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     findFiles(include: GlobPattern, exclude?: GlobPattern | undefined, maxResults?: number,
-              token: CancellationToken = CancellationToken.None): PromiseLike<URI[]> {
+        token: CancellationToken = CancellationToken.None): PromiseLike<URI[]> {
         let includePattern: string;
         if (include) {
             if (typeof include === 'string') {
@@ -102,6 +118,50 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     createFileSystemWatcher(globPattern: GlobPattern, ignoreCreateEvents?: boolean, ignoreChangeEvents?: boolean, ignoreDeleteEvents?: boolean): FileSystemWatcher {
         // FIXME: to implement
         return new Proxy(<FileSystemWatcher>{}, {});
+    }
+
+    registerTextDocumentContentProvider(scheme: string, provider: TextDocumentContentProvider): Disposable {
+        if (scheme === 'file' || scheme === 'untitled' || this.documentContentProviders.has(scheme)) {
+            throw new Error(`Text Content Document Provider for scheme '${scheme}' is already registered`);
+        }
+
+        this.documentContentProviders.set(scheme, provider);
+        this.proxy.$registerTextDocumentContentProvider(scheme);
+
+        let onDidChangeSubscription: Disposable;
+        if (typeof provider.onDidChange === 'function') {
+            onDidChangeSubscription = provider.onDidChange(async uri => {
+                if (uri.scheme === scheme && this.editorsAndDocuments.getDocument(uri.toString())) {
+                    const content = await this.$provideTextDocumentContent(uri.toString());
+                    if (content) {
+                        this.proxy.$onTextDocumentContentChange(uri.toString(), content);
+                    }
+                }
+            });
+        }
+
+        const instance = this;
+        return {
+            dispose() {
+                if (instance.documentContentProviders.delete(scheme)) {
+                    instance.proxy.$unregisterTextDocumentContentProvider(scheme);
+                }
+
+                if (onDidChangeSubscription) {
+                    onDidChangeSubscription.dispose();
+                }
+            }
+        };
+    }
+
+    async $provideTextDocumentContent(documentURI: string): Promise<string | undefined> {
+        const uri = URI.parse(documentURI);
+        const provider = this.documentContentProviders.get(uri.scheme);
+        if (provider) {
+            return provider.provideTextDocumentContent(uri, CancellationToken.None);
+        }
+
+        return undefined;
     }
 
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1737,6 +1737,36 @@ declare module '@theia/plugin' {
         dispose(): void;
     }
 
+	/**
+	 * A text document content provider allows to add readonly documents
+	 * to the editor, such as source from a dll or generated html from md.
+	 *
+	 * Content providers are [registered](#workspace.registerTextDocumentContentProvider)
+	 * for a [uri-scheme](#Uri.scheme). When a uri with that scheme is to
+	 * be [loaded](#workspace.openTextDocument) the content provider is
+	 * asked.
+	 */
+    export interface TextDocumentContentProvider {
+
+		/**
+		 * An event to signal a resource has changed.
+		 */
+        onDidChange?: Event<Uri>;
+
+		/**
+		 * Provide textual content for a given uri.
+		 *
+		 * The editor will use the returned string-content to create a readonly
+		 * [document](#TextDocument). Resources allocated should be released when
+		 * the corresponding document has been [closed](#workspace.onDidCloseTextDocument).
+		 *
+		 * @param uri An uri which scheme matches the scheme this provider was [registered](#workspace.registerTextDocumentContentProvider) for.
+		 * @param token A cancellation token.
+		 * @return A string or a thenable that resolves to such.
+		 */
+        provideTextDocumentContent(uri: Uri, token: CancellationToken): ProviderResult<string>;
+    }
+
     /**
      * Something that can be selected from a list of items.
      */
@@ -3232,6 +3262,17 @@ declare module '@theia/plugin' {
          * @readonly
          */
         export let textDocuments: TextDocument[];
+
+		/**
+		 * Register a text document content provider.
+		 *
+		 * Only one provider can be registered per scheme.
+		 *
+		 * @param scheme The uri-scheme to register for.
+		 * @param provider A content provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+        export function registerTextDocumentContentProvider(scheme: string, provider: TextDocumentContentProvider): Disposable;
 
         /**
          * An event that is emitted when a [text document](#TextDocument) is opened.


### PR DESCRIPTION
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Implementation of plugin API which allows to register additional Text Content Providers for resources with different schemes and open resources with those custom schemes.

Theia issue https://github.com/theia-ide/theia/issues/2786

VS Code plugin API https://code.visualstudio.com/docs/extensionAPI/vscode-api#_workspace

[PR](https://github.com/eclipse/che-theia-samples/pull/13) with [tree-view-sample](https://github.com/eclipse/che-theia-samples/tree/master/tree-view-sample-plugin) plugin which allows to browse FTP repository and open files will be merged after merging this PR.

![openftpresource](https://user-images.githubusercontent.com/1655894/47920292-5ff56080-deba-11e8-895f-a46128f87cdf.gif)

Few words about `registerTextModelContentProvider` method of `MonacoTextModelService`.
I tried to use this method (as it described in the interface for the same solution) but faced problems with creating and using `monaco.editor.IModel`. Then it decided to add an interface `TextContentResourceProvider` and provide a simple `Resource` for the `MonacoEditorModel`.
