### PR TITLE
Update electron 'Close Tabs' keybinding

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -27,6 +27,7 @@ import { SHELL_TABBAR_CONTEXT_MENU } from './shell/tab-bars';
 import { AboutDialog } from './about-dialog';
 import * as browser from './browser';
 import URI from '../common/uri';
+import { environment } from '../common';
 
 export namespace CommonMenus {
 
@@ -188,6 +189,8 @@ export const supportPaste = browser.isNative || (!browser.isChrome && document.q
 
 @injectable()
 export class CommonFrontendContribution implements MenuContribution, CommandContribution, KeybindingContribution {
+
+    protected readonly isElectron = environment.electron.is();
 
     constructor(
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
@@ -473,7 +476,7 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
             },
             {
                 command: CommonCommands.CLOSE_TAB.id,
-                keybinding: 'alt+w'
+                keybinding: (this.isElectron) ? 'ctrlcmd+w' : 'alt+w'
             },
             {
                 command: CommonCommands.CLOSE_OTHER_TABS.id,


### PR DESCRIPTION
Fixes #1890

- Update keybinding for the command `Close Tab` for electron,
which is natively more familiar to users who are experienced to native IDEs.
(`vscode` has the command `Ctrl/Cmd+W` as well.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
