### PR TITLE
Remove command 'Find Command...' from QuickOpen

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -21,8 +21,7 @@ import { PrefixQuickOpenService, QuickOpenHandlerRegistry } from './prefix-quick
 import { CommonMenus } from '../common-frontend-contribution';
 
 export const quickCommand: Command = {
-    id: 'quickCommand',
-    label: 'Find Command...'
+    id: 'quickCommand'
 };
 
 @injectable()
@@ -41,7 +40,8 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
 
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction(CommonMenus.VIEW_PRIMARY, {
-            commandId: quickCommand.id
+            commandId: quickCommand.id,
+            label: 'Find Command...'
         });
     }
 


### PR DESCRIPTION
Fixes #491

Removed the command `Find Command...` from QuickOpen.
The purpose of `Find Command...` is to trigger the QuickOpen so it does not make practical sense to have it listed as a command in the QuickOpen as it calls itself.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
