### PR TITLE
Initial commit for adding API to apply workspace edit

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -612,7 +612,7 @@ export interface TextEditorsMain {
     $tryRevealRange(id: string, range: Range, revealType: TextEditorRevealType): Promise<void>;
     $trySetSelections(id: string, selections: Selection[]): Promise<void>;
     $tryApplyEdits(id: string, modelVersionId: number, edits: SingleEditOperation[], opts: ApplyEditsOptions): Promise<boolean>;
-    // $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto): Promise<boolean>;
+    $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto): Promise<boolean>;
     $tryInsertSnippet(id: string, template: string, selections: Range[], opts: UndoStopOptions): Promise<boolean>;
     // $getDiffInformation(id: string): Promise<editorCommon.ILineChange[]>;
 }

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -29,6 +29,7 @@ import { DocumentsMainImpl } from './documents-main';
 import { TextEditorsMainImpl } from './text-editors-main';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { OpenerService } from '@theia/core/lib/browser/opener-service';
+import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
 
 export class EditorsAndDocumentsMain {
     private toDispose = new DisposableCollection();
@@ -53,11 +54,12 @@ export class EditorsAndDocumentsMain {
         const modelService = container.get<EditorModelService>(EditorModelService);
         const editorManager = container.get<EditorManager>(EditorManager);
         const openerService = container.get<OpenerService>(OpenerService);
+        const bulkEditService = container.get<MonacoBulkEditService>(MonacoBulkEditService);
 
         const documentsMain = new DocumentsMainImpl(this, modelService, rpc, editorManager, openerService);
         rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
 
-        const editorsMain = new TextEditorsMainImpl(this, rpc);
+        const editorsMain = new TextEditorsMainImpl(this, rpc, bulkEditService);
         rpc.set(PLUGIN_RPC_CONTEXT.TEXT_EDITORS_MAIN, editorsMain);
 
         this.stateComputer = new EditorAndDocumentStateComputer(d => this.onDelta(d), editorService, modelService);

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -25,7 +25,10 @@ import {
     ApplyEditsOptions,
     UndoStopOptions,
     DecorationRenderOptions,
-    DecorationOptions
+    DecorationOptions,
+    ResourceTextEditDto,
+    ResourceFileEditDto,
+    WorkspaceEditDto
 } from '../../api/plugin-api';
 import { Range } from '../../api/model';
 import { EditorsAndDocumentsMain } from './editors-and-documents-main';
@@ -33,13 +36,18 @@ import { RPCProtocol } from '../../api/rpc-protocol';
 import { DisposableCollection } from '@theia/core';
 import { TextEditorMain } from './text-editor-main';
 import { disposed } from '../../common/errors';
+import URI from 'vscode-uri';
+import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
 
 export class TextEditorsMainImpl implements TextEditorsMain {
 
     private toDispose = new DisposableCollection();
     private proxy: TextEditorsExt;
     private editorsToDispose = new Map<string, DisposableCollection>();
-    constructor(private readonly editorsAndDocuments: EditorsAndDocumentsMain, rpc: RPCProtocol) {
+
+    constructor(private readonly editorsAndDocuments: EditorsAndDocumentsMain,
+                rpc: RPCProtocol,
+                private readonly bulkEditService:  MonacoBulkEditService) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.TEXT_EDITORS_EXT);
         this.toDispose.push(editorsAndDocuments.onTextEditorAdd(editors => editors.forEach(this.onTextEditorAdd, this)));
         this.toDispose.push(editorsAndDocuments.onTextEditorRemove(editors => editors.forEach(this.onTextEditorRemove, this)));
@@ -101,6 +109,13 @@ export class TextEditorsMainImpl implements TextEditorsMain {
         return Promise.resolve(this.editorsAndDocuments.getEditor(id)!.applyEdits(modelVersionId, edits, opts));
     }
 
+    $tryApplyWorkspaceEdit(dto: WorkspaceEditDto): Promise<boolean> {
+        const edits  = this.reviveWorkspaceEditDto(dto);
+        return new Promise(resolve => {
+            this.bulkEditService.apply( edits).then(() => resolve(true), err => resolve(false));
+        });
+    }
+
     $tryInsertSnippet(id: string, template: string, ranges: Range[], opts: UndoStopOptions): Promise<boolean> {
         if (!this.editorsAndDocuments.getEditor(id)) {
             return Promise.reject(disposed(`TextEditor(${id})`));
@@ -130,5 +145,19 @@ export class TextEditorsMainImpl implements TextEditorsMain {
         }
         this.editorsAndDocuments.getEditor(id)!.setDecorationsFast(key, ranges);
         return Promise.resolve();
+    }
+
+    reviveWorkspaceEditDto(data: WorkspaceEditDto): monaco.languages.WorkspaceEdit {
+        if (data && data.edits) {
+            for (const edit of data.edits) {
+                if (typeof (<ResourceTextEditDto>edit).resource === 'object') {
+                    (<ResourceTextEditDto>edit).resource = URI.revive((<ResourceTextEditDto>edit).resource);
+                } else {
+                    (<ResourceFileEditDto>edit).newUri = URI.revive((<ResourceFileEditDto>edit).newUri);
+                    (<ResourceFileEditDto>edit).oldUri = URI.revive((<ResourceFileEditDto>edit).oldUri);
+                }
+            }
+        }
+        return <monaco.languages.WorkspaceEdit>data;
     }
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -367,6 +367,9 @@ export function createAPIFactory(
             findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
                 return workspaceExt.findFiles(include, undefined, maxResults, token);
             },
+            applyEdit(edit: theia.WorkspaceEdit): PromiseLike<boolean> {
+                return editors.applyWorkspaceEdit(edit);
+            },
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);
             },

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -119,6 +119,11 @@ export class TextEditorsExtImpl implements TextEditorsExt {
         return new TextEditorDecorationType(this.proxy, options);
     }
 
+    applyWorkspaceEdit(edit: theia.WorkspaceEdit): Promise<boolean> {
+        const dto = Converters.fromWorkspaceEdit(edit, this.editorsAndDocuments);
+        return this.proxy.$tryApplyWorkspaceEdit(dto);
+    }
+
 }
 
 export class TextEditorDecorationType implements theia.TextEditorDecorationType {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3813,6 +3813,25 @@ declare module '@theia/plugin' {
         export function findFiles(include: GlobPattern, exclude?: GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
 
         /**
+		 * Make changes to one or many resources or create, delete, and rename resources as defined by the given
+		 * [workspace edit](#WorkspaceEdit).
+		 *
+		 * All changes of a workspace edit are applied in the same order in which they have been added. If
+		 * multiple textual inserts are made at the same position, these strings appear in the resulting text
+		 * in the order the 'inserts' were made. Invalid sequences like 'delete file a' -> 'insert text in file a'
+		 * cause failure of the operation.
+		 *
+		 * When applying a workspace edit that consists only of text edits an 'all-or-nothing'-strategy is used.
+		 * A workspace edit with resource creations or deletions aborts the operation, e.g. consective edits will
+		 * not be attempted, when a single edit fails.
+		 *
+		 * @param edit A workspace edit.
+		 * @return A thenable that resolves when the edit could be applied.
+		 */
+		export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
+        
+        
+        /**
          * Register a filesystem provider for a given scheme, e.g. `ftp`.
          *
          * There can only be one provider per scheme and an error is being thrown when a scheme
@@ -4490,6 +4509,7 @@ declare module '@theia/plugin' {
          */
         constructor(range: Range, newText: string);
     }
+
 
     /**
      * Completion item kinds.


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>
 Tested it with this code

```
'use strict';

import * as vscode from 'vscode';
import { ExtensionContext, commands } from 'vscode';

export function activate(context: ExtensionContext) {
	context.subscriptions.push(commands.registerCommand('extension.removeString', () => {
		let activeEditor = vscode.window.activeTextEditor;
		if (activeEditor) {
		let text = activeEditor.document.getText();
		let regEx = new RegExp('SomeString');
		let match: any;
		match = regEx.exec(text);			
    	let edit = new vscode.WorkspaceEdit();
    	let startPos = activeEditor.document.positionAt(match.index);
    	let endPos = activeEditor.document.positionAt(match.index + match[0].length);
    	let range = new vscode.Range(startPos, endPos);
    	edit.delete(activeEditor.document.uri, range);
    	vscode.workspace.applyEdit(edit);
	}
	}));
}

```



