### PR TITLE
Fix rendering a menu with more than one actions which reference the same command

### DIFF
--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -19,13 +19,16 @@ import { MenuBar as MenuBarWidget, Menu as MenuWidget, Widget } from '@phosphor/
 import { CommandRegistry as PhosphorCommandRegistry } from '@phosphor/commands';
 import {
     CommandRegistry, ActionMenuNode, CompositeMenuNode,
-    MenuModelRegistry, MAIN_MENU_BAR, MenuPath
+    MenuModelRegistry, MAIN_MENU_BAR, MenuPath, ILogger
 } from '../../common';
 import { KeybindingRegistry, Keybinding } from '../keybinding';
 import { FrontendApplicationContribution, FrontendApplication } from '../frontend-application';
 
 @injectable()
 export class BrowserMainMenuFactory {
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
 
     constructor(
         @inject(CommandRegistry) protected readonly commandRegistry: CommandRegistry,
@@ -77,6 +80,10 @@ export class BrowserMainMenuFactory {
     protected addPhosphorCommand(commands: PhosphorCommandRegistry, menu: ActionMenuNode): void {
         const command = this.commandRegistry.getCommand(menu.action.commandId);
         if (!command) {
+            return;
+        }
+        if (commands.hasCommand(command.id)) {
+            this.logger.warn(`Command with ID ${command.id} is already registered`);
             return;
         }
         commands.addCommand(command.id, {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

This PR fixes #3676 
- replaces error from Phosphor about duplicated commands with a warning to browser's console
- fixes rendering a menu by skipping registering a duplicated commands in the Phosphor's command registry

So with that pacth both the browser and electron behavior will be the same - all the registered menu actions will be shown and executing the same command.