### PR TITLE
[search-in-workspace] adjust result info when a single result is found

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -469,7 +469,13 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         } else if (this.resultNumber === 0) {
             message = 'No results found.';
         } else {
-            message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
+            if (this.resultNumber === 1 && this.resultTreeWidget.fileNumber === 1) {
+                message = `${this.resultNumber} result in ${this.resultTreeWidget.fileNumber} file`;
+            } else if (this.resultTreeWidget.fileNumber === 1) {
+                message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} file`;
+            } else {
+                message = `${this.resultNumber} results in ${this.resultTreeWidget.fileNumber} files`;
+            }
         }
         return this.searchTerm !== '' ? <div className='search-info'>{message}</div> : '';
     }


### PR DESCRIPTION
Adjusts the `search-info` for the search-in-workspace widget to handle the following cases:
- **1** result in **1** file
- **n** results in **1** file
- **n** results in **n** files

Currently in master, we always display `n results in n files` which is odd when either matches, files or both contain a single result. 

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
