### PR TITLE
fix #3338 Format Document on save

### DIFF
--- a/packages/core/src/browser/saveable.ts
+++ b/packages/core/src/browser/saveable.ts
@@ -64,7 +64,7 @@ export namespace Saveable {
     }
     // tslint:disable-next-line:no-any
     export async function save(arg: any): Promise<void> {
-        const saveable = getDirty(arg);
+        const saveable = get(arg);
         if (saveable) {
             await saveable.save();
         }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -248,6 +248,11 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'default': false,
             'description': 'Enable auto indentation adjustment.'
         },
+        'editor.formatOnSave': {
+            'type': 'boolean',
+            'default': false,
+            'description': 'Enable format on manual save.'
+        },
         'editor.formatOnType': {
             'type': 'boolean',
             'default': false,
@@ -519,6 +524,7 @@ export interface EditorConfiguration {
     'editor.autoClosingBrackets'?: boolean
     'editor.autoIndent'?: boolean
     'editor.formatOnType'?: boolean
+    'editor.formatOnSave'?: boolean
     'editor.formatOnPaste'?: boolean
     'editor.dragAndDrop'?: boolean
     'editor.suggestOnTriggerCharacters'?: boolean

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -308,7 +308,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     }
 
     protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken): Promise<void> {
-        if (token.isCancellationRequested || !this.resource.saveContents || !this.dirty) {
+        if (token.isCancellationRequested || !this.resource.saveContents) {
             return;
         }
 


### PR DESCRIPTION
Fix #3338 
This is a follow-up of the pr #3640 
Since the " [monaco] re-implementation of fireWillSaveModel " on Jan 2nd, it is possible to use the "format on Save" . 

Format on Save is only available when the preference autoSave is "OFF"
and the preference 'editor.formatOnSave' is "true"

Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
