### PR TITLE
Fix loggers config file not taken into account

### DIFF
--- a/packages/core/src/node/console-logger-server.spec.ts
+++ b/packages/core/src/node/console-logger-server.spec.ts
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Container, injectable, postConstruct } from 'inversify';
+import { ConsoleLoggerServer } from './console-logger-server';
+import { LogLevel } from '../common/logger-protocol';
+import { LoggerWatcher } from '../common/logger-watcher';
+import { LogLevelCliContribution } from './logger-cli-contribution';
+import { expect } from 'chai';
+
+let server: ConsoleLoggerServer;
+let logLevelCliContribution: MockLogLevelCliContribution;
+
+@injectable()
+class MockLogLevelCliContribution extends LogLevelCliContribution {
+
+    @postConstruct()
+    init() {
+        this._logLevels['test-logger'] = LogLevel.DEBUG;
+    }
+
+    changeLogLevel(newLevel: LogLevel) {
+        this._logLevels['test-logger'] = newLevel;
+    }
+}
+
+beforeEach(() => {
+    const container = new Container;
+    container.bind(ConsoleLoggerServer).toSelf().inSingletonScope();
+    container.bind(LoggerWatcher).toSelf().inSingletonScope();
+    container.bind(MockLogLevelCliContribution).toSelf().inSingletonScope();
+    container.bind(LogLevelCliContribution).toService(MockLogLevelCliContribution);
+
+    logLevelCliContribution = container.get<MockLogLevelCliContribution>(MockLogLevelCliContribution);
+    server = container.get<ConsoleLoggerServer>(ConsoleLoggerServer);
+});
+
+describe('ConsoleLoggerServer', function() {
+    it('should respect log level config', async function() {
+        expect(await server.getLogLevel('test-logger')).eq(LogLevel.DEBUG);
+        await server.child('test-logger');
+        expect(await server.getLogLevel('test-logger')).eq(LogLevel.DEBUG);
+        logLevelCliContribution.changeLogLevel(LogLevel.WARN);
+        expect(await server.getLogLevel('test-logger')).eq(LogLevel.WARN);
+    });
+});


### PR DESCRIPTION
The ConsoleLoggerServer class fails to honor the initial settings in the
file specified by --log-config.  In init(), it correctlt saves the right
log levels for each logger.  However, when a child logger is created, it
overrides the log level (in its local loggers map) for that logger with
INFO.

ConsoleLoggerServer probably doesn't need to save the log levels, since
it just replicates what LogLevelCliContribution already does.
Therefore, remove the loggers map and use LogLevelCliContribution
directly when needing to query for a log level.

Change-Id: I14a017dede54fd64a67f8c51e32a076403b5d2cb
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
