### PR TITLE
[quickCommand] rename ID of the command palette to workbench.action.showCommands

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -21,7 +21,7 @@ import { PrefixQuickOpenService, QuickOpenHandlerRegistry } from './prefix-quick
 import { CommonMenus } from '../common-frontend-contribution';
 
 export const quickCommand: Command = {
-    id: 'quickCommand'
+    id: 'workbench.action.showCommands'
 };
 
 @injectable()


### PR DESCRIPTION
So it is matching VSCode command as well (it's already matching keybinding)
https://code.visualstudio.com/docs/getstarted/keybindings#_navigation

Change-Id: I2044bcfbf67c71f981cce50f7aeb363c12cfb166
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
