### PR TITLE
Added workspace symbols plugin api

### DIFF
--- a/packages/languages/src/browser/language-client-services.ts
+++ b/packages/languages/src/browser/language-client-services.ts
@@ -27,9 +27,13 @@ export interface Language {
     readonly filenames: Set<string>;
 }
 
+export interface WorkspaceSymbolProvider extends services.WorkspaceSymbolProvider {
+    resolveWorkspaceSymbol?(symbol: services.SymbolInformation, token: services.CancellationToken): Thenable<services.SymbolInformation>
+}
+
 export const Languages = Symbol('Languages');
 export interface Languages extends services.Languages {
-    readonly workspaceSymbolProviders?: services.WorkspaceSymbolProvider[];
+    readonly workspaceSymbolProviders?: WorkspaceSymbolProvider[];
     readonly languages?: Language[]
     getLanguage?(languageId: string): Language | undefined;
 }

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -19,11 +19,11 @@ import {
     PrefixQuickOpenService, QuickOpenModel, QuickOpenItem, OpenerService,
     QuickOpenMode, KeybindingContribution, KeybindingRegistry, QuickOpenHandler, QuickOpenOptions, QuickOpenContribution, QuickOpenHandlerRegistry
 } from '@theia/core/lib/browser';
-import { Languages, WorkspaceSymbolParams, SymbolInformation } from './language-client-services';
+import { Languages, WorkspaceSymbolParams, SymbolInformation, WorkspaceSymbolProvider, CancellationToken } from './language-client-services';
 import { CancellationTokenSource, CommandRegistry, CommandHandler, Command, SelectionService } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { CommandContribution } from '@theia/core/lib/common';
-import { Range } from 'vscode-languageserver-types';
+import { Range, Position } from 'vscode-languageserver-types';
 
 @injectable()
 export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContribution, KeybindingContribution, CommandHandler, QuickOpenHandler, QuickOpenContribution {
@@ -92,26 +92,32 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
 
             const items: QuickOpenItem[] = [];
 
+            const workspaceProviderPromises = [];
             for (const provider of this.languages.workspaceSymbolProviders) {
-                provider.provideWorkspaceSymbols(param, newCancellationSource.token).then(symbols => {
+                workspaceProviderPromises.push(provider.provideWorkspaceSymbols(param, newCancellationSource.token).then(symbols => {
                     if (symbols && !newCancellationSource.token.isCancellationRequested) {
                         for (const symbol of symbols) {
-                            items.push(this.createItem(symbol));
-                        }
-                        if (items.length === 0) {
-                            items.push(new QuickOpenItem({
-                                label: lookFor.length === 0 ? 'Type to search for symbols' : 'No symbols matching',
-                                run: () => false
-                            }));
+                            items.push(this.createItem(symbol, provider, newCancellationSource.token));
                         }
                         acceptor(items);
                     }
-                });
+                    return symbols;
+                }));
             }
+            Promise.all(workspaceProviderPromises.map(p => p.then(sym => sym, _ => undefined))).then(symbols => {
+                const filteredSymbols = symbols.filter(el => el !== undefined && el.length !== 0);
+                if (filteredSymbols.length === 0) {
+                    items.push(new QuickOpenItem({
+                        label: lookFor.length === 0 ? 'Type to search for symbols' : 'No symbols matching',
+                        run: () => false
+                    }));
+                    acceptor(items);
+                }
+            }).catch();
         }
     }
 
-    protected createItem(sym: SymbolInformation): QuickOpenItem {
+    protected createItem(sym: SymbolInformation, provider: WorkspaceSymbolProvider, token: CancellationToken): QuickOpenItem {
         const uri = new URI(sym.location.uri);
         const kind = SymbolKind[sym.kind];
         const icon = (kind) ? SymbolKind[sym.kind].toLowerCase() : 'unknown';
@@ -121,10 +127,27 @@ export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContributi
         }
         parent = (parent || '') + uri.displayName;
         return new SimpleOpenItem(sym.name, icon, parent, uri.toString(), () => {
-            this.openerService.getOpener(uri).then(opener => opener.open(uri, {
-                selection: Range.create(sym.location.range.start, sym.location.range.start)
-            }));
+
+            if (provider.resolveWorkspaceSymbol) {
+                provider.resolveWorkspaceSymbol(sym, token).then(resolvedSymbol => {
+                    if (resolvedSymbol) {
+                        this.openURL(uri, resolvedSymbol.location.range.start, resolvedSymbol.location.range.end);
+                    } else {
+                        // the symbol didn't resolve -> use given symbol
+                        this.openURL(uri, sym.location.range.start, sym.location.range.end);
+                    }
+                });
+            } else {
+                // resolveWorkspaceSymbol wasn't specified
+                this.openURL(uri, sym.location.range.start, sym.location.range.end);
+            }
         });
+    }
+
+    private openURL(uri: URI, start: Position, end: Position): void {
+        this.openerService.getOpener(uri).then(opener => opener.open(uri, {
+            selection: Range.create(start, end)
+        }));
     }
 }
 

