### PR TITLE
GH-3250: Switched back to the original JDT LS.

### DIFF
--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -58,6 +58,6 @@
     "extends": "../../configs/nyc.json"
   },
   "ls": {
-    "downloadUrl": "https://github.com/kittaakos/eclipse.jdt.ls-gh-715/raw/master/jdt-language-server-latest.tar.gz"
+    "downloadUrl": "http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz"
   }
 }


### PR DESCRIPTION
Closes #3250.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
