### PR TITLE
add minimatch to navigator & filesystem package.json

### DIFF
--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -18,6 +18,7 @@
     "fs-extra": "^4.0.2",
     "http-status-codes": "^1.3.0",
     "mime-types": "^2.1.18",
+    "minimatch": "^3.0.4",
     "mv": "^2.1.1",
     "rimraf": "^2.6.2",
     "tar-fs": "^1.16.2",

--- a/packages/navigator/package.json
+++ b/packages/navigator/package.json
@@ -6,7 +6,8 @@
     "@theia/core": "^0.3.16",
     "@theia/filesystem": "^0.3.16",
     "@theia/workspace": "^0.3.16",
-    "fuzzy": "^0.1.3"
+    "fuzzy": "^0.1.3",
+    "minimatch": "^3.0.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
"minimatch" is used in 2 extensions (filesystem and navigator) while the dependency is declared in the package.json of neither.
This change adds it back.

Signed-off-by: elaihau <liang.huang@ericsson.com>
