### PR TITLE
 [plugin-ext] Fix undefined path on windows

### DIFF
--- a/examples/browser/wdio.base.conf.js
+++ b/examples/browser/wdio.base.conf.js
@@ -198,7 +198,8 @@ function makeConfig(headless) {
             const argv = [process.argv[0], 'src-gen/backend/server.js', '--root-dir=' + rootDir];
             return require('./src-gen/backend/server')(port, host, argv).then(created => {
                 this.execArgv = [wdioRunnerScript, cliPortKey, created.address().port,
-                    '--theia-root-dir', rootDir];
+                    '--theia-root-dir', rootDir
+                ];
                 this.server = created;
             });
         },
@@ -254,14 +255,20 @@ function makeConfig(headless) {
         afterSuite: function (suite) {
             require("webdriverio");
             var fs = require("fs");
-            let result = browser.execute("return window.__coverage__;")
+            let result;
+            try {
+                result = browser.execute("return window.__coverage__;");
+            } catch (error) {
+                console.error(`Error retreiving the coverage: ${error}`);
+                return;
+            }
             try {
                 if (!fs.existsSync('coverage')) {
                     fs.mkdirSync('coverage');
                 }
                 fs.writeFileSync('coverage/coverage.json', JSON.stringify(result.value));
             } catch (err) {
-                console.log(`Error writing coverage ${err}`);
+                console.error(`Error writing coverage ${err}`);
             };
         },
         //

--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -594,12 +594,25 @@ describe('NodeFileSystem', function () {
 
     describe('08 #createFolder', () => {
 
-        it('Should be rejected with an error if a directory already exist under the desired URI.', async () => {
+        it('Should be rejected with an error if a FILE already exist under the desired URI.', async () => {
             const uri = root.resolve('foo');
-            fs.mkdirSync(FileUri.fsPath(uri));
-            expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.true;
+            fs.writeFileSync(FileUri.fsPath(uri), 'some content');
+            expect(fs.statSync(FileUri.fsPath(uri)).isDirectory()).to.be.false;
 
             await expectThrowsAsync(fileSystem.createFolder(uri.toString()), Error);
+        });
+
+        it('Should NOT be rejected with an error if a DIRECTORY already exist under the desired URI.', async () => {
+            const uri = root.resolve('foo');
+            fs.mkdirSync(FileUri.fsPath(uri));
+            expect(fs.existsSync(FileUri.fsPath(uri))).to.be.true;
+
+            const stat = await fileSystem.createFolder(uri.toString());
+            expect(stat).to.be.an('object');
+            expect(stat).to.have.property('uri')
+                .that.equals(uri.toString());
+            expect(stat).to.have.property('children')
+                .that.is.empty;
         });
 
         it('Should create a directory and return with the stat object on successful directory creation.', async () => {
@@ -614,8 +627,8 @@ describe('NodeFileSystem', function () {
                 .that.is.empty;
         });
 
-        it('Should create a directory and return with the stat object on successful directory creation.', async () => {
-            const uri = root.resolve('foo/bar');
+        it('Should create all the missing directories and return with the stat object on successful creation.', async () => {
+            const uri = root.resolve('foo/bar/foobar/barfoo');
             expect(fs.existsSync(FileUri.fsPath(uri))).to.be.false;
 
             const stat = await fileSystem.createFolder(uri.toString());

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -259,7 +259,10 @@ export class FileSystemNode implements FileSystem {
         const _uri = new URI(uri);
         const stat = await this.doGetStat(_uri, 0);
         if (stat) {
-            throw FileSystemError.FileExists(uri, 'Error occurred while creating the directory.');
+            if (stat.isDirectory) {
+                return stat;
+            }
+            throw FileSystemError.FileExists(uri, 'Error occurred while creating the directory: path is a file.');
         }
         await fs.mkdirs(FileUri.fsPath(_uri));
         const newStat = await this.doGetStat(_uri, 1);

--- a/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
+++ b/packages/plugin-ext/src/main/node/paths/plugin-paths-service.ts
@@ -48,17 +48,11 @@ export class PluginPathsServiceImpl implements PluginPathsService {
         const parentLogsDir = await this.getLogsDirPath();
 
         if (!parentLogsDir) {
-            return Promise.reject(new Error('Unable to get parent log directory'));
-        }
-
-        if (parentLogsDir && !await this.fileSystem.exists(parentLogsDir)) {
-            await this.fileSystem.createFolder(parentLogsDir);
+            throw new Error('Unable to get parent log directory');
         }
 
         const pluginDirPath = path.join(parentLogsDir, this.gererateTimeFolderName(), 'host');
-        if (!await this.fileSystem.exists(pluginDirPath)) {
-            await this.fileSystem.createFolder(pluginDirPath);
-        }
+        await this.fileSystem.createFolder(pluginDirPath);
 
         return new URI(pluginDirPath).path.toString();
     }
@@ -67,7 +61,7 @@ export class PluginPathsServiceImpl implements PluginPathsService {
         const parentStorageDir = await this.getWorkspaceStorageDirPath();
 
         if (!parentStorageDir) {
-            return Promise.reject(new Error('Unable to get parent storage directory'));
+            throw new Error('Unable to get parent storage directory');
         }
 
         if (!workspace) {
@@ -75,8 +69,7 @@ export class PluginPathsServiceImpl implements PluginPathsService {
                 this.deferredStoragePath.resolve(undefined);
                 this.storagePathInitialized = true;
             }
-            this.cachedStoragePath = undefined;
-            return Promise.resolve(undefined);
+            return this.cachedStoragePath = undefined;
         }
 
         if (!await this.fileSystem.exists(parentStorageDir)) {
@@ -94,14 +87,13 @@ export class PluginPathsServiceImpl implements PluginPathsService {
             this.deferredStoragePath.resolve(storagePathString);
             this.storagePathInitialized = true;
         }
-        this.cachedStoragePath = storagePathString;
 
-        return this.cachedStoragePath;
+        return this.cachedStoragePath = storagePathString;
     }
 
     async getLastStoragePath(): Promise<string | undefined> {
         if (this.storagePathInitialized) {
-            return Promise.resolve(this.cachedStoragePath);
+            return this.cachedStoragePath;
         } else {
             return this.deferredStoragePath.promise;
         }
@@ -157,9 +149,10 @@ export class PluginPathsServiceImpl implements PluginPathsService {
     private async getUserHomeDir(): Promise<string> {
         const homeDirStat = await this.fileSystem.getCurrentUserHome();
         if (!homeDirStat) {
-            return Promise.reject(new Error('Unable to get user home directory'));
+            throw new Error('Unable to get user home directory');
         }
-        return homeDirStat.uri;
+        const homeDirPath = await this.fileSystem.getFsPath(homeDirStat.uri);
+        return homeDirPath!;
     }
 
 }


### PR DESCRIPTION
Some path returned by the filesystem was forced as non-undefined in the
code, while at runtime the value actually ended up undefined.

Hopefully improved filesystem access.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

An error about some `execute("return window.__coverage__")` kept
appearing in the test logs. Fixed.

Closes #3978 