### PR TITLE
[git] update git ahead and behind status-bar icons

### DIFF
--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -372,7 +372,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         const { upstreamBranch, aheadBehind } = status;
         if (upstreamBranch) {
             return {
-                text: '$(refresh)' + (aheadBehind ? ` ${aheadBehind.behind}↓ ${aheadBehind.ahead}↑` : ''),
+                text: '$(refresh)' + (aheadBehind ? ` ${aheadBehind.behind} $(arrow-down) ${aheadBehind.ahead} $(arrow-up)` : ''),
                 command: GIT_COMMANDS.SYNC.id,
                 tooltip: 'Synchronize Changes'
             };


### PR DESCRIPTION
- Update `git` `ahead` and `behind` statusbar icons for better visibility and consistency with the remainder of Theia

| | Screenshot |
|:---:|:---:|
|Before |<img width="300" alt="screen shot 2018-11-23 at 8 45 48 pm" src="https://user-images.githubusercontent.com/40359487/48963460-cd982800-ef60-11e8-82de-c6acaa21f176.png"> | 
|After | <img width="339" alt="screen shot 2018-11-23 at 8 45 59 pm" src="https://user-images.githubusercontent.com/40359487/48963461-cd982800-ef60-11e8-99ae-8dcc75fe2f5a.png">|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
