### PR TITLE
Create container views to support source control other than Git

### DIFF
--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -40,6 +40,7 @@ import { GitCommitMessageValidator } from './git-commit-message-validator';
 import { GitSyncService } from './git-sync-service';
 import { GitErrorHandler } from './git-error-handler';
 import { NoScmWidget } from './no-scm-widget';
+import { bindContributionProvider } from '@theia/core/lib/common';
 
 import '../../src/browser/style/index.css';
 
@@ -71,9 +72,12 @@ export default new ContainerModule(bind => {
         id: GIT_WIDGET_FACTORY_ID,
         createWidget: () => context.container.get<GitWidget>(GitWidget)
     })).inSingletonScope();
-    bind(ScmWidgetFactory).toDynamicValue(
-        context => context.container.get<GitWidgetFactory>(GitWidgetFactory)
-    ).inSingletonScope();
+    // bind(ScmWidgetFactory).toDynamicValue(
+    //     context => context.container.get<GitWidgetFactory>(GitWidgetFactory)
+    // ).inSingletonScope();
+    bindContributionProvider(bind, ScmWidgetFactory);
+    bind(GitWidgetFactory).to(GitWidgetFactory).inSingletonScope();
+    bind(ScmWidgetFactory).to(GitWidgetFactory);
 
     bind(NoScmWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -20,9 +20,12 @@ import { WebSocketConnectionProvider, WidgetFactory, bindViewContribution, Label
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser';
 import { Git, GitPath, GitWatcher, GitWatcherPath, GitWatcherServer, GitWatcherServerProxy, ReconnectingGitWatcherServer } from '../common';
-import { GitViewContribution, GIT_WIDGET_FACTORY_ID } from './git-view-contribution';
+import { GitViewContribution, SCM_WIDGET_FACTORY_ID, NO_SCM_WIDGET_FACTORY_ID } from './git-view-contribution';
 import { bindGitDiffModule } from './diff/git-diff-frontend-module';
 import { bindGitHistoryModule } from './history/git-history-frontend-module';
+import { ScmContainerWidget } from './scm-container-widget';
+import { ScmWidgetFactory, GIT_WIDGET_FACTORY_ID } from '.';
+import { GitWidgetFactory } from './git-widget-factory';
 import { GitWidget } from './git-widget';
 import { GitResourceResolver } from './git-resource';
 import { GitRepositoryProvider } from './git-repository-provider';
@@ -36,6 +39,7 @@ import { GitRepositoryTracker } from './git-repository-tracker';
 import { GitCommitMessageValidator } from './git-commit-message-validator';
 import { GitSyncService } from './git-sync-service';
 import { GitErrorHandler } from './git-error-handler';
+import { NoScmWidget } from './no-scm-widget';
 
 import '../../src/browser/style/index.css';
 
@@ -55,10 +59,26 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(GitViewContribution);
     bind(TabBarToolbarContribution).toService(GitViewContribution);
 
+    bind(ScmContainerWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(context => ({
+        id: SCM_WIDGET_FACTORY_ID,
+        createWidget: () => context.container.get<ScmContainerWidget>(ScmContainerWidget)
+    })).inSingletonScope();
+
+    bind(GitWidgetFactory).toSelf().inSingletonScope();
     bind(GitWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({
         id: GIT_WIDGET_FACTORY_ID,
         createWidget: () => context.container.get<GitWidget>(GitWidget)
+    })).inSingletonScope();
+    bind(ScmWidgetFactory).toDynamicValue(
+        context => context.container.get<GitWidgetFactory>(GitWidgetFactory)
+    ).inSingletonScope();
+
+    bind(NoScmWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(context => ({
+        id: NO_SCM_WIDGET_FACTORY_ID,
+        createWidget: () => context.container.get<NoScmWidget>(NoScmWidget)
     })).inSingletonScope();
 
     bind(GitResourceResolver).toSelf().inSingletonScope();

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable, inject, multiInject } from 'inversify';
+import { injectable, inject, named } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { DisposableCollection, CommandRegistry, MenuModelRegistry, CommandContribution, MenuContribution, Command } from '@theia/core';
 import {
@@ -21,6 +21,7 @@ import {
     FrontendApplicationContribution, FrontendApplication, Widget
 } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { ContributionProvider } from '@theia/core';
 import { EditorManager, EditorWidget, EditorOpenerOptions, EditorContextMenu, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { GitFileChange, GitFileStatus } from '../common';
 import { ScmWidgetFactory } from './index';
@@ -128,10 +129,13 @@ export class GitViewContribution extends AbstractViewContribution<ScmContainerWi
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(GitPrompt) protected readonly prompt: GitPrompt;
 
-    constructor(@multiInject(ScmWidgetFactory) scmWidgetFactories: ScmWidgetFactory[]) {
+    constructor(
+        @inject(ContributionProvider) @named(ScmWidgetFactory)
+        protected readonly scmWidgetFactories: ContributionProvider<ScmWidgetFactory>
+    ) {
         super({
             widgetId: SCM_WIDGET_FACTORY_ID,
-            widgetName: scmWidgetFactories.length === 1 ? scmWidgetFactories[0].label : 'Source Control',
+            widgetName: scmWidgetFactories.getContributions().length === 1 ? scmWidgetFactories.getContributions()[0].label : 'Source Control',
             defaultWidgetOptions: {
                 area: 'left',
                 rank: 200

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -295,7 +295,7 @@ export class GitViewContribution extends AbstractViewContribution<ScmContainerWi
         });
         registry.registerCommand(GIT_COMMANDS.STAGE_ALL, {
             execute: async () => {
-                const widget = this.tryGetWidget();
+                const widget = this.tryGetGitWidget();
                 if (!!widget) {
                     widget.stageAll();
                 }
@@ -304,7 +304,7 @@ export class GitViewContribution extends AbstractViewContribution<ScmContainerWi
         });
         registry.registerCommand(GIT_COMMANDS.UNSTAGE_ALL, {
             execute: async () => {
-                const widget = this.tryGetWidget();
+                const widget = this.tryGetGitWidget();
                 if (!!widget) {
                     widget.unstageAll();
                 }
@@ -313,7 +313,7 @@ export class GitViewContribution extends AbstractViewContribution<ScmContainerWi
         });
         registry.registerCommand(GIT_COMMANDS.DISCARD_ALL, {
             execute: async () => {
-                const widget = this.tryGetWidget();
+                const widget = this.tryGetGitWidget();
                 if (!!widget) {
                     widget.discardAll();
                 }

--- a/packages/git/src/browser/git-widget-factory.ts
+++ b/packages/git/src/browser/git-widget-factory.ts
@@ -26,9 +26,9 @@ export class GitWidgetFactory implements ScmWidgetFactory {
     public label = 'Git';
     public widgetId = GIT_WIDGET_FACTORY_ID;
 
-    constructor(
-        @inject(Git) protected readonly git: Git,
-        ) {
+    @inject(Git) protected readonly git: Git;
+
+    constructor() {
     }
 
     isUnderSourceControl(directoryFileStat: FileStat): boolean {

--- a/packages/git/src/browser/git-widget-factory.ts
+++ b/packages/git/src/browser/git-widget-factory.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { Git, Repository } from '../common';
+import { ScmWidgetFactory } from '.';
+import { FileStat } from '@theia/filesystem/lib/common';
+import { GIT_WIDGET_FACTORY_ID } from '.';
+
+@injectable()
+export class GitWidgetFactory implements ScmWidgetFactory {
+
+    public label = 'Git';
+    public widgetId = GIT_WIDGET_FACTORY_ID;
+
+    constructor(
+        @inject(Git) protected readonly git: Git,
+        ) {
+    }
+
+    isUnderSourceControl(directoryFileStat: FileStat): boolean {
+        if (directoryFileStat.children === undefined) {
+            return false;
+        }
+        return directoryFileStat.children
+            .filter(f => f.isDirectory)
+            .map(f => f.uri.split('/').pop())
+            .some(f => f === '.git');
+    }
+
+    repositories(workspaceRootUri: string, options: Git.Options.Repositories): Promise<Repository[]> {
+        return this.git.repositories(workspaceRootUri, options);
+    }
+}

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -80,6 +80,7 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
         this.title.iconClass = 'fa git-tab-icon';
         this.scrollContainer = GitWidget.Styles.CHANGES_CONTAINER;
         this.addClass('theia-git');
+        this.addClass('singletonFill');
         this.node.tabIndex = 0;
     }
 

--- a/packages/git/src/browser/index.ts
+++ b/packages/git/src/browser/index.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { FileStat } from '@theia/filesystem/lib/common';
+import { Git, Repository } from '../common';
+
+export const ScmWidgetFactory = Symbol('ScmWidgetFactory');
+
+export const GIT_WIDGET_FACTORY_ID = 'git';
+
+export interface ScmWidgetFactory {
+    readonly label: string;
+    readonly widgetId: string;
+
+    /**
+     * Given a directory FileStat populated with its children, determine if this is a repository
+     * of appropriate type.
+     *
+     * @param fileStat
+     */
+    isUnderSourceControl(fileStat: FileStat): boolean;
+
+    /**
+     * Resolves to an array of repositories discovered in the workspace given with the workspace root URI.
+     */
+    repositories(workspaceRootUri: string, options: Git.Options.Repositories): Promise<Repository[]>;
+}

--- a/packages/git/src/browser/no-scm-widget.tsx
+++ b/packages/git/src/browser/no-scm-widget.tsx
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, multiInject, postConstruct } from 'inversify';
+import { GitRepositoryProvider } from './git-repository-provider';
+import { ScmWidgetFactory } from './index';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import * as React from 'react';
+
+@injectable()
+export abstract class NoScmWidget extends ReactWidget {
+
+    @inject(GitRepositoryProvider)
+    protected readonly repositoryProvider: GitRepositoryProvider;
+
+    constructor(
+        @multiInject(ScmWidgetFactory) public readonly scmWidgetFactories: ScmWidgetFactory[],
+    ) {
+        super();
+        this.node.tabIndex = 0;
+    }
+
+    @postConstruct()
+    protected init() {
+        this.toDispose.push(this.repositoryProvider.onDidChangeRepository(repository =>
+            this.update()
+        ));
+        this.update();
+    }
+
+    protected render(): React.ReactNode {
+        const repository = this.repositoryProvider.selectedRepository;
+        if (repository) {
+            return <div className={NoScmWidget.Styles.MAIN_CONTAINER}>
+                The repository at {repository.localUri} is not under control of a supported Source Control Manager.
+            {
+                    this.scmWidgetFactories.length === 0
+                        ? <div>No Source Control Managers are supported by this product</div>
+                        : this.scmWidgetFactories.length === 1
+                            ? <div>Only {this.scmWidgetFactories[0].widgetId} is supported.</div>
+                            : <div>The supported Source Control Managers are {this.renderList()}.</div>
+                }
+            </div>;
+        } else {
+            return <div className={NoScmWidget.Styles.MAIN_CONTAINER}>
+                Select a repository that is under source control to see details here.
+        </div>;
+        }
+    }
+
+    protected renderList(): React.ReactNode {
+        let text = this.scmWidgetFactories[0].widgetId + ', and ' + this.scmWidgetFactories[1].widgetId;
+        const theRest = this.scmWidgetFactories.slice(2);
+        for (const factory of theRest) {
+            text = factory.widgetId + ', '  + text;
+        }
+        return <div>
+            {text}
+        </div>;
+    }
+}
+
+export namespace NoScmWidget {
+    export namespace Styles {
+        export const MAIN_CONTAINER = 'theia-git-main-container';
+    }
+
+}

--- a/packages/git/src/browser/scm-container-widget.ts
+++ b/packages/git/src/browser/scm-container-widget.ts
@@ -14,10 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject, multiInject, postConstruct } from 'inversify';
+import { injectable, inject, named, postConstruct } from 'inversify';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { Repository } from '../common';
 import { GitRepositoryProvider } from './git-repository-provider';
+import { ContributionProvider } from '@theia/core';
 import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
 import { GitErrorHandler } from './git-error-handler';
 import { SingletonLayout } from '@phosphor/widgets/lib/singletonlayout';
@@ -36,20 +37,27 @@ export class ScmContainerWidget extends BaseWidget {
 
     protected singletonLayout: SingletonLayout;
 
-    constructor(
-        @multiInject(ScmWidgetFactory) public readonly scmWidgetFactories: ScmWidgetFactory[],
-        @inject(WidgetManager) protected widgetManager: WidgetManager,
-        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
-        @inject(FileSystem) protected readonly fileSystem: FileSystem,
-    ) {
+    @inject(ContributionProvider)
+    @named(ScmWidgetFactory)
+    protected readonly scmWidgetFactories: ContributionProvider<ScmWidgetFactory>;
 
+    @inject(WidgetManager)
+    protected widgetManager: WidgetManager;
+
+    @inject(GitRepositoryProvider)
+    protected readonly repositoryProvider: GitRepositoryProvider;
+
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+
+    constructor() {
         super();
         this.id = 'theia-gitContainer';
         this.addClass('theia-git');
         this.node.tabIndex = 0;
         this.singletonLayout = new SingletonLayout();
-        if (scmWidgetFactories.length === 1) {
-            const theOnlyWidgetId = scmWidgetFactories[0].widgetId;
+        if (this.scmWidgetFactories.getContributions().length === 1) {
+            const theOnlyWidgetId = this.scmWidgetFactories.getContributions()[0].widgetId;
             this.widgetManager.getOrCreateWidget(theOnlyWidgetId).then(widget => {
                 this.title.label = widget.title.label;
                 this.title.caption = widget.title.caption;
@@ -80,7 +88,7 @@ export class ScmContainerWidget extends BaseWidget {
 
     protected async getWidgetIdForRepository(repository: Repository | undefined): Promise<string> {
         if (repository) {
-            for (const factory of this.scmWidgetFactories) {
+            for (const factory of this.scmWidgetFactories.getContributions()) {
                 const fileStat = await this.fileSystem.getFileStat(repository.localUri);
                 if (fileStat) {
                     if (factory.isUnderSourceControl(fileStat)) {

--- a/packages/git/src/browser/scm-container-widget.ts
+++ b/packages/git/src/browser/scm-container-widget.ts
@@ -1,0 +1,94 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, multiInject, postConstruct } from 'inversify';
+import { EditorManager } from '@theia/editor/lib/browser';
+import { Repository } from '../common';
+import { GitRepositoryProvider } from './git-repository-provider';
+import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
+import { GitErrorHandler } from './git-error-handler';
+import { SingletonLayout } from '@phosphor/widgets/lib/singletonlayout';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
+import { ScmWidgetFactory } from './index';
+
+@injectable()
+export class ScmContainerWidget extends BaseWidget {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(GitErrorHandler)
+    protected readonly gitErrorHandler: GitErrorHandler;
+
+    protected singletonLayout: SingletonLayout;
+
+    constructor(
+        @multiInject(ScmWidgetFactory) public readonly scmWidgetFactories: ScmWidgetFactory[],
+        @inject(WidgetManager) protected widgetManager: WidgetManager,
+        @inject(GitRepositoryProvider) protected readonly repositoryProvider: GitRepositoryProvider,
+        @inject(FileSystem) protected readonly fileSystem: FileSystem,
+    ) {
+
+        super();
+        this.id = 'theia-gitContainer';
+        this.addClass('theia-git');
+        this.node.tabIndex = 0;
+        this.singletonLayout = new SingletonLayout();
+        if (scmWidgetFactories.length === 1) {
+            const theOnlyWidgetId = scmWidgetFactories[0].widgetId;
+            this.widgetManager.getOrCreateWidget(theOnlyWidgetId).then(widget => {
+                this.title.label = widget.title.label;
+                this.title.caption = widget.title.caption;
+                this.title.iconClass = widget.title.iconClass;
+            });
+        } else {
+            this.title.label = 'SCM';
+            this.title.caption = 'SCM';
+            this.title.iconClass = 'fa git-tab-icon';
+        }
+        this.layout = this.singletonLayout;
+    }
+
+    @postConstruct()
+    protected init() {
+        this.toDispose.push(this.repositoryProvider.onDidChangeRepository(repository =>
+            this.initialize(repository)
+        ));
+        this.initialize(this.repositoryProvider.selectedRepository);
+    }
+
+    protected async initialize(repository: Repository | undefined): Promise<void> {
+        const widgetId = await this.getWidgetIdForRepository(repository);
+        const widget = await this.widgetManager.getOrCreateWidget(widgetId);
+        this.singletonLayout.widget = widget;
+        this.update();
+    }
+
+    protected async getWidgetIdForRepository(repository: Repository | undefined): Promise<string> {
+        if (repository) {
+            for (const factory of this.scmWidgetFactories) {
+                const fileStat = await this.fileSystem.getFileStat(repository.localUri);
+                if (fileStat) {
+                    if (factory.isUnderSourceControl(fileStat)) {
+                        return factory.widgetId;
+                    }
+                }
+            }
+        }
+        return 'no-scm';
+    }
+}

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -36,6 +36,11 @@
     margin-bottom: 5px;
 }
 
+.theia-git .singletonFill {
+    width: 100%;
+    height: 100%;
+}
+
 .theia-git .noWrapInfo {
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
Signed-off-by: Nigel Westbury <nigelipse@miegel.org>

This PR is the first part of the changes suggested in GH-3423.  I have separated them out to make it easier to review and manage the changes.

With this change, the Git view is now a container into which multiple SCM implementation widgets may be injected.  Each SCM widget indicates if it can handle a particular repository, and the container will show the first widget that can, or a suitable message if none of the widgets can handle the repository.

If there is only a single SCM supported then the title, tooltip etc for the container view will be taken from the widget for that SCM, otherwise generic text is used.  This ensures that there is no change in the UI in core Theia but not using the name 'Git' when a repository may not be a Git repository.

With these changes, other SCMs can be contributed but they will have to copy git-widget.ts and modify it.  We should have a base class from which one can override those functions where the SCM differs.  This work will be done later but I think it will be easier for everyone if this is done in parts.  Also GitHistory has not been changed.

The singletonFill class is there to ensure that the GitWidget expands to fill the container (otherwise the latest commit section is moved up against the changes).  Let me know if you prefer a different way of doing this.

There is a message that appears when the repository is not recognised by any of the supported SCMs.  It is easy to get that message in our product (Mbed Studio) but no so easy in the Theia example.  I can get it by selecting a repository, then deleting the .git directory, then closing and re-opening the Git view.