### PR TITLE
GH-3297: Set and use an env variable as the app project path in electron

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -102,7 +102,7 @@ if (process.env.LC_ALL) {
 process.env.LC_NUMERIC = 'C';
 
 const electron = require('electron');
-const { join } = require('path');
+const { join, resolve } = require('path');
 const { isMaster } = require('cluster');
 const { fork } = require('child_process');
 const { app, BrowserWindow, ipcMain, Menu } = electron;
@@ -176,6 +176,12 @@ if (isMaster) {
         const loadMainWindow = (port) => {
             mainWindow.loadURL('file://' + join(__dirname, '../../lib/index.html') + '?port=' + port);
         };
+
+        // We cannot use the \`process.cwd()\` as the application project path (the location of the \`package.json\` in other words)
+        // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
+        // https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274
+        process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
+
         const mainPath = join(__dirname, '..', 'backend', 'main');
         // We need to distinguish between bundled application and development mode when starting the clusters.
         // See: https://github.com/electron/electron/issues/6337#issuecomment-230183287

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -92,6 +92,12 @@ module.exports = Promise.resolve()${this.compileFrontendModuleImports(frontendMo
     protected compileElectronMain(): string {
         return `// @ts-check
 
+// Useful for Electron/NW.js apps as GUI apps on macOS doesn't inherit the \`$PATH\` define
+// in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).
+// https://github.com/electron/electron/issues/550#issuecomment-162037357
+// https://github.com/theia-ide/theia/pull/3534#issuecomment-439689082
+require('fix-path')();
+
 // Workaround for https://github.com/electron/electron/issues/9225. Chrome has an issue where
 // in certain locales (e.g. PL), image metrics are wrongly computed. We explicitly set the
 // LC_NUMERIC to prevent this from happening (selects the numeric formatting category of the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",
+    "fix-path": "^2.1.0",
     "font-awesome": "^4.7.0",
     "fuzzy": "^0.1.3",
     "inversify": "^4.14.0",

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -18,7 +18,6 @@ import * as http from 'http';
 import * as https from 'https';
 import * as express from 'express';
 import * as yargs from 'yargs';
-import * as path from 'path';
 import * as fs from 'fs-extra';
 import { inject, named, injectable } from 'inversify';
 import { ILogger, ContributionProvider, MaybePromise } from '../common';
@@ -74,13 +73,13 @@ export class BackendApplicationCliContribution implements CliContribution {
     }
 
     protected appProjectPath(): string {
-        const cwd = process.cwd();
-        // Check whether we are in bundled application or development mode.
-        // In a bundled electron application, the `package.json` is in `resources/app` by default.
-        if (environment.electron.is() && !environment.electron.isDevMode()) {
-            return path.join(cwd, 'resources', 'app');
+        if (environment.electron.is()) {
+            if (process.env.THEIA_APP_PROJECT_PATH) {
+                return process.env.THEIA_APP_PROJECT_PATH;
+            }
+            throw new Error('The \'THEIA_APP_PROJECT_PATH\' environment variable must be set when running in electron.');
         }
-        return cwd;
+        return process.cwd();
     }
 
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,7 +2768,7 @@ cross-spawn-async@^2.1.1:
     lru-cache "^4.0.0"
     which "^1.2.8"
 
-cross-spawn@^4:
+cross-spawn@^4, cross-spawn@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
@@ -3149,6 +3149,11 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+default-shell@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
+  integrity sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -3666,6 +3671,19 @@ execa@^0.2.2:
     path-key "^1.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  integrity sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -4024,6 +4042,13 @@ first-chunk-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
   dependencies:
     readable-stream "^2.0.2"
+
+fix-path@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fix-path/-/fix-path-2.1.0.tgz#72ece739de9af4bd63fd02da23e9a70c619b4c38"
+  integrity sha1-cuznOd6a9L1j/QLaI+mnDGGbTDg=
+  dependencies:
+    shell-path "^2.0.0"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -8647,6 +8672,22 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shell-env@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/shell-env/-/shell-env-0.3.0.tgz#2250339022989165bda4eb7bf383afeaaa92dc34"
+  integrity sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=
+  dependencies:
+    default-shell "^1.0.0"
+    execa "^0.5.0"
+    strip-ansi "^3.0.0"
+
+shell-path@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/shell-path/-/shell-path-2.1.0.tgz#ea7d06ae1070874a1bac5c65bb9bdd62e4f67a38"
+  integrity sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=
+  dependencies:
+    shell-env "^0.3.0"
 
 shelljs@^0.8.0, shelljs@^0.8.2:
   version "0.8.2"


### PR DESCRIPTION
Closes: #3297 

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

After manually applying the proposed changes inside a bundled Theia electron application, I have managed to fix the TS language server. It starts and works as expected. This PR fixes the followings:
 - the logic that calculates the location of the application `package.json`. This was tricky because of the [`process.cwd()` differences on OS X](https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274). (Note, we [use `process.cwd()`](https://github.com/theia-ide/theia/blob/68f919220fb1da3135986a8748af6e5f52a43745/packages/core/src/node/backend-application.ts#L76-L84) to locate the `package.json` in Theia.)
 - the [`PATH` variable issue](https://github.com/sindresorhus/fix-path) on OS X when the application was started from the UI.

This PR is required for the [native Theia application](https://github.com/theia-ide/theia-apps/pull/79) with TS support.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->