### PR TITLE
Fix memory leaks on the backend

### DIFF
--- a/packages/core/src/common/logger-protocol.ts
+++ b/packages/core/src/common/logger-protocol.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { injectable } from 'inversify';
 import { JsonRpcServer } from './messaging/proxy-factory';
 
 export const ILoggerServer = Symbol('ILoggerServer');
@@ -37,6 +38,17 @@ export interface ILogLevelChangedEvent {
 
 export interface ILoggerClient {
     onLogLevelChanged(event: ILogLevelChangedEvent): void;
+}
+
+@injectable()
+export class DispatchingLoggerClient implements ILoggerClient {
+
+    readonly clients = new Set<ILoggerClient>();
+
+    onLogLevelChanged(event: ILogLevelChangedEvent): void {
+        this.clients.forEach(client => client.onLogLevelChanged(event));
+    }
+
 }
 
 export const rootLoggerName = 'root';

--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -105,7 +105,11 @@ export abstract class AbstractVSCodeDebugAdapterContribution implements DebugAda
         return debuggerContribution;
     }
 
+    protected schemaAttributes: Promise<IJSONSchema[]> | undefined;
     async getSchemaAttributes(): Promise<IJSONSchema[]> {
+        return this.schemaAttributes || (this.schemaAttributes = this.resolveSchemaAttributes());
+    }
+    protected async resolveSchemaAttributes(): Promise<IJSONSchema[]> {
         const debuggerContribution = await this.debuggerContribution;
         if (!debuggerContribution.configurationAttributes) {
             return [];

--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -18,13 +18,20 @@ import * as cluster from 'cluster';
 import { ContainerModule, interfaces } from 'inversify';
 import { ConnectionHandler, JsonRpcConnectionHandler, ILogger } from '@theia/core/lib/common';
 import { FileSystemNode } from './node-filesystem';
-import { FileSystem, FileSystemClient, fileSystemPath } from '../common';
+import { FileSystem, FileSystemClient, fileSystemPath, DispatchingFileSystemClient } from '../common';
 import { FileSystemWatcherServer, FileSystemWatcherClient, fileSystemWatcherPath } from '../common/filesystem-watcher-protocol';
 import { FileSystemWatcherServerClient } from './filesystem-watcher-client';
 import { NsfwFileSystemWatcherServer } from './nsfw-watcher/nsfw-filesystem-watcher';
 
-export function bindFileSystem(bind: interfaces.Bind): void {
-    bind(FileSystemNode).toSelf().inSingletonScope();
+export function bindFileSystem(bind: interfaces.Bind, props?: {
+    onFileSystemActivation: (context: interfaces.Context, fs: FileSystem) => void
+}): void {
+    bind(FileSystemNode).toSelf().inSingletonScope().onActivation((context, fs) => {
+        if (props && props.onFileSystemActivation) {
+            props.onFileSystemActivation(context, fs);
+        }
+        return fs;
+    });
     bind(FileSystem).toService(FileSystemNode);
 }
 
@@ -44,13 +51,21 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
 }
 
 export default new ContainerModule(bind => {
-    bindFileSystem(bind);
-    bind(ConnectionHandler).toDynamicValue(ctx =>
+    bind(DispatchingFileSystemClient).toSelf().inSingletonScope();
+    bindFileSystem(bind, {
+        onFileSystemActivation: ({ container }, fs) => {
+            fs.setClient(container.get(DispatchingFileSystemClient));
+            fs.setClient = () => {
+                throw new Error('use DispatchingFileSystemClient');
+            };
+        }
+    });
+    bind(ConnectionHandler).toDynamicValue(({ container }) =>
         new JsonRpcConnectionHandler<FileSystemClient>(fileSystemPath, client => {
-            const server = ctx.container.get<FileSystem>(FileSystem);
-            server.setClient(client);
-            client.onDidCloseConnection(() => server.dispose());
-            return server;
+            const dispatching = container.get(DispatchingFileSystemClient);
+            dispatching.clients.add(client);
+            client.onDidCloseConnection(() => dispatching.clients.delete(client));
+            return container.get(FileSystem);
         })
     ).inSingletonScope();
 


### PR DESCRIPTION
There were several causes:
- vscode debug schema attributes were mutated on each `getSchemaAttributes`
- fs/logger remote clients were never removed
  - also they were not properly handled, only the last client was used, other were ignored
- nsfw was never collected, because of a weird cycle between internals of nsfw (seems to install some global listeners), event callback and `watcher` local variable, setting `watcher` to `undefined` broke the cycle and allow GC to collect nsfw

There is still one more leak in the plugin extension: https://github.com/theia-ide/theia/issues/3523

@lmcbout @vitaliy-guliy it should fix #3477 Could you try? Now you should be able to reload as long as you want. Consequent reloads also should be faster since debug attributes are cached already.