### PR TITLE
[search-in-workspace] allow 'Find in Folder..' with multiple folders at the same time

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -148,10 +148,11 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.refresh();
     }
 
-    findInFolder(uri: string): void {
+    findInFolder(uris: string[]): void {
         this.showSearchDetails = true;
-        const value = `${uri}/**`;
-        this.searchInWorkspaceOptions.include = [value];
+        const values = Array.from(new Set(uris.map(uri => `${uri}/**`)));
+        const value = values.join(', ');
+        this.searchInWorkspaceOptions.include = values;
         const include = document.getElementById('include-glob-field');
         if (include) {
             (include as HTMLInputElement).value = value;


### PR DESCRIPTION
- allow users the ability to run the command `Find in Folder...` with multiple folders selected.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
