### PR TITLE
[monaco] Fix `MonacoWorkspace.fireWillSave`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3.19
 - [cpp] added new `cpp.clangdExecutable` and `cpp.clangdArgs` to customize language server start command.
+- [monaco] Fix document-saving that was taking too long.
 
 ## v0.3.18
 - [core] added a preference to define how to handle application exit


### PR DESCRIPTION
Since ad39cb4ba9c3b1092d486ca36538a6af4810e4e, saving took roughly one
second everytime, even for almost empty text files. The commit simply
made the model saving process properly wait for every listener, this
means that someone was behaving badly.

MonacoWorkspacer registered a promise on that event, which was never
resolved. This commit fixes it.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Fix #3849