### PR TITLE
[electron] OSX: Replace menus when changing window

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -77,11 +77,21 @@ export class ElectronMenuContribution implements FrontendApplicationContribution
             }
         }
 
+        const currentWindow = electron.remote.getCurrentWindow();
         const createdMenuBar = this.factory.createMenuBar();
+
         if (isOSX) {
             electron.remote.Menu.setApplicationMenu(createdMenuBar);
+            currentWindow.on('focus', () =>
+                // OSX: Recreate the menus when changing windows.
+                // OSX only has one menu bar for all windows, so we need to swap
+                // between them as the user switch windows.
+                electron.remote.Menu.setApplicationMenu(this.factory.createMenuBar())
+            );
+
         } else {
-            electron.remote.getCurrentWindow().setMenu(createdMenuBar);
+            // Unix/Windows: Set the per-window menus
+            currentWindow.setMenu(createdMenuBar);
         }
     }
 


### PR DESCRIPTION
OSX uses one title menu bar, shared accross all windows. This commit recreates
the menus when we switch windows, so that the actions are correctly bound to
the right window.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
