### PR TITLE
add multi root support to file search

### DIFF
--- a/packages/file-search/src/common/file-search-service.ts
+++ b/packages/file-search/src/common/file-search-service.ts
@@ -34,7 +34,7 @@ export interface FileSearchService {
 export const FileSearchService = Symbol('FileSearchService');
 export namespace FileSearchService {
     export interface Options {
-        rootUri: string,
+        rootUris: string[]
         fuzzyMatch?: boolean
         limit?: number
         useGitIgnore?: boolean

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -21,8 +21,8 @@ import { FileSearchService } from '../common/file-search-service';
 import { RawProcessFactory } from '@theia/process/lib/node';
 import { rgPath } from 'vscode-ripgrep';
 import { Deferred } from '@theia/core/lib/common/promise-util';
-import { CancellationToken, ILogger } from '@theia/core';
 import { FileUri } from '@theia/core/lib/node/file-uri';
+import { CancellationToken, ILogger } from '@theia/core';
 
 @injectable()
 export class FileSearchServiceImpl implements FileSearchService {
@@ -50,10 +50,7 @@ export class FileSearchServiceImpl implements FileSearchService {
         }
         const process = this.rawProcessFactory({
             command: rgPath,
-            args,
-            options: {
-                cwd: FileUri.fsPath(opts.rootUri)
-            }
+            args: [...args, ...opts.rootUris.map(r => FileUri.fsPath(r))]
         });
         const result: string[] = [];
         const fuzzyMatches: string[] = [];
@@ -78,10 +75,11 @@ export class FileSearchServiceImpl implements FileSearchService {
             if (result.length >= opts.limit) {
                 process.kill();
             } else {
+                const fileUriStr = FileUri.create(line).toString();
                 if (line.toLocaleLowerCase().indexOf(searchPattern.toLocaleLowerCase()) !== -1) {
-                    result.push(line);
+                    result.push(fileUriStr);
                 } else if (opts.fuzzyMatch && fuzzy.test(searchPattern, line)) {
-                    fuzzyMatches.push(line);
+                    fuzzyMatches.push(fileUriStr);
                 }
             }
         });

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -142,31 +142,10 @@ export class WorkspaceMainImpl implements WorkspaceMain {
         });
     }
 
-    $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes?: string | false,
+    async $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes?: string | false,
         maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
-        const uris: UriComponents[] = new Array();
-        let j = 0;
-        // tslint:disable-next-line:no-any
-        const promises: Promise<any>[] = new Array();
-        for (const root of this.roots) {
-            promises[j++] = this.fileSearchService.find(includePattern, { rootUri: root.uri }).then(value => {
-                const paths: string[] = new Array();
-                let i = 0;
-                value.forEach(item => {
-                    let path: string;
-                    path = root.uri.endsWith('/') ? root.uri + item : root.uri + '/' + item;
-                    paths[i++] = path;
-                });
-                return Promise.resolve(paths);
-            });
-        }
-        return Promise.all(promises).then(value => {
-            let i = 0;
-            value.forEach(path => {
-                uris[i++] = Uri.parse(path);
-            });
-            return Promise.resolve(uris);
-        });
+        const uriStrs = await this.fileSearchService.find(includePattern, { rootUris: this.roots.map(r => r.uri) });
+        return uriStrs.map(uriStr => Uri.parse(uriStr));
     }
 
     $registerFileSystemWatcher(options: FileWatcherSubscriberOptions): Promise<string> {


### PR DESCRIPTION
With this change, the file search operations are performed across all folders in the workspace, instead of the first root folder.

Signed-off-by: elaihau <liang.huang@ericsson.com>
