### PR TITLE
fix #3973: deploy VS Code extension even if they don't have code

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -28,7 +28,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
 
     accept(resolvedPlugin: PluginDeployerEntry): boolean {
 
-        console.log('PluginTheiaDirectoryHandler: accepting plugin with path', resolvedPlugin.path());
+        console.log('PluginVsCodeDirectoryHandler: accepting plugin with path', resolvedPlugin.path());
 
         // handle only directories
         if (resolvedPlugin.isFile()) {
@@ -76,10 +76,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
 
     // tslint:disable-next-line:no-any
     handle(context: PluginDeployerDirectoryHandlerContext): Promise<any> {
-        const packageJson: PluginPackage = context.pluginEntry().getValue('package.json');
-        if (packageJson.main) {
-            context.pluginEntry().accept(PluginDeployerEntryType.BACKEND);
-        }
+        context.pluginEntry().accept(PluginDeployerEntryType.BACKEND);
 
         const extensionPath = path.resolve(context.pluginEntry().path(), 'extension');
         context.pluginEntry().updatePath(extensionPath);

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -157,10 +157,33 @@ export const PluginDeployer = Symbol('PluginDeployer');
  * A plugin resolver is handling how to resolve a plugin link into a local resource.
  */
 export const PluginDeployerResolver = Symbol('PluginDeployerResolver');
+/**
+ * A resolver handle a set of resource
+ */
+export interface PluginDeployerResolver {
+
+    init?(pluginDeployerResolverInit: PluginDeployerResolverInit): void;
+
+    accept(pluginSourceId: string): boolean;
+
+    resolve(pluginResolverContext: PluginDeployerResolverContext): Promise<void>;
+
+}
 
 export const PluginDeployerDirectoryHandler = Symbol('PluginDeployerDirectoryHandler');
+export interface PluginDeployerDirectoryHandler {
+    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
+
+    handle(context: PluginDeployerDirectoryHandlerContext): Promise<void>;
+}
 
 export const PluginDeployerFileHandler = Symbol('PluginDeployerFileHandler');
+export interface PluginDeployerFileHandler {
+
+    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
+
+    handle(context: PluginDeployerFileHandlerContext): Promise<void>;
+}
 
 /**
  * This scanner process package.json object and returns plugin metadata objects.
@@ -202,19 +225,6 @@ export interface PluginDeployerResolverContext {
 export interface PluginDeployer {
 
     start(): void;
-
-}
-
-/**
- * A resolver handle a set of resource
- */
-export interface PluginDeployerResolver {
-
-    init?(pluginDeployerResolverInit: PluginDeployerResolverInit): void;
-
-    accept(pluginSourceId: string): boolean;
-
-    resolve(pluginResolverContext: PluginDeployerResolverContext): Promise<void>;
 
 }
 
@@ -292,19 +302,6 @@ export interface PluginDeployerDirectoryHandlerContext {
 
     pluginEntry(): PluginDeployerEntry;
 
-}
-
-export interface PluginDeployerFileHandler {
-
-    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
-
-    handle(context: PluginDeployerFileHandlerContext): Promise<void>;
-}
-
-export interface PluginDeployerDirectoryHandler {
-    accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
-
-    handle(context: PluginDeployerDirectoryHandlerContext): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
The simple example is `bat` extension: https://github.com/Microsoft/vscode/blob/f9dac5925447293678b81e817fa077a5bc1b9d3c/extensions/bat/package.json#L1

I've also put some symbols and interfaces together to easy code navigation. Otherwise it always tases me to the symbol and then i have to find an interface.