### PR TITLE
Allow tracing of debug adapter communication

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -10,6 +10,7 @@
     "@theia/markers": "^0.3.16",
     "@theia/monaco": "^0.3.16",
     "@theia/process": "^0.3.16",
+    "@theia/output": "^0.3.16",
     "@theia/terminal": "^0.3.16",
     "@theia/variable-resolver": "^0.3.16",
     "@theia/workspace": "^0.3.16",

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -34,6 +34,7 @@ import { DebugSessionWidget, DebugSessionWidgetFactory } from './view/debug-sess
 import { InDebugModeContext } from './debug-keybinding-contexts';
 import { DebugEditorModelFactory, DebugEditorModel } from './editor/debug-editor-model';
 import './debug-monaco-contribution';
+import { bindDebugPreferences } from './debug-preferences';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bindContributionProvider(bind, DebugSessionContribution);
@@ -64,4 +65,6 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     bind(KeybindingContext).to(InDebugModeContext).inSingletonScope();
     bindViewContribution(bind, DebugFrontendApplicationContribution);
     bind(FrontendApplicationContribution).toService(DebugFrontendApplicationContribution);
+
+    bindDebugPreferences(bind);
 });

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { PreferenceSchema, PreferenceProxy, PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser/preferences';
+import { interfaces } from 'inversify';
+
+export const debugPreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'debug.trace': {
+            type: 'boolean',
+            default: false,
+            description: 'Enable/disable tracing communications with debug adapters'
+        }
+    }
+};
+
+export class DebugConfiguration {
+    'debug.trace': boolean;
+}
+
+export const DebugPreferences = Symbol('DebugPreferences');
+export type DebugPreferences = PreferenceProxy<DebugConfiguration>;
+
+export function createDebugreferences(preferences: PreferenceService): DebugPreferences {
+    return createPreferenceProxy(preferences, debugPreferencesSchema);
+}
+
+export function bindDebugPreferences(bind: interfaces.Bind): void {
+    bind(DebugPreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createDebugreferences(preferences);
+    }).inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: debugPreferencesSchema });
+}

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -23,6 +23,8 @@ import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging/w
 import { DebugSession } from './debug-session';
 import { BreakpointManager } from './breakpoint/breakpoint-manager';
 import { DebugSessionOptions } from './debug-session-options';
+import { OutputChannelManager, OutputChannel } from '@theia/output/lib/common/output-channel';
+import { DebugPreferences } from './debug-preferences';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -76,7 +78,21 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
     @inject(MessageClient)
     protected readonly messages: MessageClient;
 
+    @inject(OutputChannelManager)
+    protected readonly outputChannelManager: OutputChannelManager;
+
+    @inject(DebugPreferences)
+    protected readonly debugPreferences: DebugPreferences;
+
+    protected traceOutputChannel: OutputChannel | undefined;
+
     get(sessionId: string, options: DebugSessionOptions): DebugSession {
+        let traceOutputChannel: OutputChannel | undefined;
+
+        if (this.debugPreferences['debug.trace']) {
+            traceOutputChannel = this.outputChannelManager.getChannel('Debug adapters');
+        }
+
         return new DebugSession(
             sessionId,
             options,
@@ -85,7 +101,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
             this.editorManager,
             this.breakpoints,
             this.labelProvider,
-            this.messages
+            this.messages,
+            traceOutputChannel,
         );
     }
 }

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -34,6 +34,7 @@ import URI from '@theia/core/lib/common/uri';
 import { BreakpointManager } from './breakpoint/breakpoint-manager';
 import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-session-options';
 import { DebugConfiguration } from '../common/debug-common';
+import { OutputChannel } from '@theia/output/lib/common/output-channel';
 
 export enum DebugState {
     Inactive,
@@ -69,9 +70,10 @@ export class DebugSession implements CompositeTreeElement {
         protected readonly editorManager: EditorManager,
         protected readonly breakpoints: BreakpointManager,
         protected readonly labelProvider: LabelProvider,
-        protected readonly messages: MessageClient
+        protected readonly messages: MessageClient,
+        protected readonly traceOutputChannel: OutputChannel | undefined,
     ) {
-        this.connection = new DebugSessionConnection(id, connectionProvider);
+        this.connection = new DebugSessionConnection(id, connectionProvider, traceOutputChannel);
         this.connection.onRequest('runInTerminal', (request: DebugProtocol.RunInTerminalRequest) => this.runInTerminal(request));
         this.toDispose.pushAll([
             this.onDidChangeEmitter,


### PR DESCRIPTION
Introduce the "debug.trace" preference.  When true, log the
communication between Theia and debug adapters to the output view.

I chose not to delete the output channels when the debug sessions close.
The reason being that if you are interested in what events led to the
end of a debug session, deleting the channel would make the interesting
output unavailable.  This seems reasonnable to me because:

- this feature is only meant to be used when debugging debug adapters
  and debug backends
- the output is only stored in the frontend and wiped on reload

Change-Id: I0f2a2557fa1ec0c61a21e7af3209c433bd9be755
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
