### PR TITLE
Fix whitespace error from spec file

### DIFF
--- a/packages/typescript/src/node/typescript-version-service-impl.spec.ts
+++ b/packages/typescript/src/node/typescript-version-service-impl.spec.ts
@@ -22,7 +22,7 @@ import { isWindows } from '@theia/core/lib/common/os';
 import { FileUri } from '@theia/core/lib/node';
 import { TypescriptVersionServiceImpl, TypescriptVersionURI } from './typescript-version-service-impl';
 
-describe('TypescriptVersionServiceImpl', function() {
+describe('TypescriptVersionServiceImpl', function () {
 
     const projectUri = FileUri.create(path.resolve(__dirname, '../../../..'));
     let impl: TypescriptVersionServiceImpl;


### PR DESCRIPTION
Missing whitespace before anonymous function causing build to fail from 
`typescript-version-service-impl.spec.ts`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
