### PR TITLE
Update problem-marker on small widths

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -131,8 +131,8 @@ export class ProblemWidget extends TreeWidget {
     protected decorateMarkerFileNode(node: MarkerInfoNode): React.ReactNode {
         return <div className='markerFileNode'>
             <div className={(node.icon || '') + ' file-icon'}></div>
-            <div>{node.name}</div>
-            <div className='path'>{node.description || ''}</div>
+            <div title={node.name} className='name'>{node.name}</div>
+            <div title={node.description || ''} className='path'>{node.description || ''}</div>
             <div className='notification-count-container'>
                 <span className='notification-count'>{node.numberOfMarkers.toString()}</span>
             </div>

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -33,13 +33,21 @@
     align-items: center;
 }
 
-.theia-marker-container .markerNode {
+.theia-marker-container .markerNode,
+.theia-marker-container .markerFileNode {
     width: calc(100% - 32px);
 }
 
 .theia-marker-container .markerNode div,
 .theia-marker-container .markerFileNode div {
     margin-right: 5px;
+}
+
+.theia-marker-container .markerFileNode .name,
+.theia-marker-container .markerFileNode .path {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .theia-marker-container .markerFileNode .path {


### PR DESCRIPTION
Fixes #3077

- Added `ellipsis` to file-maker-nodes for name, and path.
- Added `title` for both name, path so users can easily hover over items and see the full content.

|Before|After|
|:---:|:---:|
|<img width="296" alt="screen shot 2018-12-27 at 4 20 11 pm" src="https://user-images.githubusercontent.com/40359487/50495542-c1880600-09f7-11e9-8c88-41b7e6c4437b.png">|<img width="385" alt="screen shot 2018-12-27 at 4 46 13 pm" src="https://user-images.githubusercontent.com/40359487/50495527-aae1af00-09f7-11e9-8a46-b4a85801e17f.png">|




Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
