### PR TITLE
Update tslint to 5.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "sinon": "^3.3.0",
     "temp": "^0.8.3",
     "ts-node": "<7.0.0",
-    "tslint": "^5.10.0",
+    "tslint": "^5.12.0",
     "tslint-language-service": "^0.9.9",
     "typedoc": "^0.13.0",
     "typescript": "^3.1.3",

--- a/packages/mini-browser/src/browser/mini-browser-content.ts
+++ b/packages/mini-browser/src/browser/mini-browser-content.ts
@@ -597,7 +597,7 @@ export class MiniBrowserContent extends BaseWidget {
                     this.pdfContainer.style.display = 'block';
                     this.frame.style.display = 'none';
                     PDFObject.embed(url, this.pdfContainer, {
-                        // tslint:disable-next-line:max-line-length
+                        // tslint:disable-next-line:max-line-length quotemark
                         fallbackLink: `<p style="padding: 0px 15px 0px 15px">Your browser does not support inline PDFs. Click on this <a href='[url]' target="_blank">link</a> to open the PDF in a new tab.</p>`
                     });
                     this.hideLoadIndicator();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9569,9 +9569,10 @@ tslint-language-service@^0.9.9:
   dependencies:
     mock-require "^2.0.2"
 
-tslint@^5.10.0:
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+tslint@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.0.tgz#47f2dba291ed3d580752d109866fb640768fca36"
+  integrity sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
This release includes an improvement to the no-void-expression to avoid
warnings when using expressions like "x && doSomething(x)".  See
55582514 in the tslint repo for more information.

I had to add a new disable for the quotemark rule in
mini-browser-content.ts, not sure if that change of behavior in tslint
is in intended or not...

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
