### PR TITLE
add missing extension readme(s)

### DIFF
--- a/packages/getting-started/README.md
+++ b/packages/getting-started/README.md
@@ -1,0 +1,7 @@
+# Theia - Getting Started Extension
+
+The extension provides a `getting started` page to users when opening Theia without a workspace. It provides useful commands for opening new or recent workspaces, commands to update user settings, and other helpful links.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/plugin-ext-vscode/README.md
+++ b/packages/plugin-ext-vscode/README.md
@@ -1,0 +1,7 @@
+# Theia - Plugin Extension for VsCode
+
+See [here](https://www.theia-ide.org/doc/index.html) for a detailed documentation.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -1,0 +1,7 @@
+# Theia - Plugin Extension
+
+See [API.md](API.md) for a detailed documentation.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)

--- a/packages/search-in-workspace/README.md
+++ b/packages/search-in-workspace/README.md
@@ -1,0 +1,9 @@
+# Theia - Search In Workspace Extension
+
+Provides functionality used to search for files in a given workspace using different search techniques.
+
+See [here](https://www.theia-ide.org/doc/index.html) for a detailed documentation.
+
+## License
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)


### PR DESCRIPTION
Added missing `readme` to extensions. Next step would be to update the `readme` to include more valuable information that would be useful for developers to understand what exactly the extensions perform and are used for.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
