### PR TITLE
use replace-all icon in search-in-workspace tree

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -388,7 +388,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected renderReplaceButton(node: TreeNode): React.ReactNode {
-        return <span className='replace-result' onClick={e => this.replace(node, e)}></span>;
+        const isFileNode = SearchInWorkspaceFileNode.is(node);
+        return <span className={isFileNode ? 'replace-all-result' : 'replace-result'}
+            onClick={e => this.replace(node, e)}
+            title={isFileNode ? 'Replace All' : 'Replace'}></span>;
     }
 
     replaceAll(): void {
@@ -445,7 +448,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     }
 
     protected renderRemoveButton(node: TreeNode): React.ReactNode {
-        return <span className='remove-node' onClick={e => this.remove(node, e)}></span>;
+        return <span className='remove-node' onClick={e => this.remove(node, e)} title='Dismiss'></span>;
     }
 
     protected removeNode(node: TreeNode): void {

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -380,6 +380,9 @@
 .result-node-buttons .replace-result {
     background-image: var(--theia-icon-replace);
 }
+.result-node-buttons .replace-all-result {
+    background-image: var(--theia-icon-replace-all);
+}
 
 .replace-all-button.disabled {
     opacity: 0.5;


### PR DESCRIPTION
- In search-in-workspace tree widget the "replace" icon is accociated with every single node, while it does the job of "replace all" if clicked from file nodes. With this change, search-in-workspace tree renders "replace-all" icon with file nodes and "replace" with result line nodes.
- tooltipes are added to the replace, replace-all, and remove icons.

Signed-off-by: elaihau <liang.huang@ericsson.com>

