### PR TITLE
save edits only if active editor in pref widget changes

### DIFF
--- a/packages/preferences/src/browser/preferences-tree-widget.ts
+++ b/packages/preferences/src/browser/preferences-tree-widget.ts
@@ -158,7 +158,7 @@ export class PreferencesContainer extends SplitPanel implements ApplicationShell
             this.deferredEditors.resolve(this.editors);
         });
         this.editorsContainer.onEditorChanged(editor => {
-            if (this.currentEditor) {
+            if (this.currentEditor && this.currentEditor.editor.uri.toString() !== editor.editor.uri.toString()) {
                 this.currentEditor.saveable.save();
             }
             this.currentEditor = editor;


### PR DESCRIPTION
- This change fixes the bug reported in #2975. With this change, manual edits wouldn't be saved unless the active editor in preference widget changes. In other words, pref editors won't save the manual edits if the pref widget become inactive and active again.

Signed-off-by: elaihau <liang.huang@ericsson.com>

