### PR TITLE
Fix the generated `workspace-service.d.ts` file

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -498,12 +498,12 @@ export interface WorkspaceInput {
 
 }
 
-interface WorkspaceData {
+export interface WorkspaceData {
     folders: Array<{ path: string }>;
     // TODO add workspace settings settings?: { [id: string]: any };
 }
 
-namespace WorkspaceData {
+export namespace WorkspaceData {
     const validateSchema = new Ajv().compile({
         type: 'object',
         properties: {


### PR DESCRIPTION
Fixes #3558

Unfortunately, without properly declaring `export` before an interface or namespace, the typescript compiler does not generate the following `*.d.ts` file correctly resulting in issues when trying to use the package through external extensions.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
