### PR TITLE
[navigator] reveal 'Files' view when opening a workspace for the first time

### DIFF
--- a/examples/browser/test/left-panel/left-panel.ui-spec.ts
+++ b/examples/browser/test/left-panel/left-panel.ui-spec.ts
@@ -41,12 +41,12 @@ describe('theia left panel', () => {
     describe('files tab', () => {
         it('should open/close the files tab', () => {
             leftPanel.openCloseTab('Files');
-            expect(leftPanel.isFileTreeVisible()).to.be.true;
-            expect(leftPanel.isTabActive('Files')).to.be.true;
-
-            leftPanel.openCloseTab('Files');
             expect(leftPanel.isFileTreeVisible()).to.be.false;
             expect(leftPanel.isTabActive('Files')).to.be.false;
+
+            leftPanel.openCloseTab('Files');
+            expect(leftPanel.isFileTreeVisible()).to.be.true;
+            expect(leftPanel.isTabActive('Files')).to.be.true;
         });
     });
 

--- a/examples/browser/test/top-panel/top-panel.ui-spec.ts
+++ b/examples/browser/test/top-panel/top-panel.ui-spec.ts
@@ -130,8 +130,8 @@ describe('theia top panel (menubar)', () => {
     });
 
     describe('files view UI', () => {
-        it('should start with files view not visible', () => {
-            expect(leftPanel.isFileTreeVisible()).to.be.false;
+        it('should start with files view visible', () => {
+            expect(leftPanel.isFileTreeVisible()).to.be.true;
         });
         it('files view should toggle-on then toggle-off', () => {
             if (!leftPanel.isFileTreeVisible()) {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -86,7 +86,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
-        await this.openView();
+        await this.openView({ activate: true, reveal: true });
     }
 
     registerCommands(registry: CommandRegistry): void {


### PR DESCRIPTION
Fixes #830

- when a workspace is opened for the first time, reveal the `files-view` for
a better user experience (when no layout data is available). This provides
a faster and more intuitive way for users to easily view their new workspace
and also provides them with faster navigation.

<div align='center'>

**Opening a workspace for the first time**

|Before|After|
|:---:|:---:|
|<img width="1075" alt="screen shot 2019-01-03 at 2 28 28 pm" src="https://user-images.githubusercontent.com/40359487/50657447-87bd7f00-0f64-11e9-818b-3b09cca11991.png">|<img width="1075" alt="screen shot 2019-01-03 at 2 27 32 pm" src="https://user-images.githubusercontent.com/40359487/50657519-bd626800-0f64-11e9-81ab-888cf7924017.png">|

</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->