### PR TITLE
Fix 'Find Command' command label

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -22,7 +22,7 @@ import { CommonMenus } from '../common-frontend-contribution';
 
 export const quickCommand: Command = {
     id: 'quickCommand',
-    label: 'Find Command ...'
+    label: 'Find Command...'
 };
 
 @injectable()


### PR DESCRIPTION
- Fixed `Find Command` label to align with the remainder of Theia (removed whitespace)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
