### PR TITLE
[cpp] Tweak "Switch Header/Source" key binding on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [plug-in] added `languages.registerCodeLensProvider` Plug-in API
 - [core] `ctrl+alt+a` and `ctrl+alt+d` to switch tabs left/right
 - [core] added `theia.applicationName` to application `package.json` and improved window title
+- [cpp] Use `Option+Command+o` instead of `Option+o` on macOS for 'Switch Header/Source'
 
 
 ## v0.3.16

--- a/packages/cpp/src/browser/cpp-keybinding.ts
+++ b/packages/cpp/src/browser/cpp-keybinding.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
+import { isOSX } from '@theia/core/lib/common/os';
 import { EditorManager } from '@theia/editor/lib/browser';
 import {
     KeybindingContext, Keybinding, KeybindingContribution, KeybindingRegistry
@@ -44,7 +45,7 @@ export class CppKeybindingContribution implements KeybindingContribution {
             {
                 command: 'switch_source_header',
                 context: this.cppKeybindingContext.id,
-                keybinding: 'alt+o'
+                keybinding: isOSX ? 'option+cmd+o' : 'alt+o'
             }
         ].forEach(binding => {
             registry.registerKeybinding(binding);


### PR DESCRIPTION
On many keyboard layouts on macOS, Option key (alt) combine with other keys are
for printing special characters. So use Option+Command+o instead of Option+o.

Signed-off-by: Marc-Andre Laperle <malaperle@gmail.com>