### PR TITLE
support search-in-workspace having multiple roots

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -105,13 +105,12 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
 
     // Start a search of the string "what" in the workspace.
     async search(what: string, callbacks: SearchInWorkspaceCallbacks, opts?: SearchInWorkspaceOptions): Promise<number> {
-        const root = (await this.workspaceService.roots)[0];
-
-        if (!root) {
+        if (!this.workspaceService.open) {
             throw new Error('Search failed: no workspace root.');
         }
 
-        const searchId = await this.searchServer.search(what, root.uri, opts);
+        const roots = await this.workspaceService.roots;
+        const searchId = await this.searchServer.search(what, roots.map(r => r.uri), opts);
         this.pendingSearches.set(searchId, callbacks);
         this.lastKnownSearchId = searchId;
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -107,7 +107,9 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             this.hasResults = r.size > 0;
             this.resultNumber = 0;
             const results = Array.from(r.values());
-            results.forEach(result => this.resultNumber += result.children.length);
+            results.forEach(rootFolder =>
+                rootFolder.children.forEach(file => this.resultNumber += file.children.length)
+            );
             this.update();
         }));
 

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -388,3 +388,7 @@
 .search-in-workspace-tab-icon::before {
     content: "\f002"
 }
+
+.highlighted-count-container {
+    background-color: var(--theia-brand-color0);
+}

--- a/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
+++ b/packages/search-in-workspace/src/common/search-in-workspace-interface.ts
@@ -49,7 +49,12 @@ export interface SearchInWorkspaceOptions {
 
 export interface SearchInWorkspaceResult {
     /**
-     * The URI to the file containing the result.
+     * The string uri to the root folder that the search was performed.
+     */
+    root: string;
+
+    /**
+     * The string uri to the file containing the result.
      */
     fileUri: string;
 
@@ -114,9 +119,9 @@ export interface SearchInWorkspaceClient {
 export const SearchInWorkspaceServer = Symbol('SearchInWorkspaceServer');
 export interface SearchInWorkspaceServer extends JsonRpcServer<SearchInWorkspaceClient> {
     /**
-     * Start a search for WHAT in directory ROOT.  Return a unique search id.
+     * Start a search for WHAT in directories ROOTURIS.  Return a unique search id.
      */
-    search(what: string, rootUri: string, opts?: SearchInWorkspaceOptions): Promise<number>;
+    search(what: string, rootUris: string[], opts?: SearchInWorkspaceOptions): Promise<number>;
 
     /**
      * Cancel an ongoing search.


### PR DESCRIPTION
What this change include:
- enabled users to perform search across all folder in the workspace, regardless of the number of roots folder. Search results are grouped by root folder and file.

What this change does not include and will be addressed in subsequent PRs:
- root folders in the search-in-workspace tree widget cannot be removed.
- user cannot "replace all" at the root folder level.

Signed-off-by: elaihau <liang.huang@ericsson.com>

