### PR TITLE
Show short hash when on detached head

### DIFF
--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -147,7 +147,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         });
         this.repositoryTracker.onGitEvent(event => {
             const { status } = event;
-            const branch = status.branch ? status.branch : 'NO-HEAD';
+            const branch = status.branch ? status.branch : status.currentHead ? status.currentHead.substring(0, 8) : 'NO-HEAD';
             let dirty = '';
             if (status.changes.length > 0) {
                 const conflicts = this.hasConflicts(status.changes);


### PR DESCRIPTION
This fixes https://github.com/theia-ide/theia/issues/3229

VS-Code does this and I can't see anyone objecting.  It's a trivial fix.

Note that under rare circumstances there may not be a commit hash for Dugite to return as currentTip in IStatusResult, so we would still get 'NO-HEAD' if that should happen.
