### PR TITLE
Log error if debug api is used in Web Worker

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/worker/debug-stub.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/debug-stub.ts
@@ -15,21 +15,13 @@
  ********************************************************************************/
 
 import { DebugExtImpl } from '../../../plugin/node/debug/debug';
+import { RPCProtocol } from '../../../api/rpc-protocol';
 
-export function createDebugExtStub(): DebugExtImpl {
-    const err = new Error('Debug API works only in plugin container');
-
-    return new Proxy({}, {
-        get: function (obj, prop) {
-            throw err;
-        },
-
-        set(obj, prop, value) {
-            throw err;
-        },
-
+// tslint:disable:no-any
+export function createDebugExtStub(rpc: RPCProtocol): DebugExtImpl {
+    return new Proxy(new DebugExtImpl(rpc), {
         apply: function (target, that, args) {
-            throw err;
+            console.error('Debug API works only in plugin container');
         }
-    }) as DebugExtImpl;
+    });
 }

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -48,7 +48,7 @@ function initialize(contextPath: string, pluginMetadata: PluginMetadata): void {
 }
 const envExt = new EnvExtImpl(rpc);
 const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc);
-const debugExt = createDebugExtStub();
+const debugExt = createDebugExtStub(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do
It logs error instead of throwing error in case when plugin API is used in Web  Worker.