### PR TITLE
[search-in-workspace] adjust font-color for parent result in search-in-workspace

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -394,6 +394,7 @@
 
 .highlighted-count-container {
     background-color: var(--theia-brand-color0);
+    color: #ffffff;
 }
 
 .t-siw-search-container .searchHeader .search-info {


### PR DESCRIPTION
Fixed an issue for bright themes which would incorrectly display the
wrong color for the parent result in the `search-in-workspace` widget.

Addressed the following styling issue:

<img width="282" alt="screen shot 2018-12-12 at 11 18 46 am" src="https://user-images.githubusercontent.com/40359487/49883291-60114600-fe00-11e8-9b8e-2b50f6a9a508.png">


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
