### PR TITLE
[electron][navigator] Add `Open Folder` button

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -30,6 +30,7 @@ import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shel
 import { WorkspaceNode } from './navigator-tree';
 import { FileNavigatorModel } from './navigator-model';
 import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { isOSX, environment } from '@theia/core';
 import * as React from 'react';
 
 export const FILE_NAVIGATOR_ID = 'files';
@@ -172,9 +173,16 @@ export class FileNavigatorWidget extends FileTreeWidget {
         }
     }
 
+    protected canOpenWorkspaceFileAndFolder: boolean = isOSX || !environment.electron.is();
+
     protected readonly openWorkspace = () => this.doOpenWorkspace();
     protected doOpenWorkspace() {
         this.commandService.executeCommand(WorkspaceCommands.OPEN_WORKSPACE.id);
+    }
+
+    protected readonly openFolder = () => this.doOpenFolder();
+    protected doOpenFolder() {
+        this.commandService.executeCommand(WorkspaceCommands.OPEN_FOLDER.id);
     }
 
     /**
@@ -182,12 +190,22 @@ export class FileNavigatorWidget extends FileTreeWidget {
      * button when the workspace root is not yet set.
      */
     protected renderOpenWorkspaceDiv(): React.ReactNode {
+        let openButton;
+
+        if (this.canOpenWorkspaceFileAndFolder) {
+            openButton = <button className='open-workspace-button' title='Select a folder or a workspace-file to open as your workspace' onClick={this.openWorkspace}>
+                Open Workspace
+            </button>;
+        } else {
+            openButton = <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openWorkspace}>
+                Open Folder
+            </button>;
+        }
+
         return <div className='theia-navigator-container'>
             <div className='center'>You have not yet opened a workspace.</div>
             <div className='open-workspace-button-container'>
-                <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openWorkspace}>
-                    Open Workspace
-                </button>
+                {openButton}
             </div>
         </div>;
     }


### PR DESCRIPTION
Only the `Open Workspace` button is shown in the navigator.  But since native
file dialogs were added, opening a workspace specifically requires you to open
a file. This was a bit annoying.

Also because of #3216 we can corrupt the current workspace and be stuck with
it...

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>