### PR TITLE
Implement plugin global state and workspace state

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -54,6 +54,7 @@ import {
     Breakpoint
 } from './model';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
+import { KeysToAnyValues, KeysToKeysToAnyValue } from '../common/types';
 import { CancellationToken, Progress, ProgressOptions } from '@theia/plugin';
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
 import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
@@ -64,6 +65,8 @@ import { SymbolInformation } from 'vscode-languageserver-types';
 export interface PluginInitData {
     plugins: PluginMetadata[];
     preferences: { [key: string]: any };
+    globalState: KeysToKeysToAnyValue;
+    workspaceState: KeysToKeysToAnyValue;
     env: EnvInit;
     extApi?: ExtPluginApi[];
 }
@@ -142,7 +145,7 @@ export interface PluginManagerExt {
 
     $init(pluginInit: PluginInitData, configStorage: ConfigStorage): PromiseLike<void>;
 
-    $updateStoragePath(path: string): PromiseLike<void>;
+    $updateStoragePath(path: string | undefined): PromiseLike<void>;
 }
 
 export interface CommandRegistryMain {
@@ -914,6 +917,16 @@ export interface WebviewsMain {
     $unregisterSerializer(viewType: string): void;
 }
 
+export interface StorageMain {
+    $set(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean>;
+    $get(key: string, isGlobal: boolean): Promise<KeysToAnyValues>;
+    $getAll(isGlobal: boolean): Promise<KeysToKeysToAnyValue>;
+}
+
+export interface StorageExt {
+    $updatePluginsWorkspaceData(data: KeysToKeysToAnyValue): void;
+}
+
 export interface DebugExt {
     $onSessionCustomEvent(sessionId: string, event: string, body?: any): void;
     $breakpointsDidChange(all: Breakpoint[], added: Breakpoint[], removed: Breakpoint[], changed: Breakpoint[]): void;
@@ -958,6 +971,7 @@ export const PLUGIN_RPC_CONTEXT = {
     LANGUAGES_MAIN: createProxyIdentifier<LanguagesMain>('LanguagesMain'),
     CONNECTION_MAIN: createProxyIdentifier<ConnectionMain>('ConnectionMain'),
     WEBVIEWS_MAIN: createProxyIdentifier<WebviewsMain>('WebviewsMain'),
+    STORAGE_MAIN: createProxyIdentifier<StorageMain>('StorageMain'),
     TASKS_MAIN: createProxyIdentifier<TasksMain>('TasksMain'),
     LANGUAGES_CONTRIBUTION_MAIN: createProxyIdentifier<LanguagesContributionMain>('LanguagesContributionMain'),
     DEBUG_MAIN: createProxyIdentifier<DebugMain>('DebugMain')
@@ -979,6 +993,7 @@ export const MAIN_RPC_CONTEXT = {
     LANGUAGES_EXT: createProxyIdentifier<LanguagesExt>('LanguagesExt'),
     CONNECTION_EXT: createProxyIdentifier<ConnectionExt>('ConnectionExt'),
     WEBVIEWS_EXT: createProxyIdentifier<WebviewsExt>('WebviewsExt'),
+    STORAGE_EXT: createProxyIdentifier<StorageExt>('StorageExt'),
     TASKS_EXT: createProxyIdentifier<TasksExt>('TasksExt'),
     LANGUAGES_CONTRIBUTION_EXT: createProxyIdentifier<LanguagesContributionExt>('LanguagesContributionExt'),
     DEBUG_EXT: createProxyIdentifier<DebugExt>('DebugExt')

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -16,7 +16,7 @@
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
-import { LogPart } from './types';
+import { LogPart, KeysToAnyValues, KeysToKeysToAnyValue } from './types';
 import { CharacterPair, CommentRule, PluginAPIFactory, Plugin } from '../api/plugin-api';
 import { PreferenceSchema } from '@theia/core/lib/browser/preferences';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
@@ -565,7 +565,11 @@ export interface PluginServer {
     /**
      * Deploy a plugin
      */
-    deploy(pluginEntry: string): Promise<void>
+    deploy(pluginEntry: string): Promise<void>;
+
+    keyValueStorageSet(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean>;
+    keyValueStorageGet(key: string, isGlobal: boolean): Promise<KeysToAnyValues>;
+    keyValueStorageGetAll(isGlobal: boolean): Promise<KeysToKeysToAnyValue>;
 }
 
 export const ServerPluginRunner = Symbol('ServerPluginRunner');

--- a/packages/plugin-ext/src/common/types.ts
+++ b/packages/plugin-ext/src/common/types.ts
@@ -59,3 +59,7 @@ export interface LogPart {
     data: string;
     type: LogType;
 }
+
+// tslint:disable-next-line:no-any
+export interface KeysToAnyValues { [key: string]: any }
+export interface KeysToKeysToAnyValue { [key: string]: KeysToAnyValues }

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -117,7 +117,7 @@ const pluginManager = new PluginManagerExtImpl({
             }
         }
     }
-}, envExt, preferenceRegistryExt);
+}, envExt, preferenceRegistryExt, rpc);
 
 const apiFactory = createAPIFactory(
     rpc,

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -124,7 +124,7 @@ export class PluginHostRPC {
                     }
                 }
             }
