### PR TITLE
[git] disable command 'Git Clone' when no workspace is present

### DIFF
--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -27,6 +27,7 @@ import { GitWidget } from './git-widget';
 import { GitRepositoryTracker } from './git-repository-tracker';
 import { GitQuickOpenService } from './git-quick-open-service';
 import { GitSyncService } from './git-sync-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 export const GIT_WIDGET_FACTORY_ID = 'git';
 
@@ -102,6 +103,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
     @inject(GitQuickOpenService) protected readonly quickOpenService: GitQuickOpenService;
     @inject(GitRepositoryTracker) protected readonly repositoryTracker: GitRepositoryTracker;
     @inject(GitSyncService) protected readonly syncService: GitSyncService;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
 
     constructor() {
         super({
@@ -261,6 +263,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
             isVisible: () => this.syncService.canPublish()
         });
         registry.registerCommand(GIT_COMMANDS.CLONE, {
+            isEnabled: () => this.workspaceService.opened,
             // tslint:disable-next-line:no-any
             execute: (args: any[]) => {
                 let url: string | undefined = undefined;


### PR DESCRIPTION
Fixes #3543

- Disable the command `Git: Clone...` when no workspace is currently present.
- Currently, if a user attemps to call the command `Git: Clone...` without a workspace, nothing occurs.
- Consistent with other `Git` commands which are disabled if they are in the wrong context.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
