### PR TITLE
Add Webwiew API to the plugin system

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -35,6 +35,7 @@
     "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
+    "style-loader": "^0.23.1",
     "electron": "1.8.2-beta.5",
     "electron-rebuild": "^1.5.11",
     "file-loader": "^1.1.11",

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -83,7 +83,16 @@ module.exports = {
             },
             {
                 test: /\\.useable\\.css$/,
-                loader: 'style-loader/useable!css-loader'
+                use: [
+                  {
+                    loader: 'style-loader/useable',
+                    options: {
+                      singleton: true,
+                      attrs: { id: 'theia-theme' },
+                    }
+                  },
+                  'css-loader'
+                ]
             },
             {
                 test: /\\.(ttf|eot|svg)(\\?v=\\d+\\.\\d+\\.\\d+)?$/,

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -820,6 +820,48 @@ export interface LanguagesMain {
     $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void;
 }
 
+export interface WebviewPanelViewState {
+    readonly active: boolean;
+    readonly visible: boolean;
+    readonly position: number;
+}
+
+export interface WebviewPanelShowOptions {
+    readonly viewColumn?: number;
+    readonly preserveFocus?: boolean;
+}
+
+export interface WebviewsExt {
+    $onMessage(handle: string, message: any): void;
+    $onDidChangeWebviewPanelViewState(handle: string, newState: WebviewPanelViewState): void;
+    $onDidDisposeWebviewPanel(handle: string): PromiseLike<void>;
+    $deserializeWebviewPanel(newWebviewHandle: string,
+        viewType: string,
+        title: string,
+        state: any,
+        position: number,
+        options: theia.WebviewOptions & theia.WebviewPanelOptions): PromiseLike<void>;
+}
+
+export interface WebviewsMain {
+    $createWebviewPanel(handle: string,
+        viewType: string,
+        title: string,
+        showOptions: WebviewPanelShowOptions,
+        options: theia.WebviewPanelOptions & theia.WebviewOptions | undefined,
+        pluginLocation: UriComponents): void;
+    $disposeWebview(handle: string): void;
+    $reveal(handle: string, showOptions: WebviewPanelShowOptions): void;
+    $setTitle(handle: string, value: string): void;
+    $setIconPath(handle: string, value: { light: string, dark: string } | string | undefined): void;
+    $setHtml(handle: string, value: string): void;
+    $setOptions(handle: string, options: theia.WebviewOptions): void;
+    $postMessage(handle: string, value: any): Thenable<boolean>;
+
+    $registerSerializer(viewType: string): void;
+    $unregisterSerializer(viewType: string): void;
+}
+
 export const PLUGIN_RPC_CONTEXT = {
     COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
     QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
@@ -837,6 +879,7 @@ export const PLUGIN_RPC_CONTEXT = {
     OUTPUT_CHANNEL_REGISTRY_MAIN: <ProxyIdentifier<OutputChannelRegistryMain>>createProxyIdentifier<OutputChannelRegistryMain>('OutputChannelRegistryMain'),
     LANGUAGES_MAIN: createProxyIdentifier<LanguagesMain>('LanguagesMain'),
     CONNECTION_MAIN: createProxyIdentifier<ConnectionMain>('ConnectionMain'),
+    WEBVIEWS_MAIN: createProxyIdentifier<WebviewsMain>('WebviewsMain'),
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -854,4 +897,5 @@ export const MAIN_RPC_CONTEXT = {
     PREFERENCE_REGISTRY_EXT: createProxyIdentifier<PreferenceRegistryExt>('PreferenceRegistryExt'),
     LANGUAGES_EXT: createProxyIdentifier<LanguagesExt>('LanguagesExt'),
     CONNECTION_EXT: createProxyIdentifier<ConnectionExt>('ConnectionExt'),
+    WEBVIEWS_EXT: createProxyIdentifier<WebviewsExt>('WebviewsExt'),
 };

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -32,6 +32,7 @@ import { DialogsMainImpl } from './dialogs-main';
 import { TreeViewsMainImpl } from './view/tree-views-main';
 import { NotificationMainImpl } from './notification-main';
 import { ConnectionMainImpl } from './connection-main';
+import { WebviewsMainImpl } from './webviews-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
@@ -77,6 +78,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const languagesMain = new LanguagesMainImpl(rpc);
     rpc.set(PLUGIN_RPC_CONTEXT.LANGUAGES_MAIN, languagesMain);
+
+    const webviewsMain = new WebviewsMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.WEBVIEWS_MAIN, webviewsMain);
 
     const pluginConnection = new ConnectionMainImpl(rpc);
     rpc.set(PLUGIN_RPC_CONTEXT.CONNECTION_MAIN, pluginConnection);

--- a/packages/plugin-ext/src/main/browser/style/webview.css
+++ b/packages/plugin-ext/src/main/browser/style/webview.css
@@ -14,43 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.fa-spinner {
-    color: var(--theia-ui-font-color1);
-}
-
-.spinnerContainer {
-    width: 100%;
-    height: 100%;
+.theia-webview {
     display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.flexcontainer {
-    display: flex;
-}
-
-.noWrapInfo {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.row {
-    width: 100%;
-}
-
-.column {
     flex-direction: column;
+    height: 100%;
 }
 
-.pluginHeaderContainer {
-    background: var(--theia-layout-color1);
-    margin-bottom: 5px;
-    color: var(--theia-ui-font-color1);
+.theia-webview iframe {
+    flex-grow: 1;
+    border: none; margin: 0; padding: 0;
 }
-
-@import './plugin-sidebar.css';
-@import './view-registry.css';
-@import './webview.css';
-@import './tree.css';

--- a/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
+++ b/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
@@ -1,0 +1,148 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ThemeService } from '@theia/core/lib/browser/theming';
+
+export const ThemeRulesServiceSymbol = Symbol('ThemeRulesService');
+
+interface IconPath {
+    light: string,
+    dark: string
+}
+
+export class ThemeRulesService {
+    private styleElement?: HTMLStyleElement;
+    private icons = new Map<string, IconPath | string>();
+    protected readonly themeService = ThemeService.get();
+    protected readonly themeRules = new Map<string, string[]>();
+
+    static get(): ThemeRulesService {
+        const global = window as any; // tslint:disable-line
+        return global[ThemeRulesServiceSymbol] || new ThemeRulesService();
+    }
+
+    protected constructor() {
+        const global = window as any; // tslint:disable-line
+        global[ThemeRulesServiceSymbol] = this;
+
+        this.themeService.onThemeChange(() => {
+            this.updateIconStyleElement();
+        });
+    }
+
+    createStyleSheet(container: HTMLElement = document.getElementsByTagName('head')[0]): HTMLStyleElement {
+        const style = document.createElement('style');
+        style.type = 'text/css';
+        style.media = 'screen';
+        container.appendChild(style);
+        return style;
+    }
+
+    getCurrentThemeRules(): string[] {
+        const cssText: string[] = [];
+        const themeId = this.themeService.getCurrentTheme().id;
+        if (this.themeRules.has(themeId)) {
+            return <string[]>this.themeRules.get(themeId);
+        }
+        const styleElement = document.getElementById('theia-theme') as any;
+        if (!styleElement) {
+            return cssText;
+        }
+
+        const sheet: {
+            insertRule: (rule: string, index: number) => void,
+            removeRule: (index: number) => void,
+            rules: CSSRuleList
+        } | undefined = (<any>styleElement).sheet;
+        if (!sheet || !sheet.rules || !sheet.rules.length) {
+            return cssText;
+        }
+
+        const ruleList = sheet.rules;
+        for (let index = 0; index < ruleList.length; index++) {
+            if (ruleList[index] && ruleList[index].cssText) {
+                cssText.push(ruleList[index].cssText.toString());
+            }
+        }
+
+        return cssText;
+    }
+
+    setRules(styleSheet: HTMLElement, newRules: string[]): boolean {
+        const sheet: {
+            insertRule: (rule: string, index: number) => void;
+            removeRule: (index: number) => void;
+            rules: CSSRuleList;
+        } | undefined = (<any>styleSheet).sheet;
+
+        if (!sheet) {
+            return false;
+        }
+        for (let index = sheet.rules!.length; index > 0; index--) {
+            sheet.removeRule(0);
+        }
+        newRules.forEach((rule: string, index: number) => {
+            sheet.insertRule(rule, index);
+        });
+        return true;
+    }
+
+    setIconPath(webviewId: string, iconPath: IconPath | string | undefined) {
+        if (!iconPath) {
+            this.icons.delete(webviewId);
+        } else {
+            this.icons.set(webviewId, <IconPath | string>iconPath);
+        }
+        if (!this.styleElement) {
+            this.styleElement = this.createStyleSheet();
+            this.styleElement.id = 'webview-icons';
+        }
+        this.updateIconStyleElement();
+    }
+
+    private updateIconStyleElement() {
+        if (!this.styleElement) {
+            return;
+        }
+        const cssRules: string[] = [`.webview-icon::before {
+            background-repeat: no-repeat;
+            vertical-align: middle;
+            display: inline-block;
+            text-align: center;
+            height: 11px;
+            width: 11px;
+            content: "";
+        }`];
+        this.icons.forEach((value, key) => {
+            let path: string;
+            if (typeof value === 'string') {
+                path = value;
+            } else {
+                path = this.isDark() ? value.dark : value.light;
+            }
+            if (path.startsWith('/')) {
+                path = `/webview${path}`;
+            }
+            cssRules.push(`.webview-icon.${key}-file-icon::before { background-image: url(${path}); }`);
+        });
+        this.setRules(this.styleElement, cssRules);
+    }
+
+    private isDark(): boolean {
+        const currentThemeId: string = this.themeService.getCurrentTheme().id;
+        return !currentThemeId.includes('light');
+    }
+}

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -1,0 +1,239 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
+import { IdGenerator } from '../../../common/id-generator';
+import { Disposable, DisposableCollection } from '@theia/core';
+
+export interface WebviewWidgetOptions {
+    readonly allowScripts?: boolean;
+}
+
+export interface WebviewEvents {
+    onMessage?(message: any): void;
+    onKeyboardEvent?(e: KeyboardEvent): void;
+    onLoad?(contentDocument: Document): void;
+}
+
+export class WebviewWidget extends BaseWidget {
+    private static readonly ID = new IdGenerator('webview-widget-');
+    protected readonly toDispose = new DisposableCollection();
+    private iframe: HTMLIFrameElement;
+    private state: string | undefined = undefined;
+    private loadTimeout: number | undefined;
+
+    constructor(title: string, private options: WebviewWidgetOptions, private eventDelegate: WebviewEvents) {
+        super();
+        this.id = WebviewWidget.ID.nextId();
+        this.title.closable = true;
+        this.title.label = title;
+        this.addClass(WebviewWidget.Styles.WEBVIEW);
+    }
+
+    protected handleMessage(message: any) {
+        switch (message.command) {
+            case 'onmessage':
+                this.eventDelegate.onMessage!(message.data);
+                break;
+            case 'do-update-state':
+                this.state = message.data;
+        }
+    }
+
+    postMessage(message: any) {
+        this.iframe.contentWindow!.postMessage(message, '*');
+    }
+
+    setOptions(options: WebviewWidgetOptions) {
+        if (!this.iframe || this.options.allowScripts === options.allowScripts) {
+            return;
+        }
+        this.updateSandboxAttribute(this.iframe, options.allowScripts);
+        this.options = options;
+        this.reloadFrame();
+    }
+
+    setIconClass(iconClass: string) {
+        this.title.iconClass = iconClass;
+    }
+
+    setHTML(html: string) {
+        html = html.replace('theia-resource:/', '/webview/');
+        const newDocument = new DOMParser().parseFromString(html, 'text/html');
+        if (!newDocument || !newDocument.body) {
+            return;
+        }
+        (<any>newDocument.querySelectorAll('a')).forEach((a: any) => {
+            if (!a.title) {
+                a.title = a.href;
+            }
+        });
+        this.updateApiScript(newDocument);
+        const previousPendingFrame = this.iframe;
+        if (previousPendingFrame) {
+            previousPendingFrame.setAttribute('id', '');
+            this.node.removeChild(previousPendingFrame);
+        }
+        const newFrame = document.createElement('iframe');
+        newFrame.setAttribute('id', 'pending-frame');
+        newFrame.setAttribute('frameborder', '0');
+        newFrame.style.cssText = 'display: block; margin: 0; overflow: hidden; position: absolute; width: 100%; height: 100%; visibility: hidden';
+        this.node.appendChild(newFrame);
+        this.iframe = newFrame;
+        newFrame.contentDocument!.open('text/html', 'replace');
+
+        const onLoad = (contentDocument: any, contentWindow: any) => {
+            if (contentDocument.body) {
+                if (this.eventDelegate && this.eventDelegate.onKeyboardEvent) {
+                    const eventNames = ['keydown', 'keypress', 'click'];
+                    // Delegate events from the `iframe` to the application.
+                    eventNames.forEach((eventName: string) => {
+                        contentDocument.addEventListener(eventName, this.eventDelegate.onKeyboardEvent!, true);
+                        this.toDispose.push(Disposable.create(() => contentDocument.removeEventListener(eventName, this.eventDelegate.onKeyboardEvent!)));
+                    });
+                }
+                if (this.eventDelegate && this.eventDelegate.onLoad) {
+                    this.eventDelegate.onLoad(<Document>contentDocument);
+                }
+            }
+            if (newFrame && newFrame.contentDocument === contentDocument) {
+                (<any>contentWindow).postMessageExt = (e: any) => {
+                    this.handleMessage(e);
+                };
+                newFrame.style.visibility = 'visible';
+                newFrame.contentWindow!.focus();
+            }
+        };
+
+        clearTimeout(this.loadTimeout);
+        this.loadTimeout = undefined;
+        this.loadTimeout = window.setTimeout(() => {
+            clearTimeout(this.loadTimeout);
+            this.loadTimeout = undefined;
+            onLoad(newFrame.contentDocument, newFrame.contentWindow);
+        }, 200);
+
+        newFrame.contentWindow!.addEventListener('load', e => {
+            if (this.loadTimeout) {
+                clearTimeout(this.loadTimeout);
+                this.loadTimeout = undefined;
+                onLoad(e.target, newFrame.contentWindow);
+            }
+        });
+        newFrame.contentDocument!.write(newDocument!.documentElement!.innerHTML);
+        newFrame.contentDocument!.close();
+
+        this.updateSandboxAttribute(newFrame);
+    }
+
+    private reloadFrame() {
+        if (!this.iframe || !this.iframe.contentDocument || !this.iframe.contentDocument.documentElement) {
+            return;
+        }
+        this.setHTML(this.iframe.contentDocument.documentElement.innerHTML);
+    }
+
+    private updateSandboxAttribute(element: HTMLElement, isAllowScript?: boolean) {
+        if (!element) {
+            return;
+        }
+        const allowScripts = isAllowScript !== undefined ? isAllowScript : this.options.allowScripts;
+        element.setAttribute('sandbox', allowScripts ? 'allow-scripts allow-forms allow-same-origin' : 'allow-same-origin');
+    }
+
+    private updateApiScript(contentDocument: Document, isAllowScript?: boolean) {
+        if (!contentDocument) {
+            return;
+        }
+        const allowScripts = isAllowScript !== undefined ? isAllowScript : this.options.allowScripts;
+        const scriptId = 'webview-widget-codeApi';
+        if (!allowScripts) {
+            const script = contentDocument.getElementById(scriptId);
+            if (!script) {
+                return;
+            }
+            script!.parentElement!.removeChild(script!);
+            return;
+        }
+
+        const codeApiScript = contentDocument.createElement('script');
+        codeApiScript.id = scriptId;
+        codeApiScript.textContent = `
+            const acquireVsCodeApi = (function() {
+                let acquired = false;
+                let state = ${this.state ? `JSON.parse(${JSON.stringify(this.state)})` : undefined};
+                return () => {
+                    if (acquired) {
+                        throw new Error('An instance of the VS Code API has already been acquired');
+                    }
+                    acquired = true;
+                    return Object.freeze({
+                        postMessage: function(msg) {
+                            return window.postMessageExt({ command: 'onmessage', data: msg }, '*');
+                        },
+                        setState: function(newState) {
+                            state = newState;
+                            window.postMessageExt({ command: 'do-update-state', data: JSON.stringify(newState) }, '*');
+                            return newState;
+                        },
+                        getState: function() {
+                            return state;
+                        }
+                    });
+                };
+            })();
+            const acquireTheiaApi = (function() {
+                let acquired = false;
+                let state = ${this.state ? `JSON.parse(${JSON.stringify(this.state)})` : undefined};
+                return () => {
+                    if (acquired) {
+                        throw new Error('An instance of the VS Code API has already been acquired');
+                    }
+                    acquired = true;
+                    return Object.freeze({
+                        postMessage: function(msg) {
+                            return window.postMessageExt({ command: 'onmessage', data: msg }, '*');
+                        },
+                        setState: function(newState) {
+                            state = newState;
+                            window.postMessageExt({ command: 'do-update-state', data: JSON.stringify(newState) }, '*');
+                            return newState;
+                        },
+                        getState: function() {
+                            return state;
+                        }
+                    });
+                };
+            })();
+            delete window.parent;
+            delete window.top;
+            delete window.frameElement;
+         `;
+        const parent = contentDocument.head ? contentDocument.head : contentDocument.body;
+        if (parent.hasChildNodes()) {
+            parent.insertBefore(codeApiScript, parent.firstChild);
+        } else {
+            parent.appendChild(codeApiScript);
+        }
+    }
+}
+
+export namespace WebviewWidget {
+    export namespace Styles {
+
+        export const WEBVIEW = 'theia-webview';
+
+    }
+}

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -1,0 +1,149 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WebviewsMain, WebviewPanelShowOptions, MAIN_RPC_CONTEXT, WebviewsExt } from '../../api/plugin-api';
+import { interfaces } from 'inversify';
+import { RPCProtocol } from '../../api/rpc-protocol';
+import { UriComponents } from '../../common/uri-components';
+import { WebviewOptions, WebviewPanelOptions } from '@theia/plugin';
+import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
+import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
+import { WebviewWidget } from './webview/webview';
+import { ThemeService } from '@theia/core/lib/browser/theming';
+import { ThemeRulesService } from './webview/theme-rules-service';
+import { DisposableCollection } from '@theia/core';
+
+export class WebviewsMainImpl implements WebviewsMain {
+    private readonly proxy: WebviewsExt;
+    protected readonly shell: ApplicationShell;
+    protected readonly keybindingRegistry: KeybindingRegistry;
+    protected readonly themeService = ThemeService.get();
+    protected readonly themeRulesService = ThemeRulesService.get();
+
+    private readonly views = new Map<string, WebviewWidget>();
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WEBVIEWS_EXT);
+        this.shell = container.get(ApplicationShell);
+        this.keybindingRegistry = container.get(KeybindingRegistry);
+    }
+
+    $createWebviewPanel(
+        viewId: string,
+        viewType: string,
+        title: string,
+        showOptions: WebviewPanelShowOptions,
+        options: (WebviewPanelOptions & WebviewOptions) | undefined,
+        extensionLocation: UriComponents
+    ): void {
+        const toDispose = new DisposableCollection();
+        const view = new WebviewWidget(title, {
+            allowScripts: options ? options.enableScripts : false
+        }, {
+            onMessage: m => {
+                this.proxy.$onMessage(viewId, m);
+            },
+            onKeyboardEvent: e => {
+                this.keybindingRegistry.run(e);
+            },
+            onLoad: contentDocument => {
+                const styleId = 'webview-widget-theme';
+                let styleElement: HTMLStyleElement | null | undefined;
+                if (!toDispose.disposed) {
+                    // if reload the frame
+                    toDispose.dispose();
+                    styleElement = <HTMLStyleElement>contentDocument.getElementById(styleId);
+                }
+                if (!styleElement) {
+                    const parent = contentDocument.head ? contentDocument.head : contentDocument.body;
+                    styleElement = this.themeRulesService.createStyleSheet(parent);
+                    styleElement.id = styleId;
+                    parent.appendChild((styleElement));
+                }
+
+                this.themeRulesService.setRules(styleElement, this.themeRulesService.getCurrentThemeRules());
+                toDispose.push(this.themeService.onThemeChange(() => {
+                    this.themeRulesService.setRules(<HTMLElement>styleElement, this.themeRulesService.getCurrentThemeRules());
+                }));
+            }
+        });
+        view.disposed.connect(() => {
+            toDispose.dispose();
+            this.onCloseView(viewId);
+        });
+        this.views.set(viewId, view);
+        this.shell.addWidget(view, { area: 'main' });
+        this.shell.activateWidget(view.id);
+    }
+    $disposeWebview(handle: string): void {
+        const view = this.views.get(handle);
+        if (view) {
+            view.dispose();
+        }
+    }
+    $reveal(handle: string, showOptions: WebviewPanelShowOptions): void {
+        throw new Error('Method not implemented.');
+    }
+    $setTitle(handle: string, value: string): void {
+        const webview = this.getWebview(handle);
+        webview.title.label = value;
+    }
+    $setIconPath(handle: string, iconPath: { light: string; dark: string; } | string | undefined): void {
+        const webview = this.getWebview(handle);
+        webview.setIconClass(iconPath ? `webview-icon ${webview.id}-file-icon` : '');
+        this.themeRulesService.setIconPath(webview.id, iconPath);
+    }
+    $setHtml(handle: string, value: string): void {
+        const webview = this.getWebview(handle);
+        webview.setHTML(value);
+    }
+    $setOptions(handle: string, options: WebviewOptions): void {
+        const webview = this.getWebview(handle);
+        webview.setOptions( { allowScripts: options ? options.enableScripts : false });
+    }
+    $postMessage(handle: string, value: any): Thenable<boolean> {
+        const webview = this.getWebview(handle);
+        if (webview) {
+            webview.postMessage(value);
+        }
+        return Promise.resolve(webview !== undefined);
+    }
+    $registerSerializer(viewType: string): void {
+        throw new Error('Method not implemented.');
+    }
+    $unregisterSerializer(viewType: string): void {
+        throw new Error('Method not implemented.');
+    }
+
+    private getWebview(viewId: string): WebviewWidget {
+        const webview = this.views.get(viewId);
+        if (!webview) {
+            throw new Error(`Unknown Webview: ${viewId}`);
+        }
+        return webview;
+    }
+
+    private onCloseView(viewId: string) {
+        const view = this.views.get(viewId);
+        if (view) {
+            this.themeRulesService.setIconPath(view.id, undefined);
+        }
+        const cleanUp = () => {
+            this.views.delete(viewId);
+        };
+        this.proxy.$onDidDisposeWebviewPanel(viewId).then(cleanUp, cleanUp);
+    }
+}

--- a/packages/plugin-ext/src/main/node/plugin-service.ts
+++ b/packages/plugin-ext/src/main/node/plugin-service.ts
@@ -26,5 +26,13 @@ export class PluginApiContribution implements BackendApplicationContribution {
             const filePath: string = req.params.path;
             res.sendFile(pluginPath + filePath);
         });
+
+        app.get('/webview/:path(*)', (req, res) => {
+            let filePath: string = req.params.path;
+            if (filePath.charAt(0) !== '/') {
+                filePath = '/' + filePath;
+            }
+            res.sendFile(filePath);
+        });
     }
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -94,6 +94,7 @@ import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { MarkdownString } from './markdown-string';
 import { TreeViewsExtImpl } from './tree/tree-views';
 import { ConnectionExtImpl } from './connection-ext';
