### PR TITLE
Add missing messageService field in DebugSessionManager

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -17,7 +17,7 @@
 // tslint:disable:no-any
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { Emitter, Event, DisposableCollection } from '@theia/core';
+import { Emitter, Event, DisposableCollection, MessageService } from '@theia/core';
 import { LabelProvider } from '@theia/core/lib/browser';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { DebugError, DebugService } from '../common/debug-service';
@@ -101,6 +101,9 @@ export class DebugSessionManager {
 
     @inject(DebugSessionContributionRegistry)
     protected readonly sessionContributionRegistry: DebugSessionContributionRegistry;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
 
     @postConstruct()
     protected init(): void {


### PR DESCRIPTION
Commit

    b86d9b65 ("Show error message when failing to start debug session")

uses the DebugSessionManager.messageService field.  However, it was
removed as a cleanup in

    84a15be0 ("Minor refactoring to remove unused MessageService
    injections")

which results in a build failure.  Fix it by adding the field back.

Change-Id: I3718aaf626ecbb1fa82aec460812ab726a0b0d0b
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
