### PR TITLE
fix #3697 Remove blocking await.

### DIFF
--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -39,6 +39,7 @@ describe('nsfw-filesystem-watcher', function () {
         root = FileUri.create(fs.realpathSync(temp.mkdirSync('node-fs-root')));
         watcherServer = createNsfwFileSystemWatcherServer();
         watcherId = await watcherServer.watchFileChanges(root.toString());
+        await sleep(2000);
     });
 
     afterEach(async () => {

--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.ts
@@ -79,7 +79,7 @@ export class NsfwFileSystemWatcherServer implements FileSystemWatcherServer {
         const basePath = FileUri.fsPath(uri);
         this.debug('Starting watching:', basePath);
         if (fs.existsSync(basePath)) {
-            await this.start(watcherId, basePath, options);
+            this.start(watcherId, basePath, options);
         } else {
             const disposable = new DisposableCollection();
             const timer = setInterval(() => {


### PR DESCRIPTION
PR removes blocking await when starting a file watcher. This is
particularly important when starting Theia with a large workspace root
as the file watch will block Theia loading.

Signed-off-by: Casey Flynn <caseyflynn@google.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
