### PR TITLE
Ensure css is swapped only for core themes

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -256,7 +256,7 @@ function updateTheme(): void {
     if (theme === 'dark') {
         lightCss.unuse();
         darkCss.use();
-    } else {
+    } else if (theme === 'light') {
         darkCss.unuse();
         lightCss.use();
     }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Theia can be extended with different or more themes.

The css for debug images is only aware of the core `light` and `dark` themes and will currently use the `light` images for all unrecognised themes.

This PR fixes it so that the images are only swapped in for known themes allowing other themes to manage images independently.
