### PR TITLE
Remove @types/chai-as-promised dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",
-    "@types/chai-as-promised": "0.0.31",
     "@types/chai-string": "^1.4.0",
     "@types/jsdom": "^11.0.4",
     "@types/mocha": "^2.2.41",

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,12 +148,6 @@
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
 
-"@types/chai-as-promised@0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-0.0.31.tgz#e1e905ea6d971dafcad36560c8f1f7a7d690c5e5"
-  dependencies:
-    "@types/chai" "*"
-
 "@types/chai-string@^1.4.0":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.4.1.tgz#3a9d22716c27f2759bf272a4dbbdb593f18399e3"


### PR DESCRIPTION
The chai-as-promised dependency was removed a while ago, so the types
are not needed anymore.

Change-Id: Ifa5a30fa20837a4da2686d1cb7c7012d46911734
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
