### PR TITLE
Fixes #3700

### DIFF
--- a/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
@@ -83,16 +83,16 @@ describe('editor-preview-manager', () => {
         onPinnedListeners = [];
     });
 
-    it('should handle preview requests if editor.enablePreview enabled', () => {
+    it('should handle preview requests if editor.enablePreview enabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(true);
-        expect(previewManager.canHandle(new URI(), {preview: true})).to.be.greaterThan(0);
+        expect(await previewManager.canHandle(new URI(), {preview: true})).to.be.greaterThan(0);
     });
-    it('should not handle preview requests if editor.enablePreview disabled', () => {
+    it('should not handle preview requests if editor.enablePreview disabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(false);
-        expect(previewManager.canHandle(new URI(), {preview: true})).to.equal(0);
+        expect(await previewManager.canHandle(new URI(), {preview: true})).to.equal(0);
     });
-    it('should not handle requests that are not preview or currently being previewed', () => {
-        expect(previewManager.canHandle(new URI())).to.equal(0);
+    it('should not handle requests that are not preview or currently being previewed', async () => {
+        expect(await previewManager.canHandle(new URI())).to.equal(0);
     });
     it('should create a preview editor and replace where required.', async () => {
         const w = await previewManager.open(new URI(), {preview: true});
@@ -122,13 +122,13 @@ describe('editor-preview-manager', () => {
         expect(await previewManager.open(new URI(), {})).to.equal(mockPreviewWidget);
         expect((mockPreviewWidget.pinEditorWidget as sinon.SinonStub).calledOnce).to.be.true;
     });
-    it('should should transition the editor to perminent on pin events.', () => {
+    it('should should transition the editor to perminent on pin events.', async () => {
         // Fake creation call.
-        onCreateListners.pop()!({factoryId: EditorPreviewWidgetFactory.ID, widget: mockPreviewWidget});
+        await onCreateListners.pop()!({factoryId: EditorPreviewWidgetFactory.ID, widget: mockPreviewWidget});
         // Fake pinned call
         onPinnedListeners.pop()!({preview: mockPreviewWidget, editorWidget: mockEditorWidget});
 
-        expect(mockPreviewWidget.close.calledOnce).to.be.true;
+        expect(mockPreviewWidget.dispose.calledOnce).to.be.true;
         expect(mockEditorWidget.close.calledOnce).to.be.false;
         expect(mockEditorWidget.dispose.calledOnce).to.be.false;
     });

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -23,6 +23,7 @@ import { EditorPreviewWidgetFactory, EditorPreviewWidgetOptions } from './editor
 import { EditorPreviewPreferences } from './editor-preview-preferences';
 import { WidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser';
 import { MaybePromise } from '@theia/core/src/common';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 
 /**
  * Opener options containing an optional preview flag.
@@ -41,7 +42,7 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
 
     readonly label = 'Code Editor Preview';
 
-    protected currentEditorPreview: EditorPreviewWidget | undefined;
+    protected currentEditorPreview: Promise<EditorPreviewWidget | undefined>;
 
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
@@ -57,19 +58,20 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
         super.init();
         this.onCreated(widget => {
             if (widget instanceof EditorPreviewWidget) {
-                this.handlePreviewWidgetCreated(widget);
+                return this.handlePreviewWidgetCreated(widget);
             }
         });
     }
 
-    protected handlePreviewWidgetCreated(widget: EditorPreviewWidget): void {
+    protected async handlePreviewWidgetCreated(widget: EditorPreviewWidget): Promise<void> {
         // Enforces only one preview widget exists at a given time.
-        if (this.currentEditorPreview) {
-            this.currentEditorPreview.pinEditorWidget();
+        const editorPreview = await this.currentEditorPreview;
+        if (editorPreview) {
+            editorPreview.pinEditorWidget();
         }
 
-        this.currentEditorPreview = widget;
-        widget.disposed.connect(() => this.currentEditorPreview = undefined);
+        this.currentEditorPreview = Promise.resolve(widget);
+        widget.disposed.connect(() => this.currentEditorPreview = Promise.resolve(undefined));
 
         widget.onPinned(({preview, editorWidget}) => {
             // TODO(caseyflynn): I don't believe there is ever a case where
@@ -79,26 +81,33 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
             } else {
                 this.shell.addWidget(editorWidget, {area: 'main'});
             }
-            preview.close();
+            preview.dispose();
             this.shell.activateWidget(editorWidget.id);
-            this.currentEditorPreview = undefined;
+            this.currentEditorPreview = Promise.resolve(undefined);
         });
     }
 
-    protected isCurrentPreviewUri(uri: URI): boolean {
-        const currentUri = this.currentEditorPreview && this.currentEditorPreview.getResourceUri();
+    protected async isCurrentPreviewUri(uri: URI): Promise<boolean> {
+        const editorPreview = await this.currentEditorPreview;
+        const currentUri = editorPreview && editorPreview.getResourceUri();
         return !!currentUri && currentUri.isEqualOrParent(uri);
     }
 
     canHandle(uri: URI, options?: PreviewEditorOpenerOptions): MaybePromise<number> {
-        if (this.preferences['editor.enablePreview'] && (options && options.preview || this.isCurrentPreviewUri(uri))) {
-            return 200;
-        }
-        return 0;
+        return this.isCurrentPreviewUri(uri).then(isCurrentPreviewUri => {
+            if (this.preferences['editor.enablePreview'] && (options && options.preview || isCurrentPreviewUri)) {
+                return 200;
+            }
+            return 0;
+        });
     }
 
     async open(uri: URI, options?: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | EditorWidget> {
         options = {...options, mode: 'open'};
+
+        const deferred = new Deferred<EditorPreviewWidget | undefined>();
+        const previousPreview = await this.currentEditorPreview;
+        this.currentEditorPreview = deferred.promise;
 
         if (await this.editorManager.getByUri(uri)) {
             let widget: EditorWidget | EditorPreviewWidget = await this.editorManager.open(uri, options);
@@ -109,19 +118,22 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
                 widget = widget.parent;
             }
             this.shell.revealWidget(widget.id);
+            deferred.resolve(previousPreview);
             return widget;
         }
 
-        if (!this.currentEditorPreview) {
-            this.currentEditorPreview = await super.open(uri, options) as EditorPreviewWidget;
+        if (!previousPreview) {
+            this.currentEditorPreview = super.open(uri, options) as Promise<EditorPreviewWidget>;
         } else {
             const childWidget = await this.editorManager.getOrCreateByUri(uri);
-            this.currentEditorPreview.replaceEditorWidget(childWidget);
+            previousPreview.replaceEditorWidget(childWidget);
+            this.currentEditorPreview = Promise.resolve(previousPreview);
         }
 
+        const preview = await this.currentEditorPreview as EditorPreviewWidget;
         this.editorManager.open(uri, options);
-        this.shell.revealWidget(this.currentEditorPreview!.id);
-        return this.currentEditorPreview;
+        this.shell.revealWidget(preview.id);
+        return preview;
     }
 
     protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): EditorPreviewWidgetOptions {

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -118,6 +118,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
         if (Saveable.isSource(w)) {
             Saveable.apply(this);
             const dirtyListener = w.saveable.onDirtyChanged(() => {
+                dirtyListener.dispose();
                 this.pinEditorWidget();
             });
             this.toDispose.push(dirtyListener);


### PR DESCRIPTION
Dispose editor instance as opposed to closing it to resolve screen
flicker.

Ensure we disconnect dirty listener after pinning to ensure it does not
fire twice.

Throttle single / double click requests by ensuring the open operation
has resolved before allowing another open request.

Signed-off-by: Casey Flynn <caseyflynn@google.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
