### PR TITLE
[search-in-workspace] display search result information for search-in-workspace

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -164,7 +164,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     protected onAfterAttach(msg: Message) {
         super.onAfterAttach(msg);
-        ReactDOM.render(<React.Fragment>{this.renderSearchHeader()}</React.Fragment>, this.searchFormContainer);
+        ReactDOM.render(<React.Fragment>{this.renderSearchHeader()}{this.renderSearchInfo()}</React.Fragment>, this.searchFormContainer);
         Widget.attach(this.resultTreeWidget, this.contentNode);
         this.toDisposeOnDetach.push(Disposable.create(() => {
             Widget.detach(this.resultTreeWidget);
@@ -173,7 +173,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     protected onUpdateRequest(msg: Message) {
         super.onUpdateRequest(msg);
-        ReactDOM.render(<React.Fragment>{this.renderSearchHeader()}</React.Fragment>, this.searchFormContainer);
+        ReactDOM.render(<React.Fragment>{this.renderSearchHeader()}{this.renderSearchInfo()}</React.Fragment>, this.searchFormContainer);
     }
 
     protected onResize(msg: Widget.ResizeMessage): void {
@@ -471,5 +471,20 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
 
     protected splitOnComma(patterns: string): string[] {
         return patterns.split(',').map(s => s.trim());
+    }
+
+    protected renderSearchInfo(): React.ReactNode {
+        let message = '';
+        const includeValid = (this.searchInWorkspaceOptions.include
+            && this.searchInWorkspaceOptions.include.length === 1
+            && this.searchInWorkspaceOptions.include[0] === '');
+        if (!includeValid && this.resultNumber === 0) {
+            message = `No results found in '${this.searchInWorkspaceOptions.include}'`;
+        } else if (this.resultNumber === 0) {
+            message = 'No results found.';
+        } else {
+            message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
+        }
+        return this.searchTerm !== '' ? <div className='search-info'>{message}</div> : '';
     }
 }

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -395,3 +395,8 @@
 .highlighted-count-container {
     background-color: var(--theia-brand-color0);
 }
+
+.t-siw-search-container .searchHeader .search-info {
+    color: var(--theia-ui-font-color2);
+    margin-left: 17px;
+}


### PR DESCRIPTION
Display information about the `search-in-workspace` results (3 main states):
1. if results are found, display result and file count.
2. if no results are found, display no results found.
3. if no results are found and an `include glob` is present, display no results found for the specified `glob`.

| Scenario 1 | Scenario 2 | Scenario 3 |
|:---:|:---:|:---:|
|<img width="1034" alt="screen shot 2018-12-12 at 9 21 13 am" src="https://user-images.githubusercontent.com/40359487/49876406-4fa59f00-fdf1-11e8-870d-fdb0216798f4.png">| <img width="1034" alt="screen shot 2018-12-12 at 9 20 44 am" src="https://user-images.githubusercontent.com/40359487/49876437-66e48c80-fdf1-11e8-8466-d29c007938f1.png"> | <img width="1034" alt="screen shot 2018-12-12 at 9 21 05 am" src="https://user-images.githubusercontent.com/40359487/49876457-7237b800-fdf1-11e8-946b-c6ac3260bce4.png">|




Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
