### PR TITLE
Fix breaking import 'WidgetTracker'

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -62,7 +62,6 @@ import { EnvVariablesServer, envVariablesPath } from './../common/env-variables'
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { JsonSchemaStore } from './json-schema-store';
 import { TabBarToolbarRegistry, TabBarToolbarContribution, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
-import { WidgetTracker } from './widgets';
 import { bindCorePreferences } from './core-preferences';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {


### PR DESCRIPTION
Fixes breaking import 'WidgetTracker' found in `master`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
