### PR TITLE
debug: Don't log message twice

### DIFF
--- a/packages/debug/src/browser/debug-session-connection.ts
+++ b/packages/debug/src/browser/debug-session-connection.ts
@@ -192,8 +192,7 @@ export class DebugSessionConnection implements Disposable {
 
     protected handleMessage(data: string) {
         if (this.traceOutputChannel) {
-            this.traceOutputChannel.append(`${this.sessionId.substring(0, 8)} theia <- adapter: ${data}`);
-            this.traceOutputChannel.appendLine(data);
+            this.traceOutputChannel.appendLine(`${this.sessionId.substring(0, 8)} theia <- adapter: ${data}`);
         }
         const message: DebugProtocol.ProtocolMessage = JSON.parse(data);
         if (message.type === 'request') {


### PR DESCRIPTION
We log the content of the 'data' variable... remove the second one.

Change-Id: Ie3890a395d7d29a9446ec7fcf7f3fb12ac180d17
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
