### PR TITLE
Fix broken blame annotations UI

### DIFF
--- a/packages/git/src/browser/blame/blame-decorator.ts
+++ b/packages/git/src/browser/blame/blame-decorator.ts
@@ -158,7 +158,7 @@ export class BlameDecorator implements HoverProvider {
         const when = commitTime.fromNow();
         const contentWidth = BlameDecorator.maxWidth - when.length - 2;
         let content = commit.summary.substring(0, contentWidth + 1);
-        content = content.replace('\n', '↩︎');
+        content = content.replace('\n', '↩︎').replace(/'/g, "\\'");
         if (content.length > contentWidth) {
             let cropAt = content.lastIndexOf(' ', contentWidth - 4);
             if (cropAt < contentWidth / 2) {


### PR DESCRIPTION
Fixes #2956

- Had to make sure to properly escape single quotes which broke the UI for the `blame-annotations`.
Since we are writing text throught `css` `content` we had to make sure that we properly escape the surrounding single quote characters.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
