### PR TITLE
display child root in search-in-workspace result

### DIFF
--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -240,7 +240,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
 
     /**
      * Returns the root folder uri that a file belongs to.
-     * In case that a file belongs to more than one root folders, returns the root folder that has the shortest absolute path.
+     * In case that a file belongs to more than one root folders, returns the root folder that is closest to the file.
      * If the file is not from the current workspace, returns empty string.
      * @param filePath string path of the file
      * @param rootUris string URIs of the root folders in the current workspace
@@ -248,7 +248,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
     private getRoot(filePath: string, rootUris: string[]): URI {
         const roots = rootUris.filter(root => new URI(root).withScheme('file').isEqualOrParent(FileUri.create(filePath).withScheme('file')));
         if (roots.length > 0) {
-            return FileUri.create(FileUri.fsPath(roots.sort((r1, r2) => r1.length - r2.length)[0]));
+            return FileUri.create(FileUri.fsPath(roots.sort((r1, r2) => r2.length - r1.length)[0]));
         }
         return new URI();
     }


### PR DESCRIPTION
- Provided that a multi root workspace has both a folder and that folder's subfolder added as root folders, when searching for a term using the search-in-workspace widget, only the parent root displays results. Vscode behaves differently, displaying the root that is closest to the result. With this change theia matches the behavior of vsCode.

-fixes #3938

Signed-off-by: elaihau <liang.huang@ericsson.com>

