### PR TITLE
[monaco] WillSave properly wait for all listeners

### DIFF
--- a/packages/core/src/common/event.spec.ts
+++ b/packages/core/src/common/event.spec.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { Emitter } from './event';
+
+describe('Event Objects', () => {
+
+    it('Emitter firing should be synchronous', () => {
+        const emitter = new Emitter<undefined>();
+        let counter = 0;
+
+        emitter.event(() => counter++);
+        expect(counter).eq(0);
+        emitter.fire(undefined);
+        expect(counter).eq(1);
+    });
+
+});


### PR DESCRIPTION
Before, the first listener to resolve would resolve the whole promise returned
by `fireWillSaveModel`. This was an issue when multiple parties wanted to
actually apply edits to a document.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
