### PR TITLE
Add user feedback to git-diff widgets when no files have been changed

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -218,6 +218,9 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
             const fileChangeElement: React.ReactNode = this.renderGitItem(fileChange);
             files.push(fileChangeElement);
         }
+        if (!files.length) {
+            return <div>No files changed.</div>;
+        }
         return <GitDiffListContainer
             ref={ref => this.listView = ref || undefined}
             id={this.scrollContainer}


### PR DESCRIPTION
I noticed that when we attempt to do diff compare (`git-diff` widget)  without any files changed, we
silently display the widget without any results. I thought it might be better to instead
display a feedback message to end users informing them that no files have been changed.

<img width="980" alt="screen shot 2018-11-13 at 8 40 23 pm" src="https://user-images.githubusercontent.com/40359487/48454436-30c9d380-e785-11e8-9ce7-1ad18d20259f.png">

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
