### PR TITLE
[monaco] adjusted monaco quick-open description styling

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -23,8 +23,8 @@
     color: var(--theia-ui-font-color1) !important;
 }
 
-/* 
- * set z-index to 0, so tabs are not above overlay widgets 
+/*
+ * set z-index to 0, so tabs are not above overlay widgets
  */
 .p-TabBar.theia-app-centers {
     z-index: 0;
@@ -35,7 +35,7 @@
  * we need to disable the background image when using font awesome icons
  */
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.fa {
-    background-image: none;    
+    background-image: none;
     margin-right: 0px;
 }
 
@@ -43,7 +43,7 @@
  * we need to disable the background image when using file-icons
  */
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
-    background-image: none;    
+    background-image: none;
     margin-right: 0px;
 }
 
@@ -53,4 +53,9 @@
 
 .quick-open-entry .quick-open-row .monaco-icon-label .monaco-icon-label-description-container .monaco-highlighted-label .highlight {
     color: var(--theia-accent-color1);
+}
+
+.quick-open-entry .quick-open-row .monaco-icon-label .monaco-icon-label-description-container .label-description {
+    color: var(--theia-ui-font-color2);
+    font-size: calc(var(--theia-ui-font-size0) * 0.95);
 }


### PR DESCRIPTION
- Adjusted the styling of the `monaco` `quick-open` **description** styling so that it is more
distinguishable from the `name` and also aligns better with `vscode`'s styling

<div align='center'>

![dark-quickopen](https://user-images.githubusercontent.com/40359487/49312679-dafa6880-f4b2-11e8-8904-b61e48f36d83.png)
![white-quickopen](https://user-images.githubusercontent.com/40359487/49312680-db92ff00-f4b2-11e8-9741-d0081ff4bde1.png)

</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
