### PR TITLE
 [plug-in] Add document.registerDocumentSymbolProvider API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.17
 - [plug-in] added `languages.registerCodeLensProvider` Plug-in API
+- [plug-in] added `languages.registerDocumentSymbolProvider` Plug-in API
 - [core] `ctrl+alt+a` and `ctrl+alt+d` to switch tabs left/right
 - [core] added `theia.applicationName` to application `package.json` and improved window title
 

--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -300,6 +300,45 @@ export interface WorkspaceEdit {
     rejectReason?: string;
 }
 
+export enum SymbolKind {
+	File = 0,
+	Module = 1,
+	Namespace = 2,
+	Package = 3,
+	Class = 4,
+	Method = 5,
+	Property = 6,
+	Field = 7,
+	Constructor = 8,
+	Enum = 9,
+	Interface = 10,
+	Function = 11,
+	Variable = 12,
+	Constant = 13,
+	String = 14,
+	Number = 15,
+	Boolean = 16,
+	Array = 17,
+	Object = 18,
+	Key = 19,
+	Null = 20,
+	EnumMember = 21,
+	Struct = 22,
+	Event = 23,
+	Operator = 24,
+	TypeParameter = 25
+}
+
+export interface DocumentSymbol {
+	name: string;
+	detail: string;
+	kind: SymbolKind;
+	containerName?: string;
+	range: Range;
+	selectionRange: Range;
+	children?: DocumentSymbol[];
+}
+
 export interface WorkspaceFoldersChangeEvent {
     added: WorkspaceFolder[];
     removed: WorkspaceFolder[];

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -43,6 +43,7 @@ import {
     CodeLensSymbol,
     Command,
     TextEdit,
+    DocumentSymbol,
     ReferenceContext,
     Location
 } from './model';
@@ -752,6 +753,7 @@ export interface LanguagesExt {
         rangeOrSelection: Range | Selection,
         context: monaco.languages.CodeActionContext
     ): Promise<monaco.languages.CodeAction[]>;
+    $provideDocumentSymbols(handle: number, resource: UriComponents): Promise<DocumentSymbol[] | undefined>;
 }
 
 export interface LanguagesMain {
@@ -772,6 +774,7 @@ export interface LanguagesMain {
     $registerDocumentLinkProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle?: number): void;
     $emitCodeLensEvent(eventHandle: number, event?: any): void;
+    $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
 export const PLUGIN_RPC_CONTEXT = {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -230,6 +230,26 @@ export class LanguagesMainImpl implements LanguagesMain {
         }
     }
 
+    $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void {
+        const languageSelector = fromLanguageSelector(selector);
+        const symbolProvider = this.createDocumentSymbolProvider(handle, languageSelector);
+
+        const disposable = new DisposableCollection();
+        for (const language of getLanguages()) {
+            if (this.matchLanguage(languageSelector, language)) {
+                disposable.push(monaco.languages.registerDocumentSymbolProvider(language, symbolProvider));
+            }
+        }
+        this.disposables.set(handle, disposable);
+	}
+
+    protected createDocumentSymbolProvider(handle: number, selector: LanguageSelector | undefined): monaco.languages.DocumentSymbolProvider {
+        return {
+            provideDocumentSymbols: (model, token) =>
+                this.proxy.$provideDocumentSymbols(handle, model.uri).then(v => v!)
+        };
+    }
+
     protected createDefinitionProvider(handle: number, selector: LanguageSelector | undefined): monaco.languages.DefinitionProvider {
         return {
             provideDefinition: (model, position, token) => {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -47,6 +47,7 @@ import {
     DefinitionLink,
     DocumentLink,
     CodeLensSymbol,
+    DocumentSymbol,
     ReferenceContext,
     Location
 } from '../api/model';
@@ -62,6 +63,7 @@ import { CodeActionAdapter } from './languages/code-action';
 import { LinkProviderAdapter } from './languages/link-provider';
 import { CodeLensAdapter } from './languages/lens';
 import { CommandRegistryImpl } from './command-registry';
+import { OutlineAdapter } from './languages/outline';
 import { ReferenceAdapter } from './languages/reference';
 
 type Adapter = CompletionAdapter |
@@ -74,6 +76,7 @@ type Adapter = CompletionAdapter |
     LinkProviderAdapter |
     CodeLensAdapter |
     CodeActionAdapter |
+    OutlineAdapter |
     LinkProviderAdapter |
     ReferenceAdapter;
 
@@ -362,8 +365,13 @@ export class LanguagesExtImpl implements LanguagesExt {
 
     // ### Document Symbol Provider begin
     registerDocumentSymbolProvider(selector: theia.DocumentSelector, provider: theia.DocumentSymbolProvider): theia.Disposable {
-        // FIXME: to implement
-        return new Disposable(() => { });
+        const callId = this.addNewAdapter(new OutlineAdapter(this.documents, provider));
+        this.proxy.$registerOutlineSupport(callId, this.transformDocumentSelector(selector));
+        return this.createDisposable(callId);
+    }
+
+    $provideDocumentSymbols(handle: number, resource: UriComponents): Promise<DocumentSymbol[] | undefined> {
+        return this.withAdapter(handle, OutlineAdapter, adapter => adapter.provideDocumentSymbols(URI.revive(resource)));
     }
     // ### Document Symbol Provider end
 

--- a/packages/plugin-ext/src/plugin/languages/outline.ts
+++ b/packages/plugin-ext/src/plugin/languages/outline.ts
@@ -1,0 +1,126 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri/lib/umd';
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import * as Converter from '../type-converters';
+import { createToken } from '../token-provider';
+import { DocumentSymbol, Range } from '../../api/model';
+import * as types from '../types-impl';
+
+/** Adapts the calls from main to extension thread for providing the document symbols. */
+export class OutlineAdapter {
+
+	constructor(
+		private readonly documents: DocumentsExtImpl,
+		private readonly provider: theia.DocumentSymbolProvider
+	) { }
+
+	provideDocumentSymbols(resource: URI): Promise<DocumentSymbol[] | undefined> {
+		const document = this.documents.getDocumentData(resource);
+		if (!document) {
+			return Promise.reject(new Error(`There is no document for ${resource}`));
+		}
+
+		const doc = document.document;
+
+		return Promise.resolve(this.provider.provideDocumentSymbols(doc, createToken())).then(value => {
+			if (!value || value.length === 0) {
+				return undefined;
+			}
+			if (value[0] instanceof types.DocumentSymbol) {
+				return (<types.DocumentSymbol[]>value).map(Converter.fromDocumentSymbol);
+			} else {
+				return OutlineAdapter.asDocumentSymbolTree(resource, <types.SymbolInformation[]>value);
+			}
+		});
+	}
+
+	private static asDocumentSymbolTree(resource: URI, info: types.SymbolInformation[]): DocumentSymbol[] {
+		// first sort by start (and end) and then loop over all elements
+		// and build a tree based on containment.
+		info = info.slice(0).sort((a, b) => {
+			let r = a.location.range.start.compareTo(b.location.range.start);
+			if (r === 0) {
+				r = b.location.range.end.compareTo(a.location.range.end);
+			}
+			return r;
+		});
+		const res: DocumentSymbol[] = [];
+		const parentStack: DocumentSymbol[] = [];
+		for (let i = 0; i < info.length; i++) {
+			const element = <DocumentSymbol>{
+				name: info[i].name,
+				detail: '',
+				kind: Converter.SymbolKind.fromSymbolKind(info[i].kind),
+				containerName: info[i].containerName,
+				range: Converter.fromRange(info[i].location.range),
+				selectionRange: Converter.fromRange(info[i].location.range),
+				children: []
+			};
+
+			while (true) {
+				if (parentStack.length === 0) {
+					parentStack.push(element);
+					res.push(element);
+					break;
+				}
+				const parent = parentStack[parentStack.length - 1];
+				if (OutlineAdapter.containsRange(parent.range, element.range) && !OutlineAdapter.equalsRange(parent.range, element.range)) {
+					parent.children!.push(element);
+					parentStack.push(element);
+					break;
+				}
+				parentStack.pop();
+			}
+		}
+		return res;
+	}
+
+	/**
+	 * Test if `otherRange` is in `range`. If the ranges are equal, will return true.
+	 */
+	private static containsRange(range: Range, otherRange: Range): boolean {
+		if (otherRange.startLineNumber < range.startLineNumber || otherRange.endLineNumber < range.startLineNumber) {
+			return false;
+		}
+		if (otherRange.startLineNumber > range.endLineNumber || otherRange.endLineNumber > range.endLineNumber) {
+			return false;
+		}
+		if (otherRange.startLineNumber === range.startLineNumber && otherRange.startColumn < range.startColumn) {
+			return false;
+		}
+		if (otherRange.endLineNumber === range.endLineNumber && otherRange.endColumn > range.endColumn) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Test if range `a` equals `b`.
+	 */
+	private static equalsRange(a: Range, b: Range): boolean {
+		return (
+			!!a &&
+			!!b &&
+			a.startLineNumber === b.startLineNumber &&
+			a.startColumn === b.startColumn &&
+			a.endLineNumber === b.endLineNumber &&
+			a.endColumn === b.endColumn
+		);
+	}
+}

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -397,6 +397,78 @@ export function fromWorkspaceEdit(value: theia.WorkspaceEdit, documents?: any): 
     return result;
 }
 
+export namespace SymbolKind {
+    // tslint:disable-next-line:no-null-keyword
+    const fromMapping: { [kind: number]: model.SymbolKind } = Object.create(null);
+    fromMapping[types.SymbolKind.File] = model.SymbolKind.File;
+    fromMapping[types.SymbolKind.Module] = model.SymbolKind.Module;
+    fromMapping[types.SymbolKind.Namespace] = model.SymbolKind.Namespace;
+    fromMapping[types.SymbolKind.Package] = model.SymbolKind.Package;
+    fromMapping[types.SymbolKind.Class] = model.SymbolKind.Class;
+    fromMapping[types.SymbolKind.Method] = model.SymbolKind.Method;
+    fromMapping[types.SymbolKind.Property] = model.SymbolKind.Property;
+    fromMapping[types.SymbolKind.Field] = model.SymbolKind.Field;
+    fromMapping[types.SymbolKind.Constructor] = model.SymbolKind.Constructor;
+    fromMapping[types.SymbolKind.Enum] = model.SymbolKind.Enum;
+    fromMapping[types.SymbolKind.Interface] = model.SymbolKind.Interface;
+    fromMapping[types.SymbolKind.Function] = model.SymbolKind.Function;
+    fromMapping[types.SymbolKind.Variable] = model.SymbolKind.Variable;
+    fromMapping[types.SymbolKind.Constant] = model.SymbolKind.Constant;
+    fromMapping[types.SymbolKind.String] = model.SymbolKind.String;
+    fromMapping[types.SymbolKind.Number] = model.SymbolKind.Number;
+    fromMapping[types.SymbolKind.Boolean] = model.SymbolKind.Boolean;
+    fromMapping[types.SymbolKind.Array] = model.SymbolKind.Array;
+    fromMapping[types.SymbolKind.Object] = model.SymbolKind.Object;
+    fromMapping[types.SymbolKind.Key] = model.SymbolKind.Key;
+    fromMapping[types.SymbolKind.Null] = model.SymbolKind.Null;
+    fromMapping[types.SymbolKind.EnumMember] = model.SymbolKind.EnumMember;
+    fromMapping[types.SymbolKind.Struct] = model.SymbolKind.Struct;
+    fromMapping[types.SymbolKind.Event] = model.SymbolKind.Event;
+    fromMapping[types.SymbolKind.Operator] = model.SymbolKind.Operator;
+    fromMapping[types.SymbolKind.TypeParameter] = model.SymbolKind.TypeParameter;
+
+    export function fromSymbolKind(kind: theia.SymbolKind): model.SymbolKind {
+        return fromMapping[kind] || model.SymbolKind.Property;
+    }
+
+    export function toSymbolKind(kind: model.SymbolKind): theia.SymbolKind {
+        for (const k in fromMapping) {
+            if (fromMapping[k] === kind) {
+                return Number(k);
+            }
+        }
+        return types.SymbolKind.Property;
+    }
+}
+
+export function fromDocumentSymbol(info: theia.DocumentSymbol): model.DocumentSymbol {
+    const result: model.DocumentSymbol = {
+        name: info.name,
+        detail: info.detail,
+        range: fromRange(info.range)!,
+        selectionRange: fromRange(info.selectionRange)!,
+        kind: SymbolKind.fromSymbolKind(info.kind)
+    };
+    if (info.children) {
+        result.children = info.children.map(fromDocumentSymbol);
+    }
+    return result;
+}
+
+export function toDocumentSymbol(info: model.DocumentSymbol): theia.DocumentSymbol {
+    const result = new types.DocumentSymbol(
+        info.name,
+        info.detail,
+        SymbolKind.toSymbolKind(info.kind),
+        toRange(info.range),
+        toRange(info.selectionRange),
+    );
+    if (info.children) {
+        result.children = info.children.map(toDocumentSymbol) as any;
+    }
+    return result;
+}
+
 export function toWorkspaceFolder(folder: model.WorkspaceFolder): theia.WorkspaceFolder {
     return {
         uri: URI.revive(folder.uri),

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -577,3 +577,22 @@ function provideLenses(document: theia.TextDocument): theia.ProviderResult<theia
     // code here
 }
 ```
+
+#### Code Symbol Provider
+
+A document symbol provider allows to add a custom logic for symbols detection.
+
+Example of code symbol provider registration:
+
+```typescript
+const documentsSelector: theia.DocumentSelector = { scheme: 'file', language: 'typescript' };
+const provider = { provideDocumentSymbols: provideSymbols };
+
+const disposable = theia.languages.registerDocumentSymbolProvider(documentsSelector, provider);
+
+...
+
+function provideSymbols(document: theia.TextDocument): theia.ProviderResult<theia.SymbolInformation[] | theia.DocumentSymbol[]> {
+    // code here
+}
+```


### PR DESCRIPTION
This PR replaces previously added mock for `document.registerDocumentSymbolProvider` API with the implementation.
Closes #3200 
Sample plugin is here https://github.com/eclipse/che-theia-samples/pull/16