### PR TITLE
[core] Fix deprecated debug-mode detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.3.18
+- [core] Fix `@theia/core/lib/node/debug#DEBUG_MODE` flag to correctly detect when the runtime is inspected/debugged
+
 ## v0.3.17
 
 - Added better widget error handling for different use cases (ex: no workspace present, no repository present, ...)

--- a/packages/core/src/node/debug.ts
+++ b/packages/core/src/node/debug.ts
@@ -22,7 +22,7 @@ function isInDebugMode(): boolean {
     }
     if (process && process.execArgv) {
         return process.execArgv.some(arg =>
-            /^--debug=?/.test(arg) || /^--debug-brk=?/.test(arg)
+            /^--(debug|inspect)(-brk)?=?/.test(arg)
         );
     }
     return false;


### PR DESCRIPTION
This file is at least 1 year old and it seems to have been designed for Node 7
(and earlier) runtime. This commit update the detection mechanism to detect the
new inspect mode from Node 8.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
