### PR TITLE
Add nls check to vscode debug adapter

### DIFF
--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -86,13 +86,18 @@ export abstract class AbstractVSCodeDebugAdapterContribution implements DebugAda
         this.languages = this.debuggerContribution.then(({ languages }) => languages);
     }
     protected async parse(): Promise<VSCodeDebuggerContribution> {
-        const nlsMap = require(path.join(this.extensionPath, 'package.nls.json'));
         const pckPath = path.join(this.extensionPath, 'package.json');
         let text = (await fs.readFile(pckPath)).toString();
-        for (const key of Object.keys(nlsMap)) {
-            const value = nlsMap[key];
-            text = text.split('%' + key + '%').join(value);
+
+        const nlsPath = path.join(this.extensionPath, 'package.nls.json');
+        if (fs.existsSync(nlsPath)) {
+            const nlsMap = require(nlsPath);
+            for (const key of Object.keys(nlsMap)) {
+                const value = nlsMap[key];
+                text = text.split('%' + key + '%').join(value);
+            }
         }
+
         const pck: {
             contributes: {
                 debuggers: VSCodeDebuggerContribution[]


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

As not all vscode debug adapters contain `nls` translation files, this PR contains a small change to only load and parse these if they exist.
