### PR TITLE
Enable no-void-expression tslint rule as a warning

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -47,6 +47,12 @@
     "no-return-await": {
       "severity": "warning",
       "options": true
+    },
+    "no-void-expression": {
+      "severity": "warning",
+      "options": [
+        "ignore-arrow-function-shorthand"
+      ]
     }
   }
 }


### PR DESCRIPTION
In a review, I was asked to remove an unnecessary return statement in
something like:

```ts
func(): void {
  return functionThatReturnsVoid();
}
```

It turns out there is a tslint rule for that.  Enabling it in Theia
finding quite a few instances of that.  While the return keyword is not
harmful, it is a bit misleading in that it makes you think the function
returns something.  It can also be a sign that you forgot to update
something.

The "ignore-arrow-function-shorthand" option allows to avoid warning in
these cases:

    foo.setCallback((value) => functionThatReturnsVoid(value));

However, it still produces a warning if you do:

    foo.setCallback((value) => value && functionThatReturnsVoid(value));

I think this is an acceptable thing to write, so we could open a bug at
tslint about that.

Change-Id: I2449680a6086d95340a73a784463de6bdf56bd67

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