--- a/packages/monaco/src/browser/monaco-languages.ts
+++ b/packages/monaco/src/browser/monaco-languages.ts
@@ -15,13 +15,15 @@
  ********************************************************************************/
 
 import { injectable, inject, decorate } from 'inversify';
-import { MonacoLanguages as BaseMonacoLanguages, ProtocolToMonacoConverter, MonacoToProtocolConverter } from 'monaco-languageclient';
-import { Languages, Diagnostic, DiagnosticCollection, Language } from '@theia/languages/lib/browser';
+import {
+    MonacoLanguages as BaseMonacoLanguages, ProtocolToMonacoConverter,
+    MonacoToProtocolConverter
+} from 'monaco-languageclient';
+import { Languages, Diagnostic, DiagnosticCollection, Language, WorkspaceSymbolProvider } from '@theia/languages/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser/problem/problem-manager';
 import URI from '@theia/core/lib/common/uri';
 import { Mutable } from '@theia/core/lib/common/types';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { WorkspaceSymbolProvider } from 'monaco-languageclient/lib/services';
 import { MonacoDiagnosticCollection } from 'monaco-languageclient/lib/monaco-diagnostic-collection';
 
 decorate(injectable(), BaseMonacoLanguages);

--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -17,6 +17,7 @@
 import * as theia from '@theia/plugin';
 import { UriComponents } from '../common/uri-components';
 import { FileStat } from '@theia/filesystem/lib/common';
+import { SymbolInformation } from 'vscode-languageserver-types';
 
 // Should contains internal Plugin API types
 
@@ -415,4 +416,13 @@ export interface Breakpoint {
     readonly logMessage?: string;
     readonly location?: Location;
     readonly functionName?: string;
+}
+
+export interface WorkspaceSymbolProvider {
+    provideWorkspaceSymbols(params: WorkspaceSymbolParams, token: monaco.CancellationToken): Thenable<SymbolInformation[]>;
+    resolveWorkspaceSymbol(symbol: SymbolInformation, token: monaco.CancellationToken): Thenable<SymbolInformation>
+}
+
+export interface WorkspaceSymbolParams {
+    query: string
 }

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -59,6 +59,8 @@ import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-sch
 import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
+import { SymbolInformation } from 'vscode-languageserver-types';
+
 export interface PluginInitData {
     plugins: PluginMetadata[];
     preferences: { [key: string]: any };
@@ -841,6 +843,8 @@ export interface LanguagesExt {
         context: monaco.languages.CodeActionContext
     ): Promise<monaco.languages.CodeAction[]>;
     $provideDocumentSymbols(handle: number, resource: UriComponents): Promise<DocumentSymbol[] | undefined>;
+    $provideWorkspaceSymbols(handle: number, query: string): PromiseLike<SymbolInformation[]>;
+    $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation): PromiseLike<SymbolInformation>;
 }
 
 export interface LanguagesMain {
@@ -865,6 +869,7 @@ export interface LanguagesMain {
     $registerCodeLensSupport(handle: number, selector: SerializedDocumentFilter[], eventHandle?: number): void;
     $emitCodeLensEvent(eventHandle: number, event?: any): void;
     $registerOutlineSupport(handle: number, selector: SerializedDocumentFilter[]): void;
+    $registerWorkspaceSymbolProvider(handle: number): void;
 }
 
 export interface WebviewPanelViewState {

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -79,7 +79,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
     const outputChannelRegistryMain = new OutputChannelRegistryMainImpl(container);
     rpc.set(PLUGIN_RPC_CONTEXT.OUTPUT_CHANNEL_REGISTRY_MAIN, outputChannelRegistryMain);
 
-    const languagesMain = new LanguagesMainImpl(rpc);
+    const languagesMain = new LanguagesMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.LANGUAGES_MAIN, languagesMain);
 
     const webviewsMain = new WebviewsMainImpl(rpc, container);

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -69,6 +69,8 @@ import { CodeLensAdapter } from './languages/lens';
 import { CommandRegistryImpl } from './command-registry';
 import { OutlineAdapter } from './languages/outline';
 import { ReferenceAdapter } from './languages/reference';
+import { WorkspaceSymbolAdapter } from './languages/workspace-symbol';
+import { SymbolInformation } from 'vscode-languageserver-types';
 
 type Adapter = CompletionAdapter |
     SignatureHelpAdapter |
@@ -85,7 +87,8 @@ type Adapter = CompletionAdapter |
     CodeActionAdapter |
     OutlineAdapter |
     LinkProviderAdapter |
-    ReferenceAdapter;
+    ReferenceAdapter |
+    WorkspaceSymbolAdapter;
 
 export class LanguagesExtImpl implements LanguagesExt {
 
@@ -288,6 +291,22 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, DocumentHighlightAdapter, adapter => adapter.provideDocumentHighlights(URI.revive(resource), position));
     }
     // ### Document Highlight Provider end
