### PR TITLE
Show error message when failing to start debug session

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -114,8 +114,12 @@ export class DebugSessionManager {
             return this.doStart(sessionId, resolved);
         } catch (e) {
             if (DebugError.NotFound.is(e)) {
+                this.messageService.error(`The debug session type "${e.data.type}" is not supported.`);
                 return undefined;
             }
+
+            this.messageService.error('There was an error starting the debug session, check the logs for more details.');
+            console.error('Error starting the debug session', e);
             throw e;
         }
     }


### PR DESCRIPTION
Currently, if something goes wrong in the backend starting the debug
session, nothing is shown to the user (only in the javascript
console).

This patch makes DebugSessionManager show an error message if this
happens, to provide some basic feedback.

Change-Id: I409a07d932d7c22d392fb47f8ee28db3e51d7b0c
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
