### PR TITLE
Add 'tasks.registerTaskProvider' for Plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [plug-in] added `window.showTextDocument` Plug-in API
 - [plug-in] added ability to provide custom namespaces for the Plug-in API
 - [plug-in] registered a type definition provider
+- [plug-in] added `tasks.registerTaskProvider` Plug-in API
 - [preview-editor] added the ability to open editors in preview mode
 - [process] added the ability to create new node processes through forking
 - [search-in-workspace] prompt users when performing `Replace All...` to limit accidental triggering

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -13,6 +13,7 @@
     "@theia/navigator": "^0.3.17",
     "@theia/plugin": "^0.3.17",
     "@theia/workspace": "^0.3.17",
+    "@theia/task": "^0.3.17",
     "decompress": "^4.2.0",
     "jsonc-parser": "^2.0.2",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -767,6 +767,23 @@ export interface WorkspaceEditDto {
     rejectReason?: string;
 }
 
+export interface CommandProperties {
+    command: string;
+    args?: string[];
+    options?: object;
+}
+export interface TaskDto {
+    type: string;
+    label: string;
+    // tslint:disable-next-line:no-any
+    [key: string]: any;
+}
+
+export interface ProcessTaskDto extends TaskDto, CommandProperties {
+    windows?: CommandProperties;
+    cwd?: string;
+}
+
 export interface LanguagesExt {
     $provideCompletionItems(handle: number, resource: UriComponents, position: Position, context: CompletionContext): Promise<CompletionResultDto | undefined>;
     $resolveCompletionItem(handle: number, resource: UriComponents, position: Position, completion: Completion): Promise<Completion>;
@@ -837,6 +854,7 @@ export const PLUGIN_RPC_CONTEXT = {
     OUTPUT_CHANNEL_REGISTRY_MAIN: <ProxyIdentifier<OutputChannelRegistryMain>>createProxyIdentifier<OutputChannelRegistryMain>('OutputChannelRegistryMain'),
     LANGUAGES_MAIN: createProxyIdentifier<LanguagesMain>('LanguagesMain'),
     CONNECTION_MAIN: createProxyIdentifier<ConnectionMain>('ConnectionMain'),
+    TASKS_MAIN: createProxyIdentifier<TasksMain>('TasksMain'),
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -854,4 +872,15 @@ export const MAIN_RPC_CONTEXT = {
     PREFERENCE_REGISTRY_EXT: createProxyIdentifier<PreferenceRegistryExt>('PreferenceRegistryExt'),
     LANGUAGES_EXT: createProxyIdentifier<LanguagesExt>('LanguagesExt'),
     CONNECTION_EXT: createProxyIdentifier<ConnectionExt>('ConnectionExt'),
+    TASKS_EXT: createProxyIdentifier<TasksExt>('TasksExt'),
 };
+
+export interface TasksExt {
+    $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
+    $resolveTask(handle: number, task: TaskDto): Promise<TaskDto | undefined>;
+}
+
+export interface TasksMain {
+    $registerTaskProvider(handle: number, type: string): void;
+    $unregister(handle: number): void;
+}

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -32,6 +32,7 @@ import { DialogsMainImpl } from './dialogs-main';
 import { TreeViewsMainImpl } from './view/tree-views-main';
 import { NotificationMainImpl } from './notification-main';
 import { ConnectionMainImpl } from './connection-main';
+import { TasksMainImpl } from './tasks-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
@@ -80,4 +81,7 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const pluginConnection = new ConnectionMainImpl(rpc);
     rpc.set(PLUGIN_RPC_CONTEXT.CONNECTION_MAIN, pluginConnection);
+
+    const tasksMain = new TasksMainImpl(rpc, container);
+    rpc.set(PLUGIN_RPC_CONTEXT.TASKS_MAIN, tasksMain);
 }

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    TasksMain,
+    MAIN_RPC_CONTEXT,
+    TasksExt
+} from '../../api/plugin-api';
+import { RPCProtocol } from '../../api/rpc-protocol';
+import { DisposableCollection } from '@theia/core';
+import { TaskProviderRegistry, TaskResolverRegistry, TaskProvider, TaskResolver } from '@theia/task/lib/browser/task-contribution';
+import { interfaces } from 'inversify';
+
+export class TasksMainImpl implements TasksMain {
+
+    private readonly proxy: TasksExt;
+    private readonly disposables = new Map<number, monaco.IDisposable>();
+    private readonly taskProviderRegistry: TaskProviderRegistry;
+    private readonly taskResolverRegistry: TaskResolverRegistry;
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container, ) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.TASKS_EXT);
+        this.taskProviderRegistry = container.get(TaskProviderRegistry);
+        this.taskResolverRegistry = container.get(TaskResolverRegistry);
+    }
+
+    $registerTaskProvider(handle: number, type: string): void {
+        const taskProvider = this.createTaskProvider(handle);
+        const taskResolver = this.createTaskResolver(handle);
+
+        const disposable = new DisposableCollection();
+        disposable.push(this.taskProviderRegistry.register(type, taskProvider));
+        disposable.push(this.taskResolverRegistry.register(type, taskResolver));
+        this.disposables.set(handle, disposable);
+    }
+
+    $unregister(handle: number): void {
+        const disposable = this.disposables.get(handle);
+        if (disposable) {
+            disposable.dispose();
+            this.disposables.delete(handle);
+        }
+    }
+
+    protected createTaskProvider(handle: number): TaskProvider {
+        return {
+            provideTasks: () =>
+                this.proxy.$provideTasks(handle).then(v => v!),
+        };
+    }
+
+    protected createTaskResolver(handle: number): TaskResolver {
+        return {
+            resolveTask: taskConfig =>
+                this.proxy.$resolveTask(handle, taskConfig).then(v => v!),
+        };
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -75,7 +75,15 @@ import {
     WorkspaceEdit,
     SymbolInformation,
     FileType,
-    FileChangeType
+    FileChangeType,
+    ShellQuoting,
+    ShellExecution,
+    ProcessExecution,
+    TaskScope,
+    TaskPanelKind,
+    TaskRevealKind,
+    TaskGroup,
+    Task
 } from './types-impl';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
 import { TextEditorsExtImpl } from './text-editors';
@@ -94,6 +102,7 @@ import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { MarkdownString } from './markdown-string';
 import { TreeViewsExtImpl } from './tree/tree-views';
 import { ConnectionExtImpl } from './connection-ext';
+import { TasksExtImpl } from './tasks/tasks';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -118,6 +127,7 @@ export function createAPIFactory(
     const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
     rpc.set(MAIN_RPC_CONTEXT.CONNECTION_EXT, new ConnectionExtImpl(rpc));
+    const tasksExt = rpc.set(MAIN_RPC_CONTEXT.TASKS_EXT, new TasksExtImpl(rpc));
 
     return function (plugin: InternalPlugin): typeof theia {
         const commands: typeof theia.commands = {
@@ -463,6 +473,12 @@ export function createAPIFactory(
             }
         };
 
+        const tasks: typeof theia.tasks = {
+            registerTaskProvider(type: string, provider: theia.TaskProvider): theia.Disposable {
+                return tasksExt.registerTaskProvider(type, provider);
+            }
+        };
+
         return <typeof theia>{
             version: require('../../package.json').version,
             commands,
@@ -472,6 +488,7 @@ export function createAPIFactory(
             languages,
             plugins,
             debug,
+            tasks,
             // Types
             StatusBarAlignment: StatusBarAlignment,
             Disposable: Disposable,
@@ -526,7 +543,15 @@ export function createAPIFactory(
             WorkspaceEdit,
             SymbolInformation,
             FileType,
-            FileChangeType
+            FileChangeType,
+            ShellQuoting,
+            ShellExecution,
+            ProcessExecution,
+            TaskScope,
+            TaskRevealKind,
+            TaskPanelKind,
+            TaskGroup,
+            Task
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as theia from '@theia/plugin';
+import * as Converter from '../type-converters';
+import { ObjectIdentifier } from '../../common/object-identifier';
+import { createToken } from '../token-provider';
+import { TaskDto } from '../../common';
+
+export class TaskProviderAdapter {
+    private cacheId = 0;
+    private cache = new Map<number, theia.Task>();
+
+    constructor(private readonly provider: theia.TaskProvider) { }
+
+    provideTasks(): Promise<TaskDto[] | undefined> {
+        return Promise.resolve(this.provider.provideTasks(createToken())).then(tasks => {
+            if (!Array.isArray(tasks)) {
+                return undefined;
+            }
+            const result: TaskDto[] = [];
+            for (const task of tasks) {
+                const data = Converter.fromTask(task);
+                if (!data) {
+                    continue;
+                }
+
+                const id = this.cacheId++;
+                ObjectIdentifier.mixin(data, id);
+                this.cache.set(id, task);
+                result.push(data);
+            }
+            return result;
+        });
+    }
+
+    resolveTask(task: TaskDto): Promise<TaskDto | undefined> {
+        if (typeof this.provider.resolveTask !== 'function') {
+            return Promise.resolve(undefined);
+        }
+        const id = ObjectIdentifier.of(task);
+        const item = this.cache.get(id);
+        if (!item) {
+            return Promise.resolve(undefined);
+        }
+
+        return Promise.resolve(this.provider.resolveTask(item, createToken())).then(value => {
+            if (value) {
+                return Converter.fromTask(value);
+            }
+            return undefined;
+        });
+    }
+}

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {
+    PLUGIN_RPC_CONTEXT,
+    TasksExt,
+    TasksMain,
+    TaskDto
+} from '../../api/plugin-api';
+import * as theia from '@theia/plugin';
+import { Disposable } from '../types-impl';
+import { RPCProtocol } from '../../api/rpc-protocol';
+import { TaskProviderAdapter } from './task-provider';
+
+export class TasksExtImpl implements TasksExt {
+    private proxy: TasksMain;
+
+    private callId = 0;
+    private adaptersMap = new Map<number, TaskProviderAdapter>();
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.TASKS_MAIN);
+    }
+
+    registerTaskProvider(type: string, provider: theia.TaskProvider): theia.Disposable {
+        const callId = this.addNewAdapter(new TaskProviderAdapter(provider));
+        this.proxy.$registerTaskProvider(callId, type);
+        return this.createDisposable(callId);
+    }
+
+    $provideTasks(handle: number): Promise<TaskDto[] | undefined> {
+        const adapter = this.adaptersMap.get(handle);
+        if (adapter) {
+            return adapter.provideTasks();
+        } else {
+            return Promise.reject(new Error('No adapter found to provide tasks'));
+        }
+    }
+
+    $resolveTask(handle: number, task: TaskDto): Promise<TaskDto | undefined> {
+        const adapter = this.adaptersMap.get(handle);
+        if (adapter) {
+            return adapter.resolveTask(task);
+        } else {
+            return Promise.reject(new Error('No adapter found to resolve task'));
+        }
+    }
+
+    private addNewAdapter(adapter: TaskProviderAdapter): number {
+        const callId = this.nextCallId();
+        this.adaptersMap.set(callId, adapter);
+        return callId;
+    }
+
+    private nextCallId(): number {
+        return this.callId++;
+    }
+
+    private createDisposable(callId: number): theia.Disposable {
+        return new Disposable(() => {
+            this.adaptersMap.delete(callId);
+            this.proxy.$unregister(callId);
+        });
+    }
+}

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { EditorPosition, Selection, Position, DecorationOptions, WorkspaceEditDto, ResourceTextEditDto, ResourceFileEditDto } from '../api/plugin-api';
+import { EditorPosition, Selection, Position, DecorationOptions, WorkspaceEditDto, ResourceTextEditDto, ResourceFileEditDto, TaskDto, ProcessTaskDto } from '../api/plugin-api';
 import * as model from '../api/model';
 import * as theia from '@theia/plugin';
 import * as types from './types-impl';
@@ -475,4 +475,104 @@ export function toWorkspaceFolder(folder: model.WorkspaceFolder): theia.Workspac
         name: folder.name,
         index: folder.index
     };
+}
+
+export function fromTask(task: theia.Task): TaskDto | undefined {
+    if (!task) {
+        return undefined;
+    }
+
+    const taskDto = {} as TaskDto;
+    taskDto.label = task.name;
+
+    const taskDefinition = task.definition;
+    if (!taskDefinition) {
+        return taskDto;
+    }
+
+    taskDto.type = taskDefinition.type;
+    for (const key in taskDefinition) {
+        if (taskDefinition.hasOwnProperty(key)) {
+            taskDto[key] = taskDefinition[key];
+        }
+    }
+
+    const execution = task.execution;
+    if (!execution) {
+        return taskDto;
+    }
+
+    const processTaskDto = taskDto as ProcessTaskDto;
+    if (taskDefinition.type === 'shell') {
+        return fromShellExecution(execution, processTaskDto);
+    }
+
+    if (taskDefinition.type === 'process') {
+        return fromProcessExecution(<theia.ProcessExecution> execution, processTaskDto);
+    }
+
+    return processTaskDto;
+}
+
+export function fromProcessExecution(execution: theia.ProcessExecution, processTaskDto: ProcessTaskDto): ProcessTaskDto {
+    processTaskDto.command = execution.process;
+    processTaskDto.args = execution.args;
+
+    const options = execution.options;
+    if (options) {
+        processTaskDto.cwd = options.cwd;
+        processTaskDto.options = options;
+    }
+    return processTaskDto;
+}
+
+export function fromShellExecution(execution: theia.ShellExecution, processTaskDto: ProcessTaskDto): ProcessTaskDto {
+    const options = execution.options;
+    if (options) {
+        processTaskDto.cwd = options.cwd;
+        processTaskDto.args = options.shellArgs;
+        processTaskDto.options = options;
+    }
+
+    const commandLine = execution.commandLine;
+    if (commandLine) {
+        const args = commandLine.split(' ');
+        const taskCommand = args.shift();
+
+        if (taskCommand) {
+            processTaskDto.command = taskCommand;
+        }
+
+        processTaskDto.args = args;
+        return processTaskDto;
+    }
+
+    const command = execution.command;
+    if (typeof command === 'string') {
+        processTaskDto.command = command;
+        processTaskDto.args = getShellArgs(execution.args);
+        return processTaskDto;
+    } else {
+        throw new Error('Converting ShellQuotedString command is not implemented');
+    }
+}
+
+export function getShellArgs(args: undefined | (string | theia.ShellQuotedString)[]): string[] {
+    if (!args || args.length === 0) {
+        return [];
+    }
+
+    const element = args[0];
+    if (typeof element === 'string') {
+        return args as string[];
+    }
+
+    const result: string[] = [];
+    const shellQuotedArgs = args as theia.ShellQuotedString[];
+
+    shellQuotedArgs.forEach(arg => {
+        result.push(arg.value);
+    });
+
+    return result;
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5677,34 +5677,33 @@ declare module '@theia/plugin' {
 
     export enum ShellQuoting {
 
-		/**
-		 * Character escaping should be used. This for example
-		 * uses \ on bash and ` on PowerShell.
-		 */
+        /**
+         * Character escaping should be used. This for example
+         * uses \ on bash and ` on PowerShell.
+         */
         Escape = 1,
 
-		/**
-		 * Strong string quoting should be used. This for example
-		 * uses " for Windows cmd and ' for bash and PowerShell.
-		 * Strong quoting treats arguments as literal strings.
-		 * Under PowerShell echo 'The value is $(2 * 3)' will
-		 * print `The value is $(2 * 3)`
-		 */
+        /**
+         * Strong string quoting should be used. This for example
+         * uses " for Windows cmd and ' for bash and PowerShell.
+         * Strong quoting treats arguments as literal strings.
+         * Under PowerShell echo 'The value is $(2 * 3)' will
+         * print `The value is $(2 * 3)`
+         */
         Strong = 2,
 
-		/**
-		 * Weak string quoting should be used. This for example
-		 * uses " for Windows cmd, bash and PowerShell. Weak quoting
-		 * still performs some kind of evaluation inside the quoted
-		 * string.  Under PowerShell echo "The value is $(2 * 3)"
-		 * will print `The value is 6`
-		 */
+        /**
+         * Weak string quoting should be used. This for example
+         * uses " for Windows cmd, bash and PowerShell. Weak quoting
+         * still performs some kind of evaluation inside the quoted
+         * string.  Under PowerShell echo "The value is $(2 * 3)"
+         * will print `The value is 6`
+         */
         Weak = 3
     }
 
     /** A string that will be quoted depending on the used shell. */
     export interface ShellQuotedString {
-
         /** The actual string value */
         value: string;
 
@@ -5714,11 +5713,11 @@ declare module '@theia/plugin' {
 
     export interface ShellQuotingOptions {
 
-		/**
-		 * The character used to do character escaping. If a string is provided only spaces
-		 * are escaped. If a `{ escapeChar, charsToEscape }` literal is provide all characters
-		 * in `charsToEscape` are escaped using the `escapeChar`.
-		 */
+        /**
+         * The character used to do character escaping. If a string is provided only spaces
+         * are escaped. If a `{ escapeChar, charsToEscape }` literal is provide all characters
+         * in `charsToEscape` are escaped using the `escapeChar`.
+         */
         escape?: string | {
             /** The escape character */
             escapeChar: string;
@@ -5739,55 +5738,55 @@ declare module '@theia/plugin' {
         /** The shell executable */
         executable?: string;
 
-		/**
-		 * The arguments to be passed to the shell executable used to run the task. Most shells
-		 * require special arguments to execute a command. For  example `bash` requires the `-c`
-		 * argument to execute a command, `PowerShell` requires `-Command` and `cmd` requires both
-		 * `/d` and `/c`.
-		 */
+        /**
+         * The arguments to be passed to the shell executable used to run the task. Most shells
+         * require special arguments to execute a command. For  example `bash` requires the `-c`
+         * argument to execute a command, `PowerShell` requires `-Command` and `cmd` requires both
+         * `/d` and `/c`.
+         */
         shellArgs?: string[];
 
         /** The shell quotes supported by this shell */
         shellQuoting?: ShellQuotingOptions;
 
-		/**
-		 * The current working directory of the executed shell.
-		 * If omitted the tools current workspace root is used.
-		 */
+        /**
+         * The current working directory of the executed shell.
+         * If omitted the tools current workspace root is used.
+         */
         cwd?: string;
 
-		/**
-		 * The additional environment of the executed shell. If omitted
-		 * the parent process' environment is used. If provided it is merged with
-		 * the parent process' environment.
-		 */
+        /**
+         * The additional environment of the executed shell. If omitted
+         * the parent process' environment is used. If provided it is merged with
+         * the parent process' environment.
+         */
         env?: { [key: string]: string };
     }
 
     export class ShellExecution {
-		/**
-		 * Creates a shell execution with a full command line.
-		 *
-		 * @param commandLine The command line to execute.
-		 * @param options Optional options for the started the shell.
-		 */
+        /**
+         * Creates a shell execution with a full command line.
+         *
+         * @param commandLine The command line to execute.
+         * @param options Optional options for the started the shell.
+         */
         constructor(commandLine: string, options?: ShellExecutionOptions);
 
-		/**
-		 * Creates a shell execution with a command and arguments. For the real execution VS Code will
-		 * construct a command line from the command and the arguments. This is subject to interpretation
-		 * especially when it comes to quoting. If full control over the command line is needed please
-		 * use the constructor that creates a `ShellExecution` with the full command line.
-		 *
-		 * @param command The command to execute.
-		 * @param args The command arguments.
-		 * @param options Optional options for the started the shell.
-		 */
+        /**
+         * Creates a shell execution with a command and arguments. For the real execution VS Code will
+         * construct a command line from the command and the arguments. This is subject to interpretation
+         * especially when it comes to quoting. If full control over the command line is needed please
+         * use the constructor that creates a `ShellExecution` with the full command line.
+         *
+         * @param command The command to execute.
+         * @param args The command arguments.
+         * @param options Optional options for the started the shell.
+         */
         constructor(command: string | ShellQuotedString, args: (string | ShellQuotedString)[], options?: ShellExecutionOptions);
 
-		/**
-		 * The shell command line. Is `undefined` if created with a command and arguments.
-		 */
+        /**
+         * The shell command line. Is `undefined` if created with a command and arguments.
+         */
         commandLine?: string;
 
         /**
@@ -5796,49 +5795,49 @@ declare module '@theia/plugin' {
          */
         options?: ShellExecutionOptions;
 
-		/**
-		 * The shell command. Is `undefined` if created with a full command line.
-		 */
+        /**
+         * The shell command. Is `undefined` if created with a full command line.
+         */
         command?: string | ShellQuotedString;
 
-		/**
-		 * The shell args. Is `undefined` if created with a full command line.
-		 */
+        /**
+         * The shell args. Is `undefined` if created with a full command line.
+         */
         args?: (string | ShellQuotedString)[];
     }
 
     export interface ProcessExecutionOptions {
-		/**
-		 * The current working directory of the executed program or shell.
-		 * If omitted the tools current workspace root is used.
-		 */
+        /**
+         * The current working directory of the executed program or shell.
+         * If omitted the tools current workspace root is used.
+         */
         cwd?: string;
 
-		/**
-		 * The additional environment of the executed program or shell. If omitted
-		 * the parent process' environment is used. If provided it is merged with
-		 * the parent process' environment.
-		 */
+        /**
+         * The additional environment of the executed program or shell. If omitted
+         * the parent process' environment is used. If provided it is merged with
+         * the parent process' environment.
+         */
         env?: { [key: string]: string };
     }
 
     export class ProcessExecution {
 
-		/**
-		 * Creates a process execution.
-		 *
-		 * @param process The process to start.
-		 * @param options Optional options for the started process.
-		 */
+        /**
+         * Creates a process execution.
+         *
+         * @param process The process to start.
+         * @param options Optional options for the started process.
+         */
         constructor(process: string, options?: ProcessExecutionOptions);
 
-		/**
-		 * Creates a process execution.
-		 *
-		 * @param process The process to start.
-		 * @param args Arguments to be passed to the process.
-		 * @param options Optional options for the started process.
-		 */
+        /**
+         * Creates a process execution.
+         *
+         * @param process The process to start.
+         * @param args Arguments to be passed to the process.
+         * @param options Optional options for the started process.
+         */
         constructor(process: string, args: string[], options?: ProcessExecutionOptions);
 
         /** The process to be executed. */
@@ -5847,29 +5846,29 @@ declare module '@theia/plugin' {
         /** The arguments passed to the process. Defaults to an empty array. */
         args: string[];
 
-		/**
-		 * The process options used when the process is executed.
-		 * Defaults to undefined.
-		 */
+        /**
+         * The process options used when the process is executed.
+         * Defaults to undefined.
+         */
         options?: ProcessExecutionOptions;
     }
 
     export interface TaskDefinition {
-		/**
-		 * The task definition describing the task provided by an extension.
-		 * Usually a task provider defines more properties to identify
-		 * a task. They need to be defined in the package.json of the
-		 * extension under the 'taskDefinitions' extension point. The npm
-		 * task definition for example looks like this
-		 * ```typescript
-		 * interface NpmTaskDefinition extends TaskDefinition {
-		 *     script: string;
-		 * }
-		 * ```
-		 *
-		 * Note that type identifier starting with a '$' are reserved for internal
-		 * usages and shouldn't be used by extensions.
-		 */
+        /**
+         * The task definition describing the task provided by an extension.
+         * Usually a task provider defines more properties to identify
+         * a task. They need to be defined in the package.json of the
+         * extension under the 'taskDefinitions' extension point. The npm
+         * task definition for example looks like this
+         * ```typescript
+         * interface NpmTaskDefinition extends TaskDefinition {
+         *     script: string;
+         * }
+         * ```
+         *
+         * Note that type identifier starting with a '$' are reserved for internal
+         * usages and shouldn't be used by extensions.
+         */
         readonly type: string;
 
         /** Additional attributes of a concrete task definition. */
@@ -5906,10 +5905,10 @@ declare module '@theia/plugin' {
         /** Always brings the terminal to front if the task is executed. */
         Always = 1,
 
-		/**
-		 * Only brings the terminal to front if a problem is detected executing the task
-		 * (e.g. the task couldn't be started because).
-		 */
+        /**
+         * Only brings the terminal to front if a problem is detected executing the task
+         * (e.g. the task couldn't be started because).
+         */
         Silent = 2,
 
         /** The terminal never comes to front when the task is executed. */
@@ -5922,10 +5921,10 @@ declare module '@theia/plugin' {
         /** Shares a panel with other tasks. This is the default. */
         Shared = 1,
 
-		/**
-		 * Uses a dedicated panel for this tasks. The panel is not
-		 * shared with other tasks.
-		 */
+        /**
+         * Uses a dedicated panel for this tasks. The panel is not
+         * shared with other tasks.
+         */
         Dedicated = 2,
 
         /** Creates a new panel whenever this task is executed. */
@@ -5933,26 +5932,26 @@ declare module '@theia/plugin' {
     }
 
     export interface TaskPresentationOptions {
-		/**
-		 * Controls whether the task output is reveal in the user interface.
-		 * Defaults to `RevealKind.Always`.
-		 */
+        /**
+         * Controls whether the task output is reveal in the user interface.
+         * Defaults to `RevealKind.Always`.
+         */
         reveal?: TaskRevealKind;
 
-		/**
-		 * Controls whether the command associated with the task is echoed
-		 * in the user interface.
-		 */
+        /**
+         * Controls whether the command associated with the task is echoed
+         * in the user interface.
+         */
         echo?: boolean;
 
         /** Controls whether the panel showing the task output is taking focus. */
         focus?: boolean;
 
-		/**
-		 * Controls if the task panel is used for this task only (dedicated),
-		 * shared between tasks (shared) or if a new panel is created on
-		 * every task execution (new). Defaults to `TaskInstanceKind.Shared`
-		 */
+        /**
+         * Controls if the task panel is used for this task only (dedicated),
+         * shared between tasks (shared) or if a new panel is created on
+         * every task execution (new). Defaults to `TaskInstanceKind.Shared`
+         */
         panel?: TaskPanelKind;
 
         /** Controls whether to show the "Terminal will be reused by tasks, press any key to close it" message. */
@@ -5961,18 +5960,18 @@ declare module '@theia/plugin' {
 
     export class Task {
 
-		/**
-		 * Creates a new task.
-		 *
-		 * @param definition The task definition.
-		 * @param scope Specifies the task's scope.
-		 * @param name The task's name. Is presented in the user interface.
-		 * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
-		 * @param execution The process or shell execution.
-		 * @param problemMatchers the names of problem matchers to use, like '$tsc'
-		 *  or '$eslint'. Problem matchers can be contributed by an extension using
-		 *  the `problemMatchers` extension point.
-		 */
+        /**
+         * Creates a new task.
+         *
+         * @param definition The task definition.
+         * @param scope Specifies the task's scope.
+         * @param name The task's name. Is presented in the user interface.
+         * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
+         * @param execution The process or shell execution.
+         * @param problemMatchers the names of problem matchers to use, like '$tsc'
+         *  or '$eslint'. Problem matchers can be contributed by an extension using
+         *  the `problemMatchers` extension point.
+         */
         constructor(taskDefinition: TaskDefinition,
             scope: WorkspaceFolder | TaskScope.Global | TaskScope.Workspace,
             name: string,
@@ -5995,60 +5994,60 @@ declare module '@theia/plugin' {
         /** Whether the task is a background task or not. */
         isBackground?: boolean;
 
-		/**
-		 * A human-readable string describing the source of this
-		 * shell task, e.g. 'gulp' or 'npm'.
-		 */
+        /**
+         * A human-readable string describing the source of this
+         * shell task, e.g. 'gulp' or 'npm'.
+         */
         source?: string;
 
-		/**
-		 * The task group this tasks belongs to. See TaskGroup
-		 * for a predefined set of available groups.
-		 * Defaults to undefined meaning that the task doesn't
-		 * belong to any special group.
-		 */
+        /**
+         * The task group this tasks belongs to. See TaskGroup
+         * for a predefined set of available groups.
+         * Defaults to undefined meaning that the task doesn't
+         * belong to any special group.
+         */
         group?: TaskGroup;
 
         /** The presentation options. Defaults to an empty literal. */
         presentationOptions?: TaskPresentationOptions;
 
-		/**
-		 * The problem matchers attached to the task. Defaults to an empty
-		 * array.
-		 */
+        /**
+         * The problem matchers attached to the task. Defaults to an empty
+         * array.
+         */
         problemMatchers?: string[];
     }
 
     export interface TaskProvider {
-		/**
-		 * Provides tasks.
-		 * @param token A cancellation token.
-		 * @return an array of tasks
-		 */
+        /**
+         * Provides tasks.
+         * @param token A cancellation token.
+         * @return an array of tasks
+         */
         provideTasks(token?: CancellationToken): ProviderResult<Task[]>;
 
-		/**
-		 * Resolves a task that has no [`execution`](#Task.execution) set. Tasks are
-		 * often created from information found in the `tasks.json`-file. Such tasks miss
-		 * the information on how to execute them and a task provider must fill in
-		 * the missing information in the `resolveTask`-method.
-		 *
-		 * @param task The task to resolve.
-		 * @param token A cancellation token.
-		 * @return The resolved task
-		 */
+        /**
+         * Resolves a task that has no [`execution`](#Task.execution) set. Tasks are
+         * often created from information found in the `tasks.json`-file. Such tasks miss
+         * the information on how to execute them and a task provider must fill in
+         * the missing information in the `resolveTask`-method.
+         *
+         * @param task The task to resolve.
+         * @param token A cancellation token.
+         * @return The resolved task
+         */
         resolveTask(task: Task, token?: CancellationToken): ProviderResult<Task>;
     }
 
     export namespace tasks {
 
-		/**
-		 * Register a task provider.
-		 *
-		 * @param type The task kind type this provider is registered for.
-		 * @param provider A task provider.
-		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
-		 */
+        /**
+         * Register a task provider.
+         *
+         * @param type The task kind type this provider is registered for.
+         * @param provider A task provider.
+         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+         */
         export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
     }
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5674,4 +5674,381 @@ declare module '@theia/plugin' {
          */
         selection?: Range;
     }
+
+    export enum ShellQuoting {
+
+		/**
+		 * Character escaping should be used. This for example
+		 * uses \ on bash and ` on PowerShell.
+		 */
+        Escape = 1,
+
+		/**
+		 * Strong string quoting should be used. This for example
+		 * uses " for Windows cmd and ' for bash and PowerShell.
+		 * Strong quoting treats arguments as literal strings.
+		 * Under PowerShell echo 'The value is $(2 * 3)' will
+		 * print `The value is $(2 * 3)`
+		 */
+        Strong = 2,
+
+		/**
+		 * Weak string quoting should be used. This for example
+		 * uses " for Windows cmd, bash and PowerShell. Weak quoting
+		 * still performs some kind of evaluation inside the quoted
+		 * string.  Under PowerShell echo "The value is $(2 * 3)"
+		 * will print `The value is 6`
+		 */
+        Weak = 3
+    }
+
+    /** A string that will be quoted depending on the used shell. */
+    export interface ShellQuotedString {
+
+        /** The actual string value */
+        value: string;
+
+        /** The quoting style to use */
+        quoting: ShellQuoting;
+    }
+
+    export interface ShellQuotingOptions {
+
+		/**
+		 * The character used to do character escaping. If a string is provided only spaces
+		 * are escaped. If a `{ escapeChar, charsToEscape }` literal is provide all characters
+		 * in `charsToEscape` are escaped using the `escapeChar`.
+		 */
+        escape?: string | {
+            /** The escape character */
+            escapeChar: string;
+
+            /** The characters to escape */
+            charsToEscape: string;
+        };
+
+        /** The character used for strong quoting. The string's length must be 1 */
+        strong?: string;
+
+        /** The character used for weak quoting. The string's length must be 1 */
+        weak?: string;
+    }
+
+    export interface ShellExecutionOptions {
+
+        /** The shell executable */
+        executable?: string;
+
+		/**
+		 * The arguments to be passed to the shell executable used to run the task. Most shells
+		 * require special arguments to execute a command. For  example `bash` requires the `-c`
+		 * argument to execute a command, `PowerShell` requires `-Command` and `cmd` requires both
+		 * `/d` and `/c`.
+		 */
+        shellArgs?: string[];
+
+        /** The shell quotes supported by this shell */
+        shellQuoting?: ShellQuotingOptions;
+
+		/**
+		 * The current working directory of the executed shell.
+		 * If omitted the tools current workspace root is used.
+		 */
+        cwd?: string;
+
+		/**
+		 * The additional environment of the executed shell. If omitted
+		 * the parent process' environment is used. If provided it is merged with
+		 * the parent process' environment.
+		 */
+        env?: { [key: string]: string };
+    }
+
+    export class ShellExecution {
+		/**
+		 * Creates a shell execution with a full command line.
+		 *
+		 * @param commandLine The command line to execute.
+		 * @param options Optional options for the started the shell.
+		 */
+        constructor(commandLine: string, options?: ShellExecutionOptions);
+
+		/**
+		 * Creates a shell execution with a command and arguments. For the real execution VS Code will
+		 * construct a command line from the command and the arguments. This is subject to interpretation
+		 * especially when it comes to quoting. If full control over the command line is needed please
+		 * use the constructor that creates a `ShellExecution` with the full command line.
+		 *
+		 * @param command The command to execute.
+		 * @param args The command arguments.
+		 * @param options Optional options for the started the shell.
+		 */
+        constructor(command: string | ShellQuotedString, args: (string | ShellQuotedString)[], options?: ShellExecutionOptions);
+
+		/**
+		 * The shell command line. Is `undefined` if created with a command and arguments.
+		 */
+        commandLine?: string;
+
+        /**
+         * The shell options used when the command line is executed in a shell.
+         * Defaults to undefined.
+         */
+        options?: ShellExecutionOptions;
+
+		/**
+		 * The shell command. Is `undefined` if created with a full command line.
+		 */
+        command?: string | ShellQuotedString;
+
+		/**
+		 * The shell args. Is `undefined` if created with a full command line.
+		 */
+        args?: (string | ShellQuotedString)[];
+    }
+
+    export interface ProcessExecutionOptions {
+		/**
+		 * The current working directory of the executed program or shell.
+		 * If omitted the tools current workspace root is used.
+		 */
+        cwd?: string;
+
+		/**
+		 * The additional environment of the executed program or shell. If omitted
+		 * the parent process' environment is used. If provided it is merged with
+		 * the parent process' environment.
+		 */
+        env?: { [key: string]: string };
+    }
+
+    export class ProcessExecution {
+
+		/**
+		 * Creates a process execution.
+		 *
+		 * @param process The process to start.
+		 * @param options Optional options for the started process.
+		 */
+        constructor(process: string, options?: ProcessExecutionOptions);
+
+		/**
+		 * Creates a process execution.
+		 *
+		 * @param process The process to start.
+		 * @param args Arguments to be passed to the process.
+		 * @param options Optional options for the started process.
+		 */
+        constructor(process: string, args: string[], options?: ProcessExecutionOptions);
+
+        /** The process to be executed. */
+        process: string;
+
+        /** The arguments passed to the process. Defaults to an empty array. */
+        args: string[];
+
+		/**
+		 * The process options used when the process is executed.
+		 * Defaults to undefined.
+		 */
+        options?: ProcessExecutionOptions;
+    }
+
+    export interface TaskDefinition {
+		/**
+		 * The task definition describing the task provided by an extension.
+		 * Usually a task provider defines more properties to identify
+		 * a task. They need to be defined in the package.json of the
+		 * extension under the 'taskDefinitions' extension point. The npm
+		 * task definition for example looks like this
+		 * ```typescript
+		 * interface NpmTaskDefinition extends TaskDefinition {
+		 *     script: string;
+		 * }
+		 * ```
+		 *
+		 * Note that type identifier starting with a '$' are reserved for internal
+		 * usages and shouldn't be used by extensions.
+		 */
+        readonly type: string;
+
+        /** Additional attributes of a concrete task definition. */
+        [name: string]: any;
+    }
+
+    export enum TaskScope {
+        /** The task is a global task */
+        Global = 1,
+
+        /** The task is a workspace task */
+        Workspace = 2
+    }
+
+    export class TaskGroup {
+
+        /** The clean task group */
+        static Clean: TaskGroup;
+
+        /** The build task group */
+        static Build: TaskGroup;
+
+        /** The rebuild all task group */
+        static Rebuild: TaskGroup;
+
+        /** The test all task group */
+        static Test: TaskGroup;
+
+        private constructor(id: string, label: string);
+    }
+
+    /** Controls the behaviour of the terminal's visibility. */
+    export enum TaskRevealKind {
+        /** Always brings the terminal to front if the task is executed. */
+        Always = 1,
+
+		/**
+		 * Only brings the terminal to front if a problem is detected executing the task
+		 * (e.g. the task couldn't be started because).
+		 */
+        Silent = 2,
+
+        /** The terminal never comes to front when the task is executed. */
+        Never = 3
+    }
+
+    /** Controls how the task channel is used between tasks	 */
+    export enum TaskPanelKind {
+
+        /** Shares a panel with other tasks. This is the default. */
+        Shared = 1,
+
+		/**
+		 * Uses a dedicated panel for this tasks. The panel is not
+		 * shared with other tasks.
+		 */
+        Dedicated = 2,
+
+        /** Creates a new panel whenever this task is executed. */
+        New = 3
+    }
+
+    export interface TaskPresentationOptions {
+		/**
+		 * Controls whether the task output is reveal in the user interface.
+		 * Defaults to `RevealKind.Always`.
+		 */
+        reveal?: TaskRevealKind;
+
+		/**
+		 * Controls whether the command associated with the task is echoed
+		 * in the user interface.
+		 */
+        echo?: boolean;
+
+        /** Controls whether the panel showing the task output is taking focus. */
+        focus?: boolean;
+
+		/**
+		 * Controls if the task panel is used for this task only (dedicated),
+		 * shared between tasks (shared) or if a new panel is created on
+		 * every task execution (new). Defaults to `TaskInstanceKind.Shared`
+		 */
+        panel?: TaskPanelKind;
+
+        /** Controls whether to show the "Terminal will be reused by tasks, press any key to close it" message. */
+        showReuseMessage?: boolean;
+    }
+
+    export class Task {
+
+		/**
+		 * Creates a new task.
+		 *
+		 * @param definition The task definition.
+		 * @param scope Specifies the task's scope.
+		 * @param name The task's name. Is presented in the user interface.
+		 * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
+		 * @param execution The process or shell execution.
+		 * @param problemMatchers the names of problem matchers to use, like '$tsc'
+		 *  or '$eslint'. Problem matchers can be contributed by an extension using
+		 *  the `problemMatchers` extension point.
+		 */
+        constructor(taskDefinition: TaskDefinition,
+            scope: WorkspaceFolder | TaskScope.Global | TaskScope.Workspace,
+            name: string,
+            source?: string,
+            execution?: ProcessExecution | ShellExecution,
+            problemMatchers?: string | string[]);
+
+        /** The task's name */
+        name: string;
+
+        /** The task's definition. */
+        definition: TaskDefinition;
+
+        /** The task's scope. */
+        scope?: TaskScope.Global | TaskScope.Workspace | WorkspaceFolder;
+
+        /** The task's execution engine */
+        execution?: ProcessExecution | ShellExecution;
+
+        /** Whether the task is a background task or not. */
+        isBackground?: boolean;
+
+		/**
+		 * A human-readable string describing the source of this
+		 * shell task, e.g. 'gulp' or 'npm'.
+		 */
+        source?: string;
+
+		/**
+		 * The task group this tasks belongs to. See TaskGroup
+		 * for a predefined set of available groups.
+		 * Defaults to undefined meaning that the task doesn't
+		 * belong to any special group.
+		 */
+        group?: TaskGroup;
+
+        /** The presentation options. Defaults to an empty literal. */
+        presentationOptions?: TaskPresentationOptions;
+
+		/**
+		 * The problem matchers attached to the task. Defaults to an empty
+		 * array.
+		 */
+        problemMatchers?: string[];
+    }
+
+    export interface TaskProvider {
+		/**
+		 * Provides tasks.
+		 * @param token A cancellation token.
+		 * @return an array of tasks
+		 */
+        provideTasks(token?: CancellationToken): ProviderResult<Task[]>;
+
+		/**
+		 * Resolves a task that has no [`execution`](#Task.execution) set. Tasks are
+		 * often created from information found in the `tasks.json`-file. Such tasks miss
+		 * the information on how to execute them and a task provider must fill in
+		 * the missing information in the `resolveTask`-method.
+		 *
+		 * @param task The task to resolve.
+		 * @param token A cancellation token.
+		 * @return The resolved task
+		 */
+        resolveTask(task: Task, token?: CancellationToken): ProviderResult<Task>;
+    }
+
+    export namespace tasks {
+
+		/**
+		 * Register a task provider.
+		 *
+		 * @param type The task kind type this provider is registered for.
+		 * @param provider A task provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+        export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
+    }
 }


### PR DESCRIPTION
Add 'tasks.registerTaskProvider' for Plugin API
Task Provider allows a plugin to  provide and resolve tasks.

Example:

    theia.tasks.registerTaskProvider('shell', {

        provideTasks: token => {
            const buildTask = {
                name: 'yarn build',
                definition: {
                    type: 'shell'
                },
                execution: {
                    command: 'yarn',
                    args: ['run', 'build'],
                    options: {
                        cwd: '/home/rnikitenko/projects/task-provider-plugin'
                    }
                },

            };

            const watchTask = {
                name: 'yarn watch',
                definition: {
                    type: 'shell'
                },
            }

            tasks.push(buildTask);
            tasks.push(watchTask);

            return tasks;
        },

        resolveTask: task => {
            if (task.name === 'yarn watch') {
                task.execution = {
                    commandLine: 'yarn run watch',
                    options: {
                        cwd: '/home/rnikitenko/projects/task-provider-plugin'
                    }
                }
            }
            return task;
        }
    });

`
Build task in the example has name, definition and execution sections.
Watch task does not have execution section, but this info can be added when provider resolves the task.