### PR TITLE
Plugin-2801: API endpoint for window.showTextDocument, support preserveFocus

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -19,8 +19,19 @@ import { UriComponents } from '../common/uri-components';
 
 // Should contains internal Plugin API types
 
+/**
+ * Represents options to configure the behavior of showing a document in an editor.
+ */
 export interface TextDocumentShowOptions {
+    /**
+     * An optional selection to apply for the document in the editor.
+     */
     selection?: Range;
+
+    /**
+     * An optional flag that when `true` will stop the editor from taking focus.
+     */
+    preserveFocus?: boolean;
 }
 
 export interface Range {

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -25,6 +25,7 @@ import { EditorManager, EditorOpenerOptions } from '@theia/editor/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { Saveable } from '@theia/core/lib/browser';
 import { TextDocumentShowOptions } from '../../api/model';
+import { Range } from 'vscode-languageserver-types';
 
 export class DocumentsMainImpl implements DocumentsMain {
 
@@ -110,13 +111,18 @@ export class DocumentsMainImpl implements DocumentsMain {
         //   - Uncaught (in promise) Error: Cannot read property 'message' of undefined.
         try {
             let editorOpenerOptions: EditorOpenerOptions | undefined;
-            if (options && options.selection) {
-                const selection = options.selection;
-                editorOpenerOptions = {
-                    selection: {
+            if (options) {
+                let range: Range | undefined;
+                if (options.selection) {
+                    const selection = options.selection;
+                    range = {
                         start: { line: selection.startLineNumber - 1, character: selection.startColumn - 1 },
                         end: { line: selection.endLineNumber - 1, character: selection.endColumn - 1 }
-                    }
+                    };
+                }
+                editorOpenerOptions = {
+                    selection: range,
+                    mode: options.preserveFocus ? 'open' : 'activate'
                 };
             }
             await this.editorManger.open(new URI(uri.external!), editorOpenerOptions);

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -23,7 +23,7 @@ import { DocumentDataExt, setWordDefinitionFor } from './document-data';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import * as Converter from './type-converters';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
-import { Range } from '../api/model';
+import { Range, TextDocumentShowOptions } from '../api/model';
 
 export class DocumentsExtImpl implements DocumentsExt {
     private toDispose = new DisposableCollection();
@@ -152,17 +152,24 @@ export class DocumentsExtImpl implements DocumentsExt {
     }
 
     private async loadDocument(uri: URI, options?: theia.TextDocumentShowOptions): Promise<DocumentDataExt | undefined> {
-        let range: Range | undefined;
-        if (options && options.selection) {
-            const { start, end } = options.selection;
-            range = {
-                startLineNumber: start.line,
-                startColumn: start.character,
-                endLineNumber: end.line,
-                endColumn: end.character
+        let documentOptions: TextDocumentShowOptions | undefined;
+        if (options) {
+            let selection: Range | undefined;
+            if (options.selection) {
+                const { start, end } = options.selection;
+                selection = {
+                    startLineNumber: start.line,
+                    startColumn: start.character,
+                    endLineNumber: end.line,
+                    endColumn: end.character
+                };
+            }
+            documentOptions = {
+                selection,
+                preserveFocus: options.preserveFocus
             };
         }
-        await this.proxy.$tryOpenDocument(uri, { selection: range });
+        await this.proxy.$tryOpenDocument(uri, documentOptions);
         return this.editorsAndDocuments.getDocument(uri.toString());
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -164,8 +164,15 @@ export function createAPIFactory(
                 const uri: Uri = documentArg instanceof Uri ? documentArg : documentArg.uri;
                 if (optionsArg) {
                     const optionsAny: any = optionsArg;
-                    if (optionsAny.selection) {
+                    if (optionsAny.preserveFocus || optionsAny.preview || optionsAny.selection) {
                         documentOptions = optionsArg as theia.TextDocumentShowOptions;
+                    }
+                }
+                if (preserveFocus) {
+                    if (documentOptions) {
+                        documentOptions.preserveFocus = preserveFocus;
+                    } else {
+                        documentOptions = { preserveFocus };
                     }
                 }
                 await documents.openDocument(uri, documentOptions);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2376,7 +2376,7 @@ declare module '@theia/plugin' {
          * @param preserveFocus When `true` the editor will not take focus.
          * @return A promise that resolves to an [editor](#TextEditor).
          */
-        export function showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): Thenable<TextEditor>;
+        export function showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): PromiseLike<TextEditor>;
 
         /**
          * Show the given document in a text editor. [Options](#TextDocumentShowOptions) can be provided
@@ -2386,7 +2386,7 @@ declare module '@theia/plugin' {
          * @param options [Editor options](#TextDocumentShowOptions) to configure the behavior of showing the [editor](#TextEditor).
          * @return A promise that resolves to an [editor](#TextEditor).
          */
-        export function showTextDocument(document: TextDocument, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+        export function showTextDocument(document: TextDocument, options?: TextDocumentShowOptions): PromiseLike<TextEditor>;
 
         /**
          * A short-hand for `openTextDocument(uri).then(document => showTextDocument(document, options))`.
@@ -2397,7 +2397,7 @@ declare module '@theia/plugin' {
          * @param options [Editor options](#TextDocumentShowOptions) to configure the behavior of showing the [editor](#TextEditor).
          * @return A promise that resolves to an [editor](#TextEditor).
          */
-        export function showTextDocument(uri: Uri, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+        export function showTextDocument(uri: Uri, options?: TextDocumentShowOptions): PromiseLike<TextEditor>;
 
         /**
          * Shows a selection list.


### PR DESCRIPTION
API endpoint for window.showTextDocument, support preserveFocus

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
