### PR TITLE
Add 'tasks.onDidStartTask' for Plug-in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.19
 - [cpp] added new `cpp.clangdExecutable` and `cpp.clangdArgs` to customize language server start command.
 - [monaco] Fix document-saving that was taking too long.
+- [plug-in] added `tasks.onDidStartTask` Plug-in API
 
 ## v0.3.18
 - [core] added a preference to define how to handle application exit

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -798,13 +798,19 @@ export interface LanguagesContributionMain {
 export interface CommandProperties {
     command: string;
     args?: string[];
-    options?: object;
+    options?: { [key: string]: any };
 }
+
 export interface TaskDto {
     type: string;
     label: string;
     // tslint:disable-next-line:no-any
-    [key: string]: any;
+    properties?: { [key: string]: any };
+}
+
+export interface TaskExecutionDto {
+    id: number;
+    task: TaskDto;
 }
 
 export interface ProcessTaskDto extends TaskDto, CommandProperties {
@@ -987,9 +993,11 @@ export const MAIN_RPC_CONTEXT = {
 export interface TasksExt {
     $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
     $resolveTask(handle: number, task: TaskDto): Promise<TaskDto | undefined>;
+    $onDidStartTask(execution: TaskExecutionDto): void;
 }
 
 export interface TasksMain {
     $registerTaskProvider(handle: number, type: string): void;
     $unregister(handle: number): void;
+    $terminateTask(id: number): void;
 }

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -23,18 +23,45 @@ import { RPCProtocol } from '../../api/rpc-protocol';
 import { DisposableCollection } from '@theia/core';
 import { TaskProviderRegistry, TaskResolverRegistry, TaskProvider, TaskResolver } from '@theia/task/lib/browser/task-contribution';
 import { interfaces } from 'inversify';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { TaskInfo } from '@theia/task/lib/common/task-protocol';
+import { TaskWatcher } from '@theia/task/lib/common/task-watcher';
+import { TaskService } from '@theia/task/lib/browser/task-service';
 
 export class TasksMainImpl implements TasksMain {
+    private workspaceRootUri: string | undefined = undefined;
 
     private readonly proxy: TasksExt;
     private readonly disposables = new Map<number, monaco.IDisposable>();
     private readonly taskProviderRegistry: TaskProviderRegistry;
     private readonly taskResolverRegistry: TaskResolverRegistry;
+    private readonly taskWatcher: TaskWatcher;
+    private readonly taskService: TaskService;
+    private readonly workspaceService: WorkspaceService;
 
     constructor(rpc: RPCProtocol, container: interfaces.Container, ) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.TASKS_EXT);
         this.taskProviderRegistry = container.get(TaskProviderRegistry);
         this.taskResolverRegistry = container.get(TaskResolverRegistry);
+        this.workspaceService = container.get(WorkspaceService);
+        this.taskWatcher = container.get(TaskWatcher);
+        this.taskService = container.get(TaskService);
+
+        this.workspaceService.roots.then(roots => {
+            const root = roots[0];
+            if (root) {
+                this.workspaceRootUri = root.uri;
+            }
+        });
+
+        this.taskWatcher.onTaskCreated((event: TaskInfo) => {
+            if (event.ctx === this.workspaceRootUri) {
+                this.proxy.$onDidStartTask({
+                    id: event.taskId,
+                    task: event.config
+                });
+            }
+        });
     }
 
     $registerTaskProvider(handle: number, type: string): void {
@@ -53,6 +80,10 @@ export class TasksMainImpl implements TasksMain {
             disposable.dispose();
             this.disposables.delete(handle);
         }
+    }
+
+    $terminateTask(id: number): void {
+        this.taskService.kill(id);
     }
 
     protected createTaskProvider(handle: number): TaskProvider {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -558,6 +558,10 @@ export function createAPIFactory(
         const tasks: typeof theia.tasks = {
             registerTaskProvider(type: string, provider: theia.TaskProvider): theia.Disposable {
                 return tasksExt.registerTaskProvider(type, provider);
+            },
+
+            onDidStartTask(listener, thisArg?, disposables?) {
+                return tasksExt.onDidStartTask(listener, thisArg, disposables);
             }
         };
 

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -20,6 +20,7 @@ import * as theia from '@theia/plugin';
 import * as types from './types-impl';
 import * as model from '../api/model';
 import { MarkdownString, isMarkdownString } from './markdown-string';
+import { ProcessTaskDto, TaskDto } from '../api/plugin-api';
 
 describe('Type converters:', () => {
 
@@ -167,4 +168,85 @@ describe('Type converters:', () => {
 
     });
 
+    describe('convert tasks:', () => {
+        const type = 'shell';
+        const label = 'yarn build';
+        const command = 'yarn';
+        const args = ['run', 'build'];
+        const cwd = '/projects/theia';
+
+        const shellTaskDto: ProcessTaskDto = {
+            type: type,
+            label: label,
+            command: command,
+            args: args,
+            cwd: cwd,
+            options: {},
+            properties: {}
+        };
+
+        const shellPluginTask: theia.Task = {
+            name: label,
+            definition: {
+                type: type
+            },
+            execution: {
+                command: command,
+                args: args,
+                options: {
+                    cwd: cwd
+                }
+            }
+        };
+
+        const taskDtoWithCommandLine: ProcessTaskDto = {
+            type: type,
+            label: label,
+            command: command,
+            args: args,
+            cwd: cwd,
+            options: {},
+            properties: {}
+        };
+
+        const pluginTaskWithCommandLine: theia.Task = {
+            name: label,
+            definition: {
+                type: type
+            },
+            execution: {
+                commandLine: 'yarn run build',
+                options: {
+                    cwd: cwd
+                }
+            }
+        };
+
+        it('should convert to task dto', () => {
+            // when
+            const result: TaskDto | undefined = Converter.fromTask(shellPluginTask);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, shellTaskDto);
+        });
+
+        it('should convert from task dto', () => {
+            // when
+            const result: theia.Task = Converter.toTask(shellTaskDto);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, shellPluginTask);
+        });
+
+        it('should convert to task dto from task with commandline', () => {
+            // when
+            const result: TaskDto | undefined = Converter.fromTask(pluginTaskWithCommandLine);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, taskDtoWithCommandLine);
+        });
+    });
 });

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -509,9 +509,10 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     }
 
     taskDto.type = taskDefinition.type;
