### PR TITLE
[task] display placeholder 'No tasks found' when no tasks are present to attach

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -77,6 +77,12 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
         this.items = [];
 
         this.taskService.getRunningTasks().then(tasks => {
+            if (!tasks.length) {
+                this.items.push(new QuickOpenItem({
+                    label: 'No tasks found',
+                    run: (_mode: QuickOpenMode): boolean => false
+                }));
+            }
             for (const task of tasks) {
                 // can only attach to terminal processes, so only list those
                 if (task.terminalId) {


### PR DESCRIPTION
- When running the command `Attach Task`, if there no available tasks to be attached,
instead of not displaying anything, display placeholder quick-open-item 'No tasks found'.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
