### PR TITLE
Define separate style for disabled secondary button

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -147,6 +147,11 @@ button[disabled], .theia-button[disabled] {
   cursor: default;
 }
 
+button.secondary[disabled], .theia-button.secondary[disabled] {
+    color: var(--theia-ui-button-font-color-secondary-disabled);
+    background-color: var(--theia-ui-button-color-secondary-disabled);
+}
+
 .p-Widget select {
     color: var(--theia-ui-font-color1);
     font-size: var(--theia-ui-font-size1);

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -207,8 +207,10 @@ is not optimized for dense, information rich UIs.
   --theia-ui-button-color-secondary: var(--theia-secondary-brand-color1);
   --theia-ui-button-color-secondary-hover: var(--theia-secondary-brand-color0);
   --theia-ui-button-font-color-secondary: var(--theia-inverse-ui-font-color0);
-  --theia-ui-button-color-disabled: var(--theia-disabled-color1);
+  --theia-ui-button-color-disabled: var(--theia-accent-color3);
   --theia-ui-button-font-color-disabled: var(--theia-ui-font-color2);
+  --theia-ui-button-color-secondary-disabled: var(--theia-disabled-color1);
+  --theia-ui-button-font-color-secondary-disabled: var(--theia-ui-font-color2);
 
   /* Expand/collapse element */
   --theia-ui-expand-button-color: var(--theia-accent-color4);

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -209,6 +209,8 @@ is not optimized for dense, information rich UIs.
   --theia-ui-button-font-color-secondary: var(--theia-ui-font-color1);
   --theia-ui-button-color-disabled: var(--theia-accent-color3);
   --theia-ui-button-font-color-disabled: var(--theia-ui-font-color2);
+  --theia-ui-button-color-secondary-disabled: var(--theia-disabled-color0);
+  --theia-ui-button-font-color-secondary-disabled: var(--theia-ui-font-color2);
 
   /* Expand/collapse element */
   --theia-ui-expand-button-color: black;


### PR DESCRIPTION
* add separate "useable" CSS variables for disabled secondary button
* add style for secondary disabled buttons in dark and bright themes
* change color of disabled "main" button for bright theme

See #3430

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
