### PR TITLE
[languages] Trace any LS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.18
 - [core] Fix `@theia/core/lib/node/debug#DEBUG_MODE` flag to correctly detect when the runtime is inspected/debugged
+- [languages] Add a preference for every language contribution to be able to trace the communication client <-> server
 
 ## v0.3.17
 

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import * as Ajv from 'ajv';
-import { inject, injectable, named, interfaces } from 'inversify';
+import { inject, injectable, named, interfaces, postConstruct } from 'inversify';
 import { ContributionProvider, bindContributionProvider } from '../../common';
 import { PreferenceProvider } from './preference-provider';
 
@@ -66,11 +66,11 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     protected readonly preferences: { [name: string]: any } = {};
     protected validateFunction: Ajv.ValidateFunction;
 
-    constructor(
-        @inject(ContributionProvider) @named(PreferenceContribution)
-        protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>
-    ) {
-        super();
+    @inject(ContributionProvider) @named(PreferenceContribution)
+    protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>;
+
+    @postConstruct()
+    protected init(): void {
         this.preferenceContributions.getContributions().forEach(contrib => {
             this.doSetSchema(contrib.schema);
         });
@@ -113,6 +113,7 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     setSchema(schema: PreferenceSchema): void {
         this.doSetSchema(schema);
         this.updateValidate();
+        this.fireOnDidPreferencesChanged();
     }
 
     async setPreference(): Promise<void> {

--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -56,16 +56,6 @@ export const cppPreferencesSchema: PreferenceSchema = {
             default: false,
             type: 'boolean'
         },
-        'cpp.trace.server': {
-            type: 'string',
-            enum: [
-                'off',
-                'messages',
-                'verbose'
-            ],
-            default: 'off',
-            description: 'Enable/disable tracing communications with the C/C++ language server'
-        }
     }
 };
 

--- a/packages/json/src/browser/json-preferences.ts
+++ b/packages/json/src/browser/json-preferences.ts
@@ -63,16 +63,6 @@ export const jsonPreferenceSchema: PreferenceSchema = {
             'default': true,
             'description': 'Enable/disable default JSON formatter'
         },
-        'json.trace.server': {
-            'type': 'string',
-            'enum': [
-                'off',
-                'messages',
-                'verbose'
-            ],
-            'default': 'off',
-            'description': 'Enable/disable tracing communications with the JSON language server'
-        }
     }
 };
 

--- a/packages/languages/src/browser/languages-frontend-module.ts
+++ b/packages/languages/src/browser/languages-frontend-module.ts
@@ -43,5 +43,4 @@ export default new ContainerModule(bind => {
 
     bind(LanguageClientProviderImpl).toSelf().inSingletonScope();
     bind(LanguageClientProvider).toService(LanguageClientProviderImpl);
-
 });

--- a/packages/typescript/src/browser/typescript-preferences.ts
+++ b/packages/typescript/src/browser/typescript-preferences.ts
@@ -27,16 +27,6 @@ import {
 export const typescriptPreferenceSchema: PreferenceSchema = {
     'type': 'object',
     'properties': {
-        'typescript.trace.server': {
-            'type': 'string',
-            'enum': [
-                'off',
-                'messages',
-                'verbose'
-            ],
-            'default': 'off',
-            'description': 'Enable/disable tracing communications with the TS language server.'
-        },
         'typescript.server.log': {
             'type': 'string',
             'enum': [


### PR DESCRIPTION
Contributes a preference for every language contribution to be able to trace
the communication between Theia and the LS. Useful for debugging extensions and
language servers.
