### PR TITLE
support running tasks from multiple roots

### DIFF
--- a/packages/cpp/src/browser/cpp-task-provider.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.ts
@@ -29,6 +29,7 @@ interface CppBuildTaskConfiguration extends TaskConfiguration {
 }
 
 const CPP_BUILD_TASK_TYPE_KEY: string = 'cpp.build';
+const CPP_BUILD_TASK_SOURCE: string = 'cpp';
 
 @injectable()
 export class CppTaskProvider implements TaskContribution, TaskProvider, TaskResolver {
@@ -37,7 +38,7 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
     @inject(CppBuildConfigurationManager) protected readonly cppBuildConfigurationManager: CppBuildConfigurationManager;
 
     registerProviders(registry: TaskProviderRegistry) {
-        registry.register(CPP_BUILD_TASK_TYPE_KEY, this);
+        registry.register(CPP_BUILD_TASK_SOURCE, this);
     }
 
     registerResolvers(registry: TaskResolverRegistry) {
@@ -82,8 +83,9 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
         if (config.commands && config.commands.build) {
             return {
                 type: CPP_BUILD_TASK_TYPE_KEY,
+                source: CPP_BUILD_TASK_SOURCE,
                 label: `C/C++ Build - ${config.name}`,
-                config: config,
+                config
             };
         }
 

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -809,6 +809,7 @@ export interface CommandProperties {
 export interface TaskDto {
     type: string;
     label: string;
+    source?: string;
     // tslint:disable-next-line:no-any
     properties?: { [key: string]: any };
 }

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -27,6 +27,7 @@ import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service
 import { TaskInfo } from '@theia/task/lib/common/task-protocol';
 import { TaskWatcher } from '@theia/task/lib/common/task-watcher';
 import { TaskService } from '@theia/task/lib/browser/task-service';
+import { TaskConfiguration } from '@theia/task/lib/common';
 
 export class TasksMainImpl implements TasksMain {
     private workspaceRootUri: string | undefined = undefined;
@@ -89,14 +90,14 @@ export class TasksMainImpl implements TasksMain {
     protected createTaskProvider(handle: number): TaskProvider {
         return {
             provideTasks: () =>
-                this.proxy.$provideTasks(handle).then(v => v!),
+                this.proxy.$provideTasks(handle).then(v => <TaskConfiguration[]>v),
         };
     }
 
     protected createTaskResolver(handle: number): TaskResolver {
         return {
             resolveTask: taskConfig =>
-                this.proxy.$resolveTask(handle, taskConfig).then(v => v!),
+                this.proxy.$resolveTask(handle, taskConfig).then(v => <TaskConfiguration>v!),
         };
     }
 }

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -171,6 +171,7 @@ describe('Type converters:', () => {
     describe('convert tasks:', () => {
         const type = 'shell';
         const label = 'yarn build';
+        const source = 'source';
         const command = 'yarn';
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
@@ -178,6 +179,7 @@ describe('Type converters:', () => {
         const shellTaskDto: ProcessTaskDto = {
             type: type,
             label: label,
+            source,
             command: command,
             args: args,
             cwd: cwd,
@@ -187,6 +189,7 @@ describe('Type converters:', () => {
 
         const shellPluginTask: theia.Task = {
             name: label,
+            source,
             definition: {
                 type: type
             },
@@ -202,6 +205,7 @@ describe('Type converters:', () => {
         const taskDtoWithCommandLine: ProcessTaskDto = {
             type: type,
             label: label,
+            source,
             command: command,
             args: args,
             cwd: cwd,
@@ -211,6 +215,7 @@ describe('Type converters:', () => {
 
         const pluginTaskWithCommandLine: theia.Task = {
             name: label,
+            source,
             definition: {
                 type: type
             },

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -502,6 +502,7 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
 
     const taskDto = {} as TaskDto;
     taskDto.label = task.name;
+    taskDto.source = task.source;
 
     const taskDefinition = task.definition;
     if (!taskDefinition) {
@@ -540,6 +541,7 @@ export function toTask(taskDto: TaskDto): theia.Task {
 
     const result = {} as theia.Task;
     result.name = taskDto.label;
+    result.source = taskDto.source;
 
     const taskType = taskDto.type;
     const taskDefinition: theia.TaskDefinition = {
@@ -763,6 +765,6 @@ export function fromColorPresentation(colorPresentation: theia.ColorPresentation
     return {
         label: colorPresentation.label,
         textEdit: colorPresentation.textEdit ? fromTextEdit(colorPresentation.textEdit) : undefined,
-        additionalTextEdits: colorPresentation.additionalTextEdits ? colorPresentation.additionalTextEdits.map(value  => fromTextEdit(value)) : undefined
+        additionalTextEdits: colorPresentation.additionalTextEdits ? colorPresentation.additionalTextEdits.map(value => fromTextEdit(value)) : undefined
     };
 }

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -83,13 +83,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
                 isEnabled: () => true,
                 // tslint:disable-next-line:no-any
                 execute: (...args: any[]) => {
-                    let type: string | undefined;
-                    let label: string | undefined;
-                    if (args) {
-                        [type, label] = args;
-                    }
-                    if (type && label) {
-                        return this.taskService.run(type, label);
+                    const [source, label] = args;
+                    if (source && label) {
+                        return this.taskService.run(source, label);
                     }
                     return this.quickOpenTask.open();
                 }

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -22,9 +22,14 @@ export const TaskServer = Symbol('TaskServer');
 export const TaskClient = Symbol('TaskClient');
 
 export interface TaskConfiguration {
-    readonly type: string;
-    /** A label that uniquely identifies a task configuration */
+    /**
+     * Source of the task configuration.
+     * For a configured task, it is the name of the root folder, while for a provided task, it is the name of the provider.
+     */
+    readonly source: string;
+    /** A label that uniquely identifies a task configuration per source */
     readonly label: string;
+    readonly type: string;
     /** Additional task type specific properties. */
     // tslint:disable-next-line:no-any
     readonly [key: string]: any;

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -337,6 +337,7 @@ function createTaskConfig(taskType: string, command: string, args: string[]): Ta
     const options: TaskConfiguration = {
         label: 'test task',
         type: taskType,
+        source: '/source/folder',
         command: command,
         args: args,
         windows: {
@@ -357,6 +358,7 @@ function createProcessTaskConfig(processType: ProcessType, command: string, args
     const options: ProcessTaskConfiguration = {
         label: 'test task',
         type: processType,
+        source: '/source/folder',
         command: command,
         args: args,
         windows: {
@@ -387,6 +389,7 @@ function createTaskConfigTaskLongRunning(processType: ProcessType): TaskConfigur
     return <ProcessTaskConfiguration>{
         label: '[Task] long running test task (~300s)',
         type: processType,
+        source: '/source/folder',
         cwd: wsRoot,
         command: commandLongRunning,
         args: [],

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -39,7 +39,7 @@ export class TaskServerImpl implements TaskServer {
         // do nothing
     }
 
-    async getTasks(context?: string | undefined): Promise<TaskInfo[]> {
+    async getTasks(context?: string): Promise<TaskInfo[]> {
         const taskInfo: TaskInfo[] = [];
 
         const tasks = this.taskManager.getTasks(context);

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -14,8 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
-import { ILogger, Disposable, DisposableCollection, MaybePromise } from '@theia/core';
+import { injectable } from 'inversify';
+import { Disposable, DisposableCollection, MaybePromise } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
 
 /**
  * Variable can be used inside of strings using ${variableName} syntax.
@@ -37,7 +38,7 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(): MaybePromise<string | undefined>;
+    resolve(context?: URI): MaybePromise<string | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');
@@ -57,10 +58,6 @@ export class VariableRegistry implements Disposable {
     protected readonly variables: Map<string, Variable> = new Map();
     protected readonly toDispose = new DisposableCollection();
 
-    constructor(
-        @inject(ILogger) protected readonly logger: ILogger
-    ) { }
-
     dispose(): void {
         this.toDispose.dispose();
     }
@@ -71,7 +68,7 @@ export class VariableRegistry implements Disposable {
      */
     registerVariable(variable: Variable): Disposable {
         if (this.variables.has(variable.name)) {
-            this.logger.warn(`A variables with name ${variable.name} is already registered.`);
+            console.warn(`A variables with name ${variable.name} is already registered.`);
             return Disposable.NULL;
         }
         this.variables.set(variable.name, variable);
@@ -94,5 +91,13 @@ export class VariableRegistry implements Disposable {
      */
     getVariable(name: string): Variable | undefined {
         return this.variables.get(name);
+    }
+
+    /**
+     * Register an array of variables.
+     * Do nothing if a variable is already registered for the given variable name.
+     */
+    registerVariables(variables: Variable[]): Disposable[] {
+        return variables.map(v => this.registerVariable(v));
     }
 }

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -46,24 +46,24 @@ export class WorkspaceVariableContribution implements VariableContribution {
         variables.registerVariable({
             name: 'workspaceRoot',
             description: 'The path of the workspace root folder',
-            resolve: () => {
-                const uri = this.getWorkspaceRootUri();
+            resolve: (context?: URI) => {
+                const uri = this.getWorkspaceRootUri(context);
                 return uri && uri.path.toString();
             }
         });
         variables.registerVariable({
             name: 'workspaceFolder',
             description: 'The path of the workspace root folder',
-            resolve: () => {
-                const uri = this.getWorkspaceRootUri();
+            resolve: (context?: URI) => {
+                const uri = this.getWorkspaceRootUri(context);
                 return uri && uri.path.toString();
             }
         });
         variables.registerVariable({
             name: 'workspaceFolderBasename',
             description: 'The name of the workspace root folder',
-            resolve: () => {
-                const uri = this.getWorkspaceRootUri();
+            resolve: (context?: URI) => {
+                const uri = this.getWorkspaceRootUri(context);
                 return uri && uri.displayName;
             }
         });


### PR DESCRIPTION
- tasks from tasks.json are grouped together and labelled as "configured", and those from other theia extensions are grouped separately and labelled as "provided".
- tasks under the ".theia" folders from all roots are read and become runnable.
- displays source (i.e., the place where the tasks are from) along with the task labels.

Signed-off-by: elaihau <liang.huang@ericsson.com>

