### PR TITLE
[core] Add hooks on window.beforeunload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v0.3.18
 - [core] Fix `@theia/core/lib/node/debug#DEBUG_MODE` flag to correctly detect when the runtime is inspected/debugged
+- [core] Add a preference to define how to handle application exit.
+- [core] Add a way to prevent application exit from extensions.
 - [languages] Add a preference for every language contribution to be able to trace the communication client <-> server
 
-## v0.3.17
 
+## v0.3.17
 - Added better widget error handling for different use cases (ex: no workspace present, no repository present, ...)
 - Addressed multiple backend memory leaks
 - Prefixed quick-open commands for easier categorization and searching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [core] Fix `@theia/core/lib/node/debug#DEBUG_MODE` flag to correctly detect when the runtime is inspected/debugged
 - [core] Add a preference to define how to handle application exit.
 - [core] Add a way to prevent application exit from extensions.
+- [core] Prevent application exit if some editors are dirty.
 - [languages] Add a preference for every language contribution to be able to trace the communication client <-> server
 
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -17,6 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { MAIN_MENU_BAR, MenuContribution, MenuModelRegistry } from '../common/menu';
 import { KeybindingContribution, KeybindingRegistry } from './keybinding';
+import { FrontendApplicationContribution } from './frontend-application';
 import { CommandContribution, CommandRegistry, Command } from '../common/command';
 import { UriAwareCommandHandler } from '../common/uri-command-handler';
 import { SelectionService } from '../common/selection-service';
@@ -187,7 +188,7 @@ export const supportCopy = browser.isNative || document.queryCommandSupported('c
 export const supportPaste = browser.isNative || (!browser.isChrome && document.queryCommandSupported('paste'));
 
 @injectable()
-export class CommonFrontendContribution implements MenuContribution, CommandContribution, KeybindingContribution {
+export class CommonFrontendContribution implements FrontendApplicationContribution, MenuContribution, CommandContribution, KeybindingContribution {
 
     constructor(
         @inject(ApplicationShell) protected readonly shell: ApplicationShell,
@@ -510,5 +511,14 @@ export class CommonFrontendContribution implements MenuContribution, CommandCont
 
     protected async openAbout() {
         this.aboutDialog.open();
+    }
+
+    onWillStop() {
+        if (this.shell.canSaveAll()) {
+            setTimeout(() => {
+                this.messageService.info('Some documents should be saved, data will be lost otherwise.');
+            });
+            return true;
+        }
     }
 }

--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -28,12 +28,23 @@ export const corePreferenceSchema: PreferenceSchema = {
             ],
             default: 'singleClick',
             description: 'Controls how to open items in trees using the mouse.'
+        },
+        'application.confirmExit': {
+            type: 'string',
+            enum: [
+                'never',
+                'ifRequired',
+                'always',
+            ],
+            default: 'ifRequired',
+            description: 'When to confirm before closing the application window.',
         }
     }
 };
 
 export interface CoreConfiguration {
-    'list.openMode': string;
+    'application.confirmExit': 'never' | 'ifRequired' | 'always';
+    'list.openMode': 'singleClick' | 'doubleClick';
 }
 
 export const CorePreferences = Symbol('CorePreferences');
@@ -48,5 +59,5 @@ export function bindCorePreferences(bind: interfaces.Bind): void {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
         return createCorePreferences(preferences);
     }).inSingletonScope();
-    bind(PreferenceContribution).toConstantValue({ schema: corePreferenceSchema});
+    bind(PreferenceContribution).toConstantValue({ schema: corePreferenceSchema });
 }

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -140,7 +140,7 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(MessageService).toSelf().inSingletonScope();
 
     bind(CommonFrontendContribution).toSelf().inSingletonScope();
-    [CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
+    [FrontendApplicationContribution, CommandContribution, KeybindingContribution, MenuContribution].forEach(serviceIdentifier =>
         bind(serviceIdentifier).toService(CommonFrontendContribution)
     );
 


### PR DESCRIPTION
Allow extensions to prevent the closing of the browser if required.

Add a new preference `application.confirmExit`, one of three:
- `never`: never ask, even if extensions try to prevent exit
- `ifRequired`: ask if some extension tries to prevent exit
- `always` ask even if no extension prevents exit

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
