### PR TITLE
GH-3736: Use the system Git in electron.

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -14,6 +14,7 @@
     "@types/p-queue": "^2.3.1",
     "diff": "^3.4.0",
     "dugite-extra": "0.1.9",
+    "find-git-exec": "^0.0.1-alpha.2",
     "find-git-repositories": "^0.1.0",
     "fs-extra": "^4.0.2",
     "moment": "^2.21.0",
@@ -32,6 +33,10 @@
     {
       "backend": "lib/node/env/git-env-module",
       "backendElectron": "lib/electron-node/env/electron-git-env-module"
+    },
+    {
+      "backend": "lib/node/init/git-init-module",
+      "backendElectron": "lib/electron-node/init/electron-git-init-module"
     },
     {
       "frontend": "lib/browser/prompt/git-prompt-module",

--- a/packages/git/src/electron-node/init/electron-git-init-module.ts
+++ b/packages/git/src/electron-node/init/electron-git-init-module.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { GitInit } from '../../node/init/git-init';
+import { ElectronGitInit } from './electron-git-init';
+
+export default new ContainerModule(bind => {
+    bind(ElectronGitInit).toSelf();
+    bind(GitInit).toService(ElectronGitInit);
+});

--- a/packages/git/src/electron-node/init/electron-git-init.ts
+++ b/packages/git/src/electron-node/init/electron-git-init.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import findGit from 'find-git-exec';
+import { dirname } from 'path';
+import { pathExists } from 'fs-extra';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { DefaultGitInit } from '../../node/init/git-init';
+
+/**
+ * The Git initializer for electron. If Git can be found on the `PATH`, it will be used instead of the embedded Git shipped with `dugite`.
+ */
+@injectable()
+export class ElectronGitInit extends DefaultGitInit {
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    async init(): Promise<void> {
+        const { env } = process;
+        if (typeof env.LOCAL_GIT_DIRECTORY !== 'undefined' || typeof env.GIT_EXEC_PATH !== 'undefined') {
+            await this.handleExternalNotFound('Cannot use Git from the PATH when the LOCAL_GIT_DIRECTORY or the GIT_EXEC_PATH environment variables are set.');
+        } else {
+            try {
+                const { execPath, path, version } = await findGit();
+                if (!!execPath && !!path && !!version) {
+                    // https://github.com/desktop/dugite/issues/111#issuecomment-323222834
+                    // Instead of the executable path, we need the root directory of Git.
+                    const dir = dirname(dirname(path));
+                    const [execPathOk, pathOk, dirOk] = await Promise.all([pathExists(execPath), pathExists(path), pathExists(dir)]);
+                    if (execPathOk && pathOk && dirOk) {
+                        process.env.LOCAL_GIT_DIRECTORY = dir;
+                        process.env.GIT_EXEC_PATH = execPath;
+                        this.logger.info(`Using Git [${version}] from the PATH. (${path})`);
+                        return;
+                    }
+                }
+                await this.handleExternalNotFound();
+            } catch (err) {
+                await this.handleExternalNotFound(err);
+            }
+        }
+    }
+
+    // tslint:disable-next-line:no-any
+    protected async handleExternalNotFound(err?: any): Promise<void> {
+        if (err) {
+            this.logger.error(err);
+        }
+        this.logger.info('Could not find Git on the PATH. Falling back to the embedded Git.');
+    }
+
+}

--- a/packages/git/src/node/init/git-init-module.ts
+++ b/packages/git/src/node/init/git-init-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { GitInit, DefaultGitInit } from './git-init';
+
+export default new ContainerModule(bind => {
+    bind(DefaultGitInit).toSelf();
+    bind(GitInit).toService(DefaultGitInit);
+});

--- a/packages/git/src/node/init/git-init.ts
+++ b/packages/git/src/node/init/git-init.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2018 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+
+/**
+ * Initializer hook for Git.
+ */
+export const GitInit = Symbol('GitInit');
+export interface GitInit extends Disposable {
+
+    /**
+     * Called before `Git` is ready to be used in Theia. Git operations cannot be executed before the returning promise is not resolved or rejected.
+     *
+     * This implementation does nothing at all.
+     */
+    init(): Promise<void>;
+
+}
+
+/**
+ * The default initializer. It is used in the browser. Does nothing at all.
+ */
+@injectable()
+export class DefaultGitInit implements GitInit {
+
+    protected readonly toDispose = new DisposableCollection();
+
+    async init(): Promise<void> {
+        // NOOP
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+}

--- a/packages/git/src/node/test/binding-helper.ts
+++ b/packages/git/src/node/test/binding-helper.ts
@@ -21,6 +21,7 @@ import { bindGit, GitBindingOptions } from '../git-backend-module';
 import { bindLogger } from '@theia/core/lib/node/logger-backend-module';
 import { NoSyncRepositoryManager } from '.././test/no-sync-repository-manager';
 import { GitEnvProvider, DefaultGitEnvProvider } from '../env/git-env-provider';
+import { GitInit, DefaultGitInit } from '../init/git-init';
 
 // tslint:disable-next-line:no-any
 export function initializeBindings(): { container: Container, bind: interfaces.Bind } {
@@ -28,6 +29,8 @@ export function initializeBindings(): { container: Container, bind: interfaces.B
     const bind = container.bind.bind(container);
     bind(DefaultGitEnvProvider).toSelf().inRequestScope();
     bind(GitEnvProvider).toService(DefaultGitEnvProvider);
+    bind(DefaultGitInit).toSelf();
+    bind(GitInit).toService(DefaultGitInit);
     bindLogger(bind);
     return { container, bind };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,7 +4025,7 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
-find-git-exec@0.0.1-alpha.2:
+find-git-exec@0.0.1-alpha.2, find-git-exec@^0.0.1-alpha.2:
   version "0.0.1-alpha.2"
   resolved "https://registry.yarnpkg.com/find-git-exec/-/find-git-exec-0.0.1-alpha.2.tgz#02c266b3be6e411c19aa5fd6f813c96a73286fac"
   dependencies:


### PR DESCRIPTION
If Git does not exist on the `PATH`,
fall back to the embedded Git.

Closes #3736.
Closes #3571.