### PR TITLE
[debug] Add ability to fork a process for a debug adapter

### DIFF
--- a/packages/debug/src/node/debug-adapter.ts
+++ b/packages/debug/src/node/debug-adapter.ts
@@ -51,7 +51,8 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
     protected readonly processManager: ProcessManager;
 
     start(executable: DebugAdapterExecutable): CommunicationProvider {
-        const process = this.spawnProcess(executable);
+        const process = this.childProcess(executable);
+
         // FIXME: propagate onError + onExit
         return {
             input: process.input,
@@ -60,9 +61,13 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
         };
     }
 
-    private spawnProcess(executable: DebugAdapterExecutable): RawProcess {
-        const { command, args } = executable;
-        return this.processFactory({ command, args, options: { stdio: ['pipe', 'pipe', 2] } });
+    private childProcess(executable: DebugAdapterExecutable): RawProcess {
+        const { command, args, type } = executable;
+        const options = { stdio: ['pipe', 'pipe', 2] };
+        if (type === 'fork') {
+            options.stdio.push('ipc');
+        }
+        return this.processFactory({ type, command, args, options });
     }
 
     connect(debugServerPort: number): CommunicationProvider {

--- a/packages/debug/src/node/debug-model.ts
+++ b/packages/debug/src/node/debug-model.ts
@@ -65,6 +65,8 @@ export interface DebugAdapterSessionFactory {
  */
 export interface DebugAdapterExecutable {
     command: string
+    /** default: spawn */
+    type?: 'spawn' | 'fork';
     args?: string[]
 }
 


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR allows a debug adapter for use a forked node process instead of a spawned one.

Relies on #3637 being resolved and merged first.

