### PR TITLE
Add reusable message component

### DIFF
--- a/packages/core/src/browser/style/alert-messages.css
+++ b/packages/core/src/browser/style/alert-messages.css
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+ /* message container */
+.theia-alert-message-container {
+    flex: 1;
+    padding: 10px;
+}
+
+.theia-alert-message-container i {
+    padding-right: 3px;
+}
+
+/* information message */
+.theia-info-alert {
+    background-color: var(--theia-brand-color0);
+    color: var(--theia-ui-font-color0);
+    padding: 10px;
+}
+
+/* success message */
+.theia-success-alert {
+    background-color: var(--theia-success-color0);
+    color: var(--theia-ui-font-color0);
+    padding: 10px;
+}
+
+/* warning message */
+.theia-warning-alert {
+    background-color: var(--theia-warn-color0);
+    color: var(--theia-warn-font-color0);
+    padding: 10px;
+}
+
+/* error message */
+.theia-error-alert {
+    background-color: var(--theia-error-color0);
+    color: var(--theia-ui-font-color0);
+    padding: 10px;
+}

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -111,7 +111,6 @@ body {
 
 button, .theia-button {
     border: none;
-    border-radius: 0;
     color: var(--theia-ui-button-font-color);
     background-color: var(--theia-ui-button-color);
     min-width: 65px;
@@ -184,3 +183,4 @@ textarea {
 @import './ansi.css';
 @import './view-container.css';
 @import './notification.css';
+@import './alert-messages.css';

--- a/packages/core/src/browser/widgets/alert-message.tsx
+++ b/packages/core/src/browser/widgets/alert-message.tsx
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import React = require('react');
+
+export type MessageType = keyof AlertMessageIcon;
+
+interface AlertMessageIcon {
+    INFO: string;
+    SUCCESS: string;
+    WARNING: string;
+    ERROR: string;
+}
+
+const AlertMessageIcon = {
+    INFO: 'fa fa-info-circle',
+    SUCCESS: 'fa fa-check-circle',
+    WARNING: 'fa fa-exclamation-circle',
+    ERROR: 'fa fa-error-icon'
+};
+
+export interface AlertMessageProps {
+    type: MessageType;
+    header: string;
+}
+
+export class AlertMessage extends React.Component<AlertMessageProps> {
+
+    render(): React.ReactNode {
+        return <div className='theia-alert-message-container'>
+            <div className={`theia-${this.props.type.toLowerCase()}-alert`}>
+                <div className='theia-message-header'>
+                    <i className={AlertMessageIcon[this.props.type]}></i>&nbsp;
+                    {this.props.header}
+                </div>
+                <div className='theia-message-content'>{this.props.children}</div>
+            </div>
+        </div>;
+    }
+
+}

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -29,6 +29,7 @@ import { GitAvatarService } from './history/git-avatar-service';
 import * as React from 'react';
 import { GitErrorHandler } from './git-error-handler';
 import { GitDiffWidget } from './diff/git-diff-widget';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 
 export interface GitFileChangeNode extends GitFileChange {
     readonly icon: string;
@@ -378,6 +379,12 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
 
     protected render(): React.ReactNode {
         const repository = this.repositoryProvider.selectedRepository;
+        if (!repository) {
+            return <AlertMessage
+                type='WARNING'
+                header='Version control is not available at this time'
+            />;
+        }
         return <div className={GitWidget.Styles.MAIN_CONTAINER}>
             <div className='headerContainer'>
                 {this.renderCommitMessage()}

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -32,6 +32,7 @@ import { GitCommitDetails } from './git-commit-detail-widget';
 import { GitNavigableListWidget } from '../git-navigable-list-widget';
 import { GitFileChangeNode } from '../git-widget';
 import * as React from 'react';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 
 export interface GitCommitNode extends GitCommitDetails {
     fileChanges?: GitFileChange[];
@@ -250,14 +251,13 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
                 const relPath = this.relativePath(this.options.uri);
                 const repo = this.repositoryProvider.findRepository(new URI(this.options.uri));
                 const repoName = repo ? ` in ${new URI(repo.localUri).displayName}` : '';
-                path = <React.Fragment> for <i>/{decodeURIComponent(relPath)}</i>{repoName}</React.Fragment>;
+                path = ` for ${decodeURIComponent(relPath)}${repoName}`;
             }
-            content = <div className='message-container'>
-                <div className='no-history-message'>
-                    <div>There is no Git history available{path}.</div>
-                    <div>{reason}</div>
-                </div>
-            </div>;
+            content = <AlertMessage
+                type='WARNING'
+                header={`There is no Git history available${path}`}>
+                {reason}
+                </AlertMessage>;
         } else {
             content = <div className='spinnerContainer'>
                 <span className='fa fa-spinner fa-pulse fa-3x fa-fw'></span>

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -197,16 +197,6 @@
     height: 20px;
 }
 
-.theia-git .no-history-message {
-    background-color: var(--theia-warn-color0) !important;
-    color: var(--theia-warn-font-color0);
-    padding: 5px;
-}
-
-.theia-git .no-history-message div {
-    margin: 5px;
-}
-
 .theia-git .message-container {
     height: 100%;
     display: flex;

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -23,6 +23,7 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { KeybindingRegistry, SingleTextInputDialog, KeySequence, ConfirmDialog, Message, KeybindingScope } from '@theia/core/lib/browser';
 import { KeymapsParser } from './keymaps-parser';
 import { KeymapsService, KeybindingJson } from './keymaps-service';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 
 export interface KeybindingItem {
     id: string,
@@ -150,7 +151,10 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected renderMessage(): React.ReactNode {
-        return <div className='kb-search-notification'><div>No results found!</div></div>;
+        return <AlertMessage
+            type='WARNING'
+            header='No results found!'
+        />;
     }
 
     protected renderTable(): React.ReactNode {

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -159,19 +159,6 @@
     display: flex;
 }
 
-.kb-search-notification {
-    padding: 10px;
-    display: flex;
-}
-
-.kb-search-notification div {
-    background-color: var(--theia-warn-color0);
-    border-radius: 5px;
-    color: var(--theia-warn-font-color0);
-    flex: 1;
-    padding: 10px;
-}
-
 .kb-item-row td a,
 .kb-item-row td a:active,
 .kb-item-row td a:focus {


### PR DESCRIPTION
- Created `notification-message` react component to be re-used across Theia.
- Created four different message types: `info`, `success`, `warning`, `error`.
- Included icons to messages

---
Example Message Types:

|Type| Screenshot |
|:---:|:---:|
|Info|![selection_004](https://user-images.githubusercontent.com/40359487/48568331-1ef34800-e8cd-11e8-910f-b5803b0556d8.png) |
|Success|![selection_002](https://user-images.githubusercontent.com/40359487/48568334-20bd0b80-e8cd-11e8-8799-ed0332dd535f.png)|
|Warning|![selection_001](https://user-images.githubusercontent.com/40359487/48568335-2286cf00-e8cd-11e8-9690-4f17e781d1b8.png) |
|Error|![selection_003](https://user-images.githubusercontent.com/40359487/48568322-1b5fc100-e8cd-11e8-8274-3f6e85ee7e30.png)|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
