### PR TITLE
Revert "[search-in-workspace] fix incorrect file-icon in 'search-in-workspace'"

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -39,7 +39,6 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { MEMORY_TEXT } from './in-memory-text-resource';
 import { FileResourceResolver } from '@theia/filesystem/lib/browser';
 import * as React from 'react';
-import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
 
 export interface SearchInWorkspaceResultNode extends ExpandableTreeNode, SelectableTreeNode {
     children: SearchInWorkspaceResultLineNode[];
@@ -86,7 +85,6 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(TreeExpansionService) protected readonly expansionService: TreeExpansionService;
-    @inject(FileSystem) protected readonly fileSystem: FileSystem;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -189,8 +187,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     }
                 } else {
                     const children: SearchInWorkspaceResultLineNode[] = [];
-                    const fileStat = await this.fileSystem.getFileStat(result.file);
-                    const icon = fileStat ? await this.labelProvider.getIcon(fileStat) : undefined;
+                    const icon = await this.labelProvider.getIcon(new URI(result.file));
                     if (CompositeTreeNode.is(this.model.root)) {
                         resultElement = {
                             selected: false,


### PR DESCRIPTION
Reverts theia-ide/theia#3598
@elaihau noticed an issue with the `search-in-workspace` which meant that only one result per file is displayed. Reverting in order to investigate further on a fix to #3597 