### PR TITLE
[plug-in]Register code lenses from the vscode extensions

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -51,7 +51,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     vscode.commands.registerCommand = function (command: any, handler?: <T>(...args: any[]) => T | Thenable<T>): any {
         // use of the ID when registering commands
         if (typeof command === 'string' && handler) {
-            return vscode.commands.registerHandler(command, handler);
+            return registerCommand({ id: command }, handler);
         }
         return registerCommand(command, handler);
     };

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -28,22 +28,32 @@ export class CommandRegistryImpl implements CommandRegistryExt {
 
     private proxy: CommandRegistryMain;
     private commands = new Map<string, Handler>();
-
-    private readonly converter: CommandsConverter;
+    private converter: CommandsConverter;
+    private cache = new Map<number, theia.Command>();
+    private delegatingCommandId: string;
 
     // tslint:disable-next-line:no-any
     private static EMPTY_HANDLER(...args: any[]): Promise<any> { return Promise.resolve(undefined); }
 
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
-        this.converter = new CommandsConverter(this);
 
         // register internal VS Code commands
         this.registerHandler('vscode.previewHtml', CommandRegistryImpl.EMPTY_HANDLER);
     }
 
     getConverter(): CommandsConverter {
-        return this.converter;
+        if (this.converter) {
+            return this.converter;
+        } else {
+            this.delegatingCommandId = `_internal_command_delegation_${Date.now()}`;
+            const command: theia.Command = {
+                id: this.delegatingCommandId
+            };
+            this.registerCommand(command, this.executeConvertedCommand);
+            this.converter = new CommandsConverter(this.delegatingCommandId, this.cache);
+            return this.converter;
+        }
     }
 
     registerCommand(command: theia.Command, handler?: Handler): Disposable {
@@ -78,9 +88,9 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     }
 
     // tslint:disable-next-line:no-any
-    $executeCommand<T>(id: string, args: any[]): PromiseLike<T> {
+    $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
         if (this.commands.has(id)) {
-            return this.executeLocalCommand(id, args);
+            return this.executeLocalCommand(id, ...args);
         } else {
             return Promise.reject(`Command: ${id} does not exist.`);
         }
@@ -99,37 +109,56 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     private executeLocalCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
         const handler = this.commands.get(id);
         if (handler) {
-            return Promise.resolve(handler(...args));
+            const result = id === this.delegatingCommandId ?
+                handler(this, ...args)
+                : handler.apply(undefined, args);
+            return Promise.resolve(result);
         } else {
             return Promise.reject(new Error(`Command ${id} doesn't exist`));
         }
+    }
+
+    // tslint:disable-next-line:no-any
+    executeConvertedCommand(commands: CommandRegistryImpl, ...args: any[]): PromiseLike<any> {
+        const actualCmd = commands.cache.get(args[0]);
+        if (!actualCmd) {
+            return Promise.resolve(undefined);
+        }
+        return commands.executeCommand(actualCmd.command ? actualCmd.command : actualCmd.id, ...(actualCmd.arguments || []));
     }
 }
 
 /** Converter between internal and api commands. */
 export class CommandsConverter {
-
     private readonly delegatingCommandId: string;
-
     private cacheId = 0;
-    private cache = new Map<number, theia.Command>();
+    private cache: Map<number, theia.Command>;
 
-    constructor(private readonly commands: CommandRegistryImpl) {
-        this.delegatingCommandId = `_internal_command_delegation_${Date.now()}`;
-        this.commands.registerHandler(this.delegatingCommandId, this.executeConvertedCommand);
+    constructor(id: string, cache: Map<number, theia.Command>) {
+        this.cache = cache;
+        this.delegatingCommandId = id;
     }
 
     toInternal(command: theia.Command | undefined): Command | undefined {
-        if (!command || !command.label) {
+        if (!command) {
+            return undefined;
+        }
+
+        let title;
+        if (command.title) {
+            title = command.title;
+        } else if (command.label) {
+            title = command.label;
+        } else {
             return undefined;
         }
 
         const result: Command = {
-            id: command.id,
-            title: command.label
+            id: command.command ? command.command : command.id,
+            title: title
         };
 
-        if (command.id && !CommandsConverter.isFalsyOrEmpty(command.arguments)) {
+        if (command.command && !CommandsConverter.isFalsyOrEmpty(command.arguments)) {
             const id = this.cacheId++;
             ObjectIdentifier.mixin(result, id);
             this.cache.set(id, command);
@@ -157,18 +186,11 @@ export class CommandsConverter {
             return {
                 id: command.id,
                 label: command.title,
+                command: command.id,
+                title: command.title,
                 arguments: command.arguments
             };
         }
-    }
-
-    // tslint:disable-next-line:no-any
-    private executeConvertedCommand(...args: any[]): PromiseLike<any> {
-        const actualCmd = this.cache.get(args[0]);
-        if (!actualCmd) {
-            return Promise.resolve(undefined);
-        }
-        return this.commands.executeCommand(actualCmd.id, ...(actualCmd.arguments || []));
     }
 
     /**

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -403,8 +403,8 @@ export function fromDocumentHighlight(documentHighlight: theia.DocumentHighlight
 
 export function toInternalCommand(command: theia.Command): model.Command {
     return {
-        id: command.id,
-        title: command.label || '',
+        id: command.command ? command.command : command.id,
+        title: command.title ? command.title : command.label || ' ',
         tooltip: command.tooltip,
         arguments: command.arguments
     };

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -176,6 +176,17 @@ declare module '@theia/plugin' {
          * invoked with.
          */
         arguments?: any[];
+
+        // Title and command fields are needed to make Command object similar to Command from vscode API
+
+        /**
+         * Title of the command, like "save".
+         */
+        title?: string;
+        /**
+         * The identifier of the actual command handler.
+         */
+        command?: string;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
This PR solves next problems: 
- Register commands from the code lenses which were provider by vscode extension;
- Commands from the plugin should be registered more global. `command.CommandRegistry` has to know about those commands;
- Commands from code actions should be transformed correctly.

Related issue: https://github.com/theia-ide/theia/issues/3946, https://github.com/theia-ide/theia/issues/4081, https://github.com/theia-ide/theia/issues/3968
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