+
+    // ### WorkspaceSymbol Provider begin
+    registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider): theia.Disposable {
+        const callId = this.addNewAdapter(new WorkspaceSymbolAdapter(provider));
+        this.proxy.$registerWorkspaceSymbolProvider(callId);
+        return this.createDisposable(callId);
+    }
+
+    $provideWorkspaceSymbols(handle: number, query: string): PromiseLike<SymbolInformation[]> {
+        return this.withAdapter(handle, WorkspaceSymbolAdapter, adapter => adapter.provideWorkspaceSymbols(query));
+    }
+
+    $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation): PromiseLike<SymbolInformation> {
+        return this.withAdapter(handle, WorkspaceSymbolAdapter, adapter => adapter.resolveWorkspaceSymbol(symbol));
+    }
+    // ### WorkspaceSymbol Provider end
 
     // ### Document Formatting Edit begin
     registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/languages/workspace-symbol.ts
+++ b/packages/plugin-ext/src/plugin/languages/workspace-symbol.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SymbolInformation } from 'vscode-languageserver-types';
+import * as theia from '@theia/plugin';
+import * as Converter from '../type-converters';
+import { createToken } from '../token-provider';
+
+export class WorkspaceSymbolAdapter {
+
+    constructor(
+        private readonly provider: theia.WorkspaceSymbolProvider
+    ) { }
+
+    provideWorkspaceSymbols(query: string): Promise<SymbolInformation[]> {
+        return Promise.resolve(this.provider.provideWorkspaceSymbols(query, createToken())).then(workspaceSymbols => {
+            if (!workspaceSymbols) {
+                return [];
+            }
+
+            const newSymbols: SymbolInformation[] = [];
+            for (const sym of workspaceSymbols) {
+                const convertedSymbol = Converter.fromSymbolInformation(sym);
+                if (convertedSymbol) {
+                    newSymbols.push(convertedSymbol);
+                }
+            }
+            return newSymbols;
+        });
+    }
+
+    resolveWorkspaceSymbol(symbol: SymbolInformation): Promise<SymbolInformation> {
+        if (this.provider.resolveWorkspaceSymbol && typeof this.provider.resolveWorkspaceSymbol === 'function') {
+            const theiaSymbol = Converter.toSymbolInformation(symbol);
+            if (!theiaSymbol) {
+                return Promise.resolve(symbol);
+            } else {
+                return Promise.resolve(this.provider.resolveWorkspaceSymbol(theiaSymbol, undefined)).then(workspaceSymbol => {
+                    if (!workspaceSymbol) {
+                        return symbol;
+                    }
+
+                    const converted = Converter.fromSymbolInformation(workspaceSymbol);
+                    if (converted) {
+                        return converted;
+                    }
+                    return symbol;
+                });
+            }
+        }
+        return Promise.resolve(symbol);
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -457,6 +457,9 @@ export function createAPIFactory(
             registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider): theia.Disposable {
                 return languagesExt.registerDocumentHighlightProvider(selector, provider);
             },
+            registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider): theia.Disposable {
+                return languagesExt.registerWorkspaceSymbolProvider(provider);
+            },
             registerDocumentFormattingEditProvider(selector: theia.DocumentSelector, provider: theia.DocumentFormattingEditProvider): theia.Disposable {
                 return languagesExt.registerDocumentFormattingEditProvider(selector, provider);
             },

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -24,6 +24,7 @@ import URI from 'vscode-uri';
 
 const SIDE_GROUP = -2;
 const ACTIVE_GROUP = -1;
+import { SymbolInformation, Range as R, Position as P, SymbolKind as S } from 'vscode-languageserver-types';
 
 export function toViewColumn(ep?: EditorPosition): theia.ViewColumn | undefined {
     if (typeof ep !== 'number') {
@@ -525,7 +526,7 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     }
 
     if (taskDefinition.type === 'process') {
-        return fromProcessExecution(<theia.ProcessExecution> execution, processTaskDto);
+        return fromProcessExecution(<theia.ProcessExecution>execution, processTaskDto);
     }
 
     return processTaskDto;
@@ -592,4 +593,42 @@ export function getShellArgs(args: undefined | (string | theia.ShellQuotedString
     });
 
     return result;
+}
+
+export function fromSymbolInformation(symbolInformation: theia.SymbolInformation): SymbolInformation | undefined {
+    if (!symbolInformation) {
+        return undefined;
+    }
+
+    if (symbolInformation.location && symbolInformation.location.range) {
+        const p1 = P.create(symbolInformation.location.range.start.line, symbolInformation.location.range.start.character);
+        const p2 = P.create(symbolInformation.location.range.end.line, symbolInformation.location.range.end.character);
+        return SymbolInformation.create(symbolInformation.name, symbolInformation.kind++ as S, R.create(p1, p2),
+            symbolInformation.location.uri.toString(), symbolInformation.containerName);
+    }
+
+    return <SymbolInformation>{
+        name: symbolInformation.name,
+        containerName: symbolInformation.containerName,
+        kind: symbolInformation.kind++ as S,
+        location: {
+            uri: symbolInformation.location.uri.toString()
+        }
+    };
+}
+
+export function toSymbolInformation(symbolInformation: SymbolInformation): theia.SymbolInformation | undefined {
+    if (!symbolInformation) {
+        return undefined;
+    }
+
+    return <theia.SymbolInformation>{
+        name: symbolInformation.name,
+        containerName: symbolInformation.containerName,
+        kind: symbolInformation.kind,
+        location: {
+            uri: URI.parse(symbolInformation.location.uri),
+            range: symbolInformation.location.range
+        }
+    };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -773,7 +773,7 @@ export class Location {
     uri: URI;
     range: Range;
 
-    constructor(uri: URI, rangeOrPosition: Range | Position) {
+    constructor(uri: URI, rangeOrPosition: Range | Position | undefined) {
         this.uri = uri;
         if (rangeOrPosition instanceof Range) {
             this.range = rangeOrPosition;

--- a/packages/plugin/API.md
+++ b/packages/plugin/API.md
@@ -657,3 +657,39 @@ function provideSymbols(document: theia.TextDocument): theia.ProviderResult<thei
     // code here
 }
 ```
+
+#### Workspace Symbol Provider
+
+A workspace symbol provider allows you register symbols for the symbol search feature.
+
+resolveWorkspaceSymbol is not needed if all SymbolInformation's returned from 
+provideWorkspaceSymbols have a location. Otherwise resolveWorkspaceSymbol is needed 
+in order to resolve the location of the SymbolInformation.
+
+Example of workspace symbol provider registration:
+
+```typescript
+theia.languages.registerWorkspaceSymbolProvider({
+    provideWorkspaceSymbols(query: string): theia.SymbolInformation[] {
+        return [new theia.SymbolInformation('my symbol', 4, new theia.Range(new theia.Position(0, 0), new theia.Position(0, 0)), theia.Uri.parse("some_uri_to_file"))];
+    }
+} as theia.WorkspaceSymbolProvider);
+```
+
+In this case resolveWorkspaceSymbol is not needed because we have provided the location for every
+symbol returned from provideWorkspaceSymbols
+
+```typescript
+theia.languages.registerWorkspaceSymbolProvider({
+    provideWorkspaceSymbols(query: string): theia.SymbolInformation[] {
+        return [new theia.SymbolInformation('my symbol', 4, 'my container name', new theia.Location(theia.Uri.parse("some_uri_to_file"), undefined))];
+    },
+    resolveWorkspaceSymbol(symbolInformation: theia.SymbolInformation): theia.SymbolInformation {
+        symbolInformation.location.range = new theia.Range(new theia.Position(0, 0), new theia.Position(0, 0));
+        return symbolInformation;
+    }
+} as theia.WorkspaceSymbolProvider);
+```
+
+resolveWorkspaceSymbol is needed here because we have not provided the location for every
+symbol return from provideWorkspaceSymbol


### PR DESCRIPTION
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Adds workspace symbols plugin api and modified types to be consistent with VSCode.

Related to: https://github.com/theia-ide/theia/issues/3353 and https://github.com/theia-ide/theia/issues/3387