### PR TITLE
[plug-in] Add ability to provide custom namespace for Plug-in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [plug-in] added `languages.registerDocumentSymbolProvider` Plug-in API
 - [core] `ctrl+alt+a` and `ctrl+alt+d` to switch tabs left/right
 - [core] added `theia.applicationName` to application `package.json` and improved window title
+- [plug-in] added ability to provide custom namespace for Plug-in API
 - [cpp] Use `Option+Command+o` instead of `Option+o` on macOS for 'Switch Header/Source'
 
 

--- a/packages/plugin-ext/doc/how-to-add-new-plugin-namespace.md
+++ b/packages/plugin-ext/doc/how-to-add-new-plugin-namespace.md
@@ -1,0 +1,112 @@
+# This document describes how to add new plugin api namespace
+
+New Plugin API namespace should be packaged as Theia extension
+
+## Provide your API or namespace
+
+This API developed in the way that you provide your API as separate npm package.
+In that package you can declare your api.
+Example `foo.d.ts`:
+
+```typescript
+    declare module '@bar/foo' {
+        export namespace fooBar {
+            export function getFoo(): Foo;
+        }
+    }
+```
+
+## Declare `ExtPluginApiProvider` implementation
+
+```typescript
+@injectable()
+export class FooPluginApiProvider implements ExtPluginApiProvider {
+    provideApi(): ExtPluginApi {
+        return {
+            frontendExtApi: {
+                initPath: '/path/to/foo/api/implementation.js',
+                initFunction: 'fooInitializationFunction',
+                initVariable: 'foo_global_variable'
+            },
+            backendInitPath: path.join(__dirname, 'path/to/backend/foo/implementation.js')
+        };
+    }
+}
+```
+
+## Then you need to register `FooPluginApiProvider`, add next sample in your backend module
+
+Example:
+
+```typescript
+    bind(FooPluginApiProvider).toSelf().inSingletonScope();
+    bind(Symbol.for(ExtPluginApiProvider)).toService(FooPluginApiProvider);
+```
+
+## Next you need to implement `ExtPluginApiBackendInitializationFn`, which should hanlde `@bar/foo` module loading and instantiate `@foo/bar` API object, `path/to/backend/foo/implementation.js` example :
+
+```typescript
+export const provideApi: ExtPluginApiBackendInitializationFn = (rpc: RPCProtocol, pluginManager: PluginManager) => {
+    cheApiFactory = createAPIFactory(rpc);
+    plugins = pluginManager;
+
+    if (!isLoadOverride) {
+        overrideInternalLoad();
+        isLoadOverride = true;
+    }
+
+};
+
+function overrideInternalLoad(): void {
+    const module = require('module');
+    const internalLoad = module._load;
+
+    module._load = function (request: string, parent: any, isMain: {}) {
+        if (request !== '@bar/foo') {
+            return internalLoad.apply(this, arguments);
+        }
+
+        const plugin = findPlugin(parent.filename);
+        if (plugin) {
+            let apiImpl = pluginsApiImpl.get(plugin.model.id);
+            if (!apiImpl) {
+                apiImpl = cheApiFactory(plugin);
+                pluginsApiImpl.set(plugin.model.id, apiImpl);
+            }
+            return apiImpl;
+        }
+
+        if (!defaultApi) {
+            console.warn(`Could not identify plugin for '@bar/foo' require call from ${parent.filename}`);
+            defaultApi = cheApiFactory(emptyPlugin);
+        }
+
+        return defaultApi;
+    };
+}
+
+function findPlugin(filePath: string): Plugin | undefined {
+    return plugins.getAllPlugins().find(plugin => filePath.startsWith(plugin.pluginFolder));
+}
+```
+
+## Next you need to implement `createAPIFactory` factory function
+
+Example:
+
+```typescript
+import * as fooApi from '@bar/foo';
+export function createAPIFactory(rpc: RPCProtocol): ApiFactory {
+    const fooBarImpl = new FooBarImpl(rpc);
+    return function (plugin: Plugin): typeof fooApi {
+        const FooBar: typeof fooApi.fooBar = {
+            getFoo(): fooApi.Foo{
+                return fooBarImpl.getFooImpl();
+            }
+        }
+        return <typeof fooApi>{
+            fooBar : FooBar
+        };
+    }
+
+```

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -50,11 +50,13 @@ import {
     FileChangeEvent,
     TextDocumentShowOptions
 } from './model';
