### PR TITLE
Improve quick-open-file handling

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -28,6 +28,7 @@ import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { Command } from '@theia/core/lib/common';
 import { NavigationLocationService } from '@theia/editor/lib/browser/navigation/navigation-location-service';
 import * as fuzzy from 'fuzzy';
+import { MessageService } from '@theia/core/lib/common/message-service';
 
 export const quickFileOpen: Command = {
     id: 'file-search.openFile',
@@ -54,6 +55,8 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
     protected readonly labelProvider: LabelProvider;
     @inject(NavigationLocationService)
     protected readonly navigationLocationService: NavigationLocationService;
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
 
     /**
      * Whether to hide .gitignored (and other ignored) files.
@@ -193,8 +196,10 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
         };
     }
 
-    openFile(uri: URI) {
-        this.openerService.getOpener(uri).then(opener => opener.open(uri));
+    openFile(uri: URI): void {
+        this.openerService.getOpener(uri)
+            .then(opener => opener.open(uri))
+            .catch(error => this.messageService.error(error));
     }
 
     private async toItem(uriOrString: URI | string, group?: string) {


### PR DESCRIPTION
Fixes #3818

Add error handling when attempting to open files from the `quick-open-file`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
