### PR TITLE
Fix Windows drive root conversion

### DIFF
--- a/packages/core/src/node/file-uri.spec.ts
+++ b/packages/core/src/node/file-uri.spec.ts
@@ -18,6 +18,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as chai from 'chai';
 import { FileUri } from './file-uri';
+import { isWindows } from '../common/os';
 
 const expect = chai.expect;
 
@@ -64,4 +65,12 @@ describe('file-uri', () => {
         expect(uri.toString(true)).to.be.equal('file:///c:/');
     });
 
+    it('from file:///c%3A', function () {
+        if (!isWindows) {
+            this.skip();
+            return;
+        }
+        const fsPath = FileUri.fsPath('file:///c%3A');
+        expect(fsPath).to.be.equal('c:\\');
+    });
 });

--- a/packages/core/src/node/logger-cli-contribution.spec.ts
+++ b/packages/core/src/node/logger-cli-contribution.spec.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as yargs from 'yargs';
 import * as temp from 'temp';
 import * as fs from 'fs';
@@ -26,42 +26,39 @@ import * as sinon from 'sinon';
 // Allow creating temporary files, but remove them when we are done.
 const track = temp.track();
 
-const expect = chai.expect;
-
 let cli: LogLevelCliContribution;
-
 let consoleErrorSpy: sinon.SinonSpy;
 
-beforeEach(function() {
-    const container = new Container();
+describe('log-level-cli-contribution', () => {
 
-    const module = new ContainerModule(bind => {
-        bind(LogLevelCliContribution).toSelf().inSingletonScope();
+    beforeEach(() => {
+        const container = new Container();
+
+        const module = new ContainerModule(bind => {
+            bind(LogLevelCliContribution).toSelf().inSingletonScope();
+        });
+
+        container.load(module);
+
+        cli = container.get(LogLevelCliContribution);
+        yargs.reset();
+        cli.configure(yargs);
+
+        consoleErrorSpy = sinon.spy(console, 'error');
     });
 
-    container.load(module);
+    afterEach(() => {
+        consoleErrorSpy.restore();
+    });
 
-    cli = container.get(LogLevelCliContribution);
-    yargs.reset();
-    cli.configure(yargs);
-
-    consoleErrorSpy = sinon.spy(console, 'error');
-});
-
-afterEach(function() {
-    consoleErrorSpy.restore();
-});
-
-describe('log-level-cli-contribution', function() {
-
-    it('should use --log-level flag', async function() {
+    it('should use --log-level flag', async () => {
         const args: yargs.Arguments = yargs.parse(['--log-level=debug']);
         await cli.setArguments(args);
 
         expect(cli.defaultLogLevel).eq(LogLevel.DEBUG);
     });
 
-    it('should read json config file', async function() {
+    it('should read json config file', async () => {
         const file = track.openSync();
         fs.writeFileSync(file.fd, JSON.stringify({
             defaultLevel: 'info',
@@ -83,7 +80,7 @@ describe('log-level-cli-contribution', function() {
         });
     });
 
-    it('should use info as default log level', async function() {
+    it('should use info as default log level', async () => {
         const args: yargs.Arguments = yargs.parse([]);
         await cli.setArguments(args);
 
@@ -91,7 +88,7 @@ describe('log-level-cli-contribution', function() {
         expect(cli.logLevels).eql({});
     });
 
-    it('should reject wrong default log level', async function() {
+    it('should reject wrong default log level', async () => {
         const file = track.openSync();
         fs.writeFileSync(file.fd, JSON.stringify({
             defaultLevel: 'potato',
@@ -106,7 +103,7 @@ describe('log-level-cli-contribution', function() {
         sinon.assert.calledWithMatch(consoleErrorSpy, 'Unknown default log level in');
     });
 
-    it('should reject wrong logger log level', async function() {
+    it('should reject wrong logger log level', async () => {
         const file = track.openSync();
         fs.writeFileSync(file.fd, JSON.stringify({
             defaultLevel: 'info',
@@ -121,13 +118,13 @@ describe('log-level-cli-contribution', function() {
         sinon.assert.calledWithMatch(consoleErrorSpy, 'Unknown log level for logger hello in');
     });
 
-    it('should reject nonexistent config files', async function() {
+    it('should reject nonexistent config files', async () => {
         const args: yargs.Arguments = yargs.parse(['--log-config', '/tmp/cacaca']);
         await cli.setArguments(args);
         sinon.assert.calledWithMatch(consoleErrorSpy, 'no such file or directory');
     });
 
-    it('should reject config file with invalid JSON', async function() {
+    it('should reject config file with invalid JSON', async () => {
         const file = track.openSync();
         const text = JSON.stringify({
             defaultLevel: 'info',
@@ -148,7 +145,7 @@ describe('log-level-cli-contribution', function() {
     // 4) in parallel for a few minutes without failure:
     //
     //  $ while ./node_modules/.bin/mocha --opts configs/mocha.opts packages/core/lib/node/logger-cli-contribution.spec.js  --grep watch; do true; done
-    it.skip('should watch the config file', async function() {
+    it.skip('should watch the config file', async () => {
         let filename: string;
         {
             const file = track.openSync();
@@ -199,7 +196,7 @@ describe('log-level-cli-contribution', function() {
         });
     });
 
-    it('should keep original levels when changing the log levels file with a broken one', async function() {
+    it('should keep original levels when changing the log levels file with a broken one', async function () {
         this.timeout(5000);
 
         const file = track.openSync();


### PR DESCRIPTION
Signed-off-by: Nigel Westbury <nigel.westbury@arm.com>

I believe this is the fix to the issue in  GH-663.  I am surprised that this has remained open for so long, as for me I can never get the list of files for the root of my c: drive, for the reason detailed in https://github.com/theia-ide/theia/issues/663.  This fixes the problem for me and it has been tested in examples/browser.