+    taskDto.properties = {};
     for (const key in taskDefinition) {
-        if (taskDefinition.hasOwnProperty(key)) {
-            taskDto[key] = taskDefinition[key];
+        if (key !== 'type' && taskDefinition.hasOwnProperty(key)) {
+            taskDto.properties[key] = taskDefinition[key];
         }
     }
 
@@ -532,6 +533,43 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     return processTaskDto;
 }
 
+export function toTask(taskDto: TaskDto): theia.Task {
+    if (!taskDto) {
+        throw new Error('Task should be provided for converting');
+    }
+
+    const result = {} as theia.Task;
+    result.name = taskDto.label;
+
+    const taskType = taskDto.type;
+    const taskDefinition: theia.TaskDefinition = {
+        type: taskType
+    };
+
+    result.definition = taskDefinition;
+
+    if (taskType === 'process') {
+        result.execution = getProcessExecution(taskDto as ProcessTaskDto);
+    }
+
+    if (taskType === 'shell') {
+        result.execution = getShellExecution(taskDto as ProcessTaskDto);
+    }
+
+    const properties = taskDto.properties;
+    if (!properties) {
+        return result;
+    }
+
+    for (const key in properties) {
+        if (properties.hasOwnProperty(key)) {
+            taskDefinition[key] = properties[key];
+        }
+    }
+
+    return result;
+}
+
 export function fromProcessExecution(execution: theia.ProcessExecution, processTaskDto: ProcessTaskDto): ProcessTaskDto {
     processTaskDto.command = execution.process;
     processTaskDto.args = execution.args;
@@ -548,8 +586,7 @@ export function fromShellExecution(execution: theia.ShellExecution, processTaskD
     const options = execution.options;
     if (options) {
         processTaskDto.cwd = options.cwd;
-        processTaskDto.args = options.shellArgs;
-        processTaskDto.options = options;
+        processTaskDto.options = getShellExecutionOptions(options);
     }
 
     const commandLine = execution.commandLine;
@@ -575,6 +612,34 @@ export function fromShellExecution(execution: theia.ShellExecution, processTaskD
     }
 }
 
+export function getProcessExecution(processTaskDto: ProcessTaskDto): theia.ProcessExecution {
+    const execution = {} as theia.ProcessExecution;
+
+    execution.process = processTaskDto.command;
+
+    const processArgs = processTaskDto.args;
+    execution.args = processArgs ? processArgs : [];
+
+    const options = processTaskDto.options;
+    execution.options = options ? options : {};
+    execution.options.cwd = processTaskDto.cwd;
+
+    return execution;
+}
+
+export function getShellExecution(processTaskDto: ProcessTaskDto): theia.ShellExecution {
+    const execution = {} as theia.ShellExecution;
+
+    const options = processTaskDto.options;
+    execution.options = options ? options : {};
+    execution.options.cwd = processTaskDto.cwd;
+    execution.args = processTaskDto.args;
+
+    execution.command = processTaskDto.command;
+
+    return execution;
+}
+
 export function getShellArgs(args: undefined | (string | theia.ShellQuotedString)[]): string[] {
     if (!args || args.length === 0) {
         return [];
@@ -591,6 +656,34 @@ export function getShellArgs(args: undefined | (string | theia.ShellQuotedString
     shellQuotedArgs.forEach(arg => {
         result.push(arg.value);
     });
+
+    return result;
+}
+
+// tslint:disable-next-line:no-any
+export function getShellExecutionOptions(options: theia.ShellExecutionOptions): { [key: string]: any } {
+    // tslint:disable-next-line:no-any
+    const result = {} as { [key: string]: any };
+
+    const env = options.env;
+    if (env) {
+        result['env'] = env;
+    }
+
+    const executable = options.executable;
+    if (executable) {
+        result['executable'] = executable;
+    }
+
+    const shellQuoting = options.shellQuoting;
+    if (shellQuoting) {
+        result['shellQuoting'] = shellQuoting;
+    }
+
+    const shellArgs = options.shellArgs;
+    if (shellArgs) {
+        result['shellArgs'] = shellArgs;
+    }
 
     return result;
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6595,6 +6595,36 @@ declare module '@theia/plugin' {
         resolveTask(task: Task, token?: CancellationToken): ProviderResult<Task>;
     }
 
+    /**
+     * An object representing an executed Task. It can be used
+     * to terminate a task.
+     *
+     * This interface is not intended to be implemented.
+     */
+    export interface TaskExecution {
+        /**
+         * The task that got started.
+         */
+        task: Task;
+
+        /**
+         * Terminates the task execution.
+         */
+        terminate(): void;
+    }
+
+    /**
+     * An event signaling the start of a task execution.
+     *
+     * This interface is not intended to be implemented.
+     */
+    interface TaskStartEvent {
+        /**
+         * The task item representing the task that got started.
+         */
+        execution: TaskExecution;
+    }
+
     export namespace tasks {
 
         /**
@@ -6605,6 +6635,9 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
+
+        /** Fires when a task starts. */
+        export const onDidStartTask: Event<TaskStartEvent>;
     }
 
     /**

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -233,4 +233,16 @@ export class TaskService implements TaskConfigurationClient {
     protected getContext(): string | undefined {
         return this.workspaceRootUri;
     }
+
+    /** Kill task for a given id if task is found */
+    async kill(id: number): Promise<void> {
+        try {
+            await this.taskServer.kill(id);
+        } catch (error) {
+            this.logger.error(`Error killing task '${id}': ${error}`);
+            this.messageService.error(`Error killing task '${id}': ${error}`);
+            return;
+        }
+        this.logger.debug(`Task killed. Task id: ${id}`);
+    }
 }


### PR DESCRIPTION
Add:
- 'tasks.onDidStartTask' for Plug-in API
- ability to terminate task from plugin side

Example:

    
    let currentTaskExecution: theia.TaskExecution;

    theia.tasks.onDidStartTask(event => {
        currentTaskExecution = event.execution;
    });

    theia.commands.registerCommand({
        id: 'terminateTask',
        label: 'Terminate task'
    }, (...args: any[]) => {
        currentTaskExecution.terminate();
    });

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>