### PR TITLE
[electron] Upgrade electron to 0.2.14

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -36,7 +36,7 @@
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
     "style-loader": "^0.23.1",
-    "electron": "1.8.2-beta.5",
+    "electron": "^2.0.14",
     "electron-rebuild": "^1.5.11",
     "file-loader": "^1.1.11",
     "font-awesome-webpack": "0.0.5-beta.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "engines": {
     "yarn": "1.0.x || >=1.2.1",
-    "node": ">=7.9.0"
+    "node": ">=8.9.3"
   },
   "resolution": {
     "**/@types/node": "8.10.20"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "@types/yargs": "^11.1.0",
     "ajv": "^6.5.3",
     "body-parser": "^1.17.2",
-    "electron": "1.8.2-beta.5",
+    "electron": "^2.0.14",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -22,12 +22,12 @@ import { ElectronMainMenuFactory } from './electron-main-menu-factory';
 @injectable()
 export class ElectronContextMenuRenderer implements ContextMenuRenderer {
 
-    constructor( @inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
+    constructor(@inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
     }
 
     render(menuPath: MenuPath, anchor: Anchor, onHide?: () => void): void {
         const menu = this.menuFactory.createContextMenu(menuPath);
-        menu.popup();
+        menu.popup({});
         if (onHide) {
             onHide();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,6 +316,7 @@
 "@types/node@8.10.20":
   version "8.10.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
+  integrity sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==
 
 "@types/node@^8.0.24", "@types/node@^8.0.26":
   version "8.10.26"
@@ -3467,9 +3468,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@1.8.2-beta.5:
-  version "1.8.2-beta.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.2-beta.5.tgz#8324c483ed8cb4b052b3e13e514ddc858707fdeb"
+electron@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.14.tgz#fad6766645e7c0cd10b4ae822d3167959735a870"
+  integrity sha512-8HLVZuscZxVhoMUL6RlF5kMcwGUAMWw5HNwrEmRgzZyBIBbdCO4aMo9z0qknnPTUDROz8xXZFNhFvBXDu61g5Q==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR resolves #3728 by upgrading Theia to use [electron 2.0.14](https://electronjs.org/releases#2.0.14).

The electron version has been set to allow minor version updates but keep it <3.

As part of this, the minimum node version has been increased to match the version shipped with electron 2.
