### PR TITLE
[navigator] preview node ONLY on a single click

### DIFF
--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileNode, FileTreeModel } from '@theia/filesystem/lib/browser';
-import { OpenerService, open, TreeNode, ExpandableTreeNode, SelectableTreeNode, CorePreferences } from '@theia/core/lib/browser';
+import { OpenerService, open, TreeNode, ExpandableTreeNode } from '@theia/core/lib/browser';
 import { FileNavigatorTree, WorkspaceRootNode, WorkspaceNode } from './navigator-tree';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
@@ -27,7 +27,6 @@ export class FileNavigatorModel extends FileTreeModel {
     @inject(OpenerService) protected readonly openerService: OpenerService;
     @inject(FileNavigatorTree) protected readonly tree: FileNavigatorTree;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
-    @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
 
     @postConstruct()
     protected init(): void {
@@ -37,6 +36,12 @@ export class FileNavigatorModel extends FileTreeModel {
             })
         );
         super.init();
+    }
+
+    previewNode(node: TreeNode): void {
+        if (FileNode.is(node)) {
+            open(this.openerService, node.uri, { mode: 'reveal', preview: true });
+        }
     }
 
     protected doOpenNode(node: TreeNode): void {
@@ -131,13 +136,6 @@ export class FileNavigatorModel extends FileTreeModel {
             return node;
         }
         return undefined;
-    }
-
-    selectNode(node: SelectableTreeNode): void {
-        if (FileNode.is(node) && this.corePreferences['list.openMode'] === 'singleClick') {
-            open(this.openerService, node.uri, {mode: 'reveal', preview: true});
-        }
-        super.selectNode(node);
     }
 
     protected getNodeClosestToRootByUri(uri: URI): TreeNode | undefined {

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CommonCommands } from '@theia/core/lib/browser';
+import { CommonCommands, CorePreferences } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeModel, TreeNode,
@@ -38,6 +38,8 @@ export const CLASS = 'theia-Files';
 
 @injectable()
 export class FileNavigatorWidget extends FileTreeWidget {
+
+    @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -190,6 +192,13 @@ export class FileNavigatorWidget extends FileTreeWidget {
                 </button>
             </div>
         </div>;
+    }
+
+    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        if (node && this.corePreferences['list.openMode'] === 'singleClick') {
+            this.model.previewNode(node);
+        }
+        super.handleClickEvent(node, event);
     }
 
 }


### PR DESCRIPTION
Before the editor preview will be opened on any node selection in the navigator tree causing different UI glitches, now it should be opened only if a user clicked on a node via UI.