### PR TITLE
Add feedback message to outline view when no data is available

### DIFF
--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2017-2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -62,7 +62,7 @@ export class OutlineViewWidget extends TreeWidget {
         this.addClass('theia-outline-view');
     }
 
-    public setOutlineTree(roots: OutlineSymbolInformationNode[]) {
+    public setOutlineTree(roots: OutlineSymbolInformationNode[]): void {
         const nodes = this.reconcileTreeState(roots);
         this.model.root = {
             id: 'outline-view-root',
@@ -87,12 +87,12 @@ export class OutlineViewWidget extends TreeWidget {
         return nodes;
     }
 
-    protected onAfterHide(msg: Message) {
+    protected onAfterHide(msg: Message): void {
         super.onAfterHide(msg);
         this.onDidChangeOpenStateEmitter.fire(false);
     }
 
-    protected onAfterShow(msg: Message) {
+    protected onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.onDidChangeOpenStateEmitter.fire(true);
     }
@@ -101,12 +101,18 @@ export class OutlineViewWidget extends TreeWidget {
         if (OutlineSymbolInformationNode.is(node)) {
             return <div className={'symbol-icon symbol-icon-center ' + node.iconClass}></div>;
         }
-        // tslint:disable-next-line:no-null-keyword
-        return null;
+        return undefined;
     }
 
     protected isExpandable(node: TreeNode): node is ExpandableTreeNode {
         return OutlineSymbolInformationNode.is(node) && node.children.length > 0;
+    }
+
+    protected renderTree(model: TreeModel): React.ReactNode {
+        if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
+            return <div className='no-outline'>No outline information available.</div>;
+        }
+        return super.renderTree(model);
     }
 
 }

--- a/packages/outline-view/src/browser/styles/index.css
+++ b/packages/outline-view/src/browser/styles/index.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2017-2018 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,4 +16,10 @@
 
 .outline-view-tab-icon::before {
     content: "\f03a"
+}
+
+.no-outline {
+    color: var(--theia-ui-font-color2);
+    padding: 10px;
+    text-align: center;
 }


### PR DESCRIPTION
Added the feedback message `No outline information available.` when a user
does not have a file opened or no outline data is available. Addresses an issue
where the outline view is empty which may confuse some users.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
(cherry picked from commit 367b7a89b713c5d21965d60f1b819247e59ad347)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
