### PR TITLE
Support for `workspace/executeClientCommand` request

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -33,6 +33,7 @@ import {
     ActionableMessage,
     StatusReport,
     StatusNotification,
+    ExecuteClientCommand
 } from './java-protocol';
 import { MaybePromise } from '@theia/core';
 
@@ -71,6 +72,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
     protected onReady(languageClient: ILanguageClient): void {
         languageClient.onNotification(ActionableNotification.type, this.showActionableMessage.bind(this));
         languageClient.onNotification(StatusNotification.type, this.showStatusMessage.bind(this));
+        languageClient.onRequest(ExecuteClientCommand.type, params => this.commandService.executeCommand(params.command, ...params.arguments));
         super.onReady(languageClient);
     }
 

--- a/packages/java/src/browser/java-protocol.ts
+++ b/packages/java/src/browser/java-protocol.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { RequestType, NotificationType } from 'vscode-jsonrpc';
-import { VersionedTextDocumentIdentifier, TextDocumentIdentifier, Command, MessageType } from '@theia/languages/lib/browser';
+import { VersionedTextDocumentIdentifier, TextDocumentIdentifier, Command, MessageType, ExecuteCommandParams } from '@theia/languages/lib/browser';
 
 export interface StatusReport {
     message: string;
@@ -65,4 +65,8 @@ export enum CompileWorkspaceStatus {
 
 export namespace CompileWorkspaceRequest {
     export const type = new RequestType<boolean, CompileWorkspaceStatus, void, void>('java/buildWorkspace');
+}
+
+export namespace ExecuteClientCommand {
+    export const type = new RequestType<ExecuteCommandParams, undefined, void, void>('workspace/executeClientCommand');
 }


### PR DESCRIPTION
Fixes #3951 

Trivial support for `workspace/executeClientCommand` request message which is a specific JDT LS request message, an extension of LS protocol.