### PR TITLE
Remove ProcessTaskRunner.findCommand, introduce process "started" event

### DIFF
--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -4,7 +4,7 @@
   "description": "Theia process support.",
   "dependencies": {
     "@theia/core": "^0.3.19",
-    "node-pty": "0.7.6",
+    "@theia/node-pty": "0.7.8-theia004",
     "string-argv": "^0.1.1"
   },
   "publishConfig": {

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -22,6 +22,7 @@ import * as temp from 'temp';
 import * as fs from 'fs';
 import * as path from 'path';
 import { isWindows } from '@theia/core';
+import { IProcessStartEvent, ProcessErrorEvent } from './process';
 
 /* Allow to create temporary files, but delete them when we're done.  */
 const track = temp.track();
@@ -43,24 +44,21 @@ describe('RawProcess', function () {
     });
 
     it('test error on non-existent path', async function () {
-        const p = new Promise((resolve, reject) => {
-            const rawProcess = rawProcessFactory({ command: '/non-existent' });
-            rawProcess.onError(error => {
-                // tslint:disable-next-line:no-any
-                const code = (error as any).code;
-                resolve(code);
-            });
+        const error = await new Promise<ProcessErrorEvent>((resolve, reject) => {
+            const proc = rawProcessFactory({ command: '/non-existent' });
+            proc.onStart(reject);
+            proc.onError(resolve);
         });
 
-        expect(await p).to.be.equal('ENOENT');
+        expect(error.code).eq('ENOENT');
     });
 
     it('test error on non-executable path', async function () {
-        /* Create a non-executable file.  */
+        // Create a non-executable file.
         const f = track.openSync('non-executable');
         fs.writeSync(f.fd, 'echo bob');
 
-        /* Make really sure it's non-executable.  */
+        // Make really sure it's non-executable.
         let mode = fs.fstatSync(f.fd).mode;
         mode &= ~fs.constants.S_IXUSR;
         mode &= ~fs.constants.S_IXGRP;
@@ -69,22 +67,25 @@ describe('RawProcess', function () {
 
         fs.closeSync(f.fd);
 
-        const p = new Promise((resolve, reject) => {
-            const rawProcess = rawProcessFactory({ command: f.path });
-            rawProcess.onError(error => {
-                // tslint:disable-next-line:no-any
-                const code = (error as any).code;
-                resolve(code);
-            });
+        const error = await new Promise<ProcessErrorEvent>((resolve, reject) => {
+            const proc = rawProcessFactory({ command: f.path });
+            proc.onStart(reject);
+            proc.onError(resolve);
         });
 
-        /* On Windows, we get 'UNKNOWN'.  */
-        let expectedCode = 'EACCES';
-        if (isWindows) {
-            expectedCode = 'UNKNOWN';
-        }
+        // On Windows, we get 'UNKNOWN'.
+        const expectedCode = isWindows ? 'UNKNOWN' : 'EACCES';
 
-        expect(await p).to.equal(expectedCode);
+        expect(error.code).eq(expectedCode);
+    });
+
+    it('test start event', function () {
+        return new Promise<IProcessStartEvent>(async (resolve, reject) => {
+            const args = ['-e', 'process.exit(3)'];
+            const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
+            rawProcess.onStart(resolve);
+            rawProcess.onError(reject);
+        });
     });
 
     it('test exit', async function () {
@@ -109,45 +110,45 @@ describe('RawProcess', function () {
     });
 
     it('test pipe stdout stream', async function () {
-        const args = ['--version'];
-        const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
+        const output = await new Promise<string>(async (resolve, reject) => {
+            const args = ['-e', 'console.log("text to stdout")'];
+            const outStream = new stream.PassThrough();
+            const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
+            rawProcess.onError(reject);
 
-        const outStream = new stream.PassThrough();
+            rawProcess.output.pipe(outStream);
 
-        const p = new Promise<string>((resolve, reject) => {
-            let version = '';
+            let buf = '';
             outStream.on('data', data => {
-                version += data.toString();
+                buf += data.toString();
             });
             outStream.on('end', () => {
-                resolve(version.trim());
+                resolve(buf.trim());
             });
         });
 
-        rawProcess.output.pipe(outStream);
-
-        expect(await p).to.be.equal(process.version);
+        expect(output).to.be.equal('text to stdout');
     });
 
     it('test pipe stderr stream', async function () {
-        const args = ['invalidarg'];
-        const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
+        const output = await new Promise<string>(async (resolve, reject) => {
+            const args = ['-e', 'console.error("text to stderr")'];
+            const outStream = new stream.PassThrough();
+            const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
+            rawProcess.onError(reject);
 
-        const outStream = new stream.PassThrough();
+            rawProcess.errorOutput.pipe(outStream);
 
-        const p = new Promise<string>((resolve, reject) => {
-            let version = '';
+            let buf = '';
             outStream.on('data', data => {
-                version += data.toString();
+                buf += data.toString();
             });
             outStream.on('end', () => {
-                resolve(version.trim());
+                resolve(buf.trim());
             });
         });
 
-        rawProcess.errorOutput.pipe(outStream);
-
-        expect(await p).to.have.string('Error');
+        expect(output).to.be.equal('text to stderr');
     });
 
     it('test forked pipe stdout stream', async function () {

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -85,10 +85,11 @@ export class RawProcess extends Process {
             + ` with args: ${options.args ? options.args.join(' ') : ''}, `
             + ` with options: ${JSON.stringify(options.options)}`);
 
-        /* spawn can throw exceptions, for example if the file is not
-           executable, it throws an error with EACCES.  Here, we try to
-           normalize the error handling by calling the error handler
-           instead.  */
+        // About catching errors: spawn will sometimes throw directly
+        // (EACCES on Linux), sometimes return a Process object with the pid
+        // property undefined (ENOENT on Linux) and then emit an 'error' event.
+        // For now, we try to normalize that into always emitting an 'error'
+        // event.
         try {
             if (this.isForkOptions(options)) {
                 this.process = fork(
@@ -102,7 +103,11 @@ export class RawProcess extends Process {
                     options.options);
             }
 
-            this.process.on('error', this.emitOnError.bind(this));
+            this.process.on('error', (error: NodeJS.ErrnoException) => {
+                this.emitOnError({
+                    code: error.code || 'Unknown error',
+                });
+            });
             this.process.on('exit', (exitCode: number, signal: string) => {
                 // node's child_process exit sets the unused parameter to null,
                 // but we want it to be undefined instead.
@@ -115,6 +120,12 @@ export class RawProcess extends Process {
             this.output = this.process.stdout;
             this.input = this.process.stdin;
             this.errorOutput = this.process.stderr;
+
+            if (this.process.pid !== undefined) {
+                process.nextTick(() => {
+                    this.emitOnStarted();
+                });
+            }
         } catch (error) {
             /* When an error is thrown, set up some fake streams, so the client
                code doesn't break because these field are undefined.  */

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -191,8 +191,9 @@ export class TaskService implements TaskConfigurationClient {
         try {
             taskInfo = await this.taskServer.run(resolvedTask, this.getContext());
         } catch (error) {
-            this.logger.error(`Error launching task '${taskLabel}': ${error}`);
-            this.messageService.error(`Error launching task '${taskLabel}': ${error}`);
+            const errorStr = `Error launching task '${taskLabel}': ${error.message}`;
+            this.logger.error(errorStr);
+            this.messageService.error(errorStr);
             return;
         }
 

--- a/packages/task/src/common/process/task-protocol.ts
+++ b/packages/task/src/common/process/task-protocol.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { TaskConfiguration, TaskInfo } from '../task-protocol';
+import { ApplicationError } from '@theia/core/lib/common/application-error';
 
 export type ProcessType = 'shell' | 'process';
 
@@ -46,4 +47,11 @@ export interface ProcessTaskConfiguration extends TaskConfiguration, CommandProp
 export interface ProcessTaskInfo extends TaskInfo {
     /** terminal id. Defined if task is run as a terminal process */
     readonly terminalId?: number,
+}
+
+export namespace ProcessTaskError {
+    export const CouldNotRun = ApplicationError.declare(1, (code: string) => ({
+        message: `Error starting process (${code})`,
+        data: { code }
+    }));
 }

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -23,7 +23,6 @@ import { ProcessType, ProcessTaskInfo } from '../../common/process/task-protocol
 
 export const TaskProcessOptions = Symbol('TaskProcessOptions');
 export interface TaskProcessOptions extends TaskOptions {
-    command: string,
     process: Process,
     processType: ProcessType
 }

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -242,12 +242,12 @@ describe('Task server / back-end', function () {
 
     it('task using terminal process can handle command that does not exist', async function () {
         const p = taskServer.run(createProcessTaskConfig2('shell', bogusCommand, []), wsRoot);
-        await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
+        await expectThrowsAsync(p, 'ENOENT');
     });
 
     it('task using raw process can handle command that does not exist', async function () {
         const p = taskServer.run(createProcessTaskConfig2('process', bogusCommand, []), wsRoot);
-        await expectThrowsAsync(p, `Command not found: ${bogusCommand}`);
+        await expectThrowsAsync(p, 'ENOENT');
     });
 
     it('getTasks(ctx) returns tasks according to created context', async function () {

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -93,7 +93,7 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
             if (this.client !== undefined) {
                 this.client.onTerminalError({
                     'terminalId': term.id,
-                    'error': error
+                    'error': new Error(`Failed to execute terminal process (${error.code})`),
                 });
             }
         }));

--- a/packages/terminal/src/node/terminal-server.spec.ts
+++ b/packages/terminal/src/node/terminal-server.spec.ts
@@ -16,10 +16,7 @@
 
 import * as chai from 'chai';
 import { createTerminalTestContainer } from './test/terminal-test-container';
-import { TerminalWatcher } from '../common/terminal-watcher';
 import { ITerminalServer } from '../common/terminal-protocol';
-import { IBaseTerminalExitEvent } from '../common/base-terminal-protocol';
-import { isWindows } from '@theia/core/lib/common';
 
 /**
  * Globals
@@ -31,41 +28,20 @@ describe('TermninalServer', function () {
 
     this.timeout(5000);
     let terminalServer: ITerminalServer;
-    let terminalWatcher: TerminalWatcher;
 
     beforeEach(() => {
         const container = createTerminalTestContainer();
         terminalServer = container.get(ITerminalServer);
-        terminalWatcher = container.get(TerminalWatcher);
     });
 
     it('test terminal create', async function () {
         const args = ['--version'];
-        const createResult = terminalServer.create({ command: process.execPath, 'args': args });
-        expect(await createResult).to.be.greaterThan(-1);
+        const createResult = await terminalServer.create({ command: process.execPath, 'args': args });
+        expect(createResult).to.be.greaterThan(-1);
     });
 
-    it('test terminal create from non-existant path', async function () {
-        const createResult = terminalServer.create({ command: '/non-existant' });
-        if (isWindows) {
-            expect(await createResult).to.be.equal(-1);
-        } else {
-            const errorPromise = new Promise<void>((resolve, reject) => {
-                createResult.then((termId: number) => {
-                    terminalWatcher.onTerminalExit((event: IBaseTerminalExitEvent) => {
-                        if (event.terminalId === termId) {
-                            if (event.code === 1) {
-                                resolve();
-                            } else {
-                                reject();
-                            }
-                        }
-                    });
-                });
-            });
-
-            expect(await createResult).to.be.greaterThan(-1);
-            await errorPromise;
-        }
+    it('test terminal create from non-existent path', async function () {
+        const createError = await terminalServer.create({ command: '/non-existent' });
+        expect(createError).eq(-1);
     });
 });

--- a/packages/terminal/src/node/terminal-server.ts
+++ b/packages/terminal/src/node/terminal-server.ts
@@ -34,14 +34,18 @@ export class TerminalServer extends BaseTerminalServer implements ITerminalServe
         super(processManager, logger);
     }
 
-    async create(options: ITerminalServerOptions): Promise<number> {
-        try {
+    create(options: ITerminalServerOptions): Promise<number> {
+        return new Promise<number>((resolve, reject) => {
             const term = this.terminalFactory(options);
-            this.postCreate(term);
-            return term.id;
-        } catch (error) {
-            this.logger.error('Error while creating terminal', error);
-            return -1;
-        }
+            term.onStart(_ => {
+                this.postCreate(term);
+                resolve(term.id);
+            });
+            term.onError(error => {
+                this.logger.error('Error while creating terminal', error);
+                resolve(-1);
+            });
+        });
+
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,13 @@
   dependencies:
     samsam "1.3.0"
 
+"@theia/node-pty@0.7.8-theia004":
+  version "0.7.8-theia004"
+  resolved "https://registry.yarnpkg.com/@theia/node-pty/-/node-pty-0.7.8-theia004.tgz#0fe31b958df9315352d5fbeea7075047cf69c935"
+  integrity sha512-GetaD2p1qVPq/xbNCHCwKYjIr9IWjksf9V2iiv/hV6f885cJ+ie0Osr4+C159PrwzGRYW2jQVUtXghBJoyOCLg==
+  dependencies:
+    nan "2.10.0"
+
 "@typefox/monaco-editor-core@^0.14.6":
   version "0.14.6"
   resolved "https://registry.yarnpkg.com/@typefox/monaco-editor-core/-/monaco-editor-core-0.14.6.tgz#32e378f3430913504ea9c7063944444a04429892"
@@ -6683,12 +6690,6 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
-
-node-pty@0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.6.tgz#bff6148c9c5836ca7e73c7aaaec067dcbdac2f7b"
-  dependencies:
-    nan "2.10.0"
 
 nodegit-promise@~4.0.0:
   version "4.0.0"


### PR DESCRIPTION
In the long term goal of handling properly shell tasks (allowing the
user to specify "abc && def" as the command), we need to get rid of the
findCommand method in ProcessTaskRunner.  Otherwise, it will always
return that the binary "abc && def" can't be found.  Even for non-shell
tasks, it doesn't seem ideal to implement ourselves the logic of looking
through PATH.  It's better to leave that to the OS.

Instead, we want to rely on the underlying thing we use to run processes
(either node's child_process or node-pty) to return us an appropriate
error code.

With node's child_process, we can do it out-of-the-box.  With node-pty,
we use our own fork available at [1] which adds the necessary
features.  On error, the Process emits an onError event.

For the non-error case, we need to know when the process has been
successfully started, so we can inform the client that the task has been
successfully started.  To do this, I added an 'onStart' event on
Process.

[1] https://github.com/theia-ide/node-pty/tree/theia

Change-Id: Ie2db8909610129842912d312872a48aef3de23a5
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
