### PR TITLE
Add tsfmt rule to add space before parentheses of anonymous functions

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -71,6 +71,12 @@
       "always",
       "ignore-interfaces"
     ],
+    "space-before-function-paren": [
+      true,
+      {
+        "anonymous": "always"
+      }
+    ],
     "trailing-comma": false,
     "triple-equals": [
       true,

--- a/examples/browser/test/cpp/cpp-change-build-config.ui-spec.ts
+++ b/examples/browser/test/cpp/cpp-change-build-config.ui-spec.ts
@@ -100,7 +100,7 @@ int main() {}
  */
 function hasClangd() {
     try {
-        const out = cp.execSync('clangd -version', {encoding: 'utf8'});
+        const out = cp.execSync('clangd -version', { encoding: 'utf8' });
         // Match 'clangd version' at the start of
         // 'clangd version 8.0.0 (trunk 341484) (llvm/trunk 341481)'.
         return out.indexOf('clangd version') === 0;
@@ -124,8 +124,8 @@ function changeBuildConfig(name: string, driver: WebdriverIO.Client<void>) {
     driver.pause(300);
 }
 
-describe('cpp extension', function() {
-    it('should be able to change build config', function() {
+describe('cpp extension', function () {
+    it('should be able to change build config', function () {
         if (!hasClangd()) {
             this.skip();
             return;

--- a/packages/core/src/browser/preferences/preference-proxy.spec.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.spec.ts
@@ -18,9 +18,9 @@ import { createPreferenceProxy } from './preference-proxy';
 import { MockPreferenceService } from './test/mock-preference-service';
 import { expect } from 'chai';
 
-describe('preference proxy', function() {
+describe('preference proxy', function () {
     /** Verify the return type of the ready property.  */
-    it('.ready should return a promise', function() {
+    it('.ready should return a promise', function () {
 
         const proxy = createPreferenceProxy(new MockPreferenceService(), {
             properties: {}

--- a/packages/core/src/node/console-logger-server.spec.ts
+++ b/packages/core/src/node/console-logger-server.spec.ts
@@ -48,8 +48,8 @@ beforeEach(() => {
     server = container.get<ConsoleLoggerServer>(ConsoleLoggerServer);
 });
 
-describe('ConsoleLoggerServer', function() {
-    it('should respect log level config', async function() {
+describe('ConsoleLoggerServer', function () {
+    it('should respect log level config', async function () {
         expect(await server.getLogLevel('test-logger')).eq(LogLevel.DEBUG);
         await server.child('test-logger');
         expect(await server.getLogLevel('test-logger')).eq(LogLevel.DEBUG);

--- a/packages/cpp/src/browser/cpp-build-configurations.spec.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.spec.ts
@@ -28,7 +28,7 @@ import { MockPreferenceService } from '@theia/core/lib/browser/preferences/test/
 
 let container: Container;
 
-beforeEach(function() {
+beforeEach(function () {
     const m = new ContainerModule(bind => {
         bind(CppBuildConfigurationManager).to(CppBuildConfigurationManagerImpl).inSingletonScope();
         bind(StorageService).to(MockStorageService).inSingletonScope();
@@ -76,8 +76,8 @@ async function initializeTest(buildConfigurations: CppBuildConfiguration[] | und
     return configs;
 }
 
-describe('build-configurations', function() {
-    it('should work with no preferences', async function() {
+describe('build-configurations', function () {
+    it('should work with no preferences', async function () {
         const cppBuildConfigurations = await initializeTest(undefined, undefined);
 
         const configs = cppBuildConfigurations.getConfigs();
@@ -87,7 +87,7 @@ describe('build-configurations', function() {
         expect(configs).lengthOf(0);
     });
 
-    it('should work with an empty list of builds', async function() {
+    it('should work with an empty list of builds', async function () {
         const cppBuildConfigurations = await initializeTest([], undefined);
 
         const configs = cppBuildConfigurations.getConfigs();
@@ -97,7 +97,7 @@ describe('build-configurations', function() {
         expect(configs).lengthOf(0);
     });
 
-    it('should work with a simple list of builds', async function() {
+    it('should work with a simple list of builds', async function () {
         const builds = [{
             name: 'Release',
             directory: '/tmp/builds/release',
@@ -115,7 +115,7 @@ describe('build-configurations', function() {
         expect(configs).to.have.deep.members(builds);
     });
 
-    it('should work with a simple list of builds and an active config', async function() {
+    it('should work with a simple list of builds and an active config', async function () {
         const builds = [{
             name: 'Release',
             directory: '/tmp/builds/release',
@@ -133,7 +133,7 @@ describe('build-configurations', function() {
         expect(configs).to.have.deep.members(builds);
     });
 
-    it("should ignore an active config that doesn't exist", async function() {
+    it("should ignore an active config that doesn't exist", async function () {
         const builds = [{
             name: 'Release',
             directory: '/tmp/builds/release',

--- a/packages/cpp/src/browser/cpp-task-provider.spec.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.spec.ts
@@ -63,7 +63,7 @@ class MockCppBuildConfigurationManager implements CppBuildConfigurationManager {
     ready: Promise<void> = Promise.resolve();
 }
 
-beforeEach(function() {
+beforeEach(function () {
     const container: Container = new Container();
     container.bind(CppTaskProvider).toSelf().inSingletonScope();
     container.bind(TaskResolverRegistry).toSelf().inSingletonScope();
@@ -73,15 +73,15 @@ beforeEach(function() {
     // Register a task resolver of type 'shell', on which the cpp build tasks
     // depend.  Just return the task as-is, since we only need to verify what
     // CppTaskProvider passed to the shell task resolver.
-    container.get(TaskResolverRegistry).register('shell',  {
+    container.get(TaskResolverRegistry).register('shell', {
         async resolveTask(task: TaskConfiguration): Promise<TaskConfiguration> {
             return task;
         }
     });
 });
 
-describe('CppTaskProvider', function() {
-    it('provide a task for each build config with a build command', async function() {
+describe('CppTaskProvider', function () {
+    it('provide a task for each build config with a build command', async function () {
         const tasks = await taskProvider.provideTasks();
         expect(tasks).length(1);
         expect(tasks[0].config.name === 'Build 1');

--- a/packages/workspace/src/browser/workspace-service.spec.ts
+++ b/packages/workspace/src/browser/workspace-service.spec.ts
@@ -229,7 +229,7 @@ describe('WorkspaceService', () => {
             expect((<sinon.SinonStub>mockILogger.error).called).to.be.true;
         });
 
-        it('should use the workspace path in the URL fragment, if available', async function() {
+        it('should use the workspace path in the URL fragment, if available', async function () {
             const workspacePath = '/home/somewhere';
             window.location.hash = '#' + workspacePath;
             const stat = <FileStat>{

--- a/tsfmt.json
+++ b/tsfmt.json
@@ -1,0 +1,3 @@
+{
+  "insertSpaceAfterFunctionKeywordForAnonymousFunctions": true
+}


### PR DESCRIPTION
Theia and VSCode format anonymous functions differently:

Theia:

    function()

VSCode:

    function ()

As people use both tools to edit the Theia code, we constantly get
spurious diffs where these are changed back and forth.  This patch adds
a tsfmt.json (picked up by the typescript language server) to align the
Theia behavior on what VSCode does.  It also adds a tslint rule and fixes
all problematic occurences.

Change-Id: I6f1b99a8b53095597e8db2eadb056fa272b5af66
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
