### PR TITLE
[electron] Open Folder to actually open a folder

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -199,7 +199,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
                 Open Workspace
             </button>;
         } else {
-            openButton = <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openWorkspace}>
+            openButton = <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openFolder}>
                 Open Folder
             </button>;
         }


### PR DESCRIPTION
Fix a small mistake made when added a button on electron to open a folder from the navigator when no workspace is opened.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
