### PR TITLE
[plug-in] allow to expose keybindings to plug-ins

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -154,6 +154,7 @@ export interface CommandRegistryMain {
     $unregisterCommand(id: string): void;
     $executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined>;
     $getCommands(): PromiseLike<string[]>;
+    $getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined>;
 }
 
 export interface CommandRegistryExt {

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -95,6 +95,10 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         }
     }
 
+    getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined> {
+        return this.proxy.$getKeyBinding(commandId);
+    }
+
     // tslint:disable-next-line:no-any
     private executeLocalCommand<T>(id: string, args: any[]): PromiseLike<T> {
         const handler = this.commands.get(id);

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -164,6 +164,9 @@ export function createAPIFactory(
             // tslint:disable-next-line:no-any
             registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable {
                 return commandRegistry.registerHandler(commandId, handler);
+            },
+            getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined> {
+                return commandRegistry.getKeyBinding(commandId);
             }
         };
 

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -65,6 +65,31 @@ declare module '@theia/plugin' {
         workspaceContains?: string[];
     }
 
+
+    export namespace commands {
+
+        /**
+        * Get the keybindings associated to commandId.
+        * @param commandId The ID of the command for which we are looking for keybindings.
+        */
+        export function getKeyBinding(commandId: string): PromiseLike<CommandKeyBinding[] | undefined>;
+
+    }
+
+    /**
+     * Key Binding of a command
+     */
+    export interface CommandKeyBinding {
+        /**
+         * Identifier of the command.
+         */
+        id: string;
+        /**
+         * Value of the keyBinding
+         */
+        value: string;
+    }
+
     /**
      * Enumeration of the supported operating systems.
      */


### PR DESCRIPTION
So plug-ins can display/use these key bindings

Change-Id: I8e751ed7927c841f29b579a9059336ed82ebd8bf
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
