### PR TITLE
[debug] distribute bin folder

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -46,6 +46,7 @@
     "download-debug-adapters": "./bin/download-adapters.js"
   },
   "files": [
+    "bin",
     "lib",
     "src"
   ],


### PR DESCRIPTION
Otherwise, `download-debug-adapters` CLI tool is not linked on local install outside of Theia repo.