### PR TITLE
removed duplicates from search-in-workspace tree

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -213,7 +213,9 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                     const fileNode = rootFolderNode.children.find(f => f.fileUri === result.fileUri);
                     if (fileNode) {
                         const line = this.createResultLineNode(result, fileNode);
-                        fileNode.children.push(line);
+                        if (fileNode.children.findIndex(lineNode => lineNode.id === line.id) < 0) {
+                            fileNode.children.push(line);
+                        }
                         if (fileNode.children.length >= 20 && fileNode.expanded) {
                             fileNode.expanded = false;
                         }


### PR DESCRIPTION
- In a multi root workspace where the same folder gets added more than once, file node(s) in search-in-workspace result tree could possibly be associated with wrong count number(s), due to the same line result(s) being added to the result tree multiple times.
  With this change, a line result is not added to the result tree unless there is no duplicate.
- fixed #3919

Signed-off-by: elaihau <liang.huang@ericsson.com>

