### PR TITLE
[filesystem] Made `watchFileChanges` await

### DIFF
--- a/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/nsfw-watcher/nsfw-filesystem-watcher.spec.ts
@@ -39,7 +39,6 @@ describe('nsfw-filesystem-watcher', function () {
         root = FileUri.create(fs.realpathSync(temp.mkdirSync('node-fs-root')));
         watcherServer = createNsfwFileSystemWatcherServer();
         watcherId = await watcherServer.watchFileChanges(root.toString());
-        await sleep(2000);
     });
 
     afterEach(async () => {

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -133,7 +133,11 @@ export class WorkspaceService implements FrontendApplicationContribution {
         this._workspace = workspaceStat;
         if (this._workspace) {
             const uri = new URI(this._workspace.uri);
-            this.toDisposeOnWorkspace.push(await this.watcher.watchFileChanges(uri));
+            const promiseWatcherId = this.watcher.watchFileChanges(uri);
+            this.toDisposeOnWorkspace.push(Disposable.create(async () => {
+                const watcher = await promiseWatcherId;
+                watcher.dispose();
+            }));
             this.setURLFragment(uri.path.toString());
         } else {
             this.setURLFragment('');


### PR DESCRIPTION
The documentation states that the promise returned will resolve when the
watching will actually be started. Removing the awaiting from there just breaks
that assumption.

A better place to fix the issue is at the consumer end: If you know that the
call might hang, just register a callback and do not wait for it.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
