### PR TITLE
Add ability to read keybindings from 'package.json' file of a plugin

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -59,6 +59,7 @@ export interface PluginPackageContribution {
     viewsContainers?: { [location: string]: PluginPackageViewContainer[] };
     views?: { [location: string]: PluginPackageView[] };
     menus?: { [location: string]: PluginPackageMenu[] };
+    keybindings?: PluginPackageKeybinding[];
 }
 
 export interface PluginPackageViewContainer {
@@ -75,6 +76,12 @@ export interface PluginPackageView {
 export interface PluginPackageMenu {
     command: string;
     group?: string;
+}
+
+export interface PluginPackageKeybinding {
+    key: string;
+    command: string;
+    when?: string;
 }
 
 export interface PluginPackageGrammarsContribution {
@@ -302,6 +309,7 @@ export interface PluginContribution {
     viewsContainers?: { [location: string]: ViewContainer[] };
     views?: { [location: string]: View[] };
     menus?: { [location: string]: Menu[] };
+    keybindings?: Keybinding[];
 }
 
 export interface GrammarsContribution {
@@ -386,6 +394,15 @@ export interface View {
 export interface Menu {
     command: string;
     group?: string;
+}
+
+/**
+ * Keybinding contribution
+ */
+export interface Keybinding {
+    keybinding: string;
+    command: string;
+    context?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -30,6 +30,8 @@ import {
     AutoClosingPairConditional,
     AutoClosingPair,
     ViewContainer,
+    Keybinding,
+    PluginPackageKeybinding,
     PluginPackageViewContainer,
     View,
     PluginPackageView,
@@ -141,6 +143,9 @@ export class TheiaPluginScanner implements PluginScanner {
             });
         }
 
+        if (rawPlugin.contributes && rawPlugin.contributes.keybindings) {
+            contributions.keybindings = rawPlugin.contributes.keybindings.map(rawKeybinding => this.readKeybinding(rawKeybinding));
+        }
         return contributions;
     }
 
@@ -150,6 +155,14 @@ export class TheiaPluginScanner implements PluginScanner {
             type: rawConfiguration.type,
             title: rawConfiguration.title,
             properties: rawConfiguration.properties
+        };
+    }
+
+    private readKeybinding(rawKeybinding: PluginPackageKeybinding): Keybinding {
+        return {
+            keybinding: rawKeybinding.key,
+            command: rawKeybinding.command,
+            context: rawKeybinding.when
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { PluginContribution } from '../../../common';
+import { Keybinding, KeybindingRegistry, KeybindingScope } from '@theia/core/lib/browser/keybinding';
+import { KeySequence } from '@theia/core/lib/browser';
+import { ILogger } from '@theia/core/lib/common/logger';
+
+@injectable()
+export class KeybindingsContributionPointHandler {
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    @inject(KeybindingRegistry)
+    private readonly keybindingRegistry: KeybindingRegistry;
+
+    handle(contributions: PluginContribution): void {
+        if (!contributions || !contributions.keybindings) {
+            return;
+        }
+
+        const keybindings = contributions.keybindings;
+        keybindings.forEach(keybinding => {
+            const keybindingResult = this.keybindingRegistry.getKeybindingsForKeySequence(KeySequence.parse(keybinding.keybinding));
+
+            this.handleShadingKeybindings(keybinding, keybindingResult.shadow);
+            this.handlePartialKeybindings(keybinding, keybindingResult.partial);
+        });
+
+        this.keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
+    }
+
+    private handlePartialKeybindings(keybinding: Keybinding, partialKeybindings: Keybinding[]) {
+        partialKeybindings.forEach(partial => {
+            if (keybinding.context === undefined || keybinding.context === partial.context) {
+                this.logger.warn(`Partial keybinding is ignored; ${Keybinding.stringify(keybinding)} shadows ${Keybinding.stringify(partial)}`);
+            }
+        });
+    }
+
+    private handleShadingKeybindings(keybinding: Keybinding, shadingKeybindings: Keybinding[]) {
+        shadingKeybindings.forEach(shadow => {
+            if (shadow.context === undefined || shadow.context === keybinding.context) {
+                this.keybindingRegistry.unregisterKeybinding(shadow);
+
+                this.logger.warn(`Shadowing keybinding is ignored; ${Keybinding.stringify(shadow)}, shadows ${Keybinding.stringify(keybinding)}`);
+            }
+        });
+    }
+}

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -22,6 +22,7 @@ import { ViewRegistry } from './view/view-registry';
 import { PluginContribution, IndentationRules, FoldingRules, ScopeMap } from '../../common';
 import { PreferenceSchemaProvider } from '@theia/core/lib/browser';
 import { PreferenceSchema } from '@theia/core/lib/browser/preferences';
+import { KeybindingsContributionPointHandler } from './keybindings/keybindings-contribution-handler';
 
 @injectable()
 export class PluginContributionHandler {
@@ -42,6 +43,9 @@ export class PluginContributionHandler {
 
     @inject(MonacoTextmateService)
     private readonly monacoTextmateService: MonacoTextmateService;
+
+    @inject(KeybindingsContributionPointHandler)
+    private readonly keybindingsContributionHandler: KeybindingsContributionPointHandler;
 
     handleContributions(contributions: PluginContribution): void {
         if (contributions.configuration) {
@@ -126,6 +130,7 @@ export class PluginContributionHandler {
         }
 
         this.menusContributionHandler.handle(contributions);
+        this.keybindingsContributionHandler.handle(contributions);
     }
 
     private updateConfigurationSchema(schema: PreferenceSchema): void {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -45,6 +45,7 @@ import { PluginContributionHandler } from './plugin-contribution-handler';
 import { ViewRegistry } from './view/view-registry';
 import { TextContentResourceResolver } from './workspace-main';
 import { MainPluginApiProvider } from '../../common/plugin-ext-api-contribution';
+import { KeybindingsContributionPointHandler } from './keybindings/keybindings-contribution-handler';
 
 export default new ContainerModule(bind => {
     bindHostedPluginPreferences(bind);
@@ -96,6 +97,8 @@ export default new ContainerModule(bind => {
 
     bind(ViewRegistry).toSelf().inSingletonScope();
     bind(MenusContributionPointHandler).toSelf().inSingletonScope();
+
+    bind(KeybindingsContributionPointHandler).toSelf().inSingletonScope();
 
     bind(PluginContributionHandler).toSelf().inSingletonScope();
 


### PR DESCRIPTION
Add ability to register keybindings from 'package.json' file of a plugin

Example:

```
"keybindings": [
      {
        "key": "ctrl+b",
        "command": "emacs.cursor.left",
        "when": "editorTextFocus"
      },
      {
        "key": "ctrl+f",
        "command": "emacs.cursor.right",
        "when": "editorTextFocus"
      }
    ]
```
Video: https://youtu.be/Tf6TvlWEZ1Y

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>