### PR TITLE
fix #3338 Format Document on save

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -248,6 +248,11 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'default': false,
             'description': 'Enable auto indentation adjustment.'
         },
+        'editor.formatOnSave': {
+            'type': 'boolean',
+            'default': false,
+            'description': 'Enable format on save when the autoSave preference is off.'
+        },
         'editor.formatOnType': {
             'type': 'boolean',
             'default': false,
@@ -504,6 +509,7 @@ export interface EditorConfiguration {
     'editor.autoClosingBrackets'?: boolean
     'editor.autoIndent'?: boolean
     'editor.formatOnType'?: boolean
+    'editor.formatOnSave'?: boolean
     'editor.formatOnPaste'?: boolean
     'editor.dragAndDrop'?: boolean
     'editor.suggestOnTriggerCharacters'?: boolean

--- a/packages/editorconfig/package.json
+++ b/packages/editorconfig/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "^0.3.16",
     "@theia/editor": "^0.3.16",
+    "@theia/languages": "^0.3.16",
     "@theia/monaco": "^0.3.16",
     "editorconfig": "^0.15.0"
   },


### PR DESCRIPTION
Fix #3338 
Depends on issue #3617 
Note: If #3617 not available, then the java file will need to be saved twice when the user wants to format  the file and cleaning up the lines from empty spaces.  

Format on Save is only available when the preference autoSave is "OFF"
and the preference 'editor.formatOnSave' is "true"

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
