### PR TITLE
[plug-in]Initialize workspace's folders for plug-in system

### DIFF
--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -67,6 +67,10 @@ export class WorkspaceMainImpl implements WorkspaceMain {
 
         this.inPluginFileSystemWatcherManager = new InPluginFileSystemWatcherManager(this.proxy, container);
 
+        this.workspaceService.roots.then(roots => {
+            this.processWorkspaceFoldersChanged(roots);
+        });
+
         this.workspaceService.onWorkspaceChanged(roots => {
             this.processWorkspaceFoldersChanged(roots);
         });


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
This PR provides a way to initialize workspace's folders when Theia is started.
 
Related issue: https://github.com/theia-ide/theia/issues/3930

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
