### PR TITLE
[message-service] add showProgress

### DIFF
--- a/packages/messages/src/browser/notifications.ts
+++ b/packages/messages/src/browser/notifications.ts
@@ -151,17 +151,6 @@ class ProgressNotificationImpl implements ProgressNotification {
             return;
         }
         element.remove();
-        const actions = this.properties.actions;
-        if (!actions) {
-            return;
-        }
-        actions.filter(action => action.label === 'Close')
-            .forEach(action => action.fn(
-                <Notification>{
-                    element,
-                    properties: this.properties
-                })
-            );
     }
 
     show(): void {


### PR DESCRIPTION
This adds `showProgress`

```
class MessageService {
  ...

  showProgress(message: ProgressMessage, onDidCancel?: () => void): Promise<Progress>
}
```

`onDidCancel` callback is called on the caller site, which is either the FE or the BE.

