### PR TITLE
add multi root support to WorkspaceService.getWorkspaceRootUri()

### DIFF
--- a/packages/workspace/src/browser/workspace-service.spec.ts
+++ b/packages/workspace/src/browser/workspace-service.spec.ts
@@ -680,6 +680,29 @@ describe('WorkspaceService', () => {
         });
     });
 
+    describe('getWorkspaceRootUri() function', () => {
+        it('should return undefined if no uri is passed into the function', () => {
+            expect(wsService.getWorkspaceRootUri(undefined)).to.be.undefined;
+        });
+
+        it('should return the root folder uri that the file belongs to', () => {
+            wsService['_roots'] = [folderA, folderB];
+            const root = wsService.getWorkspaceRootUri(new URI(folderB.uri + '/testfile'));
+            expect(root!.toString()).to.equal(folderB.uri);
+        });
+
+        it('should return the closest root folder uri that the file belongs to', () => {
+            const home = Object.freeze(<FileStat>{
+                uri: 'file:///home',
+                lastModification: 0,
+                isDirectory: true
+            });
+            wsService['_roots'] = [folderA, folderB, home];
+            const root = wsService.getWorkspaceRootUri(new URI(folderB.uri + '/testfile'));
+            expect(root!.toString()).to.equal(folderB.uri);
+        });
+    });
+
     it('should emit roots in the current workspace when initialized', done => {
         const rootA = 'file:///folderA';
         const rootB = 'file:///folderB';

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -476,6 +476,12 @@ export class WorkspaceService implements FrontendApplicationContribution {
         }));
     }
 
+    /**
+     * Returns the workspace root uri that the given file belongs to.
+     * In case that the file is found in more than one workspace roots, returns the root that is closest to the file.
+     * If the file is not from the current workspace, returns `undefined`.
+     * @param uri URI of the file
+     */
     getWorkspaceRootUri(uri: URI | undefined): URI | undefined {
         if (!uri) {
             const root = this.tryGetRoots()[0];
@@ -484,13 +490,14 @@ export class WorkspaceService implements FrontendApplicationContribution {
             }
             return undefined;
         }
+        const rootUris: URI[] = [];
         for (const root of this.tryGetRoots()) {
             const rootUri = new URI(root.uri);
             if (rootUri && rootUri.isEqualOrParent(uri)) {
-                return rootUri;
+                rootUris.push(rootUri);
             }
         }
-        return undefined;
+        return rootUris.sort((r1, r2) => r2.toString().length - r1.toString().length)[0];
     }
 
 }


### PR DESCRIPTION
WorkspaceService.getWorkspaceRootUri() returns the first root folder that the given file belongs to, which is correct but inconsistent with other services of theia (e.g., search-in-workspace) when the file can be found in more than one root folders. With this change, the possibility of having multiple root folders is taken into account.

Signed-off-by: elaihau <liang.huang@ericsson.com>

