### PR TITLE
[plugin-ext] Fix tests: spy on logger.warn

### DIFF
--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
@@ -36,6 +36,7 @@ let handler: MenusContributionPointHandler;
 
 let notificationWarnSpy: sinon.SinonSpy;
 let registerMenuSpy: sinon.SinonSpy;
+let loggerWarnSpy: sinon.SinonSpy;
 
 const testCommandId = 'core.about';
 
@@ -56,6 +57,9 @@ before(() => {
 beforeEach(() => {
     handler = testContainer.get(MenusContributionPointHandler);
 
+    const logger = testContainer.get<ILogger>(ILogger);
+    loggerWarnSpy = sinon.spy(logger, 'warn');
+
     const messageService = testContainer.get(MessageService);
     notificationWarnSpy = sinon.spy(messageService, 'warn');
 
@@ -66,6 +70,7 @@ beforeEach(() => {
 afterEach(function () {
     notificationWarnSpy.restore();
     registerMenuSpy.restore();
+    loggerWarnSpy.restore();
 });
 
 describe('MenusContributionHandler', () => {
@@ -137,7 +142,7 @@ describe('MenusContributionHandler', () => {
             }
         });
 
-        sinon.assert.called(notificationWarnSpy);
+        sinon.assert.called(loggerWarnSpy);
     });
 
     function assertItemIsRegistered(menuPath: MenuPath, menuGroup: string = '', order?: string) {


### PR DESCRIPTION
Broken by https://github.com/theia-ide/theia/commit/640af114f3fdcbe34f23fc43be5ad320c23ea669.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
