### PR TITLE
improve tab-bar toolbar and add more contributions

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -62,7 +62,6 @@ import { EnvVariablesServer, envVariablesPath } from './../common/env-variables'
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { JsonSchemaStore } from './json-schema-store';
 import { TabBarToolbarRegistry, TabBarToolbarContribution, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
-import { WidgetTracker } from './widgets';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const themeService = ThemeService.get();
@@ -76,7 +75,6 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(ApplicationShellOptions).toConstantValue({});
     bind(ApplicationShell).toSelf().inSingletonScope();
-    bind(WidgetTracker).toService(ApplicationShell);
     bind(SidePanelHandlerFactory).toAutoFactory(SidePanelHandler);
     bind(SidePanelHandler).toSelf();
     bind(SplitPositionHandler).toSelf().inSingletonScope();
@@ -91,12 +89,12 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
         return new TabBarToolbar(commandRegistry, labelParser);
     });
 
-    bind(DockPanelRendererFactory).toFactory(context => (widgetTracker: WidgetTracker) => {
+    bind(DockPanelRendererFactory).toFactory(context => () => {
         const { container } = context;
         const tabBarToolbarRegistry = container.get(TabBarToolbarRegistry);
         const tabBarRendererFactory: () => TabBarRenderer = container.get(TabBarRendererFactory);
         const tabBarToolbarFactory: () => TabBarToolbar = container.get(TabBarToolbarFactory);
-        return new DockPanelRenderer(tabBarRendererFactory, tabBarToolbarRegistry, widgetTracker, tabBarToolbarFactory);
+        return new DockPanelRenderer(tabBarRendererFactory, tabBarToolbarRegistry, tabBarToolbarFactory);
     });
     bind(DockPanelRenderer).toSelf();
     bind(TabBarRendererFactory).toFactory(context => () => {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -634,7 +634,7 @@ export class ApplicationShell extends Widget implements WidgetTracker {
      *
      * Widgets added to the top area are not tracked regarding the _current_ and _active_ states.
      */
-    addWidget(widget: Widget, options: ApplicationShell.WidgetOptions) {
+    addWidget(widget: Widget, options: Readonly<ApplicationShell.WidgetOptions> = {}) {
         if (!widget.id) {
             console.error('Widgets added to the application shell must have a unique id property.');
             return;
@@ -656,7 +656,7 @@ export class ApplicationShell extends Widget implements WidgetTracker {
                 this.rightPanelHandler.addWidget(widget, options);
                 break;
             default:
-                throw new Error('Illegal argument: ' + options.area);
+                this.mainPanel.addWidget(widget, options);
         }
         if (options.area !== 'top') {
             this.track(widget);
@@ -1319,7 +1319,7 @@ export namespace ApplicationShell {
         /**
          * The area of the application shell where the widget will reside.
          */
-        area: Area;
+        area?: Area;
     }
 
     /**

--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -17,13 +17,13 @@
 import { injectable, inject } from 'inversify';
 import { find, map, toArray, some } from '@phosphor/algorithm';
 import { TabBar, Widget, DockPanel, Title, Panel, BoxPanel, BoxLayout, SplitPanel } from '@phosphor/widgets';
-import { Signal } from '@phosphor/signaling';
 import { MimeData } from '@phosphor/coreutils';
 import { Drag } from '@phosphor/dragdrop';
 import { AttachedProperty } from '@phosphor/properties';
 import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, SideTabBar } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
 import { FrontendApplicationStateService } from '../frontend-application-state';
+import { TheiaDockPanel } from './theia-dock-panel';
 
 /** The class name added to the left and right area panels. */
 export const LEFT_RIGHT_AREA_CLASS = 'theia-app-sides';
@@ -607,43 +607,4 @@ export namespace SidePanel {
         expanded = 'expanded',
         collapsing = 'collapsing'
     }
-}
-
-/**
- * This specialization of DockPanel adds various events that are used for implementing the
- * side panels of the application shell.
- */
-export class TheiaDockPanel extends DockPanel {
-
-    /**
-     * Emitted when a widget is added to the panel.
-     */
-    readonly widgetAdded = new Signal<this, Widget>(this);
-    /**
-     * Emitted when a widget is activated by calling `activateWidget`.
-     */
-    readonly widgetActivated = new Signal<this, Widget>(this);
-    /**
-     * Emitted when a widget is removed from the panel.
-     */
-    readonly widgetRemoved = new Signal<this, Widget>(this);
-
-    addWidget(widget: Widget, options?: DockPanel.IAddOptions): void {
-        if (this.mode === 'single-document' && widget.parent === this) {
-            return;
-        }
-        super.addWidget(widget, options);
-        this.widgetAdded.emit(widget);
-    }
-
-    activateWidget(widget: Widget): void {
-        super.activateWidget(widget);
-        this.widgetActivated.emit(widget);
-    }
-
-    protected onChildRemoved(msg: Widget.ChildMessage): void {
-        super.onChildRemoved(msg);
-        this.widgetRemoved.emit(msg.child);
-    }
-
 }

--- a/packages/core/src/browser/shell/tab-bar-toolbar.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.ts
@@ -20,7 +20,7 @@ import { LabelParser, LabelIcon } from '../label-parser';
 import { ContributionProvider } from '../../common/contribution-provider';
 import { FrontendApplicationContribution } from '../frontend-application';
 import { Disposable, DisposableCollection } from '../../common/disposable';
-import { Command, CommandRegistry, CommandService } from '../../common/command';
+import { CommandRegistry, CommandService } from '../../common/command';
 
 /**
  * Factory for instantiating tab-bar toolbars.
@@ -71,7 +71,7 @@ export class TabBarToolbar extends BaseWidget {
             itemContainer.classList.add(TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM);
             for (const labelPart of this.labelParser.parse(item.text)) {
                 const child = document.createElement('div');
-                const listener = () => this.commandService.executeCommand(item.command.id);
+                const listener = () => this.commandService.executeCommand(item.command);
                 child.addEventListener('click', listener);
                 this.toDisposeOnUpdate.push(Disposable.create(() => itemContainer.removeEventListener('click', listener)));
                 if (typeof labelPart !== 'string' && LabelIcon.is(labelPart)) {
@@ -148,7 +148,7 @@ export interface TabBarToolbarItem {
     /**
      * The command to execute.
      */
-    readonly command: Command;
+    readonly command: string;
 
     /**
      * Text of the item.
@@ -238,7 +238,7 @@ export class TabBarToolbarRegistry implements FrontendApplicationContribution {
      */
     visibleItems(widget: Widget): TabBarToolbarItem[] {
         return Array.from(this.items.values())
-            .filter(item => this.commandRegistry.isEnabled(item.id))
+            .filter(item => this.commandRegistry.isEnabled(item.command))
             .filter(item => item.isVisible(widget));
     }
 

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -301,6 +301,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
 
     constructor(
         protected readonly tabBarToolbarRegistry: TabBarToolbarRegistry,
+        // TODO: WidgetTracker is not needed anymore: remove? or make sure that noone can access it from the main container?
         protected readonly widgetTracker: WidgetTracker,
         protected readonly tabBarToolbarFactory: () => TabBarToolbar,
         protected readonly options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
@@ -327,38 +328,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         return this.node.getElementsByClassName(ToolbarAwareTabBar.Styles.TAB_BAR_CONTENT_CONTAINER)[0] as HTMLElement;
     }
 
-    // -----------------------------------------------------------------------------------------------------+
-    // Overridden to be able to update the toolbar when the tabs come and go. Does not change the behavior. |
-    // -----------------------------------------------------------------------------------------------------+
-
-    addTab(value: Title<Widget> | Title.IOptions<Widget>): Title<Widget> {
-        const result = super.addTab(value);
-        this.updateToolbar();
-        return result;
-    }
-
-    insertTab(index: number, value: Title<Widget> | Title.IOptions<Widget>): Title<Widget> {
-        const result = super.insertTab(index, value);
-        this.updateToolbar();
-        return result;
-    }
-
-    removeTab(title: Title<Widget>): void {
-        super.removeTab(title);
-        this.updateToolbar();
-    }
-
-    removeTabAt(index: number): void {
-        super.removeTabAt(index);
-        this.updateToolbar();
-    }
-
-    // ----------------------+
-    // End of customization. |
-    // ----------------------+
-
     protected onAfterAttach(msg: Message): void {
-        this.widgetTracker.currentChanged.connect(this.updateToolbar, this);
         if (this.toolbar) {
             if (this.toolbar.isAttached) {
                 Widget.detach(this.toolbar);
@@ -375,22 +345,21 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         if (this.toolbar && this.toolbar.isAttached) {
             Widget.detach(this.toolbar);
         }
-        this.widgetTracker.currentChanged.disconnect(this.updateToolbar, this);
         super.onBeforeDetach(msg);
     }
 
+    protected onUpdateRequest(msg: Message): void {
+        super.onUpdateRequest(msg);
+        this.updateToolbar();
+    }
     protected updateToolbar(): void {
-        const { currentWidget } = this.widgetTracker;
-        if (this.toolbar && currentWidget) {
-            // If the active widget does not belong to the current tab-bar, do nothing.
-            if (this.titles.map(title => title.owner).some(owner => owner === currentWidget)) {
-                const items = this.tabBarToolbarRegistry.visibleItems(currentWidget);
-                this.toolbar.updateItems(...items);
-            } else {
-                // Otherwise, discard the state.
-                this.toolbar.updateItems(...[]);
-            }
+        if (!this.toolbar) {
+            return;
         }
+        const current = this.currentTitle;
+        const widget = current && current.owner || undefined;
+        const items = widget ? this.tabBarToolbarRegistry.visibleItems(widget) : [];
+        this.toolbar.updateItems(items, widget);
     }
 
     /**

--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -24,7 +24,6 @@ import { Message } from '@phosphor/messaging';
 import { ArrayExt } from '@phosphor/algorithm';
 import { ElementExt } from '@phosphor/domutils';
 import { TabBarToolbarRegistry, TabBarToolbar } from './tab-bar-toolbar';
-import { WidgetTracker } from '../widgets';
 
 /** The class name added to hidden content nodes, which are required to render vertical side bars. */
 const HIDDEN_CONTENT_CLASS = 'theia-TabBar-hidden-content';
@@ -301,8 +300,6 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
 
     constructor(
         protected readonly tabBarToolbarRegistry: TabBarToolbarRegistry,
-        // TODO: WidgetTracker is not needed anymore: remove? or make sure that noone can access it from the main container?
-        protected readonly widgetTracker: WidgetTracker,
         protected readonly tabBarToolbarFactory: () => TabBarToolbar,
         protected readonly options?: TabBar.IOptions<Widget> & PerfectScrollbar.Options) {
 
@@ -352,6 +349,7 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
         super.onUpdateRequest(msg);
         this.updateToolbar();
     }
+
     protected updateToolbar(): void {
         if (!this.toolbar) {
             return;

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -1,0 +1,112 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { find, toArray, ArrayExt } from '@phosphor/algorithm';
+import { TabBar, Widget, DockPanel, Title } from '@phosphor/widgets';
+import { Signal } from '@phosphor/signaling';
+
+/**
+ * This specialization of DockPanel adds various events that are used for implementing the
+ * side panels of the application shell.
+ */
+export class TheiaDockPanel extends DockPanel {
+
+    /**
+     * Emitted when a widget is added to the panel.
+     */
+    readonly widgetAdded = new Signal<this, Widget>(this);
+    /**
+     * Emitted when a widget is activated by calling `activateWidget`.
+     */
+    readonly widgetActivated = new Signal<this, Widget>(this);
+    /**
+     * Emitted when a widget is removed from the panel.
+     */
+    readonly widgetRemoved = new Signal<this, Widget>(this);
+
+    constructor(options?: DockPanel.IOptions) {
+        super(options);
+        this['_onCurrentChanged'] = (sender: TabBar<Widget>, args: TabBar.ICurrentChangedArgs<Widget>) => {
+            this.markAsCurrent(args.currentTitle || undefined);
+            super['_onCurrentChanged'](sender, args);
+        };
+        this['_onTabActivateRequested'] = (sender: TabBar<Widget>, args: TabBar.ITabActivateRequestedArgs<Widget>) => {
+            this.markAsCurrent(args.title);
+            super['_onTabActivateRequested'](sender, args);
+        };
+    }
+
+    protected _currentTitle: Title<Widget> | undefined;
+    get currentTitle(): Title<Widget> | undefined {
+        return this._currentTitle;
+    }
+    get currentTabBar(): TabBar<Widget> | undefined {
+        return this._currentTitle && this.findTabBar(this._currentTitle);
+    }
+    findTabBar(title: Title<Widget>): TabBar<Widget> | undefined {
+        return find(this.tabBars(), bar => ArrayExt.firstIndexOf(bar.titles, title) > -1);
+    }
+    markAsCurrent(title: Title<Widget> | undefined): void {
+        this._currentTitle = title;
+    }
+
+    addWidget(widget: Widget, options?: DockPanel.IAddOptions): void {
+        if (this.mode === 'single-document' && widget.parent === this) {
+            return;
+        }
+        super.addWidget(widget, options);
+        this.widgetAdded.emit(widget);
+    }
+
+    activateWidget(widget: Widget): void {
+        super.activateWidget(widget);
+        this.widgetActivated.emit(widget);
+    }
+
+    protected onChildRemoved(msg: Widget.ChildMessage): void {
+        super.onChildRemoved(msg);
+        this.widgetRemoved.emit(msg.child);
+    }
+
+    nextTabBarWidget(widget: Widget): Widget | undefined {
+        const current = this.findTabBar(widget.title);
+        const next = current && this.nextTabBarInPanel(current);
+        return next && next.currentTitle && next.currentTitle.owner || undefined;
+    }
+    nextTabBarInPanel(tabBar: TabBar<Widget>): TabBar<Widget> | undefined {
+        const tabBars = toArray(this.tabBars());
+        const index = tabBars.indexOf(tabBar);
+        if (index !== -1) {
+            return tabBars[index + 1];
+        }
+        return undefined;
+    }
+
+    previousTabBarWidget(widget: Widget): Widget | undefined {
+        const current = this.findTabBar(widget.title);
+        const previous = current && this.previousTabBarInPanel(current);
+        return previous && previous.currentTitle && previous.currentTitle.owner || undefined;
+    }
+    previousTabBarInPanel(tabBar: TabBar<Widget>): TabBar<Widget> | undefined {
+        const tabBars = toArray(this.tabBars());
+        const index = tabBars.indexOf(tabBar);
+        if (index !== -1) {
+            return tabBars[index - 1];
+        }
+        return undefined;
+    }
+
+}

--- a/packages/core/src/browser/shell/theia-dock-panel.ts
+++ b/packages/core/src/browser/shell/theia-dock-panel.ts
@@ -53,13 +53,16 @@ export class TheiaDockPanel extends DockPanel {
     get currentTitle(): Title<Widget> | undefined {
         return this._currentTitle;
     }
+
     get currentTabBar(): TabBar<Widget> | undefined {
         return this._currentTitle && this.findTabBar(this._currentTitle);
     }
+
     findTabBar(title: Title<Widget>): TabBar<Widget> | undefined {
         return find(this.tabBars(), bar => ArrayExt.firstIndexOf(bar.titles, title) > -1);
     }
-    markAsCurrent(title: Title<Widget> | undefined): void {
+
+    markAsCurrent(title: Title<Widget> | undefined): void {
         this._currentTitle = title;
     }
 
@@ -86,6 +89,7 @@ export class TheiaDockPanel extends DockPanel {
         const next = current && this.nextTabBarInPanel(current);
         return next && next.currentTitle && next.currentTitle.owner || undefined;
     }
+
     nextTabBarInPanel(tabBar: TabBar<Widget>): TabBar<Widget> | undefined {
         const tabBars = toArray(this.tabBars());
         const index = tabBars.indexOf(tabBar);
@@ -100,6 +104,7 @@ export class TheiaDockPanel extends DockPanel {
         const previous = current && this.previousTabBarInPanel(current);
         return previous && previous.currentTitle && previous.currentTitle.owner || undefined;
     }
+
     previousTabBarInPanel(tabBar: TabBar<Widget>): TabBar<Widget> | undefined {
         const tabBars = toArray(this.tabBars());
         const index = tabBars.indexOf(tabBar);

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -162,8 +162,8 @@
   z-index: 1001; /* Due to the scrollbar (`z-index: 1000;`) it has a greater `z-index`. */
   display: flex;
   flex-direction: row-reverse;
-  flex-grow: 1;
   padding: 4px;
+  padding-left: 0px;
   margin-right: 4px;
 }
 
@@ -173,7 +173,7 @@
 
 .p-TabBar-content-container {
   display: flex;
-  background: var(--theia-layout-color0);
+  flex: 1;
 }
 
 .p-TabBar-toolbar .item {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -167,10 +167,6 @@
   margin-right: 4px;
 }
 
-.p-TabBar-toolbar.hidden {
-  display: none !important;
-}
-
 .p-TabBar-content-container {
   display: flex;
   flex: 1;

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -15,9 +15,8 @@
  ********************************************************************************/
 
 import { injectable, decorate, unmanaged } from 'inversify';
-import { Widget, FocusTracker } from '@phosphor/widgets';
+import { Widget } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
-import { Signal } from '@phosphor/signaling';
 import { Disposable, DisposableCollection, MaybePromise } from '../../common';
 import { KeyCode, KeysOrKeyCodes } from '../keys';
 
@@ -215,40 +214,4 @@ export function addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element
     return Disposable.create(() =>
         document.removeEventListener(type, documentListener)
     );
-}
-
-/**
- * Tracks the current and active widgets in the application. Also provides access to the currently active and current widgets.
- *
- * FIXME: remove it from Widget public API, this file should be about BaseWidget, not shell internals
- */
-export const WidgetTracker = Symbol('WidgetTracker');
-export interface WidgetTracker {
-
-    /**
-     * The current widget in the application shell. The current widget is the last widget that
-     * was active and not yet closed. See the remarks to `activeWidget` on what _active_ means.
-     */
-    currentWidget: Widget | undefined;
-
-    /**
-     * The active widget in the application shell. The active widget is the one that has focus
-     * (either the widget itself or any of its contents).
-     *
-     * _Note:_ Focus is taken by a widget through the `onActivateRequest` method. It is up to the
-     * widget implementation which DOM element will get the focus. The default implementation
-     * does not take any focus; in that case the widget is never returned by this property.
-     */
-    activeWidget: Widget | undefined;
-
-    /**
-     * A signal emitted whenever the `currentWidget` property is changed.
-     */
-    readonly currentChanged: Signal<object, FocusTracker.IChangedArgs<Widget>>;
-
-    /**
-     * A signal emitted whenever the `activeWidget` property is changed.
-     */
-    readonly activeChanged: Signal<object, FocusTracker.IChangedArgs<Widget>>;
-
 }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -219,6 +219,8 @@ export function addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element
 
 /**
  * Tracks the current and active widgets in the application. Also provides access to the currently active and current widgets.
+ *
+ * FIXME: remove it from Widget public API, this file should be about BaseWidget, not shell internals
  */
 export const WidgetTracker = Symbol('WidgetTracker');
 export interface WidgetTracker {

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -337,7 +337,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         }
     }
 
-    protected getUriToOpen(change: GitFileChange): URI {
+    getUriToOpen(change: GitFileChange): URI {
         const uri: URI = new URI(change.uri);
 
         let fromURI = uri;

--- a/packages/git/src/browser/git-frontend-module.ts
+++ b/packages/git/src/browser/git-frontend-module.ts
@@ -17,6 +17,7 @@
 import { ContainerModule } from 'inversify';
 import { ResourceResolver } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider, WidgetFactory, bindViewContribution, LabelProviderContribution, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser';
 import { Git, GitPath, GitWatcher, GitWatcherPath, GitWatcherServer, GitWatcherServerProxy, ReconnectingGitWatcherServer } from '../common';
 import { GitViewContribution, GIT_WIDGET_FACTORY_ID } from './git-view-contribution';
@@ -52,6 +53,7 @@ export default new ContainerModule(bind => {
 
     bindViewContribution(bind, GitViewContribution);
     bind(FrontendApplicationContribution).toService(GitViewContribution);
+    bind(TabBarToolbarContribution).toService(GitViewContribution);
 
     bind(GitWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(context => ({

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -301,6 +301,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         const options = this.getOpenFileOptions(widget);
         return options && this.editorManager.open(options.uri, options.options);
     }
+
     protected getOpenFileOptions(widget?: Widget): GitOpenFileOptions | undefined {
         const ref = widget ? widget : this.editorManager.currentEditor;
         if (ref instanceof EditorWidget && DiffUris.isDiffUri(ref.editor.uri)) {
@@ -320,6 +321,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         }
         return undefined;
     }
+
     protected getOpenChangesOptions(widget?: Widget): GitOpenChangesOptions | undefined {
         const view = this.tryGetWidget();
         if (!view) {

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -599,7 +599,7 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
 
     handleOpenChange = async (change: GitFileChange, options?: EditorOpenerOptions) => this.openChange(change, options);
 
-    protected getUriToOpen(change: GitFileChange): URI {
+    getUriToOpen(change: GitFileChange): URI {
         const changeUri: URI = new URI(change.uri);
         if (change.status !== GitFileStatus.New) {
             if (change.staged) {

--- a/packages/mini-browser/src/browser/mini-browser-content.ts
+++ b/packages/mini-browser/src/browser/mini-browser-content.ts
@@ -1,0 +1,649 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as PDFObject from 'pdfobject';
+import { inject, injectable, postConstruct } from 'inversify';
+import { Message } from '@phosphor/messaging';
+import { PanelLayout, SplitPanel } from '@phosphor/widgets';
+import URI from '@theia/core/lib/common/uri';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { Key, KeyCode } from '@theia/core/lib/browser/keys';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { FrontendApplicationContribution, ApplicationShell } from '@theia/core/lib/browser';
+import { FileSystemWatcher, FileChangeEvent } from '@theia/filesystem/lib/browser/filesystem-watcher';
+import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
+import { BaseWidget, addEventListener, FocusTracker, Widget } from '@theia/core/lib/browser/widgets/widget';
+import { LocationMapperService } from './location-mapper-service';
+
+import debounce = require('lodash.debounce');
+
+/**
+ * Initializer properties for the embedded browser widget.
+ */
+@injectable()
+export class MiniBrowserProps {
+
+    /**
+     * `show` if the toolbar should be visible. If `read-only`, the toolbar is visible but the address cannot be changed and it acts as a link instead.\
+     * `hide` if the toolbar should be hidden. `show` by default. If the `startPage` is not defined, this property is always `show`.
+     */
+    readonly toolbar?: 'show' | 'hide' | 'read-only';
+
+    /**
+     * If defined, the browser will load this page on startup. Otherwise, it show a blank page.
+     */
+    readonly startPage?: string;
+
+    /**
+     * Sandbox options for the underlying `iframe`. Defaults to `SandboxOptions#DEFAULT` if not provided.
+     */
+    readonly sandbox?: MiniBrowserProps.SandboxOptions[];
+
+    /**
+     * The optional icon class for the widget.
+     */
+    readonly iconClass?: string;
+
+    /**
+     * The desired name of the widget.
+     */
+    readonly name?: string;
+
+    /**
+     * `true` if the `iFrame`'s background has to be reset to the default white color. Otherwise, `false`. `false` is the default.
+     */
+    readonly resetBackground?: boolean;
+
+}
+
+export namespace MiniBrowserProps {
+
+    /**
+     * Enumeration of the supported `sandbox` options for the `iframe`.
+     */
+    export enum SandboxOptions {
+
+        /**
+         * Allows form submissions.
+         */
+        'allow-forms',
+
+        /**
+         * Allows popups, such as `window.open()`, `showModalDialog()`, `target=”_blank”`, etc.
+         */
+        'allow-popups',
+
+        /**
+         * Allows pointer lock.
+         */
+        'allow-pointer-lock',
+
+        /**
+         * Allows the document to maintain its origin. Pages loaded from https://example.com/ will retain access to that origin’s data.
+         */
+        'allow-same-origin',
+
+        /**
+         * Allows JavaScript execution. Also allows features to trigger automatically (as they’d be trivial to implement via JavaScript).
+         */
+        'allow-scripts',
+
+        /**
+         * Allows the document to break out of the frame by navigating the top-level `window`.
+         */
+        'allow-top-navigation',
+
+        /**
+         * Allows the embedded browsing context to open modal windows.
+         */
+        'allow-modals',
+
+        /**
+         * Allows the embedded browsing context to disable the ability to lock the screen orientation.
+         */
+        'allow-orientation-lock',
+
+        /**
+         * Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them.
+         * This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon a landing page.
+         */
+        'allow-popups-to-escape-sandbox',
+
+        /**
+         * Allows embedders to have control over whether an iframe can start a presentation session.
+         */
+        'allow-presentation',
+
+        /**
+         * Allows the embedded browsing context to navigate (load) content to the top-level browsing context only when initiated by a user gesture.
+         * If this keyword is not used, this operation is not allowed.
+         */
+        'allow-top-navigation-by-user-activation'
+    }
+
+    export namespace SandboxOptions {
+
+        /**
+         * The default `sandbox` options, if other is not provided.
+         *
+         * See: https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
+         */
+        export const DEFAULT: SandboxOptions[] = [
+            SandboxOptions['allow-same-origin'],
+            SandboxOptions['allow-scripts'],
+            SandboxOptions['allow-popups'],
+            SandboxOptions['allow-forms'],
+            SandboxOptions['allow-modals']
+        ];
+
+    }
+
+}
+
+/**
+ * Contribution that tracks `mouseup` and `mousedown` events.
+ *
+ * This is required to be able to track the `TabBar`, `DockPanel`, and `SidePanel` resizing and drag and drop events correctly
+ * all over the application. By default, when the mouse is over an `iframe` we lose the mouse tracking ability, so whenever
+ * we click (`mousedown`), we overlay a transparent `div` over the `iframe` in the Mini Browser, then we set the `display` of
+ * the transparent `div` to `none` on `mouseup` events.
+ */
+@injectable()
+export class MiniBrowserMouseClickTracker implements FrontendApplicationContribution {
+
+    @inject(ApplicationShell)
+    protected readonly applicationShell: ApplicationShell;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly toDisposeOnActiveChange = new DisposableCollection();
+
+    protected readonly mouseupEmitter = new Emitter<MouseEvent>();
+    protected readonly mousedownEmitter = new Emitter<MouseEvent>();
+    protected readonly mouseupListener: (e: MouseEvent) => void = e => this.mouseupEmitter.fire(e);
+    protected readonly mousedownListener: (e: MouseEvent) => void = e => this.mousedownEmitter.fire(e);
+
+    onStart(): void {
+        // Here we need to attach a `mousedown` listener to the `TabBar`s, `DockPanel`s and the `SidePanel`s. Otherwise, Phosphor handles the event and stops the propagation.
+        // Track the `mousedown` on the `TabBar` for the currently active widget.
+        this.applicationShell.activeChanged.connect((shell: ApplicationShell, args: FocusTracker.IChangedArgs<Widget>) => {
+            this.toDisposeOnActiveChange.dispose();
+            if (args.newValue) {
+                const tabBar = shell.getTabBarFor(args.newValue);
+                if (tabBar) {
+                    this.toDisposeOnActiveChange.push(addEventListener(tabBar.node, 'mousedown', this.mousedownListener, true));
+                }
+            }
+        });
+
+        // Track the `mousedown` events for the `SplitPanel`s, if any.
+        const { layout } = this.applicationShell;
+        if (layout instanceof PanelLayout) {
+            this.toDispose.pushAll(
+                layout.widgets.filter(MiniBrowserMouseClickTracker.isSplitPanel).map(splitPanel => addEventListener(splitPanel.node, 'mousedown', this.mousedownListener, true))
+            );
+        }
+        // Track the `mousedown` on each `DockPanel`.
+        const { mainPanel, bottomPanel, leftPanelHandler, rightPanelHandler } = this.applicationShell;
+        this.toDispose.pushAll([mainPanel, bottomPanel, leftPanelHandler.dockPanel, rightPanelHandler.dockPanel]
+            .map(panel => addEventListener(panel.node, 'mousedown', this.mousedownListener, true)));
+
+        // The `mouseup` event has to be tracked on the `document`. Phosphor attaches to there.
+        document.addEventListener('mouseup', this.mouseupListener, true);
+
+        // Make sure it is disposed in the end.
+        this.toDispose.pushAll([
+            this.mousedownEmitter,
+            this.mouseupEmitter,
+            Disposable.create(() => document.removeEventListener('mouseup', this.mouseupListener, true))
+        ]);
+    }
+
+    onStop(): void {
+        this.toDispose.dispose();
+        this.toDisposeOnActiveChange.dispose();
+    }
+
+    get onMouseup(): Event<MouseEvent> {
+        return this.mouseupEmitter.event;
+    }
+
+    get onMousedown(): Event<MouseEvent> {
+        return this.mousedownEmitter.event;
+    }
+
+}
+
+export namespace MiniBrowserMouseClickTracker {
+
+    export function isSplitPanel(arg: Widget): arg is SplitPanel {
+        return arg instanceof SplitPanel;
+    }
+
+}
+
+export const MiniBrowserContentFactory = Symbol('MiniBrowserContentFactory');
+export type MiniBrowserContentFactory = (props: MiniBrowserProps) => MiniBrowserContent;
+
+@injectable()
+export class MiniBrowserContent extends BaseWidget {
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    @inject(LocationMapperService)
+    protected readonly locationMapper: LocationMapperService;
+
+    @inject(KeybindingRegistry)
+    protected readonly keybindings: KeybindingRegistry;
+
+    @inject(MiniBrowserMouseClickTracker)
+    protected readonly mouseTracker: MiniBrowserMouseClickTracker;
+
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+
+    @inject(FileSystemWatcher)
+    protected readonly fileSystemWatcher: FileSystemWatcher;
+
+    protected readonly submitInputEmitter = new Emitter<string>();
+    protected readonly navigateBackEmitter = new Emitter<void>();
+    protected readonly navigateForwardEmitter = new Emitter<void>();
+    protected readonly refreshEmitter = new Emitter<void>();
+    protected readonly openEmitter = new Emitter<void>();
+
+    protected readonly input: HTMLInputElement;
+    protected readonly loadIndicator: HTMLElement;
+    protected readonly frame: HTMLIFrameElement;
+    // tslint:disable-next-line:max-line-length
+    // XXX This is a hack to be able to tack the mouse events when drag and dropping the widgets. On `mousedown` we put a transparent div over the `iframe` to avoid losing the mouse tacking.
+    protected readonly transparentOverlay: HTMLElement;
+    // XXX It is a hack. Instead of loading the PDF in an iframe we use `PDFObject` to render it in a div.
+    protected readonly pdfContainer: HTMLElement;
+
+    protected readonly initialHistoryLength: number;
+    protected readonly toDisposeOnGo = new DisposableCollection();
+
+    constructor(@inject(MiniBrowserProps) protected readonly props: MiniBrowserProps) {
+        super();
+        this.addClass(MiniBrowserContent.Styles.MINI_BROWSER);
+        this.input = this.createToolbar(this.node).input;
+        const contentArea = this.createContentArea(this.node);
+        this.frame = contentArea.frame;
+        this.transparentOverlay = contentArea.transparentOverlay;
+        this.loadIndicator = contentArea.loadIndicator;
+        this.pdfContainer = contentArea.pdfContainer;
+        this.initialHistoryLength = history.length;
+        this.toDispose.pushAll([
+            this.submitInputEmitter,
+            this.navigateBackEmitter,
+            this.navigateForwardEmitter,
+            this.refreshEmitter,
+            this.openEmitter
+        ]);
+    }
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.mouseTracker.onMousedown(e => {
+            if (this.frame.style.display !== 'none') {
+                this.transparentOverlay.style.display = 'block';
+            }
+        }));
+        this.toDispose.push(this.mouseTracker.onMouseup(e => {
+            if (this.frame.style.display !== 'none') {
+                this.transparentOverlay.style.display = 'none';
+            }
+        }));
+        const { startPage } = this.props;
+        if (startPage) {
+            setTimeout(() => this.go(startPage, true), 500);
+            this.listenOnContentChange(startPage);
+        }
+    }
+
+    protected onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        (this.getToolbarProps() !== 'hide' ? this.input : this.frame).focus();
+        this.update();
+    }
+
+    protected async listenOnContentChange(location: string): Promise<void> {
+        if (location.startsWith('file://')) {
+            if (await this.fileSystem.exists(location)) {
+                const fileUri = new URI(location);
+                const watcher = await this.fileSystemWatcher.watchFileChanges(fileUri);
+                this.toDispose.push(watcher);
+                const onFileChange = (event: FileChangeEvent) => {
+                    if (FileChangeEvent.isChanged(event, fileUri)) {
+                        this.go(location, false, false);
+                    }
+                };
+                this.toDispose.push(this.fileSystemWatcher.onFilesChanged(debounce(onFileChange, 500)));
+            }
+        }
+    }
+
+    protected createToolbar(parent: HTMLElement): HTMLDivElement & Readonly<{ input: HTMLInputElement }> {
+        const toolbar = document.createElement('div');
+        toolbar.classList.add(this.getToolbarProps() === 'read-only' ? MiniBrowserContent.Styles.TOOLBAR_READ_ONLY : MiniBrowserContent.Styles.TOOLBAR);
+        parent.appendChild(toolbar);
+        this.createPrevious(toolbar);
+        this.createNext(toolbar);
+        this.createRefresh(toolbar);
+        const input = this.createInput(toolbar);
+        input.readOnly = this.getToolbarProps() === 'read-only';
+        this.createOpen(toolbar);
+        if (this.getToolbarProps() === 'hide') {
+            toolbar.style.display = 'none';
+        }
+        return Object.assign(toolbar, { input });
+    }
+
+    protected getToolbarProps(): 'show' | 'hide' | 'read-only' {
+        return !this.props.startPage ? 'show' : this.props.toolbar || 'show';
+    }
+
+    // tslint:disable-next-line:max-line-length
+    protected createContentArea(parent: HTMLElement): HTMLElement & Readonly<{ frame: HTMLIFrameElement, loadIndicator: HTMLElement, pdfContainer: HTMLElement, transparentOverlay: HTMLElement }> {
+        const contentArea = document.createElement('div');
+        contentArea.classList.add(MiniBrowserContent.Styles.CONTENT_AREA);
+
+        const loadIndicator = document.createElement('div');
+        loadIndicator.classList.add(MiniBrowserContent.Styles.PRE_LOAD);
+        loadIndicator.style.display = 'none';
+
+        const frame = this.createIFrame();
+        this.submitInputEmitter.event(input => this.go(input, true));
+        this.navigateBackEmitter.event(this.handleBack.bind(this));
+        this.navigateForwardEmitter.event(this.handleForward.bind(this));
+        this.refreshEmitter.event(this.handleRefresh.bind(this));
+        this.openEmitter.event(this.handleOpen.bind(this));
+
+        const transparentOverlay = document.createElement('div');
+        transparentOverlay.classList.add(MiniBrowserContent.Styles.TRANSPARENT_OVERLAY);
+        transparentOverlay.style.display = 'none';
+
+        const pdfContainer = document.createElement('div');
+        pdfContainer.classList.add(MiniBrowserContent.Styles.PDF_CONTAINER);
+        pdfContainer.id = `${this.id}-pdf-container`;
+        pdfContainer.style.display = 'none';
+
+        contentArea.appendChild(transparentOverlay);
+        contentArea.appendChild(pdfContainer);
+        contentArea.appendChild(loadIndicator);
+        contentArea.appendChild(frame);
+
+        parent.appendChild(contentArea);
+        return Object.assign(contentArea, { frame, loadIndicator, pdfContainer, transparentOverlay });
+    }
+
+    protected createIFrame(): HTMLIFrameElement {
+        const frame = document.createElement('iframe');
+        const sandbox = (this.props.sandbox || MiniBrowserProps.SandboxOptions.DEFAULT).map(name => MiniBrowserProps.SandboxOptions[name]);
+        frame.sandbox.add(...sandbox);
+        this.toDispose.push(addEventListener(frame, 'load', this.onFrameLoad.bind(this)));
+        return frame;
+    }
+
+    protected onFrameLoad(): void {
+        this.hideLoadIndicator();
+        this.focus();
+    }
+
+    protected focus(): void {
+        const contentDocument = this.contentDocument();
+        if (contentDocument !== null && contentDocument.body) {
+            contentDocument.body.focus();
+        } else if (this.pdfContainer.style.display !== 'none') {
+            this.pdfContainer.focus();
+        } else if (this.getToolbarProps() !== 'hide') {
+            this.input.focus();
+        } else if (this.frame.parentElement) {
+            this.frame.parentElement.focus();
+        }
+    }
+
+    protected showLoadIndicator(): void {
+        this.loadIndicator.style.display = 'block';
+    }
+
+    protected hideLoadIndicator(): void {
+        this.loadIndicator.style.display = 'none';
+    }
+
+    protected handleBack(): void {
+        if (history.length - this.initialHistoryLength > 0) {
+            history.back();
+        }
+    }
+
+    protected handleForward(): void {
+        if (history.length > this.initialHistoryLength) {
+            history.forward();
+        }
+    }
+
+    protected handleRefresh(): void {
+        // Initial pessimism; use the location of the input.
+        let location: string | undefined = this.props.startPage;
+        // Use the the location from the `input`.
+        if (this.input && this.input.value) {
+            location = this.input.value;
+        }
+        try {
+            const { contentDocument } = this.frame;
+            if (contentDocument && contentDocument.location) {
+                location = contentDocument.location.href;
+            }
+        } catch {
+            // Security exception due to CORS when trying to access the `location.href` of the content document.
+        }
+        if (location) {
+            this.go(location, false, true);
+        }
+    }
+
+    protected handleOpen(): void {
+        const location = this.frameSrc() || this.input.value;
+        if (location) {
+            this.windowService.openNewWindow(location);
+        }
+    }
+
+    protected createInput(parent: HTMLElement): HTMLInputElement {
+        const input = document.createElement('input');
+        input.type = 'text';
+        this.toDispose.pushAll([
+            addEventListener(input, 'keydown', this.handleInputChange.bind(this)),
+            addEventListener(input, 'click', () => {
+                if (this.getToolbarProps() === 'read-only') {
+                    this.handleOpen();
+                } else {
+                    if (input.value) {
+                        input.select();
+                    }
+                }
+            })
+        ]);
+        parent.appendChild(input);
+        return input;
+    }
+
+    protected handleInputChange(e: KeyboardEvent): void {
+        const { key } = KeyCode.createKeyCode(e);
+        if (key && Key.ENTER.keyCode === key.keyCode && this.getToolbarProps() === 'show') {
+            const { srcElement } = e;
+            if (srcElement instanceof HTMLInputElement) {
+                this.mapLocation(srcElement.value).then(location => this.submitInputEmitter.fire(location));
+            }
+        }
+    }
+
+    protected createPrevious(parent: HTMLElement): HTMLElement {
+        return this.onClick(this.createButton(parent, 'Show The Previous Page', MiniBrowserContent.Styles.PREVIOUS), this.navigateBackEmitter);
+    }
+
+    protected createNext(parent: HTMLElement): HTMLElement {
+        return this.onClick(this.createButton(parent, 'Show The Next Page', MiniBrowserContent.Styles.NEXT), this.navigateForwardEmitter);
+    }
+
+    protected createRefresh(parent: HTMLElement): HTMLElement {
+        return this.onClick(this.createButton(parent, 'Reload This Page', MiniBrowserContent.Styles.REFRESH), this.refreshEmitter);
+    }
+
+    protected createOpen(parent: HTMLElement): HTMLElement {
+        const button = this.onClick(this.createButton(parent, 'Open In A New Window', MiniBrowserContent.Styles.OPEN), this.openEmitter);
+        return button;
+    }
+
+    protected createButton(parent: HTMLElement, title: string, ...className: string[]): HTMLElement {
+        const button = document.createElement('div');
+        button.title = title;
+        button.classList.add(...className, MiniBrowserContent.Styles.BUTTON);
+        parent.appendChild(button);
+        return button;
+    }
+
+    // tslint:disable-next-line:no-any
+    protected onClick(element: HTMLElement, emitter: Emitter<any>): HTMLElement {
+        this.toDispose.push(addEventListener(element, 'click', () => {
+            if (!element.classList.contains(MiniBrowserContent.Styles.DISABLED)) {
+                emitter.fire(undefined);
+            }
+        }));
+        return element;
+    }
+
+    protected mapLocation(location: string): Promise<string> {
+        return this.locationMapper.map(location);
+    }
+
+    protected setInput(value: string) {
+        if (this.input.value !== value) {
+            this.input.value = value;
+        }
+    }
+
+    protected frameSrc() {
+        let src = this.frame.src;
+        try {
+            const { contentWindow } = this.frame;
+            if (contentWindow) {
+                src = contentWindow.location.href;
+            }
+        } catch {
+            // CORS issue. Ignored.
+        }
+        if (src === 'about:blank') {
+            src = '';
+        }
+        return src;
+    }
+
+    protected contentDocument(): Document | null {
+        try {
+            let { contentDocument } = this.frame;
+            if (contentDocument === null) {
+                const { contentWindow } = this.frame;
+                if (contentWindow) {
+                    contentDocument = contentWindow.document;
+                }
+            }
+            return contentDocument;
+        } catch {
+            // tslint:disable-next-line:no-null-keyword
+            return null;
+        }
+    }
+
+    protected async go(location: string, register: boolean = false, showLoadIndicator: boolean = true): Promise<void> {
+        if (location) {
+            try {
+                this.toDisposeOnGo.dispose();
+                const url = await this.mapLocation(location);
+                this.setInput(url);
+                if (this.getToolbarProps() === 'read-only') {
+                    this.input.title = `Open ${url} In A New Window`;
+                }
+                if (showLoadIndicator) {
+                    this.showLoadIndicator();
+                }
+                if (url.endsWith('.pdf')) {
+                    this.pdfContainer.style.display = 'block';
+                    this.frame.style.display = 'none';
+                    PDFObject.embed(url, this.pdfContainer, {
+                        // tslint:disable-next-line:max-line-length
+                        fallbackLink: `<p style="padding: 0px 15px 0px 15px">Your browser does not support inline PDFs. Click on this <a href='[url]' target="_blank">link</a> to open the PDF in a new tab.</p>`
+                    });
+                    this.hideLoadIndicator();
+                } else {
+                    if (this.props.resetBackground === true) {
+                        this.frame.addEventListener('load', () => this.frame.style.backgroundColor = 'white', { once: true });
+                    }
+                    this.pdfContainer.style.display = 'none';
+                    this.frame.style.display = 'block';
+                    this.frame.src = url;
+                    // The load indicator will hide itself if the content of the iframe was loaded.
+                }
+                // Delegate all the `keypress` events from the `iframe` to the application.
+                this.toDisposeOnGo.push(addEventListener(this.frame, 'load', () => {
+                    try {
+                        const { contentDocument } = this.frame;
+                        if (contentDocument) {
+                            const keypressHandler = (e: KeyboardEvent) => this.keybindings.run(e);
+                            contentDocument.addEventListener('keypress', keypressHandler, true);
+                            this.toDisposeOnDetach.push(Disposable.create(() => contentDocument.removeEventListener('keypress', keypressHandler)));
+                        }
+                    } catch {
+                        // There is not much we could do with the security exceptions due to CORS.
+                    }
+                }));
+            } catch (e) {
+                this.hideLoadIndicator();
+                console.log(e);
+            }
+        }
+    }
+
+}
+
+export namespace MiniBrowserContent {
+
+    export namespace Styles {
+
+        export const MINI_BROWSER = 'theia-mini-browser';
+        export const TOOLBAR = 'theia-mini-browser-toolbar';
+        export const TOOLBAR_READ_ONLY = 'theia-mini-browser-toolbar-read-only';
+        export const PRE_LOAD = 'theia-mini-browser-load-indicator';
+        export const CONTENT_AREA = 'theia-mini-browser-content-area';
+        export const PDF_CONTAINER = 'theia-mini-browser-pdf-container';
+        export const PREVIOUS = 'theia-mini-browser-previous';
+        export const NEXT = 'theia-mini-browser-next';
+        export const REFRESH = 'theia-mini-browser-refresh';
+        export const OPEN = 'theia-mini-browser-open';
+        export const BUTTON = 'theia-mini-browser-button';
+        export const DISABLED = 'theia-mini-browser-button-disabled';
+        export const TRANSPARENT_OVERLAY = 'theia-mini-browser-transparent-overlay';
+
+    }
+
+}

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -23,6 +23,7 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/w
 import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { CommandContribution } from '@theia/core/lib/common/command';
+import { MenuContribution } from '@theia/core/lib/common/menu';
 import { NavigatableWidgetOptions } from '@theia/core/lib/browser/navigatable';
 import { MiniBrowserOpenHandler } from './mini-browser-open-handler';
 import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
@@ -60,6 +61,7 @@ export default new ContainerModule(bind => {
     bind(OpenHandler).toService(MiniBrowserOpenHandler);
     bind(FrontendApplicationContribution).toService(MiniBrowserOpenHandler);
     bind(CommandContribution).toService(MiniBrowserOpenHandler);
+    bind(MenuContribution).toService(MiniBrowserOpenHandler);
     bind(TabBarToolbarContribution).toService(MiniBrowserOpenHandler);
 
     bindContributionProvider(bind, LocationMapper);

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -81,8 +81,8 @@ export class MiniBrowserOpenHandler extends WidgetOpenHandler<MiniBrowser> imple
         const mergedOptions = await this.options(uri, options);
         const widget = await this.widgetManager.getOrCreateWidget<MiniBrowser>(MiniBrowser.Factory.ID, mergedOptions);
         await this.doOpen(widget, mergedOptions);
-        const { area } = mergedOptions.widgetOptions;
-        if (area !== 'main') {
+        const area = this.shell.getAreaFor(widget);
+        if (area && area !== 'main') {
             this.shell.resize(this.shell.mainPanel.node.offsetWidth / 2, area);
         }
         return widget;

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -20,6 +20,7 @@ import URI from '@theia/core/lib/common/uri';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ApplicationShell } from '@theia/core/lib/browser/shell';
 import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
+import { MenuContribution, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NavigatableWidget, NavigatableWidgetOpenHandler } from '@theia/core/lib/browser/navigatable';
 import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
@@ -31,7 +32,8 @@ import { MiniBrowser, MiniBrowserProps } from './mini-browser';
 
 export namespace MiniBrowserCommands {
     export const PREVIEW: Command = {
-        id: 'mini-browser.preview'
+        id: 'mini-browser.preview',
+        label: 'Open Preview'
     };
     export const OPEN_SOURCE: Command = {
         id: 'mini-browser.open.source'
@@ -47,7 +49,7 @@ export interface MiniBrowserOpenerOptions extends WidgetOpenerOptions, MiniBrows
 
 @injectable()
 export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBrowser>
-    implements FrontendApplicationContribution, CommandContribution, TabBarToolbarContribution {
+    implements FrontendApplicationContribution, CommandContribution, MenuContribution, TabBarToolbarContribution {
 
     /**
      * Instead of going to the backend with each file URI to ask whether it can handle the current file or not,
@@ -157,6 +159,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
             execute: widget => this.openSource(widget),
             isEnabled: widget => !!this.getSourceUri(widget),
             isVisible: widget => !!this.getSourceUri(widget)
+        });
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction(['editor_context_menu', 'navigation'], {
+            commandId: MiniBrowserCommands.PREVIEW.id
         });
     }
 

--- a/packages/mini-browser/src/browser/mini-browser.ts
+++ b/packages/mini-browser/src/browser/mini-browser.ts
@@ -14,646 +14,105 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as PDFObject from 'pdfobject';
 import { inject, injectable, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
-import { PanelLayout, SplitPanel } from '@phosphor/widgets';
 import URI from '@theia/core/lib/common/uri';
-import { ILogger } from '@theia/core/lib/common/logger';
-import { Key, KeyCode } from '@theia/core/lib/browser/keys';
-import { Emitter, Event } from '@theia/core/lib/common/event';
-import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
-import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
-import { WindowService } from '@theia/core/lib/browser/window/window-service';
-import { FrontendApplicationContribution, ApplicationShell } from '@theia/core/lib/browser';
-import { FileSystemWatcher, FileChangeEvent } from '@theia/filesystem/lib/browser/filesystem-watcher';
-import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
-import { BaseWidget, addEventListener, FocusTracker, Widget } from '@theia/core/lib/browser/widgets/widget';
-import { LocationMapperService } from './location-mapper-service';
+import { NavigatableWidget, StatefulWidget } from '@theia/core/lib/browser';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { BaseWidget, PanelLayout } from '@theia/core/lib/browser/widgets/widget';
+import { MiniBrowserProps, MiniBrowserContentFactory } from './mini-browser-content';
 
-import debounce = require('lodash.debounce');
+export { MiniBrowserProps };
 
-/**
- * Initializer properties for the embedded browser widget.
- */
 @injectable()
-export class MiniBrowserProps {
-
-    /**
-     * `show` if the toolbar should be visible. If `read-only`, the toolbar is visible but the address cannot be changed and it acts as a link instead.\
-     * `hide` if the toolbar should be hidden. `show` by default. If the `startPage` is not defined, this property is always `show`.
-     */
-    readonly toolbar?: 'show' | 'hide' | 'read-only';
-
-    /**
-     * If defined, the browser will load this page on startup. Otherwise, it show a blank page.
-     */
-    readonly startPage?: string;
-
-    /**
-     * Sandbox options for the underlying `iframe`. Defaults to `SandboxOptions#DEFAULT` if not provided.
-     */
-    readonly sandbox?: MiniBrowserProps.SandboxOptions[];
-
-    /**
-     * The optional icon class for the widget.
-     */
-    readonly iconClass?: string;
-
-    /**
-     * The desired name of the widget.
-     */
-    readonly name?: string;
-
-    /**
-     * `true` if the `iFrame`'s background has to be reset to the default white color. Otherwise, `false`. `false` is the default.
-     */
-    readonly resetBackground?: boolean;
-
-}
-
-export namespace MiniBrowserProps {
-
-    /**
-     * Enumeration of the supported `sandbox` options for the `iframe`.
-     */
-    export enum SandboxOptions {
-
-        /**
-         * Allows form submissions.
-         */
-        'allow-forms',
-
-        /**
-         * Allows popups, such as `window.open()`, `showModalDialog()`, `target=”_blank”`, etc.
-         */
-        'allow-popups',
-
-        /**
-         * Allows pointer lock.
-         */
-        'allow-pointer-lock',
-
-        /**
-         * Allows the document to maintain its origin. Pages loaded from https://example.com/ will retain access to that origin’s data.
-         */
-        'allow-same-origin',
-
-        /**
-         * Allows JavaScript execution. Also allows features to trigger automatically (as they’d be trivial to implement via JavaScript).
-         */
-        'allow-scripts',
-
-        /**
-         * Allows the document to break out of the frame by navigating the top-level `window`.
-         */
-        'allow-top-navigation',
-
-        /**
-         * Allows the embedded browsing context to open modal windows.
-         */
-        'allow-modals',
-
-        /**
-         * Allows the embedded browsing context to disable the ability to lock the screen orientation.
-         */
-        'allow-orientation-lock',
-
-        /**
-         * Allows a sandboxed document to open new windows without forcing the sandboxing flags upon them.
-         * This will allow, for example, a third-party advertisement to be safely sandboxed without forcing the same restrictions upon a landing page.
-         */
-        'allow-popups-to-escape-sandbox',
-
-        /**
-         * Allows embedders to have control over whether an iframe can start a presentation session.
-         */
-        'allow-presentation',
-
-        /**
-         * Allows the embedded browsing context to navigate (load) content to the top-level browsing context only when initiated by a user gesture.
-         * If this keyword is not used, this operation is not allowed.
-         */
-        'allow-top-navigation-by-user-activation'
-    }
-
-    export namespace SandboxOptions {
-
-        /**
-         * The default `sandbox` options, if other is not provided.
-         *
-         * See: https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
-         */
-        export const DEFAULT: SandboxOptions[] = [
-            SandboxOptions['allow-same-origin'],
-            SandboxOptions['allow-scripts'],
-            SandboxOptions['allow-popups'],
-            SandboxOptions['allow-forms'],
-            SandboxOptions['allow-modals']
-        ];
-
-    }
-
-}
-
-/**
- * Contribution that tracks `mouseup` and `mousedown` events.
- *
- * This is required to be able to track the `TabBar`, `DockPanel`, and `SidePanel` resizing and drag and drop events correctly
- * all over the application. By default, when the mouse is over an `iframe` we lose the mouse tracking ability, so whenever
- * we click (`mousedown`), we overlay a transparent `div` over the `iframe` in the Mini Browser, then we set the `display` of
- * the transparent `div` to `none` on `mouseup` events.
- */
-@injectable()
-export class MiniBrowserMouseClickTracker implements FrontendApplicationContribution {
-
-    @inject(ApplicationShell)
-    protected readonly applicationShell: ApplicationShell;
-
-    protected readonly toDispose = new DisposableCollection();
-    protected readonly toDisposeOnActiveChange = new DisposableCollection();
-
-    protected readonly mouseupEmitter = new Emitter<MouseEvent>();
-    protected readonly mousedownEmitter = new Emitter<MouseEvent>();
-    protected readonly mouseupListener: (e: MouseEvent) => void = e => this.mouseupEmitter.fire(e);
-    protected readonly mousedownListener: (e: MouseEvent) => void = e => this.mousedownEmitter.fire(e);
-
-    onStart(): void {
-        // Here we need to attach a `mousedown` listener to the `TabBar`s, `DockPanel`s and the `SidePanel`s. Otherwise, Phosphor handles the event and stops the propagation.
-        // Track the `mousedown` on the `TabBar` for the currently active widget.
-        this.applicationShell.activeChanged.connect((shell: ApplicationShell, args: FocusTracker.IChangedArgs<Widget>) => {
-            this.toDisposeOnActiveChange.dispose();
-            if (args.newValue) {
-                const tabBar = shell.getTabBarFor(args.newValue);
-                if (tabBar) {
-                    this.toDisposeOnActiveChange.push(addEventListener(tabBar.node, 'mousedown', this.mousedownListener, true));
-                }
-            }
-        });
-
-        // Track the `mousedown` events for the `SplitPanel`s, if any.
-        const { layout } = this.applicationShell;
-        if (layout instanceof PanelLayout) {
-            this.toDispose.pushAll(
-                layout.widgets.filter(MiniBrowserMouseClickTracker.isSplitPanel).map(splitPanel => addEventListener(splitPanel.node, 'mousedown', this.mousedownListener, true))
-            );
-        }
-        // Track the `mousedown` on each `DockPanel`.
-        const { mainPanel, bottomPanel, leftPanelHandler, rightPanelHandler } = this.applicationShell;
-        this.toDispose.pushAll([mainPanel, bottomPanel, leftPanelHandler.dockPanel, rightPanelHandler.dockPanel]
-            .map(panel => addEventListener(panel.node, 'mousedown', this.mousedownListener, true)));
-
-        // The `mouseup` event has to be tracked on the `document`. Phosphor attaches to there.
-        document.addEventListener('mouseup', this.mouseupListener, true);
-
-        // Make sure it is disposed in the end.
-        this.toDispose.pushAll([
-            this.mousedownEmitter,
-            this.mouseupEmitter,
-            Disposable.create(() => document.removeEventListener('mouseup', this.mouseupListener, true))
-        ]);
-    }
-
-    onStop(): void {
-        this.toDispose.dispose();
-        this.toDisposeOnActiveChange.dispose();
-    }
-
-    get onMouseup(): Event<MouseEvent> {
-        return this.mouseupEmitter.event;
-    }
-
-    get onMousedown(): Event<MouseEvent> {
-        return this.mousedownEmitter.event;
-    }
-
-}
-
-export namespace MiniBrowserMouseClickTracker {
-
-    export function isSplitPanel(arg: Widget): arg is SplitPanel {
-        return arg instanceof SplitPanel;
-    }
-
+export class MiniBrowserOptions {
+    uri: URI;
 }
 
 @injectable()
-export class MiniBrowser extends BaseWidget {
+export class MiniBrowser extends BaseWidget implements NavigatableWidget, StatefulWidget {
 
-    private static ID = 0;
-    private static ICON = 'fa fa-globe';
+    static ID = 'mini-browser';
+    static ICON = 'fa fa-globe';
+    /**
+     * A default URI to open the mini browser view (singleton widget).
+     * In order to create a new mini browser widget, a custom URI should be passed, e.g. a file URI.
+     */
+    static URI = new URI().withScheme('__minibrowser');
 
-    @inject(ILogger)
-    protected readonly logger: ILogger;
+    @inject(MiniBrowserOptions)
+    protected readonly options: MiniBrowserOptions;
 
-    @inject(WindowService)
-    protected readonly windowService: WindowService;
-
-    @inject(LocationMapperService)
-    protected readonly locationMapper: LocationMapperService;
-
-    @inject(KeybindingRegistry)
-    protected readonly keybindings: KeybindingRegistry;
-
-    @inject(MiniBrowserMouseClickTracker)
-    protected readonly mouseTracker: MiniBrowserMouseClickTracker;
-
-    @inject(FileSystem)
-    protected readonly fileSystem: FileSystem;
-
-    @inject(FileSystemWatcher)
-    protected readonly fileSystemWatcher: FileSystemWatcher;
-
-    protected readonly submitInputEmitter = new Emitter<string>();
-    protected readonly navigateBackEmitter = new Emitter<void>();
-    protected readonly navigateForwardEmitter = new Emitter<void>();
-    protected readonly refreshEmitter = new Emitter<void>();
-    protected readonly openEmitter = new Emitter<void>();
-
-    protected readonly input: HTMLInputElement;
-    protected readonly loadIndicator: HTMLElement;
-    protected readonly frame: HTMLIFrameElement;
-    // tslint:disable-next-line:max-line-length
-    // XXX This is a hack to be able to tack the mouse events when drag and dropping the widgets. On `mousedown` we put a transparent div over the `iframe` to avoid losing the mouse tacking.
-    protected readonly transparentOverlay: HTMLElement;
-    // XXX It is a hack. Instead of loading the PDF in an iframe we use `PDFObject` to render it in a div.
-    protected readonly pdfContainer: HTMLElement;
-
-    protected readonly initialHistoryLength: number;
-    protected readonly toDisposeOnGo = new DisposableCollection();
-
-    constructor(@inject(MiniBrowserProps) protected readonly props: MiniBrowserProps) {
-        super();
-        this.id = `theia-mini-browser-${MiniBrowser.ID++}`;
-        this.title.closable = true;
-        this.title.caption = this.title.label = this.props.name || 'Browser';
-        this.title.iconClass = this.props.iconClass || MiniBrowser.ICON;
-        this.addClass(MiniBrowser.Styles.MINI_BROWSER);
-        this.input = this.createToolbar(this.node).input;
-        const contentArea = this.createContentArea(this.node);
-        this.frame = contentArea.frame;
-        this.transparentOverlay = contentArea.transparentOverlay;
-        this.loadIndicator = contentArea.loadIndicator;
-        this.pdfContainer = contentArea.pdfContainer;
-        this.initialHistoryLength = history.length;
-        this.toDispose.pushAll([
-            this.submitInputEmitter,
-            this.navigateBackEmitter,
-            this.navigateForwardEmitter,
-            this.refreshEmitter,
-            this.openEmitter
-        ]);
-    }
+    @inject(MiniBrowserContentFactory)
+    protected readonly createContent: MiniBrowserContentFactory;
 
     @postConstruct()
     protected init(): void {
-        this.toDispose.push(this.mouseTracker.onMousedown(e => {
-            if (this.frame.style.display !== 'none') {
-                this.transparentOverlay.style.display = 'block';
-            }
-        }));
-        this.toDispose.push(this.mouseTracker.onMouseup(e => {
-            if (this.frame.style.display !== 'none') {
-                this.transparentOverlay.style.display = 'none';
-            }
-        }));
-        const { startPage } = this.props;
-        if (startPage) {
-            setTimeout(() => this.go(startPage, true), 500);
-            this.listenOnContentChange(startPage);
+        const { uri } = this.options;
+        if (uri.toString() === MiniBrowser.URI.toString()) {
+            this.id = MiniBrowser.ID;
+        } else {
+            this.id = `${MiniBrowser.ID}:${uri.toString()}`;
         }
+        this.title.closable = true;
+        this.layout = new PanelLayout();
     }
 
-    onActivateRequest(msg: Message): void {
+    getResourceUri(): URI | undefined {
+        return this.options.uri;
+    }
+
+    createMoveToUri(resourceUri: URI): URI | undefined {
+        return this.options.uri && this.options.uri.withPath(resourceUri.path);
+    }
+
+    protected props: MiniBrowserProps | undefined;
+    protected readonly toDisposeOnProps = new DisposableCollection();
+    setProps(raw: MiniBrowserProps): void {
+        const props: MiniBrowserProps = {
+            toolbar: raw.toolbar,
+            startPage: raw.startPage,
+            sandbox: raw.sandbox,
+            iconClass: raw.iconClass,
+            name: raw.name,
+            resetBackground: raw.resetBackground
+        };
+        if (JSON.stringify(props) === JSON.stringify(this.props)) {
+            return;
+        }
+        this.toDisposeOnProps.dispose();
+        this.toDispose.push(this.toDisposeOnProps);
+        this.props = props;
+
+        this.title.caption = this.title.label = props.name || 'Browser';
+        this.title.iconClass = props.iconClass || MiniBrowser.ICON;
+
+        const content = this.createContent(props);
+        (this.layout as PanelLayout).addWidget(content);
+        this.toDisposeOnProps.push(content);
+    }
+
+    protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        (this.getToolbarProps() !== 'hide' ? this.input : this.frame).focus();
-        this.update();
-    }
-
-    protected async listenOnContentChange(location: string): Promise<void> {
-        if (location.startsWith('file://')) {
-            if (await this.fileSystem.exists(location)) {
-                const fileUri = new URI(location);
-                const watcher = await this.fileSystemWatcher.watchFileChanges(fileUri);
-                this.toDispose.push(watcher);
-                const onFileChange = (event: FileChangeEvent) => {
-                    if (FileChangeEvent.isChanged(event, fileUri)) {
-                        this.go(location, false, false);
-                    }
-                };
-                this.toDispose.push(this.fileSystemWatcher.onFilesChanged(debounce(onFileChange, 500)));
-            }
+        const widget = (this.layout as PanelLayout).widgets[0];
+        if (widget) {
+            widget.activate();
         }
     }
 
-    protected createToolbar(parent: HTMLElement): HTMLDivElement & Readonly<{ input: HTMLInputElement }> {
-        const toolbar = document.createElement('div');
-        toolbar.classList.add(this.getToolbarProps() === 'read-only' ? MiniBrowser.Styles.TOOLBAR_READ_ONLY : MiniBrowser.Styles.TOOLBAR);
-        parent.appendChild(toolbar);
-        this.createPrevious(toolbar);
-        this.createNext(toolbar);
-        this.createRefresh(toolbar);
-        const input = this.createInput(toolbar);
-        input.readOnly = this.getToolbarProps() === 'read-only';
-        this.createOpen(toolbar);
-        if (this.getToolbarProps() === 'hide') {
-            toolbar.style.display = 'none';
+    storeState(): object {
+        const { props } = this;
+        return { props };
+    }
+
+    restoreState(oldState: object): void {
+        if (!this.toDisposeOnProps.disposed) {
+            return;
         }
-        return Object.assign(toolbar, { input });
-    }
-
-    protected getToolbarProps(): 'show' | 'hide' | 'read-only' {
-        return !this.props.startPage ? 'show' : this.props.toolbar || 'show';
-    }
-
-    // tslint:disable-next-line:max-line-length
-    protected createContentArea(parent: HTMLElement): HTMLElement & Readonly<{ frame: HTMLIFrameElement, loadIndicator: HTMLElement, pdfContainer: HTMLElement, transparentOverlay: HTMLElement }> {
-        const contentArea = document.createElement('div');
-        contentArea.classList.add(MiniBrowser.Styles.CONTENT_AREA);
-
-        const loadIndicator = document.createElement('div');
-        loadIndicator.classList.add(MiniBrowser.Styles.PRE_LOAD);
-        loadIndicator.style.display = 'none';
-
-        const frame = this.createIFrame();
-        this.submitInputEmitter.event(input => this.go(input, true));
-        this.navigateBackEmitter.event(this.handleBack.bind(this));
-        this.navigateForwardEmitter.event(this.handleForward.bind(this));
-        this.refreshEmitter.event(this.handleRefresh.bind(this));
-        this.openEmitter.event(this.handleOpen.bind(this));
-
-        const transparentOverlay = document.createElement('div');
-        transparentOverlay.classList.add(MiniBrowser.Styles.TRANSPARENT_OVERLAY);
-        transparentOverlay.style.display = 'none';
-
-        const pdfContainer = document.createElement('div');
-        pdfContainer.classList.add(MiniBrowser.Styles.PDF_CONTAINER);
-        pdfContainer.id = `${this.id}-pdf-container`;
-        pdfContainer.style.display = 'none';
-
-        contentArea.appendChild(transparentOverlay);
-        contentArea.appendChild(pdfContainer);
-        contentArea.appendChild(loadIndicator);
-        contentArea.appendChild(frame);
-
-        parent.appendChild(contentArea);
-        return Object.assign(contentArea, { frame, loadIndicator, pdfContainer, transparentOverlay });
-    }
-
-    protected createIFrame(): HTMLIFrameElement {
-        const frame = document.createElement('iframe');
-        const sandbox = (this.props.sandbox || MiniBrowserProps.SandboxOptions.DEFAULT).map(name => MiniBrowserProps.SandboxOptions[name]);
-        frame.sandbox.add(...sandbox);
-        this.toDispose.push(addEventListener(frame, 'load', this.onFrameLoad.bind(this)));
-        return frame;
-    }
-
-    protected onFrameLoad(): void {
-        this.hideLoadIndicator();
-        this.focus();
-    }
-
-    protected focus(): void {
-        const contentDocument = this.contentDocument();
-        if (contentDocument !== null && contentDocument.body) {
-            contentDocument.body.focus();
-        } else if (this.pdfContainer.style.display !== 'none') {
-            this.pdfContainer.focus();
-        } else if (this.getToolbarProps() !== 'hide') {
-            this.input.focus();
-        } else if (this.frame.parentElement) {
-            this.frame.parentElement.focus();
+        if ('props' in oldState) {
+            // tslint:disable-next-line:no-any
+            this.setProps((<any>oldState)['props']);
         }
-    }
-
-    protected showLoadIndicator(): void {
-        this.loadIndicator.style.display = 'block';
-    }
-
-    protected hideLoadIndicator(): void {
-        this.loadIndicator.style.display = 'none';
-    }
-
-    protected handleBack(): void {
-        if (history.length - this.initialHistoryLength > 0) {
-            history.back();
-        }
-    }
-
-    protected handleForward(): void {
-        if (history.length > this.initialHistoryLength) {
-            history.forward();
-        }
-    }
-
-    protected handleRefresh(): void {
-        // Initial pessimism; use the location of the input.
-        let location: string | undefined = this.props.startPage;
-        // Use the the location from the `input`.
-        if (this.input && this.input.value) {
-            location = this.input.value;
-        }
-        try {
-            const { contentDocument } = this.frame;
-            if (contentDocument && contentDocument.location) {
-                location = contentDocument.location.href;
-            }
-        } catch {
-            // Security exception due to CORS when trying to access the `location.href` of the content document.
-        }
-        if (location) {
-            this.go(location, false, true);
-        }
-    }
-
-    protected handleOpen(): void {
-        const location = this.frameSrc() || this.input.value;
-        if (location) {
-            this.windowService.openNewWindow(location);
-        }
-    }
-
-    protected createInput(parent: HTMLElement): HTMLInputElement {
-        const input = document.createElement('input');
-        input.type = 'text';
-        this.toDispose.pushAll([
-            addEventListener(input, 'keydown', this.handleInputChange.bind(this)),
-            addEventListener(input, 'click', () => {
-                if (this.getToolbarProps() === 'read-only') {
-                    this.handleOpen();
-                } else {
-                    if (input.value) {
-                        input.select();
-                    }
-                }
-            })
-        ]);
-        parent.appendChild(input);
-        return input;
-    }
-
-    protected handleInputChange(e: KeyboardEvent): void {
-        const { key } = KeyCode.createKeyCode(e);
-        if (key && Key.ENTER.keyCode === key.keyCode && this.getToolbarProps() === 'show') {
-            const { srcElement } = e;
-            if (srcElement instanceof HTMLInputElement) {
-                this.mapLocation(srcElement.value).then(location => this.submitInputEmitter.fire(location));
-            }
-        }
-    }
-
-    protected createPrevious(parent: HTMLElement): HTMLElement {
-        return this.onClick(this.createButton(parent, 'Show The Previous Page', MiniBrowser.Styles.PREVIOUS), this.navigateBackEmitter);
-    }
-
-    protected createNext(parent: HTMLElement): HTMLElement {
-        return this.onClick(this.createButton(parent, 'Show The Next Page', MiniBrowser.Styles.NEXT), this.navigateForwardEmitter);
-    }
-
-    protected createRefresh(parent: HTMLElement): HTMLElement {
-        return this.onClick(this.createButton(parent, 'Reload This Page', MiniBrowser.Styles.REFRESH), this.refreshEmitter);
-    }
-
-    protected createOpen(parent: HTMLElement): HTMLElement {
-        const button = this.onClick(this.createButton(parent, 'Open In A New Window', MiniBrowser.Styles.OPEN), this.openEmitter);
-        return button;
-    }
-
-    protected createButton(parent: HTMLElement, title: string, ...className: string[]): HTMLElement {
-        const button = document.createElement('div');
-        button.title = title;
-        button.classList.add(...className, MiniBrowser.Styles.BUTTON);
-        parent.appendChild(button);
-        return button;
-    }
-
-    // tslint:disable-next-line:no-any
-    protected onClick(element: HTMLElement, emitter: Emitter<any>): HTMLElement {
-        this.toDispose.push(addEventListener(element, 'click', () => {
-            if (!element.classList.contains(MiniBrowser.Styles.DISABLED)) {
-                emitter.fire(undefined);
-            }
-        }));
-        return element;
-    }
-
-    protected mapLocation(location: string): Promise<string> {
-        return this.locationMapper.map(location);
-    }
-
-    protected setInput(value: string) {
-        if (this.input.value !== value) {
-            this.input.value = value;
-        }
-    }
-
-    protected frameSrc() {
-        let src = this.frame.src;
-        try {
-            const { contentWindow } = this.frame;
-            if (contentWindow) {
-                src = contentWindow.location.href;
-            }
-        } catch {
-            // CORS issue. Ignored.
-        }
-        if (src === 'about:blank') {
-            src = '';
-        }
-        return src;
-    }
-
-    protected contentDocument(): Document | null {
-        try {
-            let { contentDocument } = this.frame;
-            if (contentDocument === null) {
-                const { contentWindow } = this.frame;
-                if (contentWindow) {
-                    contentDocument = contentWindow.document;
-                }
-            }
-            return contentDocument;
-        } catch {
-            // tslint:disable-next-line:no-null-keyword
-            return null;
-        }
-    }
-
-    protected async go(location: string, register: boolean = false, showLoadIndicator: boolean = true): Promise<void> {
-        if (location) {
-            try {
-                this.toDisposeOnGo.dispose();
-                const url = await this.mapLocation(location);
-                this.setInput(url);
-                if (this.getToolbarProps() === 'read-only') {
-                    this.input.title = `Open ${url} In A New Window`;
-                }
-                if (showLoadIndicator) {
-                    this.showLoadIndicator();
-                }
-                if (url.endsWith('.pdf')) {
-                    this.pdfContainer.style.display = 'block';
-                    this.frame.style.display = 'none';
-                    PDFObject.embed(url, this.pdfContainer, {
-                        // tslint:disable-next-line:max-line-length
-                        fallbackLink: `<p style="padding: 0px 15px 0px 15px">Your browser does not support inline PDFs. Click on this <a href='[url]' target="_blank">link</a> to open the PDF in a new tab.</p>`
-                    });
-                    this.hideLoadIndicator();
-                } else {
-                    if (this.props.resetBackground === true) {
-                        this.frame.addEventListener('load', () => this.frame.style.backgroundColor = 'white', { once: true });
-                    }
-                    this.pdfContainer.style.display = 'none';
-                    this.frame.style.display = 'block';
-                    this.frame.src = url;
-                    // The load indicator will hide itself if the content of the iframe was loaded.
-                }
-                // Delegate all the `keypress` events from the `iframe` to the application.
-                this.toDisposeOnGo.push(addEventListener(this.frame, 'load', () => {
-                    try {
-                        const { contentDocument } = this.frame;
-                        if (contentDocument) {
-                            const keypressHandler = (e: KeyboardEvent) => this.keybindings.run(e);
-                            contentDocument.addEventListener('keypress', keypressHandler, true);
-                            this.toDisposeOnDetach.push(Disposable.create(() => contentDocument.removeEventListener('keypress', keypressHandler)));
-                        }
-                    } catch {
-                        // There is not much we could do with the security exceptions due to CORS.
-                    }
-                }));
-            } catch (e) {
-                this.hideLoadIndicator();
-                console.log(e);
-            }
-        }
-    }
-
-}
-
-export namespace MiniBrowser {
-
-    export namespace Styles {
-
-        export const MINI_BROWSER = 'theia-mini-browser';
-        export const TOOLBAR = 'theia-mini-browser-toolbar';
-        export const TOOLBAR_READ_ONLY = 'theia-mini-browser-toolbar-read-only';
-        export const PRE_LOAD = 'theia-mini-browser-load-indicator';
-        export const CONTENT_AREA = 'theia-mini-browser-content-area';
-        export const PDF_CONTAINER = 'theia-mini-browser-pdf-container';
-        export const PREVIOUS = 'theia-mini-browser-previous';
-        export const NEXT = 'theia-mini-browser-next';
-        export const REFRESH = 'theia-mini-browser-refresh';
-        export const OPEN = 'theia-mini-browser-open';
-        export const BUTTON = 'theia-mini-browser-button';
-        export const DISABLED = 'theia-mini-browser-button-disabled';
-        export const TRANSPARENT_OVERLAY = 'theia-mini-browser-transparent-overlay';
-
-    }
-
-    export namespace Factory {
-
-        export const ID = 'mini-browser-factory';
-
     }
 
 }

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -17,6 +17,7 @@
 .theia-mini-browser {
     display: flex;
     flex-direction: column;
+    height: 100%;
 }
 
 .theia-mini-browser-toolbar {
@@ -81,22 +82,22 @@
 .theia-mini-browser-previous::before {
     content: "\f053";
 }
-  
+
 .theia-mini-browser-next::before {
     content: "\f054";
 }
-  
+
 .theia-mini-browser-refresh::before {
     content: "\f021";
 }
-  
+
 .theia-mini-browser-open::before {
     content: "\f08e";
 }
 
 .theia-mini-browser-content-area {
     position: relative;
-    display: flex; 
+    display: flex;
     height: 100%;
     width: 100%;
     flex-direction: column;
@@ -106,7 +107,7 @@
 
 .theia-mini-browser-pdf-container {
     width: 100%;
-    height: 100%;   
+    height: 100%;
 }
 
 .theia-mini-browser-load-indicator {

--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -292,7 +292,7 @@ export class SvgHandler implements MiniBrowserEndpointHandler {
     }
 
     priority(): number {
-        return CODE_EDITOR_PRIORITY + 1;
+        return 1;
     }
 
     respond(statWithContent: FileStatWithContent, response: Response): MaybePromise<Response> {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -116,7 +116,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             for (const opener of openers) {
                 const openWithCommand = WorkspaceCommands.FILE_OPEN_WITH(opener);
                 registry.registerMenuAction(NavigatorContextMenu.OPEN_WITH, {
-                    commandId: openWithCommand.id
+                    commandId: openWithCommand.id,
+                    label: opener.label,
+                    icon: opener.iconClass
                 });
             }
         });

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -222,7 +222,7 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
     registerToolbarItems(registry: TabBarToolbarRegistry): void {
         registry.registerItem({
             id: PreviewCommands.OPEN.id,
-            command: PreviewCommands.OPEN,
+            command: PreviewCommands.OPEN.id,
             isVisible: (widget: Widget) => widget instanceof EditorWidget && this.canHandleEditorUri(),
             text: '$(columns)',
             tooltip: 'Open Preview to the Side'

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -37,6 +37,9 @@ export namespace PreviewCommands {
     export const OPEN: Command = {
         id: 'preview:open'
     };
+    export const OPEN_SOURCE: Command = {
+        id: 'preview.open.source'
+    };
 }
 
 export interface PreviewOpenerOptions extends WidgetOpenerOptions {
@@ -124,9 +127,7 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
 
     protected registerOpenOnDoubleClick(ref: PreviewWidget): void {
         const disposable = ref.onDidDoubleClick(async location => {
-            const { editor } = await this.editorManager.open(new URI(location.uri), {
-                widgetOptions: { ref, mode: 'open-to-left' }
-            });
+            const { editor } = await this.openSource(ref);
             editor.revealPosition(location.range.start);
             editor.selection = location.range;
             ref.revealForSourceLine(location.range.start.line);
@@ -175,7 +176,12 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         registry.registerCommand(PreviewCommands.OPEN, {
             execute: widget => this.openForEditor(widget),
             isEnabled: widget => this.canHandleEditorUri(widget),
-            isVisible: widget => this.canHandleEditorUri(widget),
+            isVisible: widget => this.canHandleEditorUri(widget)
+        });
+        registry.registerCommand(PreviewCommands.OPEN_SOURCE, {
+            execute: widget => this.openSource(widget),
+            isEnabled: widget => widget instanceof PreviewWidget,
+            isVisible: widget => widget instanceof PreviewWidget
         });
     }
 
@@ -190,8 +196,14 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         registry.registerItem({
             id: PreviewCommands.OPEN.id,
             command: PreviewCommands.OPEN.id,
-            text: '$(columns)',
+            text: '$(eye)',
             tooltip: 'Open Preview to the Side'
+        });
+        registry.registerItem({
+            id: PreviewCommands.OPEN_SOURCE.id,
+            command: PreviewCommands.OPEN_SOURCE.id,
+            text: '$(file-o)',
+            tooltip: 'Open Source'
         });
     }
 
@@ -217,6 +229,15 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
             mode: 'reveal',
             widgetOptions: { ref, mode: 'open-to-right' }
         });
+    }
+
+    protected async openSource(ref: PreviewWidget): Promise<EditorWidget>;
+    protected async openSource(ref?: Widget): Promise<EditorWidget | undefined> {
+        if (ref instanceof PreviewWidget) {
+            return this.editorManager.open(ref.uri, {
+                widgetOptions: { ref, mode: 'open-to-left' }
+            });
+        }
     }
 
 }

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -211,10 +211,12 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
         const uri = this.getCurrentEditorUri(widget);
         return !!uri && this.previewHandlerProvider.canHandle(uri);
     }
+
     protected getCurrentEditorUri(widget?: Widget): URI | undefined {
         const current = this.getCurrentEditor(widget);
         return current && current.editor.uri;
     }
+
     protected getCurrentEditor(widget?: Widget): EditorWidget | undefined {
         const current = widget ? widget : this.editorManager.currentEditor;
         return current instanceof EditorWidget && current || undefined;

--- a/packages/preview/src/browser/preview-contribution.ts
+++ b/packages/preview/src/browser/preview-contribution.ts
@@ -35,7 +35,8 @@ export namespace PreviewCommands {
      * See in (`WorkspaceCommandContribution`)[https://bit.ly/2DncrSD].
      */
     export const OPEN: Command = {
-        id: 'preview:open'
+        id: 'preview:open',
+        label: 'Open Preview'
     };
     export const OPEN_SOURCE: Command = {
         id: 'preview.open.source'
@@ -187,8 +188,7 @@ export class PreviewContribution extends NavigatableWidgetOpenHandler<PreviewWid
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(EditorContextMenu.NAVIGATION, {
-            commandId: PreviewCommands.OPEN.id,
-            label: 'Open Preview',
+            commandId: PreviewCommands.OPEN.id
         });
     }
 

--- a/packages/preview/src/browser/preview-widget.ts
+++ b/packages/preview/src/browser/preview-widget.ts
@@ -41,7 +41,7 @@ export interface PreviewWidgetOptions {
 @injectable()
 export class PreviewWidget extends BaseWidget implements Navigatable {
 
-    protected readonly uri: URI;
+    readonly uri: URI;
     protected readonly resource: Resource;
     protected previewHandler: PreviewHandler | undefined;
     protected firstUpdate: (() => void) | undefined = undefined;

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -257,6 +257,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             await this.openTerminal({ ref, mode: 'split-right' });
         }
     }
+
     protected getTerminalRef(widget?: Widget): TerminalWidget | undefined {
         const ref = widget ? widget : this.shell.currentWidget;
         return ref instanceof TerminalWidget ? ref : undefined;

--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -17,6 +17,7 @@
 import { ContainerModule, Container } from 'inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { KeybindingContribution, WebSocketConnectionProvider, WidgetFactory, KeybindingContext } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TerminalFrontendContribution } from './terminal-frontend-contribution';
 import { TerminalWidgetImpl, TERMINAL_WIDGET_FACTORY_ID } from './terminal-widget-impl';
 import { TerminalWidget, TerminalWidgetOptions } from './base/terminal-widget';
@@ -59,7 +60,7 @@ export default new ContainerModule(bind => {
 
     bind(TerminalFrontendContribution).toSelf().inSingletonScope();
     bind(TerminalService).toService(TerminalFrontendContribution);
-    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution]) {
+    for (const identifier of [CommandContribution, MenuContribution, KeybindingContribution, TabBarToolbarContribution]) {
         bind(identifier).toService(TerminalFrontendContribution);
     }
 

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -85,10 +85,7 @@ export namespace WorkspaceCommands {
         label: 'New Folder'
     };
     export const FILE_OPEN_WITH = (opener: OpenHandler): Command => ({
-        id: `file.openWith.${opener.id}`,
-        category: FILE_CATEGORY,
-        label: opener.label,
-        iconClass: opener.iconClass
+        id: `file.openWith.${opener.id}`
     });
     export const FILE_RENAME: Command = {
         id: 'file.rename',


### PR DESCRIPTION
Fix #3453, fix #3448, fix #2763, fix #2581, fix #2580, fix #3506 
Gitpod: https://github.com/gitpod-io/gitpod/issues/137, https://github.com/gitpod-io/gitpod/issues/106

- align UX of Preview and Mini Browser
- show the tab bar toolbar for all widgets
- insert relative to the current widget of main or bottom area by default
- introduce open to left or right sidebar insertion modes for the shell
- add git toolbar items to navigate between changes and a source file
- add preview toolbar items to navigate between browser/preview and a source file
- add split terminal toolbar item

Open Preview
![toolbar](https://user-images.githubusercontent.com/3082655/48547637-6bd61f00-e8cb-11e8-8e5c-195f0996e747.gif)

Open Changes
![changes](https://user-images.githubusercontent.com/3082655/48547723-92945580-e8cb-11e8-81c3-78f51a8aac79.gif)

Split Terminal
![split](https://user-images.githubusercontent.com/3082655/48549372-e6a13900-e8cf-11e8-823b-8356b93174c7.gif)
