### PR TITLE
Implement logPath for plugin api context.

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -69,6 +69,11 @@ export interface Plugin {
     lifecycle: PluginLifecycle;
 }
 
+export interface ConfigStorage {
+    hostLogPath: string;
+    // storagePath: string,
+}
+
 export interface EnvInit {
     queryParams: QueryParameters;
 }
@@ -128,7 +133,7 @@ export const emptyPlugin: Plugin = {
 export interface PluginManagerExt {
     $stopPlugin(contextPath: string): PromiseLike<void>;
 
-    $init(pluginInit: PluginInitData): PromiseLike<void>;
+    $init(pluginInit: PluginInitData, configStorage: ConfigStorage): PromiseLike<void>;
 }
 
 export interface CommandRegistryMain {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -45,6 +45,7 @@ import { PluginContributionHandler } from './plugin-contribution-handler';
 import { ViewRegistry } from './view/view-registry';
 import { TextContentResourceResolver } from './workspace-main';
 import { MainPluginApiProvider } from '../../common/plugin-ext-api-contribution';
+import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
 import { KeybindingsContributionPointHandler } from './keybindings/keybindings-contribution-handler';
 
 export default new ContainerModule(bind => {
@@ -79,6 +80,11 @@ export default new ContainerModule(bind => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
         const hostedWatcher = ctx.container.get(HostedPluginWatcher);
         return connection.createProxy<HostedPluginServer>(hostedServicePath, hostedWatcher.getHostedPluginClient());
+    }).inSingletonScope();
+
+    bind(PluginPathsService).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<PluginPathsService>(pluginPathsServicePath);
     }).inSingletonScope();
 
     bindViewContribution(bind, PluginFrontendViewContribution);

--- a/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
+++ b/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export const pluginPathsServicePath = '/services/plugin-paths';
+
+// Service to create plugin configuration folders for different purpose.
+export const PluginPathsService = Symbol('PluginPathsService');
+export interface PluginPathsService {
+    // Return hosted log path. Create directory by this path if it is not exist on the file system.
+    provideHostLogPath(): Promise<string>
+}

--- a/packages/plugin-ext/src/main/node/paths/const.ts
+++ b/packages/plugin-ext/src/main/node/paths/const.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export namespace PluginPaths {
+    export const LINUX_CONF_FOLDER = '.config';
+    export const APPLICATION_CONF_FOLDER = 'eclipse-theia';
+    export const APP_DATA_WINDOWS_FOLDER = 'AppData';
+    export const ROAMING_WINDOWS_FOLDER = 'Roaming';
+    export const LOG_PARENT_FOLDER_NAME = 'logs';
+}

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from  'inversify';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { join } from 'path';
+import URI from '@theia/core/lib/common/uri';
+import { isWindows } from '@theia/core';
+import { PluginPaths } from './const';
+import { PluginPathsService } from '../../common/plugin-paths-protocol';
+
+// Service to provide configuration paths for plugin api.
+@injectable()
+export class PluginPathsServiceImpl implements PluginPathsService {
+
+    private windowsConfFolders = [PluginPaths.APP_DATA_WINDOWS_FOLDER, PluginPaths.ROAMING_WINDOWS_FOLDER];
+    private linuxConfFolders = [PluginPaths.LINUX_CONF_FOLDER];
+
+    constructor(@inject(FileSystem) readonly fs: FileSystem) {
+    }
+
+    async provideHostLogPath(): Promise<string> {
+        const parentLogDir = await this.getParentLogDirPath();
+
+        if (!parentLogDir) {
+            return Promise.reject(new Error('Unable to get parent log directory'));
+        }
+
+        if (parentLogDir && !await this.fs.exists(parentLogDir)) {
+            await this.fs.createFolder(parentLogDir);
+        }
+
+        const pluginDirPath = join(parentLogDir, this.gererateTimeFolderName(), 'host');
+        if (!await this.fs.exists(pluginDirPath)) {
+            await this.fs.createFolder(pluginDirPath);
+        }
+
+        return new URI(pluginDirPath).path.toString();
+    }
+
+    /** Generate time folder name in format: YYYYMMDDTHHMMSS, for example: 20181205T093828 */
+    gererateTimeFolderName(): string {
+        return new Date().toISOString().replace(/[-:]|(\..*)/g, '');
+    }
+
+    async getParentLogDirPath(): Promise<string | undefined> {
+        const userHomeDir = await this.fs.getCurrentUserHome();
+        let parentLogDirPath;
+        if (userHomeDir) {
+            parentLogDirPath = join(
+                userHomeDir.uri,
+                ...(isWindows ? this.windowsConfFolders : this.linuxConfFolders),
+                PluginPaths.APPLICATION_CONF_FOLDER,
+                PluginPaths.LOG_PARENT_FOLDER_NAME
+            );
+        }
+        return parentLogDirPath;
+    }
+}

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -29,6 +29,8 @@ import { PluginTheiaDirectoryHandler } from './handlers/plugin-theia-directory-h
 import { GithubPluginDeployerResolver } from './plugin-github-resolver';
 import { HttpPluginDeployerResolver } from './plugin-http-resolver';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
+import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
+import { PluginPathsServiceImpl } from './paths/plugin-paths-service';
 
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
@@ -46,6 +48,13 @@ export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginDeployerDirectoryHandler).to(PluginTheiaDirectoryHandler).inSingletonScope();
 
     bind(PluginServer).to(PluginDeployerImpl).inSingletonScope();
+
+    bind(PluginPathsService).to(PluginPathsServiceImpl).inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(pluginPathsServicePath, () =>
+            ctx.container.get(PluginPathsService)
+        )
+    ).inSingletonScope();
 
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler(pluginServerJsonRpcPath, () =>

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2364,6 +2364,11 @@ declare module '@theia/plugin' {
          * @return The absolute path of the resource.
          */
         asAbsolutePath(relativePath: string): string;
+
+        /**
+         * Return log path for current of the extension.
+         */
+        logPath: string;
     }
 
     /**


### PR DESCRIPTION
Implement logPath for plugin api context.
Create hosted log folder in the ~/.conf/Theia folder and return this path in the PluginContext#logPath. 
Example of the host log path:
/home/theia-dev/.config/Theia/logs/20181210T104714/host/theia.log-path-plugin
On the file system we create only parent folder 
`/home/theia-dev/.config/eclipse-theia/logs/20181210T104714/host`
like defined in the https://code.visualstudio.com/docs/extensionAPI/vscode-api#1295 docs. 