+import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 
 export interface PluginInitData {
     plugins: PluginMetadata[];
     preferences: { [key: string]: any };
     env: EnvInit;
+    extApi?: ExtPluginApi[];
 }
 
 export interface Plugin {

--- a/packages/plugin-ext/src/common/index.ts
+++ b/packages/plugin-ext/src/common/index.ts
@@ -23,3 +23,4 @@ export * from '../common/plugin-protocol';
 export * from '../plugin/plugin-context';
 export * from '../api/plugin-api';
 export * from '../main/node/temp-dir-util';
+export * from './plugin-ext-api-contribution';

--- a/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
+++ b/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { RPCProtocol } from '../api/rpc-protocol';
+import { PluginManager, Plugin } from '../api/plugin-api';
+import { interfaces } from 'inversify';
+
+export const ExtPluginApiProvider = 'extPluginApi';
+/**
+ * Provider for extension API description
+ */
+export interface ExtPluginApiProvider {
+    /**
+     * Provide API description
+     */
+    provideApi(): ExtPluginApi;
+}
+
+/**
+ * Plugin API extension description.
+ * This inteface describes scripts for both plugin runtimes: frontend(WebWorker) and backend(NodeJs)
+ */
+export interface ExtPluginApi {
+
+    /**
+     * Path to the script which should be loaded to provide api, module should export `provideApi` function with
+     * [ExtPluginApiBackendInitializationFn](#ExtPluginApiBackendInitializationFn) signature
+     */
+    backendInitPath?: string;
+
+    /**
+     * Initialization information for frontend part of Plugin API
+     */
+    frontendExtApi?: FrontendExtPluginApi;
+}
+
+export interface ExtPluginApiFrontendInitializationFn {
+    (rpc: RPCProtocol, plugins: Map<string, Plugin>): void;
+}
+
+export interface ExtPluginApiBackendInitializationFn {
+    (rpc: RPCProtocol, pluginManager: PluginManager): void;
+}
+
+/**
+ * Interface contains information for frontend(WebWorker) Plugin API extension initialization
+ */
+export interface FrontendExtPluginApi {
+    /**
+     * path to js file
+     */
+    initPath: string;
+    /** global variable name */
+    initVariable: string;
+    /**
+     * init function name,
+     * function should have  [ExtPluginApiFrontendInitializationFn](#ExtPluginApiFrontendInitializationFn)
+     */
+    initFunction: string;
+}
+
+export const MainPluginApiProvider = Symbol('mainPluginApi');
+
+/**
+ * Implementation should contains main(Theia) part of new namespace in Plugin API.
+ * [initialize](#initialize) will be called once per plugin runtime
+ */
+export interface MainPluginApiProvider {
+    initialize(rpc: RPCProtocol, container: interfaces.Container): void;
+}

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -19,6 +19,7 @@ import { Disposable } from '@theia/core/lib/common/disposable';
 import { LogPart } from './types';
 import { CharacterPair, CommentRule, PluginAPIFactory, Plugin } from '../api/plugin-api';
 import { PreferenceSchema } from '@theia/core/lib/browser/preferences';
+import { ExtPluginApi } from './plugin-ext-api-contribution';
 
 export const hostedServicePath = '/services/hostedPlugin';
 
@@ -467,6 +468,8 @@ export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
     deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
     getDeployedBackendMetadata(): Promise<PluginMetadata[]>;
     deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
+
+    getExtPluginAPI(): Promise<ExtPluginApi[]>;
 
     onMessage(message: string): Promise<void>;
 

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -23,6 +23,7 @@ import { getPluginId, PluginMetadata } from '../../../common/plugin-protocol';
 import * as theia from '@theia/plugin';
 import { EnvExtImpl } from '../../../plugin/env';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
+import { ExtPluginApi } from '../../../common/plugin-ext-api-contribution';
 
 // tslint:disable-next-line:no-any
 const ctx = self as any;
@@ -100,6 +101,19 @@ const pluginManager = new PluginManagerExtImpl({
         }
 
         return [result, foreign];
+    },
+    initExtApi(extApi: ExtPluginApi[]) {
+        for (const api of extApi) {
+            try {
+                if (api.frontendExtApi) {
+                    ctx.importScripts(api.frontendExtApi.initPath);
+                    ctx[api.frontendExtApi.initVariable][api.frontendExtApi.initFunction](rpc, pluginsModulesNames);
+                }
+
+            } catch (e) {
+                console.error(e);
+            }
+        }
     }
 }, envExt, preferenceRegistryExt);
 

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -29,6 +29,7 @@ import { HostedPluginsManager, HostedPluginsManagerImpl } from './hosted-plugins
 import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath } from '../../common/plugin-protocol';
 import { GrammarsReader } from './scanners/grammars-reader';
 import { HostedPluginProcess } from './hosted-plugin-process';
+import { ExtPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 
 export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginReader).toSelf().inSingletonScope();
