### PR TITLE
Adjust AlertMessage font-color for bright themes

### DIFF
--- a/packages/core/src/browser/style/alert-messages.css
+++ b/packages/core/src/browser/style/alert-messages.css
@@ -27,14 +27,14 @@
 /* information message */
 .theia-info-alert {
     background-color: var(--theia-brand-color0);
-    color: var(--theia-ui-font-color0);
+    color: #ffffff;
     padding: 10px;
 }
 
 /* success message */
 .theia-success-alert {
     background-color: var(--theia-success-color0);
-    color: var(--theia-ui-font-color0);
+    color: #ffffff;
     padding: 10px;
 }
 
@@ -48,6 +48,6 @@
 /* error message */
 .theia-error-alert {
     background-color: var(--theia-error-color0);
-    color: var(--theia-ui-font-color0);
+    color: #ffffff;
     padding: 10px;
 }


### PR DESCRIPTION
Before the change, the color was determined through variables defined
through the dark and bright variables.css but this should not apply
for `AlertMessage`s since we control the background color and want
the proper contrast. If a white theme was used before, we displayed
black font which was not the intended or wanted styling.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
