### PR TITLE
Implement open link command

### DIFF
--- a/packages/plugin-ext-vscode/package.json
+++ b/packages/plugin-ext-vscode/package.json
@@ -3,15 +3,18 @@
   "version": "0.3.17",
   "description": "Theia - Plugin Extension for VsCode",
   "dependencies": {
+    "@theia/core": "^0.3.17",
     "@theia/plugin": "^0.3.17",
-    "@theia/plugin-ext": "^0.3.17"
+    "@theia/plugin-ext": "^0.3.17",
+    "vscode-uri": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"
   },
   "theiaExtensions": [
     {
-      "backend": "lib/node/plugin-vscode-backend-module"
+      "backend": "lib/node/plugin-vscode-backend-module",
+      "frontend": "lib/browser/plugin-vscode-frontend-module"
     }
   ],
   "keywords": [

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { CommandContribution, CommandRegistry, Command } from '@theia/core';
+import { CommandService } from '@theia/core/lib/common/command';
+import theiaURI from '@theia/core/lib/common/uri';
+import URI from 'vscode-uri';
+
+export namespace VscodeCommands {
+    export const OPEN: Command = {
+        id: 'vscode.open',
+        label: 'VSCode open link'
+    };
+}
+
+@injectable()
+export class PluginVscodeCommandsContribution implements CommandContribution {
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(VscodeCommands.OPEN, {
+            isVisible: () => false,
+            execute: (resource: URI) => {
+                this.commandService.executeCommand('theia.open', new theiaURI(resource));
+            }
+        });
+    }
+}

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-frontend-module.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-frontend-module.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { ContainerModule } from 'inversify';
+import { CommandContribution } from '@theia/core';
+import { PluginVscodeCommandsContribution } from './plugin-vscode-commands-contribution';
+
+export default new ContainerModule(bind => {
+    bind(PluginVscodeCommandsContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toDynamicValue(context => context.container.get(PluginVscodeCommandsContribution));
+});

--- a/packages/plugin-ext/src/main/browser/commands.ts
+++ b/packages/plugin-ext/src/main/browser/commands.ts
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { Command, CommandService } from '@theia/core/lib/common/command';
+import { AbstractDialog } from '@theia/core/lib/browser';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+
+@injectable()
+export class OpenUriCommandHandler {
+    public static readonly COMMAND_METADATA: Command = {
+        id: 'theia.open'
+    };
+
+    private openNewTabDialog: OpenNewTabDialog;
+
+    constructor(
+        @inject(WindowService)
+        protected readonly windowService: WindowService,
+        @inject(CommandService)
+        protected readonly commandService: CommandService
+    ) {
+        this.openNewTabDialog = new OpenNewTabDialog(windowService);
+    }
+
+    public execute(resource: URI | string | undefined): void {
+        if (!resource) {
+            return;
+        }
+
+        const uriString = resource.toString();
+        if (uriString.startsWith('http://') || uriString.startsWith('https://')) {
+            this.openWebUri(uriString);
+        } else {
+            this.commandService.executeCommand('editor.action.openLink', uriString);
+        }
+    }
+
+    private openWebUri(uri: string): void {
+        try {
+            this.windowService.openNewWindow(uri);
+        } catch (err) {
+            // browser has blocked opening of a new tab
+            this.openNewTabDialog.showOpenNewTabDialog(uri);
+        }
+    }
+}
+
+class OpenNewTabDialog extends AbstractDialog<string> {
+    protected readonly windowService: WindowService;
+    protected readonly openButton: HTMLButtonElement;
+    protected readonly messageNode: HTMLDivElement;
+    protected readonly linkNode: HTMLAnchorElement;
+    value: string;
+
+    constructor(windowService: WindowService) {
+        super({
+            title: 'Your browser prevented opening of a new tab'
+        });
+        this.windowService = windowService;
+
+        this.linkNode = document.createElement('a');
+        this.linkNode.target = '_blank';
+        this.linkNode.setAttribute('style', 'color: var(--theia-ui-dialog-font-color);');
+        this.contentNode.appendChild(this.linkNode);
+
+        const messageNode = document.createElement('div');
+        messageNode.innerText = 'You are going to open: ';
+        messageNode.appendChild(this.linkNode);
+        this.contentNode.appendChild(messageNode);
+
+        this.appendCloseButton();
+        this.openButton = this.appendAcceptButton('Open');
+    }
+
+    showOpenNewTabDialog(uri: string): void {
+        this.value = uri;
+
+        this.linkNode.innerHTML = uri;
+        this.linkNode.href = uri;
+        this.openButton.onclick = () => {
+            this.windowService.openNewWindow(uri);
+        };
+
+        // show dialog window to user
+        this.open();
+    }
+}

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -24,6 +24,7 @@ import { HostedPluginSupport } from '../../hosted/browser/hosted-plugin';
 import { HostedPluginWatcher } from '../../hosted/browser/hosted-plugin-watcher';
 import { HostedPluginLogViewer } from '../../hosted/browser/hosted-plugin-log-viewer';
 import { HostedPluginManagerClient } from '../../hosted/browser/hosted-plugin-manager-client';
+import { OpenUriCommandHandler } from './commands';
 import { PluginApiFrontendContribution } from './plugin-frontend-contribution';
 import { HostedPluginServer, hostedServicePath, PluginServer, pluginServerJsonRpcPath } from '../../common/plugin-protocol';
 import { ModalNotification } from './dialogs/modal-notification';
@@ -58,6 +59,7 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).to(HostedPluginInformer).inSingletonScope();
     bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();
 
+    bind(OpenUriCommandHandler).toSelf().inSingletonScope();
     bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(PluginApiFrontendContribution);
 

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -18,6 +18,8 @@ import { injectable, inject } from 'inversify';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { HostedPluginManagerClient, HostedPluginCommands } from '../../hosted/browser/hosted-plugin-manager-client';
 import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
+import { OpenUriCommandHandler } from './commands';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class PluginApiFrontendContribution implements CommandContribution {
@@ -27,6 +29,9 @@ export class PluginApiFrontendContribution implements CommandContribution {
 
     @inject(PluginExtDeployCommandService)
     protected readonly pluginExtDeployCommandService: PluginExtDeployCommandService;
+
+    @inject(OpenUriCommandHandler)
+    protected readonly openUriCommandHandler: OpenUriCommandHandler;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(HostedPluginCommands.START, {
@@ -52,6 +57,11 @@ export class PluginApiFrontendContribution implements CommandContribution {
         // this command only for compatibility reason
         commands.registerCommand({ id: 'workbench.action.closeActiveEditor' }, {
             execute: () => commands.executeCommand('core.close.tab')
+        });
+
+        commands.registerCommand(OpenUriCommandHandler.COMMAND_METADATA, {
+            execute: (arg: URI) => this.openUriCommandHandler.execute(arg),
+            isVisible: () => false
         });
     }
 


### PR DESCRIPTION
This PR adds open resource command into Theia (for API like usage) with `theia.open` id.
The command is implemented for opening a link in browser.
Also adds a command with `vscode.open` id  for VSCode compatibiliance.

Resolves https://github.com/theia-ide/theia/issues/3639
