### PR TITLE
[plugin] fix keybinding collision between plugin and debug console

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
@@ -35,7 +35,7 @@ export class PluginFrontendViewContribution extends AbstractViewContribution<Plu
                 rank: 300
             },
             toggleCommandId: 'pluginsView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+y'
+            toggleKeybinding: 'ctrlcmd+shift+l'
         });
     }
 


### PR DESCRIPTION
- Fixed keybinding collision between `debug:console:toggle` and `pluginsView:toggle`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
