### PR TITLE
 [cpp] Add a preference to start a specific clangd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.3.19
+- [cpp] added new `cpp.clangdExecutable` and `cpp.clangdArgs` to customize language server start command.
+
 ## v0.3.18
 - [core] added a preference to define how to handle application exit
 - [core] added a way to prevent application exit from extensions

--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -22,7 +22,6 @@ import {
 } from '@theia/languages/lib/browser';
 import { Languages, Workspace } from '@theia/languages/lib/browser';
 import { ILogger } from '@theia/core/lib/common/logger';
-import { MessageService } from '@theia/core/lib/common/message-service';
 import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
 import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
 import { CppBuildConfigurationsStatusBarElement } from './cpp-build-configurations-statusbar-element';
@@ -48,12 +47,13 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     @inject(CppBuildConfigurationsStatusBarElement)
     protected readonly cppBuildConfigurationsStatusBarElement: CppBuildConfigurationsStatusBarElement;
 
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
     constructor(
         @inject(Workspace) protected readonly workspace: Workspace,
         @inject(Languages) protected readonly languages: Languages,
         @inject(LanguageClientFactory) protected readonly languageClientFactory: LanguageClientFactory,
-        @inject(MessageService) protected readonly messageService: MessageService,
-        @inject(ILogger) protected readonly logger: ILogger
     ) {
         super(workspace, languages, languageClientFactory);
     }
@@ -85,7 +85,7 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
         // createOptions will be called to send the initialize request
         // to the new instance of clangd.
         if (this.running) {
-          this.restart();
+            this.restart();
         }
     }
 

--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -22,9 +22,10 @@ import {
 } from '@theia/languages/lib/browser';
 import { Languages, Workspace } from '@theia/languages/lib/browser';
 import { ILogger } from '@theia/core/lib/common/logger';
-import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS } from '../common';
+import { CPP_LANGUAGE_ID, CPP_LANGUAGE_NAME, HEADER_AND_SOURCE_FILE_EXTENSIONS, CppStartParameters } from '../common';
 import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
 import { CppBuildConfigurationsStatusBarElement } from './cpp-build-configurations-statusbar-element';
+import { CppPreferences } from './cpp-preferences';
 
 /**
  * Clangd extension to set clangd-specific "initializationOptions" in the
@@ -40,6 +41,9 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
 
     readonly id = CPP_LANGUAGE_ID;
     readonly name = CPP_LANGUAGE_NAME;
+
+    @inject(CppPreferences)
+    protected readonly cppPreferences: CppPreferences;
 
     @inject(CppBuildConfigurationManager)
     protected readonly cppBuildConfigurations: CppBuildConfigurationManager;
@@ -126,5 +130,12 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
             return false;
         };
         return clientOptions;
+    }
+
+    protected getStartParameters(): CppStartParameters {
+        return {
+            clangdExecutable: this.cppPreferences['cpp.clangdExecutable'],
+            clangdArgs: this.cppPreferences['cpp.clangdArgs']
+        };
     }
 }

--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -17,6 +17,7 @@
 import { PreferenceSchema, PreferenceProxy, PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser/preferences';
 import { interfaces } from 'inversify';
 import { CppBuildConfiguration } from './cpp-build-configurations';
+import { CLANGD_EXECUTABLE_DEFAULT } from '../common';
 
 export const cppPreferencesSchema: PreferenceSchema = {
     type: 'object',
@@ -56,12 +57,24 @@ export const cppPreferencesSchema: PreferenceSchema = {
             default: false,
             type: 'boolean'
         },
+        'cpp.clangdExecutable': {
+            description: 'Specify the executable name/path to run in order to start clangd.',
+            default: CLANGD_EXECUTABLE_DEFAULT,
+            type: 'string'
+        },
+        'cpp.clangdArgs': {
+            description: 'Specify the arguments to pass to clangd when starting the language server.',
+            default: '',
+            type: 'string'
+        }
     }
 };
 
 export class CppConfiguration {
     'cpp.buildConfigurations': CppBuildConfiguration[];
     'cpp.experimentalCommands': boolean;
+    'cpp.clangdExecutable': string;
+    'cpp.clangdArgs': string;
 }
 
 export const CppPreferences = Symbol('CppPreferences');

--- a/packages/cpp/src/common/index.ts
+++ b/packages/cpp/src/common/index.ts
@@ -21,3 +21,10 @@ export const CPP_LANGUAGE_NAME = 'C/C++';
 export const HEADER_FILE_EXTENSIONS = ['h', 'hxx', 'hh', 'hpp', 'inc'];
 export const SOURCE_FILE_EXTENSIONS = ['c', 'cxx', 'C', 'c++', 'cc', 'cpp'];
 export const HEADER_AND_SOURCE_FILE_EXTENSIONS = SOURCE_FILE_EXTENSIONS.concat(HEADER_FILE_EXTENSIONS);
+
+export const CLANGD_EXECUTABLE_DEFAULT = 'clangd';
+
+export interface CppStartParameters {
+    clangdExecutable: string;
+    clangdArgs: string;
+}

--- a/packages/process/src/node/utils.ts
+++ b/packages/process/src/node/utils.ts
@@ -22,8 +22,11 @@ const stringArgv = require('string-argv');
  * Parses the given line into an array of args respecting escapes and string literals.
  * @param line the given line to parse
  */
-export function parseArgs(line: string): string[] {
-    return stringArgv(line);
+export function parseArgs(line: string | undefined): string[] {
+    if (line) {
+        return stringArgv(line);
+    }
+    return [];
 }
 
 // Polyfill for Object.entries, until we upgrade to ES2017.


### PR DESCRIPTION
Before we used to rely on a ENV variable, but it is easier to just have
a preference that the user can see in the preference editor.

Defaults to `clangd` which will try to lookup the executable in your
path.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>
