### PR TITLE
Fix await-promise warnings in dugite-git.spec.ts

### DIFF
--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -558,7 +558,7 @@ describe('git', async function () {
 
             await init(git, repository);
 
-            const expectDiff: (expected: ChangeDelta[]) => void = async expected => {
+            const expectDiff: (expected: ChangeDelta[]) => Promise<void> = async expected => {
                 const actual = (await git.diff(repository)).map(change => ChangeDelta.map(repository, change)).sort(ChangeDelta.compare);
                 expect(actual).to.be.deep.equal(expected);
             };
@@ -587,7 +587,7 @@ describe('git', async function () {
 
             await init(git, repository);
 
-            const expectDiff: (expected: ChangeDelta[]) => void = async expected => {
+            const expectDiff: (expected: ChangeDelta[]) => Promise<void> = async expected => {
                 const actual = (await git.diff(repository)).map(change => ChangeDelta.map(repository, change)).sort(ChangeDelta.compare);
                 expect(actual).to.be.deep.equal(expected);
             };
@@ -626,7 +626,7 @@ describe('git', async function () {
 
             await init(git, repository);
 
-            const expectDiff: (fromRevision: string, toRevision: string, expected: ChangeDelta[], filePath?: string) => void = async (fromRevision, toRevision, expected, filePath) => {
+            const expectDiff: (fromRevision: string, toRevision: string, expected: ChangeDelta[], filePath?: string) => Promise<void> = async (fromRevision, toRevision, expected, filePath) => {
                 const range = { fromRevision, toRevision };
                 let uri: string | undefined;
                 if (filePath) {


### PR DESCRIPTION
The expectDiff functions are async, so they implicitly return a Promise,
but the variables are marked as returning void, which triggers the
warning.  Mark them as returning Promise<void> to get rid of the
warning.

Change-Id: Ibf7c27b076e1ad26d4c8ad3453aeb5171bda9d5b
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
