### PR TITLE
[wip][core] align tree styling with vscode

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -40,7 +40,7 @@
 }
 
 .theia-TreeNode:hover {
-    background: var(--theia-accent-color4);
+    background: var(--theia-layout-color1);
     cursor: pointer;
 }
 
@@ -73,11 +73,12 @@
 
 .theia-Tree:focus .theia-TreeNode.theia-mod-selected,
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
-    background: var(--theia-accent-color3);
+    background: var(--theia-brand-dark-color0);
+    color: var(--theia-ui-white-font-color) !important;
 }
 
 .theia-Tree .theia-TreeNode.theia-mod-selected {
-    background: var(--theia-accent-color4);
+    background: var(--theia-layout-color2);
 }
 
 .theia-TreeNode.theia-mod-not-selectable {

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -53,6 +53,8 @@ is not optimized for dense, information rich UIs.
   --theia-ui-icon-font-color: #ffffff;
   --theia-ui-bar-font-color0: var(--theia-ui-font-color0);
   --theia-ui-bar-font-color1: var(--theia-ui-font-color1);
+  --theia-ui-white-font-color: #ffffff;
+  --theia-ui-black-font-color: #000000;
 
   /* Use the inverse UI colors against the brand/accent/warn/error colors. */
 
@@ -93,6 +95,10 @@ is not optimized for dense, information rich UIs.
   --theia-brand-color1: var(--md-blue-500);
   --theia-brand-color2: var(--md-blue-300);
   --theia-brand-color3: var(--md-blue-100);
+
+  /* Brand colors - Darker */
+  --theia-brand-dark-color0: var(--md-blue-800);
+  --theia-brand-dark-color1: var(--md-blue-900);
 
   /* Secondary Brand colors */
 

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -53,6 +53,8 @@ is not optimized for dense, information rich UIs.
   --theia-ui-icon-font-color: #d4d4d4;
   --theia-ui-bar-font-color0: #eeeeee;
   --theia-ui-bar-font-color1: #d4d4d4;
+  --theia-ui-white-font-color: #ffffff;
+  --theia-ui-black-font-color: #000000;
 
   /* Use the inverse UI colors against the brand/accent/warn/error colors. */
 
@@ -93,6 +95,10 @@ is not optimized for dense, information rich UIs.
   --theia-brand-color1: var(--md-blue-500);
   --theia-brand-color2: var(--md-blue-300);
   --theia-brand-color3: var(--md-blue-100);
+
+/* Brand colors - Darker */
+--theia-brand-dark-color0: var(--md-blue-800);
+--theia-brand-dark-color1: var(--md-blue-900);
 
   /* Secondary Brand colors */
 

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -364,3 +364,7 @@
 .git-change-list-buttons-container .toolbar-button:hover {
     background: var(--theia-content-font-color3);
 }
+
+.theia-git .gitItem.theia-mod-selected .status {
+    color: var(--theia-ui-font-color0) !important;
+}

--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -48,3 +48,14 @@
 .navigator-tab-icon::before {
     content: "\f0c5"
 }
+
+#files .theia-Tree:focus .theia-TreeNode.theia-mod-selected,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected
+.theia-TreeNodeSegment {
+    color: var(--theia-ui-white-font-color) !important;
+}
+
+#files .theia-Tree:focus .theia-TreeNode.theia-mod-selected,
+.theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected .theia-TreeNodeTail {
+    color: var(--theia-ui-white-font-color) !important;
+}


### PR DESCRIPTION
Fixes #3960

- Adjusts the font `color` for trees when hovering to not clash with our highlight color
- Adjusts the styling for hovering, active tree elements

|Dark|Light|
|:---:|:---:|
| <img width="1239" alt="screen shot 2019-01-09 at 8 18 44 pm" src="https://user-images.githubusercontent.com/40359487/50939716-ff4f4a80-144b-11e9-8700-21c23da20795.png">|<img width="1239" alt="screen shot 2019-01-09 at 8 19 08 pm" src="https://user-images.githubusercontent.com/40359487/50939717-ff4f4a80-144b-11e9-96b5-6677f19e9919.png">|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
