### PR TITLE
[task] display placeholder 'No tasks found' when no tasks are present

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -43,6 +43,12 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
         this.items = [];
 
         const configuredTasks = await this.taskConfigurations.getTasks();
+        if (!configuredTasks.length) {
+            this.items.push(new QuickOpenItem({
+                label: 'No tasks found',
+                run: (mode: QuickOpenMode): boolean => false
+            }));
+        }
         for (const task of configuredTasks) {
             this.items.push(new TaskRunQuickOpenItem(task, this.taskService, false));
         }


### PR DESCRIPTION
- When running the command `Run Task`, where there are no available tasks,
instead of not displaying anything, display feedback to end-users by adding
a placeholder item stating `No tasks found`

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
