### PR TITLE
[editor] update navigation-location stack by listening to filesystem changes

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "^0.3.17",
     "@theia/languages": "^0.3.17",
+    "@theia/filesystem": "^0.3.17",
     "@theia/variable-resolver": "^0.3.17",
     "@types/base64-arraybuffer": "0.1.0",
     "base64-arraybuffer": "^0.1.5"

--- a/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.spec.ts
@@ -17,6 +17,7 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 
 let disableJSDOM = enableJSDOM();
 
+import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { Container } from 'inversify';
 import { ILogger } from '@theia/core/lib/common/logger';
@@ -28,6 +29,9 @@ import { NoopNavigationLocationUpdater } from './test/mock-navigation-location-u
 import { NavigationLocationSimilarity } from './navigation-location-similarity';
 import { CursorLocation, Position, NavigationLocation } from './navigation-location';
 import { NavigationLocationService } from './navigation-location-service';
+import { FileSystemNode } from '@theia/filesystem/lib/node/node-filesystem';
+import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watcher';
 
 disableJSDOM();
 
@@ -137,6 +141,8 @@ describe('navigation-location-service', () => {
     }
 
     function init(): NavigationLocationService {
+        const mockFilesystem = sinon.createStubInstance(FileSystemNode);
+        const mockFileSystemWatcher = sinon.createStubInstance(FileSystemWatcher);
         const container = new Container({ defaultScope: 'Singleton' });
         container.bind(NavigationLocationService).toSelf();
         container.bind(NavigationLocationSimilarity).toSelf();
@@ -146,6 +152,8 @@ describe('navigation-location-service', () => {
         container.bind(NoopNavigationLocationUpdater).toSelf();
         container.bind(NavigationLocationUpdater).toService(NoopNavigationLocationUpdater);
         container.bind(OpenerService).toService(MockOpenerService);
+        container.bind(FileSystem).toConstantValue(mockFilesystem);
+        container.bind(FileSystemWatcher).toConstantValue(mockFileSystemWatcher);
         return container.get(NavigationLocationService);
     }
 


### PR DESCRIPTION
Fixes #3818

The navigation-location stack was not updating when a uri was removed, deleted or rename which meant that the location stack was stale. (example: when searching for files in the `quick-file-open`, deleted files were still displayed.) This PR handles
updating the stack by listening for changes.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
