### PR TITLE
[electron] Center window + dynamic size

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -101,56 +101,73 @@ if (process.env.LC_ALL) {
 }
 process.env.LC_NUMERIC = 'C';
 
+const electron = require('electron');
 const { join } = require('path');
 const { isMaster } = require('cluster');
 const { fork } = require('child_process');
-const { app, BrowserWindow, ipcMain, Menu } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu } = electron;
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
-const windows = [];
-
-function createNewWindow(theUrl) {
-    const newWindow = new BrowserWindow({ width: 1024, height: 728, show: !!theUrl, title: applicationName });
-    if (windows.length === 0) {
-        newWindow.webContents.on('new-window', (event, url, frameName, disposition, options) => {
-            // If the first electron window isn't visible, then all other new windows will remain invisible.
-            // https://github.com/electron/electron/issues/3751
-            options.show = true;
-            options.width = 1024;
-            options.height = 728;
-            options.title = applicationName;
-        });
-    }
-    windows.push(newWindow);
-    if (!!theUrl) {
-        newWindow.loadURL(theUrl);
-    } else {
-        newWindow.on('ready-to-show', () => newWindow.show());
-    }
-    newWindow.on('closed', () => {
-        const index = windows.indexOf(newWindow);
-        if (index !== -1) {
-            windows.splice(index, 1);
-        }
-        if (windows.length === 0) {
-            app.exit(0);
-        }
-    });
-    return newWindow;
-}
 
 if (isMaster) {
-    app.on('window-all-closed', () => {
-        if (process.platform !== 'darwin') {
-            app.quit();
-        }
-    });
-    ipcMain.on('create-new-window', (event, url) => {
-        createNewWindow(url);
-    });
     app.on('ready', () => {
+        const { screen } = electron;
+
         // Remove the default electron menus, waiting for the application to set its own.
         Menu.setApplicationMenu(Menu.buildFromTemplate([]));
+
+        // Window list tracker.
+        const windows = [];
+
+        function createNewWindow(theUrl) {
+
+            // We must center by hand because \`browserWindow.center()\` fails on multi-screen setups
+            // See: https://github.com/electron/electron/issues/3490
+            const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+            const height = Math.floor(bounds.height * (2/3));
+            const width = Math.floor(bounds.width * (2/3));
+
+            const y = Math.floor(bounds.y + (bounds.height - height) / 2);
+            const x = Math.floor(bounds.x + (bounds.width - width) / 2);
+
+            const newWindow = new BrowserWindow({ width, height, x, y, show: !!theUrl, title: applicationName });
+
+            if (windows.length === 0) {
+                newWindow.webContents.on('new-window', (event, url, frameName, disposition, options) => {
+                    // If the first electron window isn't visible, then all other new windows will remain invisible.
+                    // https://github.com/electron/electron/issues/3751
+                    options.show = true;
+                    options.width = width;
+                    options.height = height;
+                    options.title = applicationName;
+                });
+            }
+            windows.push(newWindow);
+            if (!!theUrl) {
+                newWindow.loadURL(theUrl);
+            } else {
+                newWindow.on('ready-to-show', () => newWindow.show());
+            }
+            newWindow.on('closed', () => {
+                const index = windows.indexOf(newWindow);
+                if (index !== -1) {
+                    windows.splice(index, 1);
+                }
+                if (windows.length === 0) {
+                    app.exit(0);
+                }
+            });
+            return newWindow;
+        }
+
+        app.on('window-all-closed', () => {
+            if (process.platform !== 'darwin') {
+                app.quit();
+            }
+        });
+        ipcMain.on('create-new-window', (event, url) => {
+            createNewWindow(url);
+        });
 
         // Check whether we are in bundled application or development mode.
         // @ts-ignore


### PR DESCRIPTION
`electron.screen` is only defined once the electron `app` is ready, it is
undefined before, hence the refactoring.

Sets up the default new window size as `2/3` of the screen that is below the
mouse when a new window is being created. Window is also centered on screen.

Fixes #3418

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
