### PR TITLE
[java] Add `workspace/executeClientCommand`

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -25,7 +25,8 @@ import {
     BaseLanguageClientContribution,
     Workspace, Languages,
     LanguageClientFactory,
-    LanguageClientOptions
+    LanguageClientOptions,
+    ExecuteCommandParams
 } from '@theia/languages/lib/browser';
 import { JAVA_LANGUAGE_ID, JAVA_LANGUAGE_NAME, JavaStartParams } from '../common';
 import {
@@ -33,6 +34,7 @@ import {
     ActionableMessage,
     StatusReport,
     StatusNotification,
+    ExecuteClientCommandRequest,
 } from './java-protocol';
 import { MaybePromise } from '@theia/core';
 
@@ -69,6 +71,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
     }
 
     protected onReady(languageClient: ILanguageClient): void {
+        languageClient.onRequest(ExecuteClientCommandRequest.type, this.executeClientCommand.bind(this));
         languageClient.onNotification(ActionableNotification.type, this.showActionableMessage.bind(this));
         languageClient.onNotification(StatusNotification.type, this.showStatusMessage.bind(this));
         super.onReady(languageClient);
@@ -78,6 +81,10 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         const client: ILanguageClient & Readonly<{ languageId: string }> = Object.assign(super.createLanguageClient(connection), { languageId: this.id });
         client.registerFeature(SemanticHighlightingService.createNewFeature(this.semanticHighlightingService, client));
         return client;
+    }
+
+    protected executeClientCommand(params: ExecuteCommandParams) {
+        return this.commandService.executeCommand(params.command, ...params.arguments);
     }
 
     protected showStatusMessage(message: StatusReport) {

--- a/packages/java/src/browser/java-protocol.ts
+++ b/packages/java/src/browser/java-protocol.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { RequestType, NotificationType } from 'vscode-jsonrpc';
-import { VersionedTextDocumentIdentifier, TextDocumentIdentifier, Command, MessageType } from '@theia/languages/lib/browser';
+import { VersionedTextDocumentIdentifier, TextDocumentIdentifier, Command, MessageType, ExecuteCommandParams } from '@theia/languages/lib/browser';
 
 export interface StatusReport {
     message: string;
@@ -42,6 +42,10 @@ export interface SemanticHighlightingParams {
 export interface SemanticHighlightingInformation {
     readonly line: number;
     readonly tokens: string | undefined;
+}
+
+export namespace ExecuteClientCommandRequest {
+    export const type = new RequestType<ExecuteCommandParams, any, void, void>('workspace/executeClientCommand');
 }
 
 export namespace ClassFileContentsRequest {


### PR DESCRIPTION
Aligns with the Java VS Code extension:
https://github.com/redhat-developer/vscode-java/blob/master/src/extension.ts#L183

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Fixes: #3951
