### PR TITLE
[plug-in] languages.registerCodeLensProvider API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.3.17
+- [plug-in] added `languages.registerCodeLensProvider` Plug-in API
+
+
 ## v0.3.16
 - [plug-in] added `DocumentLinkProvider` Plug-in API
 - [plug-in] Terminal.sendText API adds a new line to the text being sent to the terminal if `addNewLine` parameter wasn't specified

--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -236,6 +236,12 @@ export interface DocumentLinkProvider {
     resolveLink?: (link: DocumentLink, token: monaco.CancellationToken) => DocumentLink | PromiseLike<DocumentLink[]>;
 }
 
+export interface CodeLensSymbol {
+    range: Range;
+    id?: string;
+    command?: Command;
+}
+
 export interface CodeAction {
     title: string;
     command?: Command;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -40,6 +40,7 @@ import {
     Definition,
     DefinitionLink,
     DocumentLink,
+    CodeLensSymbol,
     Command,
     TextEdit
 } from './model';
@@ -740,6 +741,8 @@ export interface LanguagesExt {
     ): Promise<ModelSingleEditOperation[] | undefined>;
     $provideDocumentLinks(handle: number, resource: UriComponents): Promise<DocumentLink[] | undefined>;
     $resolveDocumentLink(handle: number, link: DocumentLink): Promise<DocumentLink | undefined>;
+    $provideCodeLenses(handle: number, resource: UriComponents): Promise<CodeLensSymbol[] | undefined>;
+    $resolveCodeLens(handle: number, resource: UriComponents, symbol: CodeLensSymbol): Promise<CodeLensSymbol | undefined>;
     $provideCodeActions(
         handle: number,
         resource: UriComponents,
@@ -763,6 +766,8 @@ export interface LanguagesMain {
     $registerRangeFormattingProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerOnTypeFormattingProvider(handle: number, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;
     $registerDocumentLinkProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+    $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle?: number): void;
+    $emitCodeLensEvent(eventHandle: number, event?: any): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -28,7 +28,7 @@ import { fromLanguageSelector } from '../../plugin/type-converters';
 import { UriComponents } from '../../common/uri-components';
 import { LanguageSelector } from '../../plugin/languages';
 import { DocumentFilter, MonacoModelIdentifier, testGlob, getLanguages } from 'monaco-languageclient/lib';
-import { DisposableCollection } from '@theia/core';
+import { DisposableCollection, Emitter } from '@theia/core';
 
 export class LanguagesMainImpl implements LanguagesMain {
 
@@ -177,6 +177,42 @@ export class LanguagesMainImpl implements LanguagesMain {
             resolveLink: (link: monaco.languages.ILink, token) =>
                 this.proxy.$resolveDocumentLink(handle, link).then(v => v!)
         };
+    }
+
+    $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle: number): void {
+        const languageSelector = fromLanguageSelector(selector);
+        const lensProvider = this.createCodeLensProvider(handle, languageSelector);
+
+        if (typeof eventHandle === 'number') {
+            const emitter = new Emitter<monaco.languages.CodeLensProvider>();
+            this.disposables.set(eventHandle, emitter);
+            lensProvider.onDidChange = emitter.event;
+        }
+
+        const disposable = new DisposableCollection();
+        for (const language of getLanguages()) {
+            if (this.matchLanguage(languageSelector, language)) {
+                disposable.push(monaco.languages.registerCodeLensProvider(language, lensProvider));
+            }
+        }
+        this.disposables.set(handle, disposable);
+    }
+
+    protected createCodeLensProvider(handle: number, selector: LanguageSelector | undefined): monaco.languages.CodeLensProvider {
+        return {
+            provideCodeLenses: (model, token) =>
+                this.proxy.$provideCodeLenses(handle, model.uri).then(v => v!)
+            ,
+            resolveCodeLens: (model, codeLens, token) =>
+                this.proxy.$resolveCodeLens(handle, model.uri, codeLens).then(v => v!)
+        };
+    }
+
+    $emitCodeLensEvent(eventHandle: number, event?: any): void {
+        const obj = this.disposables.get(eventHandle);
+        if (obj instanceof Emitter) {
+            obj.fire(event);
+        }
     }
 
     protected createDefinitionProvider(handle: number, selector: LanguageSelector | undefined): monaco.languages.DefinitionProvider {

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -1,0 +1,83 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri/lib/umd';
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import { CodeLensSymbol } from '../../api/model';
+import * as Converter from '../type-converters';
+import { ObjectIdentifier } from '../../common/object-identifier';
+import { createToken } from '../token-provider';
+import { CommandsConverter } from '../command-registry';
+
+/** Adapts the calls from main to extension thread for providing/resolving the code lenses. */
+export class CodeLensAdapter {
+
+	private static readonly BAD_CMD: theia.Command = { id: 'missing', label: '<<MISSING COMMAND>>' };
+
+	private cacheId = 0;
+	private cache = new Map<number, theia.CodeLens>();
+
+	constructor(
+		private readonly provider: theia.CodeLensProvider,
+		private readonly documents: DocumentsExtImpl,
+		private readonly commands: CommandsConverter
+	) { }
+
+	provideCodeLenses(resource: URI): Promise<CodeLensSymbol[] | undefined> {
+		const document = this.documents.getDocumentData(resource);
+		if (!document) {
+			return Promise.reject(new Error(`There is no document for ${resource}`));
+		}
+
+		const doc = document.document;
+
+		return Promise.resolve(this.provider.provideCodeLenses(doc, createToken())).then(lenses => {
+			if (Array.isArray(lenses)) {
+				return lenses.map(lens => {
+					const id = this.cacheId++;
+					const lensSymbol = ObjectIdentifier.mixin({
+						range: Converter.fromRange(lens.range)!,
+						command: this.commands.toInternal(lens.command)
+					}, id);
+					this.cache.set(id, lens);
+					return lensSymbol;
+				});
+			}
+			return undefined;
+		});
+	}
+
+	resolveCodeLens(resource: URI, symbol: CodeLensSymbol): Promise<CodeLensSymbol | undefined> {
+		const lens = this.cache.get(ObjectIdentifier.of(symbol));
+		if (!lens) {
+			return Promise.resolve(undefined);
+		}
+
+		let resolve: Promise<theia.CodeLens | undefined>;
+		if (typeof this.provider.resolveCodeLens !== 'function' || lens.isResolved) {
+			resolve = Promise.resolve(lens);
+		} else {
+			resolve = Promise.resolve(this.provider.resolveCodeLens(lens, createToken()));
+		}
+
+		return resolve.then(newLens => {
+			newLens = newLens || lens;
+			symbol.command = this.commands.toInternal(newLens.command || CodeLensAdapter.BAD_CMD);
+			return symbol;
+		});
+	}
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -107,7 +107,7 @@ export function createAPIFactory(
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = new OutputChannelRegistryExt(rpc);
-    const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents));
+    const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
 
     return function (plugin: InternalPlugin): typeof theia {

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -533,7 +533,26 @@ const disposable = theia.languages.registerDocumentLinkProvider(documentsSelecto
 
 ...
 
-function provideLinks(document: theia.TextDocument): theia.ProviderResult<theia.DocumentLink> {
+function provideLinks(document: theia.TextDocument): theia.ProviderResult<theia.DocumentLink[]> {
+    // code here
+}
+```
+
+#### Code Lens Provider
+
+A code lens provider allows to add a custom lens detection logic.
+
+Example of code lens provider registration:
+
+```typescript
+const documentsSelector: theia.DocumentSelector = { scheme: 'file', language: 'typescript' };
+const provider = { provideCodeLenses: provideLenses };
+
+const disposable = theia.languages.registerCodeLensProvider(documentsSelector, provider);
+
+...
+
+function provideLenses(document: theia.TextDocument): theia.ProviderResult<theia.CodeLens[]> {
     // code here
 }
 ```


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>
Closes https://github.com/theia-ide/theia/issues/3199
This PR adds the `languages.registerCodeLensProvider` Plug-in API.
Related PR with the sample Plug-in https://github.com/eclipse/che-theia-samples/pull/14
It's needed for https://github.com/eclipse/che/issues/10574