### PR TITLE
Fix rule definitions in errors.tslint.json

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -1,18 +1,14 @@
 {
   "defaultSeverity": "error",
   "rules": {
-    "arrow-parens": {
-      "options": [
-        true,
-        "ban-single-arg-parens"
-      ]
-    },
-    "arrow-return-shorthand": {
-      "options": [
-        true,
-        "multiline"
-      ]
-    },
+    "arrow-parens": [
+      true,
+      "ban-single-arg-parens"
+    ],
+    "arrow-return-shorthand": [
+      true,
+      "multiline"
+    ],
     "class-name": true,
     "comment-format": [
       true,
@@ -25,13 +21,11 @@
       "SPDX-License-Identifier: EPL-2\\.0 OR GPL-2\\.0 WITH Classpath-exception-2\\.0"
     ],
     "forin": true,
-    "indent": {
-      "options": [
-        true,
-        "spaces",
-        4
-      ]
-    },
+    "indent": [
+      true,
+      "spaces",
+      4
+    ],
     "interface-over-type-literal": true,
     "jsdoc-format": [
       true,
@@ -58,23 +52,19 @@
       "check-whitespace"
     ],
     "one-variable-per-declaration": true,
-    "prefer-const": {
-      "options": [
-        true,
-        {
-          "destructuring": "all"
-        }
-      ]
-    },
-    "quotemark": {
-      "options": [
-        true,
-        "single",
-        "jsx-single",
-        "avoid-escape",
-        "avoid-template"
-      ]
-    },
+    "prefer-const": [
+      true,
+      {
+        "destructuring": "all"
+      }
+    ],
+    "quotemark": [
+      true,
+      "single",
+      "jsx-single",
+      "avoid-escape",
+      "avoid-template"
+    ],
     "radix": false,
     "semicolon": [
       true,

--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -3,13 +3,11 @@
     "await-promise": {
       "severity": "warning",
       "options": [
-        true,
         "Thenable"
       ]
     },
     "no-any": {
-      "severity": "warning",
-      "options": true
+      "severity": "warning"
     },
     "no-implicit-dependencies": {
       "severity": "warning",
@@ -45,8 +43,7 @@
       ]
     },
     "no-return-await": {
-      "severity": "warning",
-      "options": true
+      "severity": "warning"
     },
     "no-void-expression": {
       "severity": "warning",

--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -124,10 +124,10 @@ export interface Completion {
 export interface SingleEditOperation {
     range: Range;
     text: string;
-	/**
-	 * This indicates that this operation has "insert" semantics.
-	 * i.e. forceMoveMarkers = true => if `range` is collapsed, all markers at the position will be moved.
-	 */
+    /**
+     * This indicates that this operation has "insert" semantics.
+     * i.e. forceMoveMarkers = true => if `range` is collapsed, all markers at the position will be moved.
+     */
     forceMoveMarkers?: boolean;
 }
 
@@ -344,42 +344,42 @@ export interface WorkspaceEdit {
 }
 
 export enum SymbolKind {
-	File = 0,
-	Module = 1,
-	Namespace = 2,
-	Package = 3,
-	Class = 4,
-	Method = 5,
-	Property = 6,
-	Field = 7,
-	Constructor = 8,
-	Enum = 9,
-	Interface = 10,
-	Function = 11,
-	Variable = 12,
-	Constant = 13,
-	String = 14,
-	Number = 15,
-	Boolean = 16,
-	Array = 17,
-	Object = 18,
-	Key = 19,
-	Null = 20,
-	EnumMember = 21,
-	Struct = 22,
-	Event = 23,
-	Operator = 24,
-	TypeParameter = 25
+    File = 0,
+    Module = 1,
+    Namespace = 2,
+    Package = 3,
+    Class = 4,
+    Method = 5,
+    Property = 6,
+    Field = 7,
+    Constructor = 8,
+    Enum = 9,
+    Interface = 10,
+    Function = 11,
+    Variable = 12,
+    Constant = 13,
+    String = 14,
+    Number = 15,
+    Boolean = 16,
+    Array = 17,
+    Object = 18,
+    Key = 19,
+    Null = 20,
+    EnumMember = 21,
+    Struct = 22,
+    Event = 23,
+    Operator = 24,
+    TypeParameter = 25
 }
 
 export interface DocumentSymbol {
-	name: string;
-	detail: string;
-	kind: SymbolKind;
-	containerName?: string;
-	range: Range;
-	selectionRange: Range;
-	children?: DocumentSymbol[];
+    name: string;
+    detail: string;
+    kind: SymbolKind;
+    containerName?: string;
+    range: Range;
+    selectionRange: Range;
+    children?: DocumentSymbol[];
 }
 
 export interface WorkspaceFoldersChangeEvent {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -308,7 +308,7 @@ export class LanguagesMainImpl implements LanguagesMain {
             }
         }
         this.disposables.set(handle, disposable);
-	}
+    }
 
     protected createDocumentSymbolProvider(handle: number, selector: LanguageSelector | undefined): monaco.languages.DocumentSymbolProvider {
         return {

--- a/packages/plugin-ext/src/plugin/languages/outline.ts
+++ b/packages/plugin-ext/src/plugin/languages/outline.ts
@@ -25,102 +25,102 @@ import * as types from '../types-impl';
 /** Adapts the calls from main to extension thread for providing the document symbols. */
 export class OutlineAdapter {
 
-	constructor(
-		private readonly documents: DocumentsExtImpl,
-		private readonly provider: theia.DocumentSymbolProvider
-	) { }
+    constructor(
+        private readonly documents: DocumentsExtImpl,
+        private readonly provider: theia.DocumentSymbolProvider
+    ) { }
 
-	provideDocumentSymbols(resource: URI): Promise<DocumentSymbol[] | undefined> {
-		const document = this.documents.getDocumentData(resource);
-		if (!document) {
-			return Promise.reject(new Error(`There is no document for ${resource}`));
-		}
+    provideDocumentSymbols(resource: URI): Promise<DocumentSymbol[] | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There is no document for ${resource}`));
+        }
 
-		const doc = document.document;
+        const doc = document.document;
 
-		return Promise.resolve(this.provider.provideDocumentSymbols(doc, createToken())).then(value => {
-			if (!value || value.length === 0) {
-				return undefined;
-			}
-			if (value[0] instanceof types.DocumentSymbol) {
-				return (<types.DocumentSymbol[]>value).map(Converter.fromDocumentSymbol);
-			} else {
-				return OutlineAdapter.asDocumentSymbolTree(resource, <types.SymbolInformation[]>value);
-			}
-		});
-	}
+        return Promise.resolve(this.provider.provideDocumentSymbols(doc, createToken())).then(value => {
+            if (!value || value.length === 0) {
+                return undefined;
+            }
+            if (value[0] instanceof types.DocumentSymbol) {
+                return (<types.DocumentSymbol[]>value).map(Converter.fromDocumentSymbol);
+            } else {
+                return OutlineAdapter.asDocumentSymbolTree(resource, <types.SymbolInformation[]>value);
+            }
+        });
+    }
 
-	private static asDocumentSymbolTree(resource: URI, info: types.SymbolInformation[]): DocumentSymbol[] {
-		// first sort by start (and end) and then loop over all elements
-		// and build a tree based on containment.
-		info = info.slice(0).sort((a, b) => {
-			let r = a.location.range.start.compareTo(b.location.range.start);
-			if (r === 0) {
-				r = b.location.range.end.compareTo(a.location.range.end);
-			}
-			return r;
-		});
-		const res: DocumentSymbol[] = [];
-		const parentStack: DocumentSymbol[] = [];
-		for (let i = 0; i < info.length; i++) {
-			const element = <DocumentSymbol>{
-				name: info[i].name,
-				detail: '',
-				kind: Converter.SymbolKind.fromSymbolKind(info[i].kind),
-				containerName: info[i].containerName,
-				range: Converter.fromRange(info[i].location.range),
-				selectionRange: Converter.fromRange(info[i].location.range),
-				children: []
-			};
+    private static asDocumentSymbolTree(resource: URI, info: types.SymbolInformation[]): DocumentSymbol[] {
+        // first sort by start (and end) and then loop over all elements
+        // and build a tree based on containment.
+        info = info.slice(0).sort((a, b) => {
+            let r = a.location.range.start.compareTo(b.location.range.start);
+            if (r === 0) {
+                r = b.location.range.end.compareTo(a.location.range.end);
+            }
+            return r;
+        });
+        const res: DocumentSymbol[] = [];
+        const parentStack: DocumentSymbol[] = [];
+        for (let i = 0; i < info.length; i++) {
+            const element = <DocumentSymbol>{
+                name: info[i].name,
+                detail: '',
+                kind: Converter.SymbolKind.fromSymbolKind(info[i].kind),
+                containerName: info[i].containerName,
+                range: Converter.fromRange(info[i].location.range),
+                selectionRange: Converter.fromRange(info[i].location.range),
+                children: []
+            };
 
-			while (true) {
-				if (parentStack.length === 0) {
-					parentStack.push(element);
-					res.push(element);
-					break;
-				}
-				const parent = parentStack[parentStack.length - 1];
-				if (OutlineAdapter.containsRange(parent.range, element.range) && !OutlineAdapter.equalsRange(parent.range, element.range)) {
-					parent.children!.push(element);
-					parentStack.push(element);
-					break;
-				}
-				parentStack.pop();
-			}
-		}
-		return res;
-	}
+            while (true) {
+                if (parentStack.length === 0) {
+                    parentStack.push(element);
+                    res.push(element);
+                    break;
+                }
+                const parent = parentStack[parentStack.length - 1];
+                if (OutlineAdapter.containsRange(parent.range, element.range) && !OutlineAdapter.equalsRange(parent.range, element.range)) {
+                    parent.children!.push(element);
+                    parentStack.push(element);
+                    break;
+                }
+                parentStack.pop();
+            }
+        }
+        return res;
+    }
 
-	/**
-	 * Test if `otherRange` is in `range`. If the ranges are equal, will return true.
-	 */
-	private static containsRange(range: Range, otherRange: Range): boolean {
-		if (otherRange.startLineNumber < range.startLineNumber || otherRange.endLineNumber < range.startLineNumber) {
-			return false;
-		}
-		if (otherRange.startLineNumber > range.endLineNumber || otherRange.endLineNumber > range.endLineNumber) {
-			return false;
-		}
-		if (otherRange.startLineNumber === range.startLineNumber && otherRange.startColumn < range.startColumn) {
-			return false;
-		}
-		if (otherRange.endLineNumber === range.endLineNumber && otherRange.endColumn > range.endColumn) {
-			return false;
-		}
-		return true;
-	}
+    /**
+     * Test if `otherRange` is in `range`. If the ranges are equal, will return true.
+     */
+    private static containsRange(range: Range, otherRange: Range): boolean {
+        if (otherRange.startLineNumber < range.startLineNumber || otherRange.endLineNumber < range.startLineNumber) {
+            return false;
+        }
+        if (otherRange.startLineNumber > range.endLineNumber || otherRange.endLineNumber > range.endLineNumber) {
+            return false;
+        }
+        if (otherRange.startLineNumber === range.startLineNumber && otherRange.startColumn < range.startColumn) {
+            return false;
+        }
+        if (otherRange.endLineNumber === range.endLineNumber && otherRange.endColumn > range.endColumn) {
+            return false;
+        }
+        return true;
+    }
 
-	/**
-	 * Test if range `a` equals `b`.
-	 */
-	private static equalsRange(a: Range, b: Range): boolean {
-		return (
-			!!a &&
-			!!b &&
-			a.startLineNumber === b.startLineNumber &&
-			a.startColumn === b.startColumn &&
-			a.endLineNumber === b.endLineNumber &&
-			a.endColumn === b.endColumn
-		);
-	}
+    /**
+     * Test if range `a` equals `b`.
+     */
+    private static equalsRange(a: Range, b: Range): boolean {
+        return (
+            !!a &&
+            !!b &&
+            a.startLineNumber === b.startLineNumber &&
+            a.startColumn === b.startColumn &&
+            a.endLineNumber === b.endLineNumber &&
+            a.endColumn === b.endColumn
+        );
+    }
 }


### PR DESCRIPTION
Opening error.tslint.json in Theia, I noticed it complains about content
not matching the expected schema.  I turns out that some rules including
an "options" field are not taken into account.  This patch fixes it, as
well as some files that were infringing the indent rule.

Change-Id: Iec23facc5ca4cca4e22cf964f873ef37d59ffe37

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
