### PR TITLE
Fix plugin initialization when browser is refreshed

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -151,6 +151,7 @@ export class HostedPluginSupport {
                     }
                     const rpc = this.createServerRpc(pluginID, hostKey);
                     const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
+                    hostedExtManager.$stopPlugin('');
                     hostedExtManager.$init({
                         plugins: plugins,
                         preferences: this.preferenceServiceImpl.getPreferences(),

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -74,7 +74,11 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     $stopPlugin(contextPath: string): PromiseLike<void> {
         this.activatedPlugins.forEach(plugin => {
             if (plugin.stopFn) {
-                plugin.stopFn();
+                try {
+                    plugin.stopFn();
+                } catch (e) {
+                    console.error(e);
+                }
             }
 
             // dispose any objects
@@ -83,6 +87,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
                 dispose(pluginContext.subscriptions);
             }
         });
+
         return Promise.resolve();
     }
 
@@ -90,8 +95,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.storageProxy = this.rpc.set(
             MAIN_RPC_CONTEXT.STORAGE_EXT,
             new KeyValueStorageProxy(this.rpc.getProxy(PLUGIN_RPC_CONTEXT.STORAGE_MAIN),
-                                     pluginInit.globalState,
-                                     pluginInit.workspaceState)
+                pluginInit.globalState,
+                pluginInit.workspaceState)
         );
 
         // init query parameters


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does PR do:
Stops remote plugins before initialization

### Reference issue
https://github.com/theia-ide/theia/issues/3970