### PR TITLE
Fixing commands with arguments execution

### DIFF
--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { CommandRegistry, CommandHandler, Command, CommandContribution } from './command';
+import { ContributionProvider } from './contribution-provider';
+import * as chai from 'chai';
+
+const expect = chai.expect;
+
+describe('Commands', () => {
+    it('should properly pass arguments when any', async () => {
+        const commandRegistry = new CommandRegistry(
+            new EmptyContributionProvider()
+        );
+
+        // Registering a concat command to test
+        commandRegistry.registerCommand(
+            <Command>{ id: 'concat' },
+            new ConcatCommandHandler()
+        );
+
+        expect(
+            'commandarg1_commandarg2_commandarg3'
+        ).equals(
+            await commandRegistry.executeCommand(
+                'concat',
+                'commandarg1',
+                '_commandarg2',
+                '_commandarg3')
+        );
+    });
+});
+
+class EmptyContributionProvider implements ContributionProvider<CommandContribution> {
+    getContributions(recursive?: boolean | undefined): CommandContribution[] {
+        return [];
+    }
+}
+
+class ConcatCommandHandler implements CommandHandler {
+    execute(...args: string[]) {
+        let concat = '';
+        args.forEach(element => {
+            concat += element;
+        });
+        return concat;
+    }
+}

--- a/packages/file-search/src/browser/quick-file-open-contribution.ts
+++ b/packages/file-search/src/browser/quick-file-open-contribution.ts
@@ -29,7 +29,7 @@ export class QuickFileOpenFrontendContribution implements CommandContribution, K
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickFileOpen, {
             // tslint:disable-next-line:no-any
-            execute: (args: any[]) => {
+            execute: (...args: any[]) => {
                 if (args) {
                     const [fileURI] = args;
                     return this.quickFileOpenService.openFile(new URI(fileURI));

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -267,7 +267,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         registry.registerCommand(GIT_COMMANDS.CLONE, {
             isEnabled: () => this.workspaceService.opened,
             // tslint:disable-next-line:no-any
-            execute: (args: any[]) => {
+            execute: (...args: any[]) => {
                 let url: string | undefined = undefined;
                 let folder: string | undefined = undefined;
                 let branch: string | undefined = undefined;

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -82,7 +82,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             {
                 isEnabled: () => true,
                 // tslint:disable-next-line:no-any
-                execute: (args: any[]) => {
+                execute: (...args: any[]) => {
                     if (args) {
                         const [type, label] = args;
                         return this.taskService.run(type, label);


### PR DESCRIPTION
For instance when using the `clone` command from the Plugin API it is trying to clone `h`, instead of `https://github.com/theia-ide/theia.git`
