### PR TITLE
Enable INI syntax highlighting for `.properties` and `.toml` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [cpp] added new `cpp.clangdExecutable` and `cpp.clangdArgs` to customize language server start command.
 - [monaco] Fix document-saving that was taking too long.
 - [plug-in] added `tasks.onDidStartTask` Plug-in API
+- Enabled INI syntax highlighting for `.properties` and `.toml` files
 
 ## v0.3.18
 - [core] added a preference to define how to handle application exit

--- a/packages/textmate-grammars/src/browser/ini.ts
+++ b/packages/textmate-grammars/src/browser/ini.ts
@@ -26,8 +26,9 @@ export class IniContribution implements LanguageGrammarDefinitionContribution {
     registerTextmateLanguage(registry: TextmateRegistry) {
         monaco.languages.register({
             id: this.id,
-            extensions: ['.ini'],
-            aliases: ['Ini', 'ini']
+            extensions: ['.ini', '.properties', '.toml'],
+            aliases: ['INI', 'ini', 'properties', 'toml'],
+            mimetypes: ['text/x-ini', 'text/x-properties', 'text/x-toml'],
         });
         monaco.languages.setLanguageConfiguration(this.id, {
             comments: {


### PR DESCRIPTION
[.properties](https://en.wikipedia.org/wiki/.properties) and [.toml](https://en.wikipedia.org/wiki/TOML) files are of same family as [.ini](https://en.wikipedia.org/wiki/INI_file) files, and they all use basically the same syntax.

This pull request aims to support `.properties` and `.toml` files. To illustrate, see how a (currently unhighlighted) `Cargo.toml` would get highlighted as INI:

<img width="1138" alt="screenshot 2019-01-10 at 16 09 20" src="https://user-images.githubusercontent.com/599268/50986424-1606a780-1507-11e9-9696-4cdd59e3b158.png">

I also notice that the current INI implementation has a few problems (but they're orthogonal to the addition of `.properties` and `.toml`, so shouldn't block this pull request):
- Both `.ini` and `.properties` sometimes allow `key : value` as an alternative to `key = value`, but this doesn't seem to work in the current INI implementation.
- Unquoted values like integers (e.g. `answer = 42`) should be highlighted as well, but in the current implementation they're not.