-        }, envExt, preferencesManager);
+        }, envExt, preferencesManager, rpc);
         return pluginManager;
     }
 }

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -34,6 +34,7 @@ import { NotificationMainImpl } from './notification-main';
 import { ConnectionMainImpl } from './connection-main';
 import { WebviewsMainImpl } from './webviews-main';
 import { TasksMainImpl } from './tasks-main';
+import { StorageMainImpl } from './plugin-storage';
 import { LanguagesContributionMainImpl } from './languages-contribution-main';
 import { DebugMainImpl } from './debug/debug-main';
 
@@ -84,6 +85,9 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const webviewsMain = new WebviewsMainImpl(rpc, container);
     rpc.set(PLUGIN_RPC_CONTEXT.WEBVIEWS_MAIN, webviewsMain);
+
+    const storageMain = new StorageMainImpl(container);
+    rpc.set(PLUGIN_RPC_CONTEXT.STORAGE_MAIN, storageMain);
 
     const pluginConnection = new ConnectionMainImpl(rpc);
     rpc.set(PLUGIN_RPC_CONTEXT.CONNECTION_MAIN, pluginConnection);

--- a/packages/plugin-ext/src/main/browser/plugin-storage.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-storage.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces } from 'inversify';
+import { StorageMain } from '../../api/plugin-api';
+import { PluginServer } from '../../common/plugin-protocol';
+import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
+
+export class StorageMainImpl implements StorageMain {
+
+    private pluginServer: PluginServer;
+
+    constructor(container: interfaces.Container) {
+        this.pluginServer = container.get(PluginServer);
+    }
+
+    $set(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean> {
+        return this.pluginServer.keyValueStorageSet(key, value, isGlobal);
+    }
+
+    $get(key: string, isGlobal: boolean): Promise<KeysToAnyValues> {
+        return this.pluginServer.keyValueStorageGet(key, isGlobal);
+    }
+
+    $getAll(isGlobal: boolean): Promise<KeysToKeysToAnyValue> {
+        return this.pluginServer.keyValueStorageGetAll(isGlobal);
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -16,7 +16,7 @@
 
 import * as theia from '@theia/plugin';
 import { interfaces, injectable } from 'inversify';
-import { WorkspaceExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain } from '../../api/plugin-api';
+import { WorkspaceExt, StorageExt, MAIN_RPC_CONTEXT, WorkspaceMain, WorkspaceFolderPickOptionsMain } from '../../api/plugin-api';
 import { RPCProtocol } from '../../api/rpc-protocol';
 import Uri from 'vscode-uri';
 import { UriComponents } from '../../common/uri-components';
@@ -25,15 +25,19 @@ import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-o
 import { FileStat } from '@theia/filesystem/lib/common';
 import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
 import URI from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { Resource } from '@theia/core/lib/common/resource';
 import { Emitter, Event, Disposable, ResourceResolver } from '@theia/core';
 import { FileWatcherSubscriberOptions } from '../../api/model';
 import { InPluginFileSystemWatcherManager } from './in-plugin-filesystem-watcher-manager';
 import { StoragePathService } from './storage-path-service';
+import { PluginServer } from '../../common/plugin-protocol';
 
 export class WorkspaceMainImpl implements WorkspaceMain {
 
     private proxy: WorkspaceExt;
+
+    private storageProxy: StorageExt;
 
     private quickOpenService: MonacoQuickOpenService;
 
@@ -45,28 +49,40 @@ export class WorkspaceMainImpl implements WorkspaceMain {
 
     private resourceResolver: TextContentResourceResolver;
 
+    private pluginServer: PluginServer;
+
+    private workspaceService: WorkspaceService;
+
+    private storagePathService: StoragePathService;
+
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WORKSPACE_EXT);
+        this.storageProxy = rpc.getProxy(MAIN_RPC_CONTEXT.STORAGE_EXT);
         this.quickOpenService = container.get(MonacoQuickOpenService);
         this.fileSearchService = container.get(FileSearchService);
         this.resourceResolver = container.get(TextContentResourceResolver);
-        const storagePathService = container.get(StoragePathService);
+        this.pluginServer = container.get(PluginServer);
+        this.workspaceService = container.get(WorkspaceService);
+        this.storagePathService = container.get(StoragePathService);
 
         this.inPluginFileSystemWatcherManager = new InPluginFileSystemWatcherManager(this.proxy, container);
 
-        // Plugin Context `storagePath` should be already updated when API event `onDidChangeWorkspaceFolders` fires.
-        // This is why `StoragePathService.onWorkspaceChanged` is used instead of `WorkspaceService.onWorkspaceChanged`.
-        storagePathService.onWorkspaceChanged(roots => {
-            this.notifyWorkspaceFoldersChanged(roots);
+        this.workspaceService.onWorkspaceChanged(roots => {
+            this.processWorkspaceFoldersChanged(roots);
         });
     }
 
-    notifyWorkspaceFoldersChanged(roots: FileStat[]): void {
+    async processWorkspaceFoldersChanged(roots: FileStat[]): Promise<void> {
         if (this.isAnyRootChanged(roots) === false) {
             return;
         }
-
         this.roots = roots;
+
+        await this.storagePathService.updateStoragePath(roots);
+
+        const keyValueStorageWorkspacesData = await this.pluginServer.keyValueStorageGetAll(false);
+        this.storageProxy.$updatePluginsWorkspaceData(keyValueStorageWorkspacesData);
+
         this.proxy.$onWorkspaceFoldersChanged({ roots });
     }
 

--- a/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
+++ b/packages/plugin-ext/src/main/common/plugin-paths-protocol.ts
@@ -21,7 +21,12 @@ export const pluginPathsServicePath = '/services/plugin-paths';
 // Service to create plugin configuration folders for different purpose.
 export const PluginPathsService = Symbol('PluginPathsService');
 export interface PluginPathsService {
-    // Return hosted log path. Create directory by this path if it is not exist on the file system.
+    // Builds hosted log path. Create directory by this path if it is not exist on the file system.
     provideHostLogPath(): Promise<string>;
-    provideHostStoragePath(workspace: FileStat, roots: FileStat[]): Promise<string>;
+    // Builds storage path for given workspace
+    provideHostStoragePath(workspace: FileStat | undefined, roots: FileStat[]): Promise<string | undefined>;
+    // Returns last resolved storage path
+    getLastStoragePath(): Promise<string | undefined>;
+    // Returns Theia data directory (one for all Theia workspaces, so doesn't change)
+    getTheiaDirPath(): Promise<string>;
 }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -20,7 +20,7 @@ import { injectable, optional, multiInject, inject } from 'inversify';
 import {
     PluginDeployerResolver, PluginDeployerFileHandler, PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginDeployer, PluginDeployerResolverInit, PluginDeployerFileHandlerContext,
-    PluginDeployerDirectoryHandlerContext, HostedPluginServer, PluginDeployerEntryType, PluginServer,
+    PluginDeployerDirectoryHandlerContext, HostedPluginServer, PluginDeployerEntryType,
 } from '../../common/plugin-protocol';
 import { PluginDeployerEntryImpl } from './plugin-deployer-entry-impl';
 import { PluginDeployerResolverContextImpl, PluginDeployerResolverInitImpl } from './plugin-deployer-resolver-context-impl';
@@ -30,7 +30,7 @@ import { PluginDeployerDirectoryHandlerContextImpl } from './plugin-deployer-dir
 import { ILogger } from '@theia/core';
 
 @injectable()
-export class PluginDeployerImpl implements PluginDeployer, PluginServer {
+export class PluginDeployerImpl implements PluginDeployer {
 
     @inject(ILogger)
     protected readonly logger: ILogger;

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -17,6 +17,7 @@
 import { interfaces } from 'inversify';
 import { PluginApiContribution } from './plugin-service';
 import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { PluginsKeyValueStorage } from './plugins-key-value-storage';
 import { PluginDeployerContribution } from './plugin-deployer-contribution';
 import {
     PluginDeployer, PluginDeployerResolver, PluginDeployerFileHandler,
@@ -31,6 +32,7 @@ import { HttpPluginDeployerResolver } from './plugin-http-resolver';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
 import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
 import { PluginPathsServiceImpl } from './paths/plugin-paths-service';
+import { PluginServerHandler } from './plugin-server-handler';
 
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
@@ -47,7 +49,9 @@ export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginDeployerFileHandler).to(PluginTheiaFileHandler).inSingletonScope();
     bind(PluginDeployerDirectoryHandler).to(PluginTheiaDirectoryHandler).inSingletonScope();
 
-    bind(PluginServer).to(PluginDeployerImpl).inSingletonScope();
+    bind(PluginServer).to(PluginServerHandler).inSingletonScope();
+
+    bind(PluginsKeyValueStorage).toSelf().inSingletonScope();
 
     bind(PluginPathsService).to(PluginPathsServiceImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>

--- a/packages/plugin-ext/src/main/node/plugin-server-handler.ts
+++ b/packages/plugin-ext/src/main/node/plugin-server-handler.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { PluginDeployerImpl } from './plugin-deployer-impl';
+import { PluginsKeyValueStorage } from './plugins-key-value-storage';
+import { PluginServer, PluginDeployer } from '../../common/plugin-protocol';
+import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
+
+@injectable()
+export class PluginServerHandler implements PluginServer {
+
+    @inject(PluginDeployer)
+    protected readonly pluginDeployer: PluginDeployerImpl;
+
+    @inject(PluginsKeyValueStorage)
+    protected readonly pluginsKeyValueStorage: PluginsKeyValueStorage;
+
+    deploy(pluginEntry: string): Promise<void> {
+        return this.pluginDeployer.deploy(pluginEntry);
+    }
+
+    keyValueStorageSet(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean> {
+        return this.pluginsKeyValueStorage.set(key, value, isGlobal);
+    }
+
+    keyValueStorageGet(key: string, isGlobal: boolean): Promise<KeysToAnyValues> {
+        return this.pluginsKeyValueStorage.get(key, isGlobal);
+    }
+
+    keyValueStorageGetAll(isGlobal: boolean = false): Promise<KeysToKeysToAnyValue> {
+        return this.pluginsKeyValueStorage.getAll(isGlobal);
+    }
+
+}

--- a/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
+++ b/packages/plugin-ext/src/main/node/plugins-key-value-storage.ts
@@ -1,0 +1,142 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { PluginPaths } from './paths/const';
+import { PluginPathsService } from '../common/plugin-paths-protocol';
+import { KeysToAnyValues, KeysToKeysToAnyValue } from '../../common/types';
+
+@injectable()
+export class PluginsKeyValueStorage {
+    private theiaDirPath: string | undefined;
+    private globalDataPath: string | undefined;
+
+    private deferredTheiaDirPath: Deferred<string>;
+
+    constructor(
+        @inject(PluginPathsService) private readonly pluginPathsService: PluginPathsService,
+        @inject(FileSystem) protected readonly fileSystem: FileSystem
+    ) {
+        this.deferredTheiaDirPath = new Deferred<string>();
+
+        this.pluginPathsService.getTheiaDirPath().then((theiaDirPathUri: string) =>
+            this.fileSystem.getFsPath(theiaDirPathUri)
+        ).then((theiaDirPath: string | undefined) => {
+            this.theiaDirPath = theiaDirPath!;
+            this.globalDataPath = path.join(this.theiaDirPath, PluginPaths.PLUGINS_GLOBAL_STORAGE_DIR, 'global-state.json');
+
+            if (!fs.existsSync(path.dirname(this.globalDataPath))) {
+                this.createDirectories(path.dirname(this.globalDataPath));
+            }
+
+            this.deferredTheiaDirPath.resolve(this.theiaDirPath);
+        });
+    }
+
+    private createDirectories(pathString: string): void {
+        const toCreate: string[] = [];
+
+        while (!fs.existsSync(pathString)) {
+            toCreate.push(path.basename(pathString));
+            pathString = path.dirname(pathString);
+        }
+
+        while (toCreate.length > 0) {
+            pathString = path.join(pathString, toCreate.pop()!);
+            fs.mkdirSync(pathString);
+        }
+    }
+
+    async set(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean> {
+        const dataPath = await this.getDataPath(isGlobal);
+        if (!dataPath) {
+            return Promise.reject('Cannot save data: no opened workspace');
+        }
+
+        const data = this.readFromFile(dataPath);
+
+        if (value === undefined || value === {}) {
+            delete data[key];
+        } else {
+            data[key] = value;
+        }
+
+        this.writeToFile(dataPath, data);
+        return Promise.resolve(true);
+    }
+
+    async get(key: string, isGlobal: boolean): Promise<KeysToAnyValues> {
+        const dataPath = await this.getDataPath(isGlobal);
+        if (!dataPath) {
+            return Promise.resolve({});
+        }
+
+        const data = this.readFromFile(dataPath);
+        return Promise.resolve(data[key]);
+    }
+
+    async getAll(isGlobal: boolean): Promise<KeysToKeysToAnyValue> {
+        const dataPath = await this.getDataPath(isGlobal);
+        if (!dataPath) {
+            return Promise.resolve({});
+        }
+
+        const data = this.readFromFile(dataPath);
+        return Promise.resolve(data);
+    }
+
+    private async getDataPath(isGlobal: boolean): Promise<string | undefined> {
+        if (this.theiaDirPath === undefined) {
+            // wait for Theia data directory path if it hasn't been initialized yet
+            await this.deferredTheiaDirPath.promise;
+        }
+
+        if (isGlobal) {
+            return this.globalDataPath!;
+        } else {
+            const storagePath = await this.pluginPathsService.getLastStoragePath();
+            return storagePath ? path.join(storagePath, 'workspace-state.json') : undefined;
+        }
+    }
+
+    private readFromFile(pathToFile: string): KeysToKeysToAnyValue {
+        if (!fs.existsSync(pathToFile)) {
+            return {};
+        }
+
+        const rawData = fs.readFileSync(pathToFile, 'utf8');
+        try {
+            return JSON.parse(rawData);
+        } catch (error) {
+            console.error('Failed to parse data from "', pathToFile, '". Reason:', error);
+            return {};
+        }
+    }
+
+    private writeToFile(pathToFile: string, data: KeysToKeysToAnyValue): void {
+        if (!fs.existsSync(path.dirname(pathToFile))) {
+            fs.mkdirSync(path.dirname(pathToFile));
+        }
+
+        const rawData = JSON.stringify(data);
+        fs.writeFileSync(pathToFile, rawData, 'utf8');
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as theia from '@theia/plugin';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { StorageMain, StorageExt } from '../api/plugin-api';
+import { KeysToAnyValues, KeysToKeysToAnyValue } from '../common/types';
+
+export class Memento implements theia.Memento {
+
+    private cache: KeysToAnyValues;
+
+    constructor(
+        private readonly pluginId: string,
+        private readonly isPluginGlobalData: boolean,
+        private readonly storage: KeyValueStorageProxy
+    ) {
+        this.cache = storage.getPerPluginData(pluginId, isPluginGlobalData);
+
+        if (!this.isPluginGlobalData) {
+            this.storage.storageDataChangedEvent((data: KeysToKeysToAnyValue) => {
+                this.cache = data[this.pluginId] ? data[this.pluginId] : {};
+            });
+        }
+    }
+
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        if (key && this.cache[key]) {
+            return this.cache[key];
+        } else {
+            return defaultValue;
+        }
+    }
+
+    // tslint:disable-next-line:no-any
+    update(key: string, value: any): Promise<void> {
+        this.cache[key] = value;
+        return this.storage.setPerPluginData(this.pluginId, this.cache, this.isPluginGlobalData).then(_ => undefined);
+    }
+}
+
+/**
+ * Singleton.
+ * Is used to proxy storage requests to main side.
+ */
+export class KeyValueStorageProxy implements StorageExt {
+
+    private storageDataChangedEmitter = new Emitter<KeysToKeysToAnyValue>();
+    public readonly storageDataChangedEvent: Event<KeysToKeysToAnyValue> = this.storageDataChangedEmitter.event;
+
+    private readonly proxy: StorageMain;
+
+    private globalDataCache: KeysToKeysToAnyValue;
+    private workspaceDataCache: KeysToKeysToAnyValue;
+
+    constructor(
+        proxy: StorageMain,
+        initGlobalData: KeysToKeysToAnyValue,
+        initWorkspaceData: KeysToKeysToAnyValue
+    ) {
+        this.proxy = proxy;
+
+        this.globalDataCache = initGlobalData;
+        this.workspaceDataCache = initWorkspaceData;
+    }
+
+    getPerPluginData(key: string, isGlobal: boolean): KeysToAnyValues {
+        if (isGlobal) {
+            const existed = this.globalDataCache[key];
+            return existed ? existed : {};
+        } else {
+            const existed = this.workspaceDataCache[key];
+            return existed ? existed : {};
+        }
+    }
+
+    setPerPluginData(key: string, value: KeysToAnyValues, isGlobal: boolean): Promise<boolean> {
+        if (isGlobal) {
+            this.globalDataCache[key] = value;
+        } else {
+            this.workspaceDataCache[key] = value;
+        }
+
+        return this.proxy.$set(key, value, isGlobal);
+    }
+
+    $updatePluginsWorkspaceData(workspaceData: KeysToKeysToAnyValue): void {
+        this.workspaceDataCache = workspaceData;
+        this.storageDataChangedEmitter.fire(workspaceData);
+    }
+
+}

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2394,6 +2394,39 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * A memento represents a storage utility. It can store and retrieve
+     * values.
+     */
+    export interface Memento {
+
+        /**
+         * Return a value.
+         *
+         * @param key A string.
+         * @return The stored value or `undefined`.
+         */
+        get<T>(key: string): T | undefined;
+
+        /**
+         * Return a value.
+         *
+         * @param key A string.
+         * @param defaultValue A value that should be returned when there is no
+         * value (`undefined`) with the given key.
+         * @return The stored value or the defaultValue.
+         */
+        get<T>(key: string, defaultValue: T): T;
+
+        /**
+         * Store a value. The value must be JSON-stringifyable.
+         *
+         * @param key A string.
+         * @param value A value. MUST not contain cyclic references.
+         */
+        update(key: string, value: any): PromiseLike<void>;
+    }
+
+    /**
      * Content settings for a webview.
      */
     export interface WebviewOptions {


### PR DESCRIPTION
Implement `globalState` and `workspaceState` in plugin context.
Provides global state and workspace state data before plugin start.
Makes sure, that on workspace folders changed event in plugin the workspace state is already actual.

Resolves https://github.com/theia-ide/theia/issues/3732
