### PR TITLE
Fix keys declaration file

### DIFF
--- a/packages/core/src/browser/keys.ts
+++ b/packages/core/src/browser/keys.ts
@@ -488,11 +488,11 @@ export namespace KeyModifier {
      * The CTRL key, independently of the platform.
      * _Note:_ In general `KeyModifier.CtrlCmd` should be preferred over this constant.
      */
-    export const CTRL = isOSX ? KeyModifier.MacCtrl : KeyModifier.CtrlCmd;
+    export const CTRL: KeyModifier.MacCtrl | KeyModifier.CtrlCmd = isOSX ? KeyModifier.MacCtrl : KeyModifier.CtrlCmd;
     /**
      * An alias for the SHIFT key (`KeyModifier.Shift`).
      */
-    export const SHIFT = KeyModifier.Shift;
+    export const SHIFT: KeyModifier.Shift = KeyModifier.Shift;
 
     /**
      * `true` if the argument represents a modifier. Otherwise, `false`.


### PR DESCRIPTION
- Fixed an issue with `keys.d.ts` which broke any extender attempting to use `@theia/core`.
TypeScript did not understand the type of the exported const `SHIFT` so it mistakenly wrote implementation  in the declaration file which threw errors when compiling.

<div align='center'>

Before: `keys.d.ts`

![keys](https://user-images.githubusercontent.com/40359487/49373422-1de35880-f6cc-11e8-8675-2dfc3c788b77.png)

After: `keys.d.ts`

![keys2](https://user-images.githubusercontent.com/40359487/49373997-fee5c600-f6cd-11e8-861d-d2954898d6f3.png)



</div>


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
