### PR TITLE
Renrer hyperlinks in tree nodes

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/tree.css
+++ b/packages/plugin-ext/src/main/browser/style/tree.css
@@ -14,42 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.fa-spinner {
-    color: var(--theia-ui-font-color1);
+.theia-TreeNodeHyperlink {
+    color: var(--theia-accent-color1);
 }
 
-.spinnerContainer {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+.theia-TreeNodeHyperlink:focus {
+    border: none;
 }
-
-.flexcontainer {
-    display: flex;
-}
-
-.noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.row {
-    width: 100%;
-}
-
-.column {
-    flex-direction: column;
-}
-
-.pluginHeaderContainer {
-    background: var(--theia-layout-color1);
-    margin-bottom: 5px;
-    color: var(--theia-ui-font-color1);
-}
-
-@import './plugin-sidebar.css';
-@import './view-registry.css';
-@import './tree.css';


### PR DESCRIPTION
Makes it possible to display hyperlinks in Tree View.
Receives a text with a markdown `[label](url)` from a plugin, parses and displays as hyperlinks. Something like GitHub does.

Issue https://github.com/theia-ide/theia/issues/3304

Plugin demonstrating the feature https://github.com/eclipse/che-theia-samples/tree/master/tree-view-sample-plugin

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

![hyperlinks in the tree](https://user-images.githubusercontent.com/1655894/48421744-c3f31100-e765-11e8-8521-dca7117a41d0.png)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
