### PR TITLE
show not-highlighted file open search results

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -93,6 +93,7 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
             placeholder,
             fuzzyMatchLabel: true,
             fuzzyMatchDescription: true,
+            showItemsWithoutHighlight: true,
             onClose: () => {
                 this.isOpen = false;
                 this.cancelIndicator.cancel();


### PR DESCRIPTION
- Search results don't show up in the "file quick open" (CTRL+P) if neither the label (i.e., file name) or description (i.e., path or folder name) has highlighted segments. It is wrong because the search term could be the file path, which is not always used as the label or description. This change makes sure all matched and fuzzy-matched file search results are displayed as options in the file open.
- fixed #2395

Signed-off-by: elaihau <liang.huang@ericsson.com>

