### PR TITLE
[debug] fix #3416: terminate debuggee properly

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -482,7 +482,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             execute: () => this.start(true)
         });
         registry.registerCommand(DebugCommands.STOP, {
-            execute: () => this.manager.currentSession && this.manager.currentSession.disconnect(),
+            execute: () => this.manager.currentSession && this.manager.currentSession.terminate(),
             isEnabled: () => this.manager.state !== DebugState.Inactive
         });
         registry.registerCommand(DebugCommands.RESTART, {
@@ -558,7 +558,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
 
         registry.registerCommand(DebugSessionContextCommands.STOP, {
-            execute: () => this.selectedSession && this.selectedSession.disconnect(),
+            execute: () => this.selectedSession && this.selectedSession.terminate(),
             isEnabled: () => !!this.selectedSession && this.selectedSession.state !== DebugState.Inactive,
             isVisible: () => !this.selectedThread
         });

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -81,7 +81,7 @@ export class DebugToolBar extends ReactWidget {
 
     protected start = () => this.model.start();
     protected restart = () => this.model.restart();
-    protected stop = () => this.model.currentSession && this.model.currentSession.disconnect();
+    protected stop = () => this.model.currentSession && this.model.currentSession.terminate();
     protected continue = () => this.model.currentThread && this.model.currentThread.continue();
     protected pause = () => this.model.currentThread && this.model.currentThread.pause();
     protected stepOver = () => this.model.currentThread && this.model.currentThread.stepOver();

--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -23,7 +23,7 @@
 
 import * as net from 'net';
 import { injectable, inject } from 'inversify';
-import { DisposableCollection } from '@theia/core';
+import { Disposable, DisposableCollection } from '@theia/core';
 import {
     RawProcessFactory,
     ProcessManager,
@@ -94,7 +94,11 @@ export class DebugAdapterSessionImpl implements DebugAdapterSession {
     ) {
         this.contentLength = -1;
         this.buffer = new Buffer(0);
-        this.toDispose.push(this.communicationProvider);
+        this.toDispose.pushAll([
+            this.communicationProvider,
+            Disposable.create(() => this.write(JSON.stringify({ seq: -1, type: 'request', command: 'disconnect' }))),
+            Disposable.create(() => this.write(JSON.stringify({ seq: -1, type: 'request', command: 'terminate' })))
+        ]);
     }
 
     async start(channel: WebSocketChannel): Promise<void> {


### PR DESCRIPTION
There are 3 cases to consider:
- a session is stopped by a user via UI
- a session is restarted by a user via UI
- a session is stopped by page reload

In all cases, there should not be dangling processes. One can test in Theia repo with `Launch Backend` configuration.