### PR TITLE
[navigator] disable 'File: Delete' for root

### DIFF
--- a/packages/workspace/src/browser/workspace-delete-handler.ts
+++ b/packages/workspace/src/browser/workspace-delete-handler.ts
@@ -37,6 +37,10 @@ export class WorkspaceDeleteHandler implements UriCommandHandler<URI[]> {
         return !!uris.length && !this.isRootDeleted(uris);
     }
 
+    isEnabled(uris: URI[]): boolean {
+        return !!uris.length && !this.isRootDeleted(uris);
+    }
+
     protected isRootDeleted(uris: URI[]): boolean {
         const rootUris = this.workspaceService.tryGetRoots().map(root => new URI(root.uri));
         return rootUris.some(rootUri => uris.some(uri => uri.isEqualOrParent(rootUri)));


### PR DESCRIPTION
Fixes #3593

- Added missing `File:Delete` handling for `isEnabled`.
- We can no longer `delete` the root directory which is now consistent with the `FileNavigator` context-menu.
- Fixes mutliple issues for when a user proceeds to `delete` the root directory and perform various subsequent actions.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
