### PR TITLE
Fix clangd being started early when a build config is active

### DIFF
--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -84,7 +84,9 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
         // Restart clangd.  The new config will be picked up when
         // createOptions will be called to send the initialize request
         // to the new instance of clangd.
-        this.restart();
+        if (this.running) {
+          this.restart();
+        }
     }
 
     protected get documentSelector() {


### PR DESCRIPTION
If a C/C++ build config is active, clangd will be started when the
workspace is started, even if no C/C++ file is open.  The reason is that
we emit an onActiveConfigChange event on startup, to tell the world
about the initially selected config.  This calls "restart" on the
language client contribution, and causes clangd to be started.

Fix this be first checking if clangd is already running before calling
restart.

Fixes #3853

Change-Id: Ie2bef70b42da44ec096aee0d404aefd0f666c73a
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
