### PR TITLE
Plugin-2801: API endpoint for window.showTextDocument

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -19,6 +19,10 @@ import { UriComponents } from '../common/uri-components';
 
 // Should contains internal Plugin API types
 
+export interface TextDocumentShowOptions {
+    selection?: Range;
+}
+
 export interface Range {
     /**
      * Line number on which the range starts (starts at 1).

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -44,7 +44,8 @@ import {
     Command,
     TextEdit,
     ReferenceContext,
-    Location
+    Location,
+    TextDocumentShowOptions
 } from './model';
 
 export interface PluginInitData {
@@ -627,7 +628,7 @@ export interface DocumentsExt {
 
 export interface DocumentsMain {
     $tryCreateDocument(options?: { language?: string; content?: string; }): Promise<UriComponents>;
-    $tryOpenDocument(uri: UriComponents): Promise<void>;
+    $tryOpenDocument(uri: UriComponents, options?: TextDocumentShowOptions): Promise<void>;
     $trySaveDocument(uri: UriComponents): Promise<boolean>;
 }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -155,6 +155,27 @@ export function createAPIFactory(
             onDidChangeTextEditorVisibleRanges(listener, thisArg?, disposables?) {
                 return editors.onDidChangeTextEditorVisibleRanges(listener, thisArg, disposables);
             },
+            async showTextDocument(documentArg: theia.TextDocument | Uri,
+                                   optionsArg?: theia.TextDocumentShowOptions | theia.ViewColumn,
+                                   preserveFocus?: boolean
+            ): Promise<theia.TextEditor> {
+                // Todo pass additional arguments to documents service, when the API will support them.
+                let documentOptions: theia.TextDocumentShowOptions | undefined;
+                const uri: Uri = documentArg instanceof Uri ? documentArg : documentArg.uri;
+                if (optionsArg) {
+                    const optionsAny: any = optionsArg;
+                    if (optionsAny.selection) {
+                        documentOptions = optionsArg as theia.TextDocumentShowOptions;
+                    }
+                }
+                await documents.openDocument(uri, documentOptions);
+                const textEditor = editors.getVisibleTextEditors().find(editor => editor.document.uri.toString() === uri.toString());
+                if (textEditor) {
+                    return Promise.resolve(textEditor);
+                } else {
+                    throw new Error(`Failed to show text document ${documentArg.toString()}`);
+                }
+            },
             // tslint:disable-next-line:no-any
             showQuickPick(items: any, options: theia.QuickPickOptions, token?: theia.CancellationToken): any {
                 if (token) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2366,6 +2366,40 @@ declare module '@theia/plugin' {
         export const onDidChangeTextEditorViewColumn: Event<TextEditorViewColumnChangeEvent>;
 
         /**
+         * Show the given document in a text editor. A [column](#ViewColumn) can be provided
+         * to control where the editor is being shown. Might change the [active editor](#window.activeTextEditor).
+         *
+         * @param document A text document to be shown.
+         * @param column A view column in which the [editor](#TextEditor) should be shown. The default is the [active](#ViewColumn.Active), other values
+         * are adjusted to be `Min(column, columnCount + 1)`, the [active](#ViewColumn.Active)-column is not adjusted. Use [`ViewColumn.Beside`](#ViewColumn.Beside)
+         * to open the editor to the side of the currently active one.
+         * @param preserveFocus When `true` the editor will not take focus.
+         * @return A promise that resolves to an [editor](#TextEditor).
+         */
+        export function showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): Thenable<TextEditor>;
+
+        /**
+         * Show the given document in a text editor. [Options](#TextDocumentShowOptions) can be provided
+         * to control options of the editor is being shown. Might change the [active editor](#window.activeTextEditor).
+         *
+         * @param document A text document to be shown.
+         * @param options [Editor options](#TextDocumentShowOptions) to configure the behavior of showing the [editor](#TextEditor).
+         * @return A promise that resolves to an [editor](#TextEditor).
+         */
+        export function showTextDocument(document: TextDocument, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+
+        /**
+         * A short-hand for `openTextDocument(uri).then(document => showTextDocument(document, options))`.
+         *
+         * @see [openTextDocument](#openTextDocument)
+         *
+         * @param uri A resource identifier.
+         * @param options [Editor options](#TextDocumentShowOptions) to configure the behavior of showing the [editor](#TextEditor).
+         * @return A promise that resolves to an [editor](#TextEditor).
+         */
+        export function showTextDocument(uri: Uri, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+
+        /**
          * Shows a selection list.
          * @param items
          * @param options
@@ -5462,5 +5496,35 @@ declare module '@theia/plugin' {
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
 		export function registerDebugConfigurationProvider(debugType: string, provider: DebugConfigurationProvider): Disposable;
+    }
+
+    /**
+     * Represents options to configure the behavior of showing a [document](#TextDocument) in an [editor](#TextEditor).
+     */
+    export interface TextDocumentShowOptions {
+        /**
+         * An optional view column in which the [editor](#TextEditor) should be shown.
+         * The default is the [active](#ViewColumn.Active), other values are adjusted to
+         * be `Min(column, columnCount + 1)`, the [active](#ViewColumn.Active)-column is
+         * not adjusted. Use [`ViewColumn.Beside`](#ViewColumn.Beside) to open the
+         * editor to the side of the currently active one.
+         */
+        viewColumn?: ViewColumn;
+
+        /**
+         * An optional flag that when `true` will stop the [editor](#TextEditor) from taking focus.
+         */
+        preserveFocus?: boolean;
+
+        /**
+         * An optional flag that controls if an [editor](#TextEditor)-tab will be replaced
+         * with the next editor or if it will be kept.
+         */
+        preview?: boolean;
+
+        /**
+         * An optional selection to apply for the document in the [editor](#TextEditor).
+         */
+        selection?: Range;
     }
 }


### PR DESCRIPTION
API endpoint for [window.showTextDocument](https://code.visualstudio.com/docs/extensionAPI/vscode-api#_window). Supports selection option, other options will be implemented later.
fixes https://github.com/theia-ide/theia/issues/2801