### PR TITLE
[electron] Remove default menus on startup

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -104,12 +104,14 @@ process.env.LC_NUMERIC = 'C';
 const { join } = require('path');
 const { isMaster } = require('cluster');
 const { fork } = require('child_process');
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu } = require('electron');
+
+const props = require('../../package.json').theia || {};
 
 const windows = [];
 
 function createNewWindow(theUrl) {
-    const newWindow = new BrowserWindow({ width: 1024, height: 728, show: !!theUrl });
+    const newWindow = new BrowserWindow({ width: 1024, height: 728, show: !!theUrl, title: props.applicationName || 'Theia' });
     if (windows.length === 0) {
         newWindow.webContents.on('new-window', (event, url, frameName, disposition, options) => {
             // If the first electron window isn't visible, then all other new windows will remain invisible.
@@ -147,6 +149,9 @@ if (isMaster) {
         createNewWindow(url);
     });
     app.on('ready', () => {
+        // Remove the default electron menus, waiting for the application to set its own.
+        Menu.setApplicationMenu(null);
+
         // Check whether we are in bundled application or development mode.
         // @ts-ignore
         const devMode = process.defaultApp || /node_modules[\/]electron[\/]/.test(process.execPath);


### PR DESCRIPTION
When we open an Electron window, a bunch of menus are defined by default.  This
is annoying because when we want to quickly open a workspace, we might click on
those, then once the application really starts it will destroy the menus and we
have to clic back on it to finally do what we wanted in the first place.  This
commit removes the menus until the application sets them back.  The generated
code will also look for an `applicationName` field inside the `package.json` of
the application as title of the created window, again until everything is
loaded.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
