### PR TITLE
[preferences] update preferences 'description' styling

### DIFF
--- a/packages/core/src/browser/style/tree-decorators.css
+++ b/packages/core/src/browser/style/tree-decorators.css
@@ -21,7 +21,7 @@
 
 .theia-caption-suffix {
     white-space: nowrap;
-    padding-left: 2px;
+    padding: 0px 2px 0px 2px;
 }
 
 .theia-caption-suffix-tail {


### PR DESCRIPTION
Fixes #3622

- Updated `tree-decorator`'s `.theia-caption-suffix` styling to have consistent right and left padding for better display. At time if we have multiple suffix like in the case of the preferences widget, we only add left padding, while it'd be more uniform to have padding on both sides causing less display issues.

||Preferences|
|:---:|:---:|
|Before|![screen shot 2018-11-23 at 6 53 14 pm](https://user-images.githubusercontent.com/40359487/48962824-fb2aa480-ef53-11e8-84cc-9ba6efa21899.jpg)|
|After|![screen shot 2018-11-23 at 6 54 04 pm](https://user-images.githubusercontent.com/40359487/48962825-fb2aa480-ef53-11e8-8158-8074ccad637b.jpg)|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
