### PR TITLE
[search-in-workspace] adjust the result path for search-in-workspace

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -31,7 +31,7 @@ import {
     DiffUris,
     FOLDER_ICON
 } from '@theia/core/lib/browser';
-import { Path, CancellationTokenSource, Emitter, Event } from '@theia/core';
+import { CancellationTokenSource, Emitter, Event } from '@theia/core';
 import { EditorManager, EditorDecoration, TrackedRangeStickiness, OverviewRulerLane, EditorWidget, ReplaceOperation, EditorOpenerOptions } from '@theia/editor/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileResourceResolver } from '@theia/filesystem/lib/browser';
@@ -345,18 +345,13 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         return nodes;
     }
 
-    protected getFileNodesByLineNode(lineNode: SearchInWorkspaceResultLineNode): SearchInWorkspaceFileNode[] {
-        const nodes: SearchInWorkspaceFileNode[] = [];
-
-        return nodes;
-    }
-
-    protected filenameAndPath(rootUri: string, uriStr: string): { name: string, path: string } {
-        const fileUri: URI = new URI(uriStr);
-        const name = fileUri.displayName;
-        const rootPath = new URI(rootUri).path.toString();
-        const path = new Path(fileUri.path.toString().substr(rootPath.length + 1)).dir.toString();
-        return { name, path };
+    protected filenameAndPath(rootUriStr: string, uriStr: string): { name: string, path: string } {
+        const uri: URI = new URI(uriStr);
+        const relativePath = new URI(rootUriStr).relative(uri.parent);
+        return {
+            name: uri.displayName,
+            path: relativePath ? relativePath.toString() : ''
+        };
     }
 
     protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {


### PR DESCRIPTION
Fixes #3776 

The PR adjusts the path displayed for results which are directly children of the root.
Previously, for a result found in the root directory we displayed the `file-name` as the path which was incorrect.

<img width="1013" alt="screen shot 2018-12-06 at 9 30 52 pm" src="https://user-images.githubusercontent.com/40359487/49624282-db0cd380-f99e-11e8-93ab-dea984261749.png">


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
