### PR TITLE
GH-3759: Set the electron version in dev mode too.

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -188,6 +188,15 @@ if (isMaster) {
         // https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274
         process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
 
+        // Set the electron version for both the dev and the production mode. (https://github.com/theia-ide/theia/issues/3254)
+        // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
+        const { versions } = process;
+        // @ts-ignore
+        if (versions && typeof versions.electron !== 'undefined') {
+            // @ts-ignore
+            process.env.THEIA_ELECTRON_VERSION = versions.electron;
+        }
+
         const mainPath = join(__dirname, '..', 'backend', 'main');
         // We need to distinguish between bundled application and development mode when starting the clusters.
         // See: https://github.com/electron/electron/issues/6337#issuecomment-230183287
@@ -199,12 +208,6 @@ if (isMaster) {
                 app.exit(1);
             });
         } else {
-            const { versions } = process;
-            // @ts-ignore
-            if (versions && typeof versions.electron !== 'undefined') {
-                // @ts-ignore
-                process.env.THEIA_ELECTRON_VERSION = versions.electron;
-            }
             const cp = fork(mainPath, [], { env: Object.assign({}, process.env) });
             cp.on('message', (message) => {
                 loadMainWindow(message);


### PR DESCRIPTION
Otherwise, the forked backend processes do not know they are serving an
electron frontend and the ports will default to 3000.

Starting multiple electron apps in dev mode should be possible.

Closes: #3759
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
