### PR TITLE
Remove unused 'toDocumentSymbol' method from 'plugin-ext'

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -470,20 +470,6 @@ export function fromDocumentSymbol(info: theia.DocumentSymbol): model.DocumentSy
     return result;
 }
 
-export function toDocumentSymbol(info: model.DocumentSymbol): theia.DocumentSymbol {
-    const result = new types.DocumentSymbol(
-        info.name,
-        info.detail,
-        SymbolKind.toSymbolKind(info.kind),
-        toRange(info.range),
-        toRange(info.selectionRange),
-    );
-    if (info.children) {
-        result.children = info.children.map(toDocumentSymbol) as any;
-    }
-    return result;
-}
-
 export function toWorkspaceFolder(folder: model.WorkspaceFolder): theia.WorkspaceFolder {
     return {
         uri: URI.revive(folder.uri),


### PR DESCRIPTION
Suggested [here](https://github.com/theia-ide/theia/pull/3753/files/baf6c9769c24f13821358358d7dea04b9dfe5799#r239396735)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
