### PR TITLE
[workspace] disable 'Duplicate' for root directories

### DIFF
--- a/packages/filesystem/src/common/filesystem-utils.ts
+++ b/packages/filesystem/src/common/filesystem-utils.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { FileStat } from './filesystem';
+import URI from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core/lib/common';
 
 export namespace FileSystemUtils {
@@ -33,5 +35,24 @@ export namespace FileSystemUtils {
         }
 
         return resourcePath;
+    }
+
+    /**
+     * Generate unique URI for a given parent which does not collide
+     * @param parentUri the parent URI
+     * @param parent the parent FileStat
+     * @param name the resource name
+     * @param ext the resource extension
+     */
+    export function generateUniqueResourceURI(parentUri: URI, parent: FileStat, name: string, ext: string = ''): URI {
+        const children = !parent.children ? [] : parent.children!.map(child => new URI(child.uri));
+
+        let index = 1;
+        let base = name + ext;
+        while (children.some(child => child.path.base === base)) {
+            index = index + 1;
+            base = name + '_' + index + ext;
+        }
+        return parentUri.resolve(base);
     }
 }

--- a/packages/workspace/src/browser/workspace-duplicate-handler.ts
+++ b/packages/workspace/src/browser/workspace-duplicate-handler.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from '@theia/core/lib/common/uri';
+import { injectable, inject } from 'inversify';
+import { WorkspaceUtils } from './workspace-utils';
+import { WorkspaceService } from './workspace-service';
+import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { UriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { FileSystemUtils } from '@theia/filesystem/lib/common/filesystem-utils';
+
+/**
+ * Workspace Duplicate URI CommandHandler
+ * @class
+ */
+@injectable()
+export class WorkspaceDuplicateHandler implements UriCommandHandler<URI[]> {
+
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+
+    @inject(WorkspaceUtils)
+    protected readonly workspaceUtils: WorkspaceUtils;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    /**
+     * Determine if the given command is visible
+     * @param uris
+     * @returns true if @param uris is not undefined, and does not contain a root directory
+     */
+    isVisible(uris: URI[]): boolean {
+        return !!uris.length && !this.workspaceUtils.containsRootDirectory(uris);
+    }
+
+    /**
+     * Determine if the given command is enabled
+     * @param uris
+     * @readonly true if @param uris is not undefined, and does not contain a root directory
+     */
+    isEnabled(uris: URI[]): boolean {
+        return !!uris.length && !this.workspaceUtils.containsRootDirectory(uris);
+    }
+
+    /**
+     * Execute the given command
+     * @param uris
+     * @returns Promise<void>
+     */
+    async execute(uris: URI[]): Promise<void> {
+        await Promise.all(uris.map(async uri => {
+            const parent = await this.fileSystem.getFileStat(uri.parent.toString());
+            if (parent) {
+                const parentUri = new URI(parent.uri);
+                const name = uri.path.name + '_copy';
+                const ext = uri.path.ext;
+                const target = FileSystemUtils.generateUniqueResourceURI(parentUri, parent, name, ext);
+                try {
+                    this.fileSystem.copy(uri.toString(), target.toString());
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        }));
+    }
+
+}

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -40,6 +40,8 @@ import { WorkspaceUriLabelProviderContribution } from './workspace-uri-contribut
 import { bindWorkspacePreferences } from './workspace-preferences';
 import { QuickOpenWorkspace } from './quick-open-workspace';
 import { WorkspaceDeleteHandler } from './workspace-delete-handler';
+import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
+import { WorkspaceUtils } from './workspace-utils';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -70,6 +72,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(CommandContribution).to(WorkspaceCommandContribution).inSingletonScope();
     bind(MenuContribution).to(FileMenuContribution).inSingletonScope();
     bind(WorkspaceDeleteHandler).toSelf().inSingletonScope();
+    bind(WorkspaceDuplicateHandler).toSelf().inSingletonScope();
 
     bind(WorkspaceStorageService).toSelf().inSingletonScope();
     rebind(StorageService).toService(WorkspaceStorageService);
@@ -78,4 +81,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(VariableContribution).to(WorkspaceVariableContribution).inSingletonScope();
 
     bind(QuickOpenWorkspace).toSelf().inSingletonScope();
+
+    bind(WorkspaceUtils).toSelf().inSingletonScope();
 });

--- a/packages/workspace/src/browser/workspace-utils.ts
+++ b/packages/workspace/src/browser/workspace-utils.ts
@@ -1,0 +1,43 @@
+
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from 'inversify';
+import { WorkspaceService } from './workspace-service';
+
+/**
+ * Collection of workspace utility functions
+ * @class
+ */
+@injectable()
+export class WorkspaceUtils {
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    /**
+     * Determine if root directory exists
+     * for a given array of URIs
+     * @param uris
+     */
+    containsRootDirectory(uris: URI[]): boolean {
+        // obtain all roots URIs for a given workspace
+        const rootUris = this.workspaceService.tryGetRoots().map(root => new URI(root.uri));
+        // return true if at least a single URI is a root directory
+        return rootUris.some(rootUri => uris.some(uri => uri.isEqualOrParent(rootUri)));
+    }
+}


### PR DESCRIPTION
- Refactored `DuplicateHandler` into it's own class
- Add `findVacantChildUri` into `FileSystemUtils`
- Add `isEnabled`, `isVisible` for the command `Duplicate`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
