### PR TITLE
[git] add default configured remote for git pull & git push

### DIFF
--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -26,6 +26,11 @@ import { FileUri } from '@theia/core/lib/node/file-uri';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { GitErrorHandler } from './git-error-handler';
 
+export enum GitAction {
+    PULL,
+    PUSH
+}
+
 /**
  * Service delegating into the `Quick Open Service`, so that the Git commands can be further refined.
  * For instance, the `remote` can be specified for `pull`, `push`, and `fetch`. And the branch can be
@@ -113,6 +118,25 @@ export class GitQuickOpenService {
             };
             const items = remotes.map(remote => new GitQuickOpenItem(remote, execute));
             this.open(items, 'Pick a remote to fetch from:');
+        }
+    }
+
+    async performDefaultGitAction(action: GitAction): Promise<void> {
+        const repository = this.getRepository();
+        const remote = await this.getRemotes();
+        const defaultRemote = remote[0];
+        if (repository) {
+            try {
+                if (action === GitAction.PULL) {
+                    await this.git.pull(repository, { remote: defaultRemote });
+                    console.log(`Git Pull: sucessfully completed from ${defaultRemote}.`);
+                } else if (action === GitAction.PUSH) {
+                    await this.git.push(repository, { remote: defaultRemote });
+                    console.log(`Git Push: sucessfully completed to ${defaultRemote}.`);
+                }
+            } catch (error) {
+                this.gitErrorHandler.handleError(error);
+            }
         }
     }
 

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -25,7 +25,7 @@ import { EditorManager, EditorWidget, EditorOpenerOptions, EditorContextMenu, ED
 import { GitFileChange, GitFileStatus } from '../common';
 import { GitWidget } from './git-widget';
 import { GitRepositoryTracker } from './git-repository-tracker';
-import { GitQuickOpenService } from './git-quick-open-service';
+import { GitQuickOpenService, GitAction } from './git-quick-open-service';
 import { GitSyncService } from './git-sync-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { GitPrompt } from '../common/git-prompt';
@@ -43,13 +43,21 @@ export namespace GIT_COMMANDS {
         id: 'git.fetch',
         label: 'Git: Fetch...'
     };
+    export const PULL_DEFAULT = {
+        id: 'git.pull.default',
+        label: 'Git: Pull'
+    };
     export const PULL = {
         id: 'git.pull',
-        label: 'Git: Pull...'
+        label: 'Git: Pull from...'
+    };
+    export const PUSH_DEFAULT = {
+        id: 'git.push.default',
+        label: 'Git: Push'
     };
     export const PUSH = {
         id: 'git.push',
-        label: 'Git: Push...'
+        label: 'Git: Push to...'
     };
     export const MERGE = {
         id: 'git.merge',
@@ -184,7 +192,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
 
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
-        [GIT_COMMANDS.FETCH, GIT_COMMANDS.PULL, GIT_COMMANDS.PUSH, GIT_COMMANDS.MERGE].forEach(command =>
+        [GIT_COMMANDS.FETCH, GIT_COMMANDS.PULL_DEFAULT, GIT_COMMANDS.PULL, GIT_COMMANDS.PUSH_DEFAULT, GIT_COMMANDS.PUSH, GIT_COMMANDS.MERGE].forEach(command =>
             menus.registerMenuAction(GitWidget.ContextMenu.OTHER_GROUP, {
                 commandId: command.id,
                 label: command.label.slice('Git: '.length)
@@ -224,8 +232,16 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
             execute: () => this.quickOpenService.fetch(),
             isEnabled: () => !!this.repositoryTracker.selectedRepository
         });
+        registry.registerCommand(GIT_COMMANDS.PULL_DEFAULT, {
+            execute: () => this.quickOpenService.performDefaultGitAction(GitAction.PULL),
+            isEnabled: () => !!this.repositoryTracker.selectedRepository
+        });
         registry.registerCommand(GIT_COMMANDS.PULL, {
             execute: () => this.quickOpenService.pull(),
+            isEnabled: () => !!this.repositoryTracker.selectedRepository
+        });
+        registry.registerCommand(GIT_COMMANDS.PUSH_DEFAULT, {
+            execute: () => this.quickOpenService.performDefaultGitAction(GitAction.PUSH),
             isEnabled: () => !!this.repositoryTracker.selectedRepository
         });
         registry.registerCommand(GIT_COMMANDS.PUSH, {


### PR DESCRIPTION
Fixes #2195

- Added the commands `Git: Pull` and `Git: Push` which use the default configured remote
- Re-named the command `Git: Pull...` to `Git: Pull from...` to align
- Re-named the command `Git: Push...` to `Git: Push to...` to align

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
