### PR TITLE
[monaco] Fix regex for the electron runtime

### DIFF
--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -50,7 +50,7 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
                             keybinding = { ...keybinding, ctrlKey: true, metaKey: false };
                         }
                     }
-                    const isInDiffEditor = item.when && /(?<!\!\s*)isInDiffEditor/gm.test(item.when.serialize());
+                    const isInDiffEditor = item.when && /(^|[^!])\bisInDiffEditor\b/gm.test(item.when.serialize());
                     registry.registerKeybinding({
                         command,
                         keybinding: this.keyCode(keybinding).toString(),


### PR DESCRIPTION
The Electron version we use embbeds Node 8.2.1 which doesn't support
negative-lookbehinds in regexs.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Fix #3745