### PR TITLE
[process] Add ability to create a new node process by forking

### DIFF
--- a/packages/process/src/node/process-backend-module.ts
+++ b/packages/process/src/node/process-backend-module.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { ContainerModule, Container } from 'inversify';
-import { RawProcess, RawProcessOptions, RawProcessFactory } from './raw-process';
+import { RawProcess, RawProcessOptions, RawProcessFactory, RawForkOptions } from './raw-process';
 import { TerminalProcess, TerminalProcessOptions, TerminalProcessFactory } from './terminal-process';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { ProcessManager } from './process-manager';
@@ -31,7 +31,7 @@ export default new ContainerModule(bind => {
         return parentLogger.child('process');
     }).inSingletonScope().whenTargetNamed('process');
     bind(RawProcessFactory).toFactory(ctx =>
-        (options: RawProcessOptions) => {
+        (options: RawProcessOptions | RawForkOptions) => {
             const child = new Container({ defaultScope: 'Singleton' });
             child.parent = ctx.container;
 

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -28,8 +28,30 @@ export enum ProcessType {
     'Terminal'
 }
 
+/**
+ * Options to spawn a new process (`spawn`).
+ *
+ * For more information please refer to the spawn function of Node's
+ * child_process module:
+ *
+ *   https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
+ */
 export interface ProcessOptions {
     readonly command: string,
+    args?: string[],
+    options?: object
+}
+
+/**
+ * Options to fork a new process using the current Node interpeter (`fork`).
+ *
+ * For more information please refer to the fork function of Node's
+ * child_process module:
+ *
+ *   https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options
+ */
+export interface ForkOptions {
+    readonly modulePath: string,
     args?: string[],
     options?: object
 }
@@ -47,7 +69,7 @@ export abstract class Process {
         protected readonly processManager: ProcessManager,
         protected readonly logger: ILogger,
         @unmanaged() protected readonly type: ProcessType,
-        protected readonly options: ProcessOptions
+        protected readonly options: ProcessOptions | ForkOptions
     ) {
         this.exitEmitter = new Emitter<IProcessExitEvent>();
         this.errorEmitter = new Emitter<Error>();
@@ -77,9 +99,10 @@ export abstract class Process {
     protected handleOnExit(event: IProcessExitEvent) {
         this._killed = true;
         const signalSuffix = event.signal ? `, signal: ${event.signal}` : '';
+        const executable = this.isForkOptions(this.options) ? this.options.modulePath : this.options.command;
 
         this.logger.debug(`Process ${this.pid} has exited with code ${event.code}${signalSuffix}.`,
-            this.options.command, this.options.args);
+            executable, this.options.args);
     }
 
     protected emitOnError(err: Error) {
@@ -92,4 +115,7 @@ export abstract class Process {
         this.logger.error(error);
     }
 
+    protected isForkOptions(options: ForkOptions | any): options is ForkOptions {
+        return !!options && !!options.modulePath;
+    }
 }

--- a/packages/process/src/node/test/process-fork-test.js
+++ b/packages/process/src/node/test/process-fork-test.js
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (C) 2018 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+if (process.argv[2] === 'version') {
+    console.log('1.0.0');
+} else {
+    process.stderr.write('Error: Argument expected')
+    process.exit(1)
+}


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

When running Theia on the desktop in electron, we have the need to create a new node process.
We would prefer to use the version of node shipped with electron rather than have our users install a new node instance.

Therefore, this PR adds the ability to fork the main process.