@@ -61,4 +62,5 @@ export function bindHostedBackend(bind: interfaces.Bind): void {
     bind(HostedInstanceManager).to(NodeHostedPluginRunner).inSingletonScope();
     bind(PluginScanner).to(TheiaPluginScanner).inSingletonScope();
     bindContributionProvider(bind, Symbol.for(HostedPluginUriPostProcessorSymbolName));
+    bindContributionProvider(bind, Symbol.for(ExtPluginApiProvider));
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-service.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-service.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { injectable, inject } from 'inversify';
+import { injectable, inject, named } from 'inversify';
 import { HostedPluginServer, HostedPluginClient, PluginMetadata, PluginDeployerEntry, DebugConfiguration } from '../../common/plugin-protocol';
 import { HostedPluginReader } from './plugin-reader';
 import { HostedInstanceManager } from './hosted-instance-manager';
@@ -21,6 +21,8 @@ import { HostedPluginSupport } from './hosted-plugin';
 import { HostedPluginsManager } from './hosted-plugins-manager';
 import URI from '@theia/core/lib/common/uri';
 import { ILogger } from '@theia/core';
+import { ContributionProvider } from '@theia/core';
+import { ExtPluginApiProvider, ExtPluginApi } from '../../common/plugin-ext-api-contribution';
 
 @injectable()
 export class HostedPluginServerImpl implements HostedPluginServer {
@@ -29,6 +31,10 @@ export class HostedPluginServerImpl implements HostedPluginServer {
     protected readonly logger: ILogger;
     @inject(HostedPluginsManager)
     protected readonly hostedPluginsManager: HostedPluginsManager;
+
+    @inject(ContributionProvider)
+    @named(Symbol.for(ExtPluginApiProvider))
+    protected readonly extPluginAPIContributions: ContributionProvider<ExtPluginApiProvider>;
 
     /**
      * Managed plugin metadata backend entries.
@@ -158,4 +164,7 @@ export class HostedPluginServerImpl implements HostedPluginServer {
         return this.hostedPluginsManager.isWatchCompilationRunning(path);
     }
 
+    getExtPluginAPI(): Promise<ExtPluginApi[]> {
+        return Promise.resolve(this.extPluginAPIContributions.getContributions().map(p => p.provideApi()));
+    }
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -18,7 +18,7 @@ import '../../../src/main/style/status-bar.css';
 
 import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution, FrontendApplication, WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
-import { MaybePromise, CommandContribution, ResourceResolver } from '@theia/core/lib/common';
+import { MaybePromise, CommandContribution, ResourceResolver, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
 import { HostedPluginWatcher } from '../../hosted/browser/hosted-plugin-watcher';
@@ -43,6 +43,7 @@ import { MenusContributionPointHandler } from './menus/menus-contribution-handle
 import { PluginContributionHandler } from './plugin-contribution-handler';
 import { ViewRegistry } from './view/view-registry';
 import { TextContentResourceResolver } from './workspace-main';
+import { MainPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 
 export default new ContainerModule(bind => {
     bindHostedPluginPreferences(bind);
@@ -98,4 +99,5 @@ export default new ContainerModule(bind => {
 
     bind(TextContentResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(TextContentResourceResolver);
+    bindContributionProvider(bind, MainPluginApiProvider);
 });

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -17,12 +17,12 @@
 import { PluginManagerExt, PluginInitData, PluginManager, Plugin, PluginAPI } from '../api/plugin-api';
 import { PluginMetadata } from '../common/plugin-protocol';
 import * as theia from '@theia/plugin';
-
 import { join } from 'path';
 import { dispose } from '../common/disposable-util';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvExtImpl } from './env';
 import { PreferenceRegistryExtImpl } from './preference-registry';
+import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 
 export interface PluginHost {
 
@@ -30,6 +30,8 @@ export interface PluginHost {
     loadPlugin(plugin: Plugin): any;
 
     init(data: PluginMetadata[]): [Plugin[], Plugin[]];
+
+    initExtApi(extApi: ExtPluginApi[]): void;
 }
 
 interface StopFn {
@@ -74,6 +76,10 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.envExt.setQueryParameters(pluginInit.env.queryParams);
 
         this.preferencesManager.init(pluginInit.preferences);
+
+        if (pluginInit.extApi) {
+            this.host.initExtApi(pluginInit.extApi);
+        }
 
         const [plugins, foreignPlugins] = this.host.init(pluginInit.plugins);
         // add foreign plugins


### PR DESCRIPTION
This pull request provide ability to provide custom Plug-in namespace as Theia extension.
The lifecycle for that namespace will the same as for standard Theia plugin API object
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
