### PR TITLE
make debug-auto-launch VS Code extension to display status bar items properly

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,6 +19,9 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
+/** Set up en as a default locale for VS Code extensions using vscode-nls */
+process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });
+
 const pluginsApiImpl = new Map<string, typeof theia>();
 const plugins = new Array<Plugin>();
 let defaultApi: typeof theia;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -251,7 +251,7 @@ export interface MessageRegistryMain {
 }
 
 export interface StatusBarMessageRegistryMain {
-    $setMessage(text: string,
+    $setMessage(text: string | undefined,
         priority: number,
         alignment: theia.StatusBarAlignment,
         color: string | undefined,

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -157,6 +157,31 @@ export interface PluginPackageLanguageContributionConfiguration {
 }
 
 export const PluginScanner = Symbol('PluginScanner');
+/**
+ * This scanner process package.json object and returns plugin metadata objects.
+ */
+export interface PluginScanner {
+    /**
+     * The type of plugin's API (engine name)
+     */
+    apiType: PluginEngine;
+
+    /**
+     * Creates plugin's model.
+     *
+     * @param {PluginPackage} plugin
+     * @returns {PluginModel}
+     */
+    getModel(plugin: PluginPackage): PluginModel;
+
+    /**
+     * Creates plugin's lifecycle.
+     *
+     * @returns {PluginLifecycle}
+     */
+    getLifecycle(plugin: PluginPackage): PluginLifecycle;
+}
+
 export const PluginDeployer = Symbol('PluginDeployer');
 
 /**
@@ -189,31 +214,6 @@ export interface PluginDeployerFileHandler {
     accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
 
     handle(context: PluginDeployerFileHandlerContext): Promise<void>;
-}
-
-/**
- * This scanner process package.json object and returns plugin metadata objects.
- */
-export interface PluginScanner {
-    /**
-     * The type of plugin's API (engine name)
-     */
-    apiType: PluginEngine;
-
-    /**
-     * Creates plugin's model.
-     *
-     * @param {PluginPackage} plugin
-     * @returns {PluginModel}
-     */
-    getModel(plugin: PluginPackage): PluginModel;
-
-    /**
-     * Creates plugin's lifecycle.
-     *
-     * @returns {PluginLifecycle}
-     */
-    getLifecycle(plugin: PluginPackage): PluginLifecycle;
 }
 
 export interface PluginDeployerResolverInit {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { MessageService, Command, Emitter, Event, UriSelection } from '@theia/core/lib/common';
@@ -26,6 +27,7 @@ import { HostedPluginServer } from '../../common/plugin-protocol';
 import { DebugConfiguration as HostedDebugConfig } from '../../common';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { HostedPluginPreferences } from './hosted-plugin-preferences';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 
 /**
  * Commands to control Hosted plugin instances.
@@ -171,12 +173,16 @@ export class HostedPluginManagerClient {
         this.isDebug = true;
 
         await this.start({ debugMode: this.hostedPluginPreferences['hosted-plugin.debugMode'] });
+        const outFiles = this.pluginLocation && [path.join(FileUri.fsPath(this.pluginLocation), '**', '*.js')];
         await this.debugSessionManager.start({
             configuration: {
                 type: 'node',
                 request: 'attach',
                 timeout: 30000,
-                name: 'Hosted Plugin'
+                name: 'Hosted Plugin',
+                smartStep: true,
+                sourceMaps: !!outFiles,
+                outFiles
             }
         });
     }

--- a/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
@@ -18,6 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as net from 'net';
+import * as path from 'path';
 import * as request from 'request';
 
 import URI from '@theia/core/lib/common/uri';
@@ -27,6 +28,8 @@ import { HostedPluginUriPostProcessor, HostedPluginUriPostProcessorSymbolName } 
 import { HostedPluginSupport } from './hosted-plugin';
 import { DebugConfiguration } from '../../common';
 import { environment } from '@theia/core';
+import { MetadataScanner } from './metadata-scanner';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 const processTree = require('ps-tree');
 
 export const HostedInstanceManager = Symbol('HostedInstanceManager');
@@ -101,6 +104,9 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
 
     @inject(HostedPluginSupport)
     protected readonly hostedPluginSupport: HostedPluginSupport;
+
+    @inject(MetadataScanner)
+    protected readonly metadata: MetadataScanner;
 
     isRunning(): boolean {
         return this.isPluginRunnig;
@@ -223,13 +229,10 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
     }
 
     isPluginValid(uri: URI): boolean {
-        const packageJsonPath = uri.path.toString() + '/package.json';
-        if (fs.existsSync(packageJsonPath)) {
-            const packageJson = require(packageJsonPath);
-            const plugin = packageJson['theiaPlugin'];
-            if (plugin && (plugin['frontend'] || plugin['backend'])) {
-                return true;
-            }
+        const pckPath = path.join(FileUri.fsPath(uri), 'package.json');
+        if (fs.existsSync(pckPath)) {
+            const pck = require(pckPath);
+            return !!this.metadata.getScanner(pck);
         }
         return false;
     }

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -29,7 +29,7 @@ export class MetadataScanner {
         });
     }
 
-    public getPluginMetadata(plugin: PluginPackage): PluginMetadata {
+    getPluginMetadata(plugin: PluginPackage): PluginMetadata {
         const scanner = this.getScanner(plugin);
         return {
             host: 'main',
@@ -45,7 +45,7 @@ export class MetadataScanner {
      * @param {PluginPackage} plugin
      * @returns {PluginScanner}
      */
-    private getScanner(plugin: PluginPackage): PluginScanner {
+    getScanner(plugin: PluginPackage): PluginScanner {
         let scanner;
         if (plugin && plugin.engines) {
             const scanners = Object.keys(plugin.engines)

--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -29,7 +29,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
         this.delegate = container.get(StatusBar);
     }
 
-    $setMessage(text: string,
+    $setMessage(text: string | undefined,
                 priority: number,
                 alignment: number,
                 color: string | undefined,
@@ -37,7 +37,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
                 command: string | undefined): PromiseLike<string> {
         const id = this.uniqueId;
         const entry = {
-            text,
+            text: text || '',
             priority,
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color,


### PR DESCRIPTION
- fix #3992 - tolerate missing text fo status bar items 
- fix #4010 - allow to debug VS Code extensions  via the plugin-hosted extension, needed it to figure out why debug-auto-launch cannot load messages properly
- configure vscode-nls with en locale by default for VS Code extensions using it for internationalization

Auto attach status is now properly displayed:
<img width="1234" alt="screen shot 2019-01-11 at 09 35 24" src="https://user-images.githubusercontent.com/3082655/51024347-9c63cd80-1589-11e9-874a-c3a97683c19a.png">
