### PR TITLE
re-vamp 'onDidChangeWorkspaceFolders', implement 'asRelativePath'

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -16,6 +16,7 @@
 
 import * as theia from '@theia/plugin';
 import { UriComponents } from '../common/uri-components';
+import { FileStat } from '@theia/filesystem/lib/common';
 
 // Should contains internal Plugin API types
 
@@ -382,9 +383,8 @@ export interface DocumentSymbol {
     children?: DocumentSymbol[];
 }
 
-export interface WorkspaceFoldersChangeEvent {
-    added: WorkspaceFolder[];
-    removed: WorkspaceFolder[];
+export interface WorkspaceRootsChangeEvent {
+    roots: FileStat[];
 }
 
 export interface WorkspaceFolder {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -48,7 +48,8 @@ import {
     Location,
     FileWatcherSubscriberOptions,
     FileChangeEvent,
-    TextDocumentShowOptions
+    TextDocumentShowOptions,
+    WorkspaceRootsChangeEvent
 } from './model';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { CancellationToken, Progress, ProgressOptions } from '@theia/plugin';
@@ -347,7 +348,7 @@ export interface WorkspaceMain {
 }
 
 export interface WorkspaceExt {
-    $onWorkspaceFoldersChanged(event: theia.WorkspaceFoldersChangeEvent): void;
+    $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void;
     $provideTextDocumentContent(uri: string): Promise<string | undefined>;
     $fileChanged(event: FileChangeEvent): void;
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -353,9 +353,12 @@ export function createAPIFactory(
                 // FIXME: to implement
                 return new Disposable(() => { });
             },
-            getWorkspaceFolder(uri: Uri): theia.WorkspaceFolder | Uri | undefined {
+            getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | Uri | undefined {
                 return workspaceExt.getWorkspaceFolder(uri);
-            }
+            },
+            asRelativePath(pathOrUri: theia.Uri | string, includeWorkspace?: boolean): string | undefined {
+                return workspaceExt.getRelativePath(pathOrUri, includeWorkspace);
+            },
         };
 
         const env: typeof theia.env = {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3606,6 +3606,20 @@ declare module '@theia/plugin' {
          * @return A workspace folder or `undefined`
          */
         export function getWorkspaceFolder(uri: Uri): WorkspaceFolder | Uri | undefined;
+
+        /**
+         * Returns a path that is relative to the workspace folder or folders.
+         *
+         * When there are no [workspace folders](#workspace.workspaceFolders) or when the path
+         * is not contained in them, the input is returned.
+         *
+         * @param pathOrUri A path or uri. When a uri is given its [fsPath](#Uri.fsPath) is used.
+         * @param includeWorkspaceFolder When `true` and when the given path is contained inside a
+         * workspace folder the name of the workspace is prepended. Defaults to `true` when there are
+         * multiple workspace folders and `false` otherwise.
+         * @return A path relative to the root or the input.
+         */
+        export function asRelativePath(pathOrUri: string | Uri, includeWorkspaceFolder?: boolean): string | undefined;
     }
 
     export namespace env {


### PR DESCRIPTION
Changes for Plugin API:

- implemented `asRelativePath`
- re-vamped `onDidChangeWorkspaceFolders` to support updating (adding/deleting) of workspace root folder(s)

fixes https://github.com/theia-ide/theia/issues/3573

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
