### PR TITLE
[quality] fix remaining 'no-any'

### DIFF
--- a/packages/typescript/src/node/typescript-version-service-impl.spec.ts
+++ b/packages/typescript/src/node/typescript-version-service-impl.spec.ts
@@ -29,6 +29,7 @@ describe('TypescriptVersionServiceImpl', function () {
 
     beforeEach(() => {
         impl = new TypescriptVersionServiceImpl();
+        // tslint:disable-next-line:no-any
         (impl as any).applicationPackage = {
             projectPath: FileUri.fsPath(projectUri)
         };

--- a/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
+++ b/packages/workspace/src/browser/workspace-uri-contribution.spec.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
     container = new Container();
     container.bind(ApplicationShell).toConstantValue({
         currentChanged: new Signal({})
+    // tslint:disable-next-line:no-any
     } as any);
     const workspaceService = new WorkspaceService();
     workspaceService.tryGetRoots = () => roots;


### PR DESCRIPTION
`no-any` tslint rule is now set to `error` severity, and this pr addresses remaining violations which were not picked up due to not rebasing before merging.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
