### PR TITLE
Add Terminal preferences and allow ctrl+c and ctrl+v on terminal if it has a selection

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-module.ts
+++ b/packages/terminal/src/browser/terminal-frontend-module.ts
@@ -26,11 +26,13 @@ import { IShellTerminalServer, shellTerminalPath, ShellTerminalServerProxy } fro
 import { TerminalActiveContext } from './terminal-keybinding-contexts';
 import { createCommonBindings } from '../common/terminal-common-module';
 import { TerminalService } from './base/terminal-service';
+import { bindTerminalPreferences } from './terminal-preferences';
 
 import '../../src/browser/terminal.css';
 import 'xterm/lib/xterm.css';
 
 export default new ContainerModule(bind => {
+    bindTerminalPreferences(bind);
     bind(KeybindingContext).to(TerminalActiveContext).inSingletonScope();
 
     bind(TerminalWidget).to(TerminalWidgetImpl).inTransientScope();

--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2018 Bitsler and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceContribution, PreferenceSchema } from '@theia/core/lib/browser';
+
+export const TerminalConfigSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'terminal.enableCopy': {
+            type: 'boolean',
+            description: 'Enable ctrl-c (cmd-c on macOS) to copy selected text',
+            default: true
+        },
+        'terminal.enablePaste': {
+            type: 'boolean',
+            description: 'Enable ctrl-v (cmd-v on macOS) to paste from clipboard',
+            default: true
+        }
+    }
+};
+
+export interface TerminalConfiguration {
+    'terminal.enableCopy': boolean
+    'terminal.enablePaste': boolean
+}
+
+export const TerminalPreferences = Symbol('TerminalPreferences');
+export type TerminalPreferences = PreferenceProxy<TerminalConfiguration>;
+
+export function createTerminalPreferences(preferences: PreferenceService): TerminalPreferences {
+    return createPreferenceProxy(preferences, TerminalConfigSchema);
+}
+
+export function bindTerminalPreferences(bind: interfaces.Bind): void {
+    bind(TerminalPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createTerminalPreferences(preferences);
+    });
+    bind(PreferenceContribution).toConstantValue({ schema: TerminalConfigSchema });
+}

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -18,7 +18,8 @@ import * as Xterm from 'xterm';
 import { proposeGeometry } from 'xterm/lib/addons/fit/fit';
 import { inject, injectable, named, postConstruct } from 'inversify';
 import { Disposable, Event, Emitter, ILogger, DisposableCollection } from '@theia/core';
-import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop } from '@theia/core/lib/browser';
+import { Widget, Message, WebSocketConnectionProvider, StatefulWidget, isFirefox, MessageLoop, KeyCode } from '@theia/core/lib/browser';
+import { isOSX } from '@theia/core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ShellTerminalServerProxy } from '../common/shell-terminal-protocol';
 import { terminalsPath } from '../common/terminal-protocol';
@@ -28,6 +29,7 @@ import { ThemeService } from '@theia/core/lib/browser/theming';
 import { TerminalWidgetOptions, TerminalWidget } from './base/terminal-widget';
 import { MessageConnection } from 'vscode-jsonrpc';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { TerminalPreferences } from './terminal-preferences';
 
 export const TERMINAL_WIDGET_FACTORY_ID = 'terminal';
 
@@ -72,6 +74,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(ThemeService) protected readonly themeService: ThemeService;
     @inject(ILogger) @named('terminal') protected readonly logger: ILogger;
     @inject('terminal-dom-id') public readonly id: string;
+    @inject(TerminalPreferences) protected readonly preferences: TerminalPreferences;
 
     protected readonly toDisposeOnConnect = new DisposableCollection();
 
@@ -114,7 +117,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 selection: cssProps.selection
             });
         }));
-
+        this.attachCustomKeyEventHandler();
         this.term.on('title', (title: string) => {
             if (this.options.useServerTitle) {
                 this.title.label = title;
@@ -404,4 +407,29 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         const { cols, rows } = this.term;
         this.shellTerminalServer.resize(this.terminalId, cols, rows);
     }
+
+    protected get enableCopy(): boolean {
+        return this.preferences['terminal.enableCopy'];
+    }
+
+    protected get enablePaste(): boolean {
+        return this.preferences['terminal.enablePaste'];
+    }
+
+    protected customKeyHandler(event: KeyboardEvent): boolean {
+        const keyBindings = KeyCode.createKeyCode(event).toString();
+        const ctrlCmdCopy = (isOSX && keyBindings === 'meta+c') || (!isOSX && keyBindings === 'ctrl+c');
+        const ctrlCmdPaste = (isOSX && keyBindings === 'meta+v') || (!isOSX && keyBindings === 'ctrl+v');
+        if (ctrlCmdCopy && this.enableCopy && this.term.hasSelection()) {
+            return false;
+        }
+        if (ctrlCmdPaste && this.enablePaste) {
+            return false;
+        }
+        return true;
+    }
+    protected attachCustomKeyEventHandler(): void {
+        this.term.attachCustomKeyEventHandler(e => this.customKeyHandler(e));
+    }
+
 }


### PR DESCRIPTION
**Background:**
Since theia let most key bindings be handled by xtermjs, the usual
copy&paste key shortcuts no longer works.

Theia did this intentionally to have key bindings such as ctrl+c to
propagate into xterm, which then is used to send a kill signal SIGINT.

**About:**
This PR adds `Terminal` to preferences with `enableCopy` and `enablePaste` as initial options.
- `enableCopy` [Boolean] - Enables `ctrl-c` or `cmd-c`(for OSX) to copy selected texts from the terminal.
If there is no text selected, the command will propagate normally to xterm.
- `enablePaste` [Boolean] - Enabled `ctrl-v` or `cmd-v`(for OSX) to paste from clipboard,

This PR uses xterm's `attachCustomKeyEventHandler` to listen for key strokes and the selection is returned by xterm's `hasSelection` function.

Signed-off-by: Uni Sayo <unibtc@gmail.com>