### PR TITLE
Gh 3658

### DIFF
--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -45,6 +45,19 @@ export namespace Event {
         get maxListeners(): number { return 0; },
         set maxListeners(maxListeners: number) { }
     });
+
+    /**
+     * Given an event and a `map` function, returns another event which maps each element
+     * through the mapping function.
+     */
+    export function map<I, O>(event: Event<I>, mapFunc: (i: I) => O): Event<O> {
+        return Object.assign((listener: (e: O) => any, thisArgs?: any, disposables?: Disposable[]) =>
+            event(i => listener.call(thisArgs, mapFunc(i)), undefined, disposables)
+            , {
+                maxListeners: 0
+            }
+        );
+    }
 }
 
 class CallbackList {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -76,6 +76,7 @@ export interface PluginPackageView {
 export interface PluginPackageMenu {
     command: string;
     group?: string;
+    when?: string;
 }
 
 export interface PluginPackageKeybinding {
@@ -394,6 +395,7 @@ export interface View {
 export interface Menu {
     command: string;
     group?: string;
+    when?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -200,7 +200,8 @@ export class TheiaPluginScanner implements PluginScanner {
     private readMenu(rawMenu: PluginPackageMenu): Menu {
         const result: Menu = {
             command: rawMenu.command,
-            group: rawMenu.group
+            group: rawMenu.group,
+            when: rawMenu.when
         };
         return result;
     }

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -38,8 +38,11 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
                 execute: (...args: any[]) => {
                     this.proxy.$executeCommand(command.id, ...args);
                 },
+                // Always enabled - a command can be executed programmatically or via the commands palette.
                 isEnabled() { return true; },
-                isVisible() { return true; }
+                // By default, a command isn't be visible in all menus but in the commands palette only.
+                // Visibility rules are defined via the `menus` contribution point.
+                isVisible() { return false; }
             }));
     }
     $unregisterCommand(id: string): void {

--- a/packages/plugin-ext/src/main/browser/context-key/context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/context-key/context-key-service.ts
@@ -1,0 +1,409 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// adjusted to Theia APIs
+
+import { injectable, unmanaged, inject } from 'inversify';
+import { PreferenceService } from '@theia/core/lib/browser';
+import { Event, Emitter, DisposableCollection, Disposable } from '@theia/core/lib/common';
+import { ContextKeyExpr, Context, ContextKey, ContextKeyChangeEvent, ContextKeyService, ContextKeyServiceTarget, ReadableSet } from './context-key';
+
+const KEYBINDING_CONTEXT_ATTR = 'data-keybinding-context';
+
+// tslint:disable:no-any
+export class DefaultContext implements Context {
+
+    protected value: { [key: string]: any; };
+
+    constructor(protected readonly id: number, protected readonly parent: DefaultContext | undefined) {
+        // tslint:disable-next-line:no-null-keyword
+        this.value = Object.create(null);
+        this.value['_contextId'] = id;
+    }
+
+    public setValue(key: string, value: any): boolean {
+        if (this.value[key] !== value) {
+            this.value[key] = value;
+            return true;
+        }
+        return false;
+    }
+
+    public removeValue(key: string): boolean {
+        if (key in this.value) {
+            delete this.value[key];
+            return true;
+        }
+        return false;
+    }
+
+    public getValue<T>(key: string): T | undefined {
+        const ret = this.value[key];
+        if (typeof ret === 'undefined' && this.parent) {
+            return this.parent.getValue<T>(key);
+        }
+        return ret;
+    }
+
+    collectAllValues(): { [key: string]: any; } {
+        // tslint:disable-next-line:no-null-keyword
+        let result = this.parent ? this.parent.collectAllValues() : Object.create(null);
+        result = { ...result, ...this.value };
+        delete result['_contextId'];
+        return result;
+    }
+}
+
+class NullContext extends DefaultContext {
+
+    static readonly INSTANCE = new NullContext();
+
+    constructor() {
+        super(-1, undefined);
+    }
+
+    public setValue(key: string, value: any): boolean {
+        return false;
+    }
+
+    public removeValue(key: string): boolean {
+        return false;
+    }
+
+    public getValue<T>(key: string): T | undefined {
+        return undefined;
+    }
+
+    collectAllValues(): { [key: string]: any; } {
+        // tslint:disable-next-line:no-null-keyword
+        return Object.create(null);
+    }
+}
+
+class ConfigAwareContextValuesContainer extends DefaultContext {
+
+    private static keyPrefix = 'config.';
+
+    private readonly values = new Map<string, any>();
+    private readonly listener: Disposable;
+
+    constructor(readonly id: number, private readonly configurationService: PreferenceService, readonly emitter: Emitter<string | string[]>) {
+        super(id, undefined);
+
+        this.listener = this.configurationService.onPreferenceChanged(event => {
+            const changedKeys: string[] = [];
+            const contextKey = `config.${event.preferenceName}`;
+            if (this.values.has(contextKey)) {
+                this.values.delete(contextKey);
+                changedKeys.push(contextKey);
+            }
+            emitter.fire(changedKeys);
+        });
+    }
+
+    dispose(): void {
+        this.listener.dispose();
+    }
+
+    getValue(key: string): any {
+        if (key.indexOf(ConfigAwareContextValuesContainer.keyPrefix) !== 0) {
+            return super.getValue(key);
+        }
+
+        if (this.values.has(key)) {
+            return this.values.get(key);
+        }
+
+        const configKey = key.substr(ConfigAwareContextValuesContainer.keyPrefix.length);
+        const configValue = this.configurationService.get(configKey);
+        let value: any = undefined;
+        switch (typeof configValue) {
+            case 'number':
+            case 'boolean':
+            case 'string':
+                value = configValue;
+                break;
+        }
+
+        this.values.set(key, value);
+        return value;
+    }
+
+    setValue(key: string, value: any): boolean {
+        return super.setValue(key, value);
+    }
+
+    removeValue(key: string): boolean {
+        return super.removeValue(key);
+    }
+
+    collectAllValues(): { [key: string]: any; } {
+        const result: {
+            [key: string]: any
+            // tslint:disable-next-line:no-null-keyword
+        } = Object.create(null);
+        this.values.forEach((value, index) => result[index] = value);
+        return { ...result, ...super.collectAllValues() };
+    }
+}
+
+class ContextKeyImpl<T> implements ContextKey<T> {
+
+    constructor(private readonly parent: AbstractContextKeyService, private readonly key: string, private readonly defaultValue: T | undefined) {
+        this.reset();
+    }
+
+    public set(value: T): void {
+        this.parent.setContext(this.key, value);
+    }
+
+    public reset(): void {
+        if (typeof this.defaultValue === 'undefined') {
+            this.parent.removeContext(this.key);
+        } else {
+            this.parent.setContext(this.key, this.defaultValue);
+        }
+    }
+
+    public get(): T | undefined {
+        return this.parent.getContextKeyValue<T>(this.key);
+    }
+}
+
+class SimpleContextKeyChangeEvent implements ContextKeyChangeEvent {
+    constructor(private readonly key: string) { }
+    affectsSome(keys: ReadableSet<string>): boolean {
+        return keys.has(this.key);
+    }
+}
+
+class ArrayContextKeyChangeEvent implements ContextKeyChangeEvent {
+    constructor(private readonly keys: string[]) { }
+    affectsSome(keys: ReadableSet<string>): boolean {
+        for (const key of this.keys) {
+            if (keys.has(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+@injectable()
+export abstract class AbstractContextKeyService implements ContextKeyService {
+
+    protected isDisposed: boolean;
+    protected onDidChangeContextEvent: Event<ContextKeyChangeEvent>;
+    protected onDidChangeContextKey: Emitter<string | string[]>;
+
+    constructor(@unmanaged() protected readonly myContextId: number) {
+        this.isDisposed = false;
+        this.onDidChangeContextKey = new Emitter<string>();
+    }
+
+    abstract dispose(): void;
+
+    public createKey<T>(key: string, defaultValue: T | undefined): ContextKey<T> {
+        if (this.isDisposed) {
+            throw new Error('AbstractContextKeyService has been disposed');
+        }
+        return new ContextKeyImpl(this, key, defaultValue);
+    }
+
+    public get onDidChangeContext(): Event<ContextKeyChangeEvent> {
+        if (!this.onDidChangeContextEvent) {
+            this.onDidChangeContextEvent = Event.map(this.onDidChangeContextKey.event, ((changedKeyOrKeys: string | string[]): ContextKeyChangeEvent =>
+                typeof changedKeyOrKeys === 'string'
+                    ? new SimpleContextKeyChangeEvent(changedKeyOrKeys)
+                    : new ArrayContextKeyChangeEvent(changedKeyOrKeys)
+            ));
+        }
+        return this.onDidChangeContextEvent;
+    }
+
+    public createScoped(domNode: ContextKeyServiceTarget): ContextKeyService {
+        if (this.isDisposed) {
+            throw new Error('AbstractContextKeyService has been disposed');
+        }
+        return new ScopedContextKeyService(this, this.onDidChangeContextKey, domNode);
+    }
+
+    public contextMatchesRules(rules: ContextKeyExpr | undefined): boolean {
+        if (this.isDisposed) {
+            throw new Error('AbstractContextKeyService has been disposed');
+        }
+        const context = this.getContextValuesContainer(this.myContextId);
+        if (!rules) {
+            return true;
+        }
+        return rules.evaluate(context);
+    }
+
+    public getContextKeyValue<T>(key: string): T | undefined {
+        if (this.isDisposed) {
+            return undefined;
+        }
+        return this.getContextValuesContainer(this.myContextId).getValue<T>(key);
+    }
+
+    public setContext(key: string, value: any): void {
+        if (this.isDisposed) {
+            return;
+        }
+        const myContext = this.getContextValuesContainer(this.myContextId);
+        if (!myContext) {
+            return;
+        }
+        if (myContext.setValue(key, value)) {
+            this.onDidChangeContextKey.fire(key);
+        }
+    }
+
+    public removeContext(key: string): void {
+        if (this.isDisposed) {
+            return;
+        }
+        if (this.getContextValuesContainer(this.myContextId).removeValue(key)) {
+            this.onDidChangeContextKey.fire(key);
+        }
+    }
+
+    public getContext(target: ContextKeyServiceTarget | null): Context {
+        if (this.isDisposed) {
+            return NullContext.INSTANCE;
+        }
+        return this.getContextValuesContainer(findContextAttr(target));
+    }
+
+    public abstract getContextValuesContainer(contextId: number): DefaultContext;
+    public abstract createChildContext(parentContextId?: number): number;
+    public abstract disposeContext(contextId: number): void;
+}
+
+@injectable()
+export class ContextKeyServiceImpl extends AbstractContextKeyService implements ContextKeyService {
+
+    private lastContextId: number;
+    private contexts: {
+        [contextId: string]: DefaultContext;
+    };
+
+    private toDispose: DisposableCollection;
+
+    constructor(@inject(PreferenceService) configurationService: PreferenceService) {
+        super(0);
+        this.toDispose = new DisposableCollection();
+        this.lastContextId = 0;
+        // tslint:disable-next-line:no-null-keyword
+        this.contexts = Object.create(null);
+
+        const myContext = new ConfigAwareContextValuesContainer(this.myContextId, configurationService, this.onDidChangeContextKey);
+        this.contexts[String(this.myContextId)] = myContext;
+        this.toDispose.push(myContext);
+    }
+
+    public dispose(): void {
+        this.isDisposed = true;
+        this.toDispose.dispose();
+    }
+
+    public getContextValuesContainer(contextId: number): DefaultContext {
+        if (this.isDisposed) {
+            return NullContext.INSTANCE;
+        }
+        return this.contexts[String(contextId)];
+    }
+
+    public createChildContext(parentContextId: number = this.myContextId): number {
+        if (this.isDisposed) {
+            throw new Error('ContextKeyService has been disposed');
+        }
+        const id = (++this.lastContextId);
+        this.contexts[String(id)] = new DefaultContext(id, this.getContextValuesContainer(parentContextId));
+        return id;
+    }
+
+    public disposeContext(contextId: number): void {
+        if (this.isDisposed) {
+            return;
+        }
+        delete this.contexts[String(contextId)];
+    }
+}
+
+class ScopedContextKeyService extends AbstractContextKeyService {
+
+    constructor(private readonly parent: AbstractContextKeyService, emitter: Emitter<string | string[]>, private domNode?: ContextKeyServiceTarget) {
+        super(parent.createChildContext());
+        this.onDidChangeContextKey = emitter;
+
+        if (domNode) {
+            this.domNode = domNode;
+            this.domNode.setAttribute(KEYBINDING_CONTEXT_ATTR, String(this.myContextId));
+        }
+    }
+
+    public dispose(): void {
+        this.isDisposed = true;
+        this.parent.disposeContext(this.myContextId);
+        if (this.domNode) {
+            this.domNode.removeAttribute(KEYBINDING_CONTEXT_ATTR);
+            this.domNode = undefined;
+        }
+    }
+
+    public get onDidChangeContext(): Event<ContextKeyChangeEvent> {
+        return this.parent.onDidChangeContext;
+    }
+
+    public getContextValuesContainer(contextId: number): DefaultContext {
+        if (this.isDisposed) {
+            return NullContext.INSTANCE;
+        }
+        return this.parent.getContextValuesContainer(contextId);
+    }
+
+    public createChildContext(parentContextId: number = this.myContextId): number {
+        if (this.isDisposed) {
+            throw new Error('ScopedContextKeyService has been disposed');
+        }
+        return this.parent.createChildContext(parentContextId);
+    }
+
+    public disposeContext(contextId: number): void {
+        if (this.isDisposed) {
+            return;
+        }
+        this.parent.disposeContext(contextId);
+    }
+}
+
+function findContextAttr(domNode: ContextKeyServiceTarget | null): number {
+    while (domNode) {
+        if (domNode.hasAttribute(KEYBINDING_CONTEXT_ATTR)) {
+            const attr = domNode.getAttribute(KEYBINDING_CONTEXT_ATTR);
+            if (attr) {
+                return parseInt(attr, 10);
+            }
+            return NaN;
+        }
+        domNode = domNode.parentElement;
+    }
+    return 0;
+}

--- a/packages/plugin-ext/src/main/browser/context-key/context-key.spec.ts
+++ b/packages/plugin-ext/src/main/browser/context-key/context-key.spec.ts
@@ -1,0 +1,113 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// adjusted to Theia APIs
+
+import 'mocha';
+import * as assert from 'assert';
+import { ContextKeyExpr } from './context-key';
+
+// tslint:disable:no-any
+function createContext(ctx: any) {
+    return {
+        getValue: (key: string) => ctx[key]
+    };
+}
+
+describe('ContextKeyExpr', () => {
+    it('ContextKeyExpr.equals', () => {
+        const a = ContextKeyExpr.and(
+            ContextKeyExpr.has('a1'),
+            ContextKeyExpr.and(ContextKeyExpr.has('and.a')),
+            ContextKeyExpr.has('a2'),
+            ContextKeyExpr.regex('d3', /d.*/),
+            ContextKeyExpr.regex('d4', /\*\*3*/),
+            ContextKeyExpr.equals('b1', 'bb1'),
+            ContextKeyExpr.equals('b2', 'bb2'),
+            ContextKeyExpr.notEquals('c1', 'cc1'),
+            ContextKeyExpr.notEquals('c2', 'cc2'),
+            ContextKeyExpr.not('d1'),
+            ContextKeyExpr.not('d2')
+        );
+        const b = ContextKeyExpr.and(
+            ContextKeyExpr.equals('b2', 'bb2'),
+            ContextKeyExpr.notEquals('c1', 'cc1'),
+            ContextKeyExpr.not('d1'),
+            ContextKeyExpr.regex('d4', /\*\*3*/),
+            ContextKeyExpr.notEquals('c2', 'cc2'),
+            ContextKeyExpr.has('a2'),
+            ContextKeyExpr.equals('b1', 'bb1'),
+            ContextKeyExpr.regex('d3', /d.*/),
+            ContextKeyExpr.has('a1'),
+            ContextKeyExpr.and(ContextKeyExpr.equals('and.a', true)),
+            ContextKeyExpr.not('d2')
+        );
+        assert(a.equals(b), 'expressions should be equal');
+    });
+
+    it('normalize', () => {
+        const key1IsTrue = ContextKeyExpr.equals('key1', true);
+        const key1IsNotFalse = ContextKeyExpr.notEquals('key1', false);
+        const key1IsFalse = ContextKeyExpr.equals('key1', false);
+        const key1IsNotTrue = ContextKeyExpr.notEquals('key1', true);
+
+        assert.ok(key1IsTrue.normalize()!.equals(ContextKeyExpr.has('key1')));
+        assert.ok(key1IsNotFalse.normalize()!.equals(ContextKeyExpr.has('key1')));
+        assert.ok(key1IsFalse.normalize()!.equals(ContextKeyExpr.not('key1')));
+        assert.ok(key1IsNotTrue.normalize()!.equals(ContextKeyExpr.not('key1')));
+    });
+
+    it('evaluate', () => {
+        /* tslint:disable:triple-equals */
+        const context = createContext({
+            'a': true,
+            'b': false,
+            'c': '5',
+            'd': 'd'
+        });
+        function testExpression(expr: string, expected: boolean): void {
+            const rules = ContextKeyExpr.deserialize(expr);
+            assert.equal(rules!.evaluate(context), expected, expr);
+        }
+        function testBatch(expr: string, value: any): void {
+            testExpression(expr, !!value);
+            testExpression(expr + ' == true', !!value);
+            testExpression(expr + ' != true', !value);
+            testExpression(expr + ' == false', !value);
+            testExpression(expr + ' != false', !!value);
+            testExpression(expr + ' == 5', value == <any>'5');
+            testExpression(expr + ' != 5', value != <any>'5');
+            testExpression('!' + expr, !value);
+            testExpression(expr + ' =~ /d.*/', /d.*/.test(value));
+            testExpression(expr + ' =~ /D/i', /D/i.test(value));
+        }
+
+        testBatch('a', true);
+        testBatch('b', false);
+        testBatch('c', '5');
+        testBatch('d', 'd');
+        testBatch('z', undefined);
+
+        testExpression('a && !b', true && !false);
+        testExpression('a && b', true && false);
+        testExpression('a && !b && c == 5', true && !false && '5' == '5');
+        testExpression('d =~ /e.*/', false);
+        /* tslint:enable:triple-equals */
+    });
+});

--- a/packages/plugin-ext/src/main/browser/context-key/context-key.ts
+++ b/packages/plugin-ext/src/main/browser/context-key/context-key.ts
@@ -1,0 +1,588 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+// adjusted to Theia APIs
+
+import { Event } from '@theia/core/lib/common';
+
+export const enum ContextKeyExprType {
+    Defined = 1,
+    Not = 2,
+    Equals = 3,
+    NotEquals = 4,
+    And = 5,
+    Regex = 6
+}
+
+// tslint:disable:no-any
+export abstract class ContextKeyExpr {
+
+    public static has(key: string): ContextKeyExpr {
+        return new ContextKeyDefinedExpr(key);
+    }
+
+    public static equals(key: string, value: any): ContextKeyExpr {
+        return new ContextKeyEqualsExpr(key, value);
+    }
+
+    public static notEquals(key: string, value: any): ContextKeyExpr {
+        return new ContextKeyNotEqualsExpr(key, value);
+    }
+
+    public static regex(key: string, value: RegExp): ContextKeyExpr {
+        return new ContextKeyRegexExpr(key, value);
+    }
+
+    public static not(key: string): ContextKeyExpr {
+        return new ContextKeyNotExpr(key);
+    }
+
+    public static and(...expr: (ContextKeyExpr | undefined)[]): ContextKeyExpr {
+        return new ContextKeyAndExpr(expr);
+    }
+
+    public static deserialize(serialized: string | undefined): ContextKeyExpr | undefined {
+        if (!serialized) {
+            return undefined;
+        }
+
+        const pieces = serialized.split('&&');
+        const result = new ContextKeyAndExpr(pieces.map(p => this.deserializeOne(p)));
+        return result.normalize();
+    }
+
+    private static deserializeOne(serializedOne: string): ContextKeyExpr {
+        serializedOne = serializedOne.trim();
+
+        if (serializedOne.indexOf('!=') >= 0) {
+            const pieces = serializedOne.split('!=');
+            return new ContextKeyNotEqualsExpr(pieces[0].trim(), this.deserializeValue(pieces[1]));
+        }
+
+        if (serializedOne.indexOf('==') >= 0) {
+            const pieces = serializedOne.split('==');
+            return new ContextKeyEqualsExpr(pieces[0].trim(), this.deserializeValue(pieces[1]));
+        }
+
+        if (serializedOne.indexOf('=~') >= 0) {
+            const pieces = serializedOne.split('=~');
+            return new ContextKeyRegexExpr(pieces[0].trim(), this.deserializeRegexValue(pieces[1]));
+        }
+
+        if (/^\!\s*/.test(serializedOne)) {
+            return new ContextKeyNotExpr(serializedOne.substr(1).trim());
+        }
+
+        return new ContextKeyDefinedExpr(serializedOne);
+    }
+
+    private static deserializeValue(serializedValue: string): any {
+        serializedValue = serializedValue.trim();
+
+        if (serializedValue === 'true') {
+            return true;
+        }
+
+        if (serializedValue === 'false') {
+            return false;
+        }
+
+        const m = /^'([^']*)'$/.exec(serializedValue);
+        if (m) {
+            return m[1].trim();
+        }
+
+        return serializedValue;
+    }
+
+    private static deserializeRegexValue(serializedValue: string): RegExp | undefined {
+        if (serializedValue.trim().length === 0) {
+            console.warn('missing regexp-value for =~-expression');
+            return undefined;
+        }
+
+        const start = serializedValue.indexOf('/');
+        const end = serializedValue.lastIndexOf('/');
+        if (start === end || start < 0 /* || to < 0 */) {
+            console.warn(`bad regexp-value '${serializedValue}', missing /-enclosure`);
+            return undefined;
+        }
+
+        const value = serializedValue.slice(start + 1, end);
+        const caseIgnoreFlag = serializedValue[end + 1] === 'i' ? 'i' : '';
+        try {
+            return new RegExp(value, caseIgnoreFlag);
+        } catch (e) {
+            console.warn(`bad regexp-value '${serializedValue}', parse error: ${e}`);
+            return undefined;
+        }
+    }
+
+    public abstract getType(): ContextKeyExprType;
+    public abstract equals(other: ContextKeyExpr): boolean;
+    public abstract evaluate(context: Context): boolean;
+    public abstract normalize(): ContextKeyExpr | undefined;
+    public abstract serialize(): string;
+    public abstract keys(): string[];
+}
+
+function cmp(a: ContextKeyExpr, b: ContextKeyExpr): number {
+    const aType = a.getType();
+    const bType = b.getType();
+    if (aType !== bType) {
+        return aType - bType;
+    }
+    switch (aType) {
+        case ContextKeyExprType.Defined:
+            return (<ContextKeyDefinedExpr>a).cmp(<ContextKeyDefinedExpr>b);
+        case ContextKeyExprType.Not:
+            return (<ContextKeyNotExpr>a).cmp(<ContextKeyNotExpr>b);
+        case ContextKeyExprType.Equals:
+            return (<ContextKeyEqualsExpr>a).cmp(<ContextKeyEqualsExpr>b);
+        case ContextKeyExprType.NotEquals:
+            return (<ContextKeyNotEqualsExpr>a).cmp(<ContextKeyNotEqualsExpr>b);
+        case ContextKeyExprType.Regex:
+            return (<ContextKeyRegexExpr>a).cmp(<ContextKeyRegexExpr>b);
+        default:
+            throw new Error('Unknown ContextKeyExpr!');
+    }
+}
+
+export class ContextKeyDefinedExpr implements ContextKeyExpr {
+    constructor(protected key: string) { }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.Defined;
+    }
+
+    public cmp(other: ContextKeyDefinedExpr): number {
+        if (this.key < other.key) {
+            return -1;
+        }
+        if (this.key > other.key) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyDefinedExpr) {
+            return (this.key === other.key);
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        return (!!context.getValue(this.key));
+    }
+
+    public normalize(): ContextKeyExpr {
+        return this;
+    }
+
+    public serialize(): string {
+        return this.key;
+    }
+
+    public keys(): string[] {
+        return [this.key];
+    }
+}
+
+export class ContextKeyEqualsExpr implements ContextKeyExpr {
+    constructor(private key: string, private value: any) { }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.Equals;
+    }
+
+    public cmp(other: ContextKeyEqualsExpr): number {
+        if (this.key < other.key) {
+            return -1;
+        }
+        if (this.key > other.key) {
+            return 1;
+        }
+        if (this.value < other.value) {
+            return -1;
+        }
+        if (this.value > other.value) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyEqualsExpr) {
+            return (this.key === other.key && this.value === other.value);
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        /* tslint:disable:triple-equals */
+        return (context.getValue(this.key) == this.value);
+        /* tslint:enable:triple-equals */
+    }
+
+    public normalize(): ContextKeyExpr {
+        if (typeof this.value === 'boolean') {
+            if (this.value) {
+                return new ContextKeyDefinedExpr(this.key);
+            }
+            return new ContextKeyNotExpr(this.key);
+        }
+        return this;
+    }
+
+    public serialize(): string {
+        if (typeof this.value === 'boolean') {
+            return this.normalize().serialize();
+        }
+
+        return this.key + ' == \'' + this.value + '\'';
+    }
+
+    public keys(): string[] {
+        return [this.key];
+    }
+}
+
+export class ContextKeyNotEqualsExpr implements ContextKeyExpr {
+    constructor(private key: string, private value: any) { }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.NotEquals;
+    }
+
+    public cmp(other: ContextKeyNotEqualsExpr): number {
+        if (this.key < other.key) {
+            return -1;
+        }
+        if (this.key > other.key) {
+            return 1;
+        }
+        if (this.value < other.value) {
+            return -1;
+        }
+        if (this.value > other.value) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyNotEqualsExpr) {
+            return (this.key === other.key && this.value === other.value);
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        /* tslint:disable:triple-equals */
+        return (context.getValue(this.key) != this.value);
+        /* tslint:enable:triple-equals */
+    }
+
+    public normalize(): ContextKeyExpr {
+        if (typeof this.value === 'boolean') {
+            if (this.value) {
+                return new ContextKeyNotExpr(this.key);
+            }
+            return new ContextKeyDefinedExpr(this.key);
+        }
+        return this;
+    }
+
+    public serialize(): string {
+        if (typeof this.value === 'boolean') {
+            return this.normalize().serialize();
+        }
+
+        return this.key + ' != \'' + this.value + '\'';
+    }
+
+    public keys(): string[] {
+        return [this.key];
+    }
+}
+
+export class ContextKeyNotExpr implements ContextKeyExpr {
+    constructor(private key: string) { }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.Not;
+    }
+
+    public cmp(other: ContextKeyNotExpr): number {
+        if (this.key < other.key) {
+            return -1;
+        }
+        if (this.key > other.key) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyNotExpr) {
+            return (this.key === other.key);
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        return (!context.getValue(this.key));
+    }
+
+    public normalize(): ContextKeyExpr {
+        return this;
+    }
+
+    public serialize(): string {
+        return '!' + this.key;
+    }
+
+    public keys(): string[] {
+        return [this.key];
+    }
+}
+
+export class ContextKeyRegexExpr implements ContextKeyExpr {
+    constructor(private key: string, private regexp: RegExp | undefined) { }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.Regex;
+    }
+
+    public cmp(other: ContextKeyRegexExpr): number {
+        if (this.key < other.key) {
+            return -1;
+        }
+        if (this.key > other.key) {
+            return 1;
+        }
+        const thisSource = this.regexp ? this.regexp.source : '';
+        const otherSource = other.regexp ? other.regexp.source : '';
+        if (thisSource < otherSource) {
+            return -1;
+        }
+        if (thisSource > otherSource) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyRegexExpr) {
+            const thisSource = this.regexp ? this.regexp.source : '';
+            const otherSource = other.regexp ? other.regexp.source : '';
+            return (this.key === other.key && thisSource === otherSource);
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        const value = context.getValue<any>(this.key);
+        return this.regexp ? this.regexp.test(value) : false;
+    }
+
+    public normalize(): ContextKeyExpr {
+        return this;
+    }
+
+    public serialize(): string {
+        const value = this.regexp
+            ? `/${this.regexp.source}/${this.regexp.ignoreCase ? 'i' : ''}`
+            : '/invalid/';
+        return `${this.key} =~ ${value}`;
+    }
+
+    public keys(): string[] {
+        return [this.key];
+    }
+}
+
+export class ContextKeyAndExpr implements ContextKeyExpr {
+    public readonly expr: ContextKeyExpr[];
+
+    constructor(expr: (ContextKeyExpr | undefined)[]) {
+        this.expr = ContextKeyAndExpr.normalizeArr(expr);
+    }
+
+    public getType(): ContextKeyExprType {
+        return ContextKeyExprType.And;
+    }
+
+    public equals(other: ContextKeyExpr): boolean {
+        if (other instanceof ContextKeyAndExpr) {
+            if (this.expr.length !== other.expr.length) {
+                return false;
+            }
+            const length = this.expr.length;
+            for (let i = 0; i < length; i++) {
+                if (!this.expr[i].equals(other.expr[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    public evaluate(context: Context): boolean {
+        const length = this.expr.length;
+        for (let i = 0; i < length; i++) {
+            if (!this.expr[i].evaluate(context)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static normalizeArr(arr: (ContextKeyExpr | undefined)[]): ContextKeyExpr[] {
+        let expr: ContextKeyExpr[] = [];
+
+        if (arr) {
+            const length = arr.length;
+            for (let i = 0; i < length; i++) {
+                let e: ContextKeyExpr | undefined = arr[i];
+                if (!e) {
+                    continue;
+                }
+
+                e = e.normalize();
+                if (!e) {
+                    continue;
+                }
+
+                if (e instanceof ContextKeyAndExpr) {
+                    expr = expr.concat(e.expr);
+                    continue;
+                }
+
+                expr.push(e);
+            }
+
+            expr.sort(cmp);
+        }
+
+        return expr;
+    }
+
+    public normalize(): ContextKeyExpr | undefined {
+        if (this.expr.length === 0) {
+            return undefined;
+        }
+
+        if (this.expr.length === 1) {
+            return this.expr[0];
+        }
+
+        return this;
+    }
+
+    public serialize(): string {
+        if (this.expr.length === 0) {
+            return '';
+        }
+        if (this.expr.length === 1) {
+            const normalized = this.normalize();
+            if (!normalized) {
+                return '';
+            }
+            return normalized.serialize();
+        }
+        return this.expr.map(e => e.serialize()).join(' && ');
+    }
+
+    public keys(): string[] {
+        const result: string[] = [];
+        for (const expr of this.expr) {
+            result.push(...expr.keys());
+        }
+        return result;
+    }
+}
+
+export class RawContextKey<T> extends ContextKeyDefinedExpr {
+
+    constructor(key: string, private defaultValue: T | undefined) {
+        super(key);
+    }
+
+    public bindTo(target: ContextKeyService): ContextKey<T> {
+        return target.createKey(this.key, this.defaultValue);
+    }
+
+    public getValue(target: ContextKeyService): T | undefined {
+        return target.getContextKeyValue<T>(this.key);
+    }
+
+    public toNegated(): ContextKeyExpr {
+        return ContextKeyExpr.not(this.key);
+    }
+
+    public isEqualTo(value: string): ContextKeyExpr {
+        return ContextKeyExpr.equals(this.key, value);
+    }
+
+    public notEqualsTo(value: string): ContextKeyExpr {
+        return ContextKeyExpr.notEquals(this.key, value);
+    }
+}
+
+export interface Context {
+    getValue<T>(key: string): T | undefined;
+}
+
+export interface ContextKey<T> {
+    set(value: T): void;
+    reset(): void;
+    get(): T | undefined;
+}
+
+export interface ContextKeyServiceTarget {
+    parentElement: ContextKeyServiceTarget | null;
+    setAttribute(attr: string, value: string): void;
+    removeAttribute(attr: string): void;
+    hasAttribute(attr: string): boolean;
+    getAttribute(attr: string): string | null;
+}
+
+export interface ReadableSet<T> {
+    has(value: T): boolean;
+}
+
+export interface ContextKeyChangeEvent {
+    affectsSome(keys: ReadableSet<string>): boolean;
+}
+
+export const ContextKeyService = Symbol('ContextKeyService');
+export interface ContextKeyService {
+    dispose(): void;
+
+    onDidChangeContext: Event<ContextKeyChangeEvent>;
+    createKey<T>(key: string, defaultValue: T | undefined): ContextKey<T>;
+    contextMatchesRules(rules: ContextKeyExpr | undefined): boolean;
+    getContextKeyValue<T>(key: string): T | undefined;
+
+    createScoped(target?: ContextKeyServiceTarget): ContextKeyService;
+    getContext(target: ContextKeyServiceTarget | null): Context;
+}

--- a/packages/plugin-ext/src/main/browser/context-key/mock-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/context-key/mock-context-key-service.ts
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Event } from '@theia/core/lib/common';
+import { ContextKeyService, ContextKey, ContextKeyChangeEvent, ContextKeyExpr, ContextKeyServiceTarget, Context } from './context-key';
+
+@injectable()
+export class MockContextKeyService implements ContextKeyService {
+
+    dispose(): void { }
+
+    onDidChangeContext: Event<ContextKeyChangeEvent>;
+
+    createKey<T>(key: string, defaultValue: T | undefined): ContextKey<T> {
+        return {
+            get: () => undefined,
+            set(v: T) { },
+            reset() { }
+        };
+    }
+
+    contextMatchesRules(rules: ContextKeyExpr | undefined): boolean {
+        return true;
+    }
+
+    getContextKeyValue<T>(key: string): T | undefined {
+        return undefined;
+    }
+
+    createScoped(target?: ContextKeyServiceTarget): ContextKeyService {
+        return this;
+    }
+
+    getContext(target: ContextKeyServiceTarget | null): Context {
+        return {
+            getValue: () => undefined
+        };
+    }
+}

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -15,12 +15,14 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { MenuPath, ILogger } from '@theia/core';
-import { MenuModelRegistry } from '@theia/core/lib/common';
+import { MenuPath, ILogger, CommandRegistry } from '@theia/core';
 import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { MenuModelRegistry } from '@theia/core/lib/common';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
-import { PluginContribution } from '../../../common';
 import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-views-main';
+import { PluginContribution, Menu } from '../../../common';
+import { ContextKeyService, ContextKeyExpr } from '../context-key/context-key';
+import { CommandHandler } from '@theia/core';
 
 @injectable()
 export class MenusContributionPointHandler {
@@ -28,44 +30,95 @@ export class MenusContributionPointHandler {
     @inject(MenuModelRegistry)
     protected readonly menuRegistry: MenuModelRegistry;
 
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
     @inject(ILogger)
     protected readonly logger: ILogger;
 
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    // menu location to command IDs
+    protected readonly registeredMenus: Map<string, Set<string>> = new Map();
+
+    /**
+     * Handles the `menus` contribution point.
+     * In VSCode, a menu can have more than one item for the same command. Each item may have it's own visibility rules.
+     * In Theia, a menu can't have more than one item for the same command.
+     * So, several handlers for the same command are registered to support different visibility rules for a menu item in different contexts.
+     */
     handle(contributions: PluginContribution): void {
-        if (!contributions.menus) {
+        const allMenus = contributions.menus;
+        if (!allMenus) {
             return;
         }
-
-        for (const location in contributions.menus) {
-            if (contributions.menus.hasOwnProperty(location)) {
-                const menuPath = this.parseMenuPath(location);
+        for (const location in allMenus) {
+            if (allMenus.hasOwnProperty(location)) {
+                const menuPath = MenusContributionPointHandler.parseMenuPath(location);
                 if (!menuPath) {
                     this.logger.warn(`Plugin contributes items to a menu with invalid identifier: ${location}`);
                     continue;
                 }
-                const menus = contributions.menus[location];
+                const menus = allMenus[location];
                 menus.forEach(menu => {
-                    const [group = '', order = undefined] = (menu.group || '').split('@');
-                    // Registering a menu action requires the related command to be already registered.
-                    // But Theia plugin registers the commands dynamically via the Commands API.
-                    // Let's wait for ~2 sec. It should be enough to finish registering all the contributed commands.
-                    // FIXME: remove this workaround (timer) once the https://github.com/theia-ide/theia/issues/3344 is fixed
-                    setTimeout(() => {
-                        this.menuRegistry.registerMenuAction([...menuPath, group], {
-                            commandId: menu.command,
-                            order
-                        });
-                    }, 2000);
+                    if (!this.isMenuItemRegistered(location, menu.command)) {
+                        this.registerMenuAction(menuPath, location, menu);
+                    }
                 });
+                menus.filter(menu => menu.when).forEach(menu => this.registerCommandHandler(menu));
             }
         }
     }
 
-    protected parseMenuPath(value: string): MenuPath | undefined {
+    protected static parseMenuPath(value: string): MenuPath | undefined {
         switch (value) {
             case 'editor/context': return EDITOR_CONTEXT_MENU;
             case 'explorer/context': return NAVIGATOR_CONTEXT_MENU;
             case 'view/item/context': return VIEW_ITEM_CONTEXT_MENU;
         }
+    }
+
+    protected isMenuItemRegistered(location: string, commandId: string): boolean {
+        const commands = this.registeredMenus.get(location);
+        return commands !== undefined && commands.has(commandId);
+    }
+
+    protected registerMenuAction(menuPath: MenuPath, location: string, menu: Menu): void {
+        const [group = '', order = undefined] = (menu.group || '').split('@');
+        // Registering a menu action requires the related command to be already registered.
+        // But Theia plugin registers the commands dynamically via the Commands API.
+        // Let's wait for ~2 sec. It should be enough to finish registering all the contributed commands.
+        // FIXME: remove this workaround (timer) once the https://github.com/theia-ide/theia/issues/3344 is fixed
+        setTimeout(() => {
+            this.menuRegistry.registerMenuAction([...menuPath, group], {
+                commandId: menu.command,
+                order
+            });
+        }, 2000);
+
+        let commands = this.registeredMenus.get(location);
+        if (!commands) {
+            commands = new Set();
+        }
+        commands.add(menu.command);
+        this.registeredMenus.set(location, commands);
+    }
+
+    /** Register a handler for the command that should be called by the specified menu item. */
+    protected registerCommandHandler(menu: Menu): void {
+        this.commands.registerHandler(menu.command, this.newHandler(menu));
+    }
+
+    /**
+     * Creates a command handler that executes nothing but allows
+     * a related menu item be visible depending on the provided rules.
+     */
+    protected newHandler(menu: Menu): CommandHandler {
+        return {
+            execute: () => undefined,
+            isEnabled: () => false,
+            isVisible: () => this.contextKeyService.contextMatchesRules(ContextKeyExpr.deserialize(menu.when))
+        };
     }
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -40,6 +40,8 @@ import { PluginExtDeployCommandService } from './plugin-ext-deploy-command';
 import { TextEditorService, TextEditorServiceImpl } from './text-editor-service';
 import { EditorModelService, EditorModelServiceImpl } from './text-editor-model-service';
 import { UntitledResourceResolver } from './editor/untitled-resource';
+import { ContextKeyService } from './context-key/context-key';
+import { ContextKeyServiceImpl } from './context-key/context-key-service';
 import { MenusContributionPointHandler } from './menus/menus-contribution-handler';
 import { PluginContributionHandler } from './plugin-contribution-handler';
 import { ViewRegistry } from './view/view-registry';
@@ -122,4 +124,5 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(LanguageClientContributionProvider).toService(LanguageClientContributionProviderImpl);
     bind(LanguageClientProviderImpl).toSelf().inSingletonScope();
     rebind(LanguageClientProvider).toService(LanguageClientProviderImpl);
+    bind(ContextKeyService).to(ContextKeyServiceImpl).inSingletonScope();
 });


### PR DESCRIPTION
closes #3658

The PR:
- adds a common service for working with [`when` expressions](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts);
- allows to define an applicable context (visibility) for the [menu items](https://github.com/Azure/vscode-kubernetes-tools/blob/master/package.json#L270) contributed via the `menus` contribution point using `when` expressions;
- adds support for evaluating the contexts:
  - `view` and `viewItem` - global UI contexts
  - `config.*` - preferences contexts evaluated to a boolean value

##### Demo
The VSCode Kubernetes extension contributes the [menu actions](https://github.com/Azure/vscode-kubernetes-tools/blob/master/package.json#L270) that should be visible in the context menus of the custom (contributed) views (`Clusters`, `Helm repos`). Items visibility depends on the current view and selected tree item.

![k8s](https://user-images.githubusercontent.com/1636395/50306994-bb49d500-049f-11e9-9fe2-659ddf83bc7a.gif)
