### PR TITLE
[plugin] Display information message when no plugins are available

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -20,6 +20,7 @@ import { DisposableCollection } from '@theia/core';
 import { OpenerService } from '@theia/core/lib/browser';
 import { HostedPluginServer, PluginMetadata } from '../../common/plugin-protocol';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
 import * as React from 'react';
 
 @injectable()
@@ -68,6 +69,9 @@ export class PluginWidget extends ReactWidget {
 
     protected render(): React.ReactNode {
         if (this.ready) {
+            if (!this.plugins.length) {
+                return <AlertMessage type='INFO' header='No plugins currently available.' />;
+            }
             return <React.Fragment>{this.renderPluginList()}</React.Fragment>;
         } else {
             return <div className='spinnerContainer'>


### PR DESCRIPTION
- When working around in Theia I noticed that if no plugins are available and one opens the
`Plugins View` nothing gets displayed which may look odd to end-users who would expect some feedback. This PR addresses that issue by displaying an `information alert message`.

<div align='center'>

![selection_016](https://user-images.githubusercontent.com/40359487/49309865-a1256400-f4aa-11e8-855e-e745701a940c.png)

</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
