### PR TITLE
Use ripgrep's --json output

### DIFF
--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -9,7 +9,7 @@
     "@theia/process": "^0.3.16",
     "@theia/workspace": "^0.3.16",
     "fuzzy": "^0.1.3",
-    "vscode-ripgrep": "^1.0.1"
+    "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,7 +9,7 @@
     "@theia/navigator": "^0.3.16",
     "@theia/process": "^0.3.16",
     "@theia/workspace": "^0.3.16",
-    "vscode-ripgrep": "^1.0.1"
+    "vscode-ripgrep": "^1.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9974,9 +9974,10 @@ vscode-nsfw@^1.0.17:
     nan "^2.0.0"
     promisify-node "^0.3.0"
 
-vscode-ripgrep@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.1.0.tgz#93c1e39d88342ee1b15530a12898ce930d511948"
+vscode-ripgrep@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.2.4.tgz#b3cfbe08ed13f6cf6b134147ea4d982970ab4f70"
+  integrity sha512-TysaK20aCSfsFIQGd0DfMshjkHof0fG6zx7DoO0tdWNAZgsvoqLtOWdqHcocICRZ3RSpdiMiEJRaMK+iOzx16w==
 
 vscode-textmate@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This patch replaces the current parsing of ripgrep's output, which
uses ANSI color control characters to identify fields, with the new
JSON output.

Change-Id: Ia497ada84522d1c12e6fde746c9700875a283cff
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