+import { WebviewsExtImpl } from './webviews';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -117,6 +118,7 @@ export function createAPIFactory(
     const outputChannelRegistryExt = new OutputChannelRegistryExt(rpc);
     const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
+    const webviewExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEWS_EXT, new WebviewsExtImpl(rpc));
     rpc.set(MAIN_RPC_CONTEXT.CONNECTION_EXT, new ConnectionExtImpl(rpc));
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -247,7 +249,15 @@ export function createAPIFactory(
             createOutputChannel(name: string): theia.OutputChannel {
                 return outputChannelRegistryExt.createOutputChannel(name);
             },
-
+            createWebviewPanel(viewType: string,
+                title: string,
+                showOptions: theia.ViewColumn | { viewColumn: theia.ViewColumn, preserveFocus?: boolean },
+                options: theia.WebviewPanelOptions & theia.WebviewOptions): theia.WebviewPanel {
+                return webviewExt.createWebview(viewType, title, showOptions, options, Uri.file(plugin.pluginPath));
+            },
+            registerWebviewPanelSerializer(viewType: string, serializer: theia.WebviewPanelSerializer): theia.Disposable {
+                return webviewExt.registerWebviewPanelSerializer(viewType, serializer);
+            },
             get state(): theia.WindowState {
                 return windowStateExt.getWindowState();
             },

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -22,6 +22,9 @@ import { LanguageSelector, LanguageFilter, RelativePattern } from './languages';
 import { isMarkdownString } from './markdown-string';
 import URI from 'vscode-uri';
 
+const SIDE_GROUP = -2;
+const ACTIVE_GROUP = -1;
+
 export function toViewColumn(ep?: EditorPosition): theia.ViewColumn | undefined {
     if (typeof ep !== 'number') {
         return undefined;
@@ -36,6 +39,18 @@ export function toViewColumn(ep?: EditorPosition): theia.ViewColumn | undefined 
     }
 
     return undefined;
+}
+
+export function fromViewColumn(column?: theia.ViewColumn): number {
+    if (typeof column === 'number' && column >= types.ViewColumn.One) {
+        return column - 1;
+    }
+
+    if (column! === <number>types.ViewColumn.Beside) {
+        return SIDE_GROUP;
+    }
+
+    return ACTIVE_GROUP;
 }
 
 export function toSelection(selection: Selection): types.Selection {

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -1,0 +1,309 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WebviewsExt, WebviewPanelViewState, WebviewsMain, PLUGIN_RPC_CONTEXT, /* WebviewsMain, PLUGIN_RPC_CONTEXT  */ } from '../api/plugin-api';
+import * as theia from '@theia/plugin';
+import { RPCProtocol } from '../api/rpc-protocol';
+import URI from 'vscode-uri/lib/umd';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { fromViewColumn, toViewColumn } from './type-converters';
+import { IdGenerator } from '../common/id-generator';
+import { Disposable } from './types-impl';
+
+export class WebviewsExtImpl implements WebviewsExt {
+    private readonly proxy: WebviewsMain;
+    private readonly idGenerator = new IdGenerator('v');
+    private readonly webviewPanels = new Map<string, WebviewPanelImpl>();
+    private readonly serializers = new Map<string, theia.WebviewPanelSerializer>();
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.WEBVIEWS_MAIN);
+    }
+
+    $onMessage(handle: string, message: any): void {
+        const panel = this.getWebviewPanel(handle);
+        if (panel) {
+            panel.webview.onMessageEmitter.fire(message);
+        }
+    }
+    $onDidChangeWebviewPanelViewState(handle: string, newState: WebviewPanelViewState): void {
+        const panel = this.getWebviewPanel(handle);
+        if (panel) {
+            const viewColumn = toViewColumn(newState.position);
+            if (panel.active !== newState.active || panel.visible !== newState.visible || panel.viewColumn !== viewColumn) {
+                panel.setActive(newState.active);
+                panel.setVisible(newState.visible);
+                panel.setViewColumn(viewColumn!);
+                panel.onDidChangeViewStateEmitter.fire({ webviewPanel: panel });
+            }
+        }
+    }
+    $onDidDisposeWebviewPanel(handle: string): PromiseLike<void> {
+        const panel = this.getWebviewPanel(handle);
+        if (panel) {
+            panel.dispose();
+            this.webviewPanels.delete(handle);
+        }
+        return Promise.resolve();
+    }
+    $deserializeWebviewPanel(viewId: string,
+        viewType: string,
+        title: string,
+        // tslint:disable-next-line:no-any
+        state: any,
+        position: number,
+        options: theia.WebviewOptions & theia.WebviewPanelOptions): PromiseLike<void> {
+        const serializer = this.serializers.get(viewType);
+        if (!serializer) {
+            return Promise.reject(new Error(`No serializer found for '${viewType}'`));
+        }
+
+        const webview = new WebviewImpl(viewId, this.proxy, options);
+        const revivedPanel = new WebviewPanelImpl(viewId, this.proxy, viewType, title, toViewColumn(position)!, options, webview);
+        this.webviewPanels.set(viewId, revivedPanel);
+        return serializer.deserializeWebviewPanel(revivedPanel, state);
+    }
+
+    createWebview(viewType: string,
+        title: string,
+        showOptions: theia.ViewColumn | { viewColumn: theia.ViewColumn, preserveFocus?: boolean },
+        options: (theia.WebviewPanelOptions & theia.WebviewOptions) | undefined,
+        extensionLocation: URI): theia.WebviewPanel {
+
+        const viewColumn = typeof showOptions === 'object' ? showOptions.viewColumn : showOptions;
+        const webviewShowOptions = {
+            viewColumn: fromViewColumn(viewColumn),
+            preserveFocus: typeof showOptions === 'object' && !!showOptions.preserveFocus
+        };
+
+        const viewId = this.idGenerator.nextId();
+        this.proxy.$createWebviewPanel(viewId, viewType, title, webviewShowOptions, options, extensionLocation);
+
+        const webview = new WebviewImpl(viewId, this.proxy, options);
+        const panel = new WebviewPanelImpl(viewId, this.proxy, viewType, title, viewColumn, options, webview);
+        this.webviewPanels.set(viewId, panel);
+        return panel;
+
+    }
+
+    registerWebviewPanelSerializer(
+        viewType: string,
+        serializer: theia.WebviewPanelSerializer
+    ): theia.Disposable {
+        if (this.serializers.has(viewType)) {
+            throw new Error(`Serializer for '${viewType}' already registered`);
+        }
+
+        this.serializers.set(viewType, serializer);
+        this.proxy.$registerSerializer(viewType);
+
+        return new Disposable(() => {
+            this.serializers.delete(viewType);
+            this.proxy.$unregisterSerializer(viewType);
+        });
+    }
+
+    private getWebviewPanel(viewId: string): WebviewPanelImpl | undefined {
+        return this.webviewPanels.get(viewId);
+    }
+}
+
+export class WebviewImpl implements theia.Webview {
+    private isDisposed = false;
+    private _html: string;
+    private _options: theia.WebviewOptions;
+
+    public readonly onMessageEmitter = new Emitter<any>();
+    public readonly onDidReceiveMessage: Event<any> = this.onMessageEmitter.event;
+
+    constructor(private readonly viewId: string,
+        private readonly proxy: WebviewsMain,
+        options: theia.WebviewOptions | undefined) {
+        this._options = options!;
+    }
+
+    dispose() {
+        if (this.isDisposed) {
+            return;
+        }
+        this.isDisposed = true;
+        this.onMessageEmitter.dispose();
+    }
+
+    postMessage(message: any): PromiseLike<boolean> {
+        this.checkIsDisposed();
+        return this.proxy.$postMessage(this.viewId, message);
+    }
+
+    get options(): theia.WebviewOptions {
+        this.checkIsDisposed();
+        return this._options;
+    }
+
+    set options(newOptions: theia.WebviewOptions) {
+        this.checkIsDisposed();
+        this.proxy.$setOptions(this.viewId, newOptions);
+        this._options = newOptions;
+    }
+
+    get html(): string {
+        this.checkIsDisposed();
+        return this._html;
+    }
+
+    set html(newHtml: string) {
+        this.checkIsDisposed();
+        if (this._html !== newHtml) {
+            this._html = newHtml;
+            this.proxy.$setHtml(this.viewId, newHtml);
+        }
+    }
+
+    private checkIsDisposed() {
+        if (this.isDisposed) {
+            throw new Error('This Webview is disposed!');
+        }
+    }
+}
+
+export class WebviewPanelImpl implements theia.WebviewPanel {
+
+    private isDisposed = false;
+    private _active = true;
+    private _visible = true;
+
+    readonly onDisposeEmitter = new Emitter<void>();
+    public readonly onDidDispose: Event<void> = this.onDisposeEmitter.event;
+
+    readonly onDidChangeViewStateEmitter = new Emitter<theia.WebviewPanelOnDidChangeViewStateEvent>();
+    public readonly onDidChangeViewState: Event<theia.WebviewPanelOnDidChangeViewStateEvent> = this.onDidChangeViewStateEmitter.event;
+
+    constructor(private readonly viewId: string,
+        private readonly proxy: WebviewsMain,
+        private readonly _viewType: string,
+        private _title: string,
+        private _viewColumn: theia.ViewColumn,
+        private readonly _options: theia.WebviewPanelOptions | undefined,
+        private readonly _webview: WebviewImpl
+    ) {
+
+    }
+
+    dispose() {
+        if (this.isDisposed) {
+            return;
+        }
+
+        this.isDisposed = true;
+        this.onDisposeEmitter.fire(void 0);
+
+        this.proxy.$disposeWebview(this.viewId);
+        this._webview.dispose();
+
+        this.onDisposeEmitter.dispose();
+        this.onDidChangeViewStateEmitter.dispose();
+    }
+
+    get viewType(): string {
+        this.checkIsDisposed();
+        return this._viewType;
+    }
+
+    get title(): string {
+        this.checkIsDisposed();
+        return this._title;
+    }
+
+    set title(newTitle: string) {
+        this.checkIsDisposed();
+        if (this._title !== newTitle) {
+            this._title = newTitle;
+            this.proxy.$setTitle(this.viewId, newTitle);
+        }
+    }
+
+    set iconPath(iconPath: theia.Uri | { light: theia.Uri; dark: theia.Uri }) {
+        this.checkIsDisposed();
+        if (URI.isUri(iconPath)) {
+            this.proxy.$setIconPath(this.viewId, (<theia.Uri>iconPath).path);
+        } else {
+            this.proxy.$setIconPath(this.viewId, {
+                light: (<{ light: theia.Uri; dark: theia.Uri }>iconPath).light.path,
+                dark: (<{ light: theia.Uri; dark: theia.Uri }>iconPath).dark.path
+            });
+        }
+    }
+
+    get webview() {
+        this.checkIsDisposed();
+        return this._webview;
+    }
+
+    get options(): theia.WebviewPanelOptions {
+        this.checkIsDisposed();
+        return this._options!;
+    }
+
+    get viewColumn(): theia.ViewColumn {
+        this.checkIsDisposed();
+        return this._viewColumn;
+    }
+
+    setViewColumn(value: theia.ViewColumn) {
+        this.checkIsDisposed();
+        this._viewColumn = value;
+    }
+
+    get active(): boolean {
+        this.checkIsDisposed();
+        return this._active;
+    }
+
+    setActive(value: boolean) {
+        this.checkIsDisposed();
+        this._active = value;
+    }
+
+    get visible(): boolean {
+        this.checkIsDisposed();
+        return this._visible;
+    }
+
+    setVisible(value: boolean) {
+        this.checkIsDisposed();
+        this._visible = value;
+    }
+
+    reveal(viewColumn?: theia.ViewColumn, preserveFocus?: boolean): void {
+        this.checkIsDisposed();
+        this.proxy.$reveal(this.viewId, {
+            viewColumn: viewColumn ? fromViewColumn(viewColumn) : undefined,
+            preserveFocus: !!preserveFocus
+        });
+    }
+
+    // tslint:disable-next-line:no-any
+    postMessage(message: any): PromiseLike<boolean> {
+        this.checkIsDisposed();
+        return this.proxy.$postMessage(this.viewId, message);
+    }
+
+    private checkIsDisposed() {
+        if (this.isDisposed) {
+            throw new Error('This WebviewPanel is disposed!');
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9164,6 +9164,13 @@ strong-log-transformer@^1.0.6:
     moment "^2.6.0"
     through "^2.3.4"
 
+style-loader@^0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.23.1.tgz#cb9154606f3e771ab6c4ab637026a1049174d925"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^1.0.0"
+
 style-loader@~0.13.1:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.2.tgz#74533384cf698c7104c7951150b49717adc2f3bb"


### PR DESCRIPTION
This API allows plugins to create fully customizable views as an iframe within Theia. This frame can render almost any HTML content, and it communicates with extensions using message passing.

Simple example:
```
// Create and show webview panel
const panel = theia.window.createWebviewPanel('testId', 'Test',  theia.ViewColumn.One);
panel.webview.html ='<html><head></head><body><h1>Test</h1></body></html>';
```
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
