### PR TITLE
[git] handle `git-view` when no workspace or repository is present

### DIFF
--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -378,6 +378,14 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
 
     protected render(): React.ReactNode {
         const repository = this.repositoryProvider.selectedRepository;
+        if (!repository) {
+            return <div className='warning-message'>
+                <div>
+                    <i className='fa fa-exclamation-triangle'></i>&nbsp;
+                    Version control is not available at this time.
+                </div>
+            </div>;
+        }
         return <div className={GitWidget.Styles.MAIN_CONTAINER}>
             <div className='headerContainer'>
                 {this.renderCommitMessage()}

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -253,8 +253,11 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                 path = <React.Fragment> for <i>/{decodeURIComponent(relPath)}</i>{repoName}</React.Fragment>;
             }
             content = <div className='message-container'>
-                <div className='no-history-message'>
-                    <div>There is no Git history available{path}.</div>
+                <div className='warning-message'>
+                    <div>
+                        <i className='fa fa-exclamation-triangle'></i>&nbsp;
+                        There is no Git history available{path}.
+                    </div>
                     <div>{reason}</div>
                 </div>
             </div>;

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -197,16 +197,6 @@
     height: 20px;
 }
 
-.theia-git .no-history-message {
-    background-color: var(--theia-warn-color0) !important;
-    color: var(--theia-warn-font-color0);
-    padding: 5px;
-}
-
-.theia-git .no-history-message div {
-    margin: 5px;
-}
-
 .theia-git .message-container {
     height: 100%;
     display: flex;

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -344,3 +344,13 @@
     padding: 0 5px;
     text-align: center;
 }
+
+.theia-git .warning-message {
+    background-color: var(--theia-warn-color0) !important;
+    color: var(--theia-warn-font-color0);
+    padding: 5px;
+}
+
+.theia-git .warning-message div {
+    margin: 5px;
+}


### PR DESCRIPTION
- Currently if no workspace, or repository is present we still display the `git-view` content
which leads to confusion. Instead an message will be shown to end users to notify them that no
version control is available.

![selection_023](https://user-images.githubusercontent.com/40359487/48558597-aa61de80-e8b7-11e8-9611-adf00b937ef2.png)


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
