### PR TITLE
[path] lower-case windows drive letters

### DIFF
--- a/packages/core/src/common/uri.spec.ts
+++ b/packages/core/src/common/uri.spec.ts
@@ -145,4 +145,12 @@ describe('uri', () => {
             expect(uri.withPath('hubba-bubba').toString(true)).equals('file:///hubba-bubba?x=12#baz');
         });
     });
+
+    describe('#relative()', () => {
+        it('drive letters should be in lowercase', () => {
+            const uri = new URI('file:///C:/projects/theia');
+            const path = uri.relative(new URI(uri.resolve('node_modules/typescript/lib').toString()));
+            expect(String(path)).equals('node_modules/typescript/lib');
+        });
+    });
 });


### PR DESCRIPTION
`vscode-uri` always normalizes drive letters to lower case: https://github.com/Microsoft/vscode-uri/blob/b1d3221579f97f28a839b6f996d76fc45e9964d8/src/index.ts#L1025

Our path does not expect it leading to bogus behavior in some cases, for instance, trying to relativize `/c:/projects/theia/node_modules/typescript/lib` against `/C:/projects/theia` fails. 

This PR adjusts `Path` with `vscode-uri` expectations.