### PR TITLE
[plug-in] implement "registerRenameProvider" of Languages API

### DIFF
--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -466,3 +466,17 @@ export interface DocumentColorProvider {
     provideDocumentColors(model: monaco.editor.ITextModel): PromiseLike<ColorInformation[]>;
     provideColorPresentations(model: monaco.editor.ITextModel, colorInfo: ColorInformation): PromiseLike<ColorPresentation[]>;
 }
+
+export interface Rejection {
+    rejectReason?: string;
+}
+
+export interface RenameLocation {
+    range: Range;
+    text: string;
+}
+
+export interface RenameProvider {
+    provideRenameEdits(model: monaco.editor.ITextModel, position: Position, newName: string): PromiseLike<WorkspaceEdit & Rejection>;
+    resolveRenameLocation?(model: monaco.editor.ITextModel, position: Position): PromiseLike<RenameLocation & Rejection>;
+}

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -53,6 +53,7 @@ import {
     Location,
     Breakpoint,
     ColorPresentation,
+    RenameLocation,
 } from './model';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from '../common/types';
@@ -861,6 +862,8 @@ export interface LanguagesExt {
     ): PromiseLike<monaco.languages.FoldingRange[] | undefined>;
     $provideDocumentColors(handle: number, resource: UriComponents): PromiseLike<RawColorInfo[]>;
     $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo): PromiseLike<ColorPresentation[]>;
+    $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string): PromiseLike<WorkspaceEditDto | undefined>;
+    $resolveRenameLocation(handle: number, resource: UriComponents, position: Position): PromiseLike<RenameLocation | undefined>;
 }
 
 export interface LanguagesMain {
@@ -888,6 +891,7 @@ export interface LanguagesMain {
     $registerWorkspaceSymbolProvider(handle: number): void;
     $registerFoldingRangeProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerDocumentColorProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+    $registerRenameProvider(handle: number, selector: SerializedDocumentFilter[], supportsResoveInitialValues: boolean): void;
 }
 
 export interface WebviewPanelViewState {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -21,7 +21,10 @@ import {
     SerializedIndentationRule,
     SerializedOnEnterRule,
     MAIN_RPC_CONTEXT,
-    LanguagesExt
+    LanguagesExt,
+    WorkspaceEditDto,
+    ResourceTextEditDto,
+    ResourceFileEditDto,
 } from '../../api/plugin-api';
 import { interfaces } from 'inversify';
 import { SerializedDocumentFilter, MarkerData, Range, WorkspaceSymbolProvider } from '../../api/model';
@@ -32,6 +35,7 @@ import { LanguageSelector } from '../../plugin/languages';
 import { DocumentFilter, MonacoModelIdentifier, testGlob, getLanguages } from 'monaco-languageclient/lib';
 import { DisposableCollection, Emitter } from '@theia/core';
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
+import URI from 'vscode-uri/lib/umd';
 
 export class LanguagesMainImpl implements LanguagesMain {
 
@@ -630,6 +634,38 @@ export class LanguagesMainImpl implements LanguagesMain {
         };
     }
 
+    $registerRenameProvider(handle: number, selector: SerializedDocumentFilter[], supportsResolveLocation: boolean): void {
+        const languageSelector = fromLanguageSelector(selector);
+        const renameProvider = this.createRenameProvider(handle, languageSelector, supportsResolveLocation);
+        const disposable = new DisposableCollection();
+        for (const language of getLanguages()) {
+            if (this.matchLanguage(languageSelector, language)) {
+                disposable.push(monaco.languages.registerRenameProvider(language, renameProvider));
+            }
+        }
+        this.disposables.set(handle, disposable);
+    }
+
+    protected createRenameProvider(handle: number, selector: LanguageSelector | undefined, supportsResolveLocation: boolean): monaco.languages.RenameProvider {
+        return {
+            provideRenameEdits: (model, position, newName, token) => {
+                if (!this.matchModel(selector, MonacoModelIdentifier.fromModel(model))) {
+                    return undefined!;
+                }
+                return this.proxy.$provideRenameEdits(handle, model.uri, position, newName)
+                    .then(v => reviveWorkspaceEditDto(v!));
+            },
+            resolveRenameLocation: supportsResolveLocation
+                ? (model, position, token) => {
+                    if (!this.matchModel(selector, MonacoModelIdentifier.fromModel(model))) {
+                        return undefined!;
+                    }
+                    return this.proxy.$resolveRenameLocation(handle, model.uri, position).then(v => v!);
+                }
+                : undefined
+        };
+    }
+
     protected matchModel(selector: LanguageSelector | undefined, model: MonacoModelIdentifier): boolean {
         if (Array.isArray(selector)) {
             return selector.some(filter => this.matchModel(filter, model));
@@ -723,4 +759,18 @@ function reviveOnEnterRules(onEnterRules?: SerializedOnEnterRule[]): monaco.lang
         return undefined;
     }
     return onEnterRules.map(reviveOnEnterRule);
+}
+
+export function reviveWorkspaceEditDto(data: WorkspaceEditDto): monaco.languages.WorkspaceEdit {
+    if (data && data.edits) {
+        for (const edit of data.edits) {
+            if (typeof (<ResourceTextEditDto>edit).resource === 'object') {
+                (<ResourceTextEditDto>edit).resource = URI.revive((<ResourceTextEditDto>edit).resource);
+            } else {
+                (<ResourceFileEditDto>edit).newUri = URI.revive((<ResourceFileEditDto>edit).newUri);
+                (<ResourceFileEditDto>edit).oldUri = URI.revive((<ResourceFileEditDto>edit).oldUri);
+            }
+        }
+    }
+    return <monaco.languages.WorkspaceEdit>data;
 }

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -26,8 +26,6 @@ import {
     UndoStopOptions,
     DecorationRenderOptions,
     DecorationOptions,
-    ResourceTextEditDto,
-    ResourceFileEditDto,
     WorkspaceEditDto
 } from '../../api/plugin-api';
 import { Range } from '../../api/model';
@@ -36,7 +34,7 @@ import { RPCProtocol } from '../../api/rpc-protocol';
 import { DisposableCollection } from '@theia/core';
 import { TextEditorMain } from './text-editor-main';
 import { disposed } from '../../common/errors';
-import URI from 'vscode-uri';
+import { reviveWorkspaceEditDto } from './languages-main';
 import { MonacoBulkEditService } from '@theia/monaco/lib/browser/monaco-bulk-edit-service';
 
 export class TextEditorsMainImpl implements TextEditorsMain {
@@ -110,7 +108,7 @@ export class TextEditorsMainImpl implements TextEditorsMain {
     }
 
     $tryApplyWorkspaceEdit(dto: WorkspaceEditDto): Promise<boolean> {
-        const edits  = this.reviveWorkspaceEditDto(dto);
+        const edits  = reviveWorkspaceEditDto(dto);
         return new Promise(resolve => {
             this.bulkEditService.apply( edits).then(() => resolve(true), err => resolve(false));
         });
@@ -147,17 +145,4 @@ export class TextEditorsMainImpl implements TextEditorsMain {
         return Promise.resolve();
     }
 
-    reviveWorkspaceEditDto(data: WorkspaceEditDto): monaco.languages.WorkspaceEdit {
-        if (data && data.edits) {
-            for (const edit of data.edits) {
-                if (typeof (<ResourceTextEditDto>edit).resource === 'object') {
-                    (<ResourceTextEditDto>edit).resource = URI.revive((<ResourceTextEditDto>edit).resource);
-                } else {
-                    (<ResourceFileEditDto>edit).newUri = URI.revive((<ResourceFileEditDto>edit).newUri);
-                    (<ResourceFileEditDto>edit).oldUri = URI.revive((<ResourceFileEditDto>edit).oldUri);
-                }
-            }
-        }
-        return <monaco.languages.WorkspaceEdit>data;
-    }
 }

--- a/packages/plugin-ext/src/plugin/languages/rename.ts
+++ b/packages/plugin-ext/src/plugin/languages/rename.ts
@@ -1,0 +1,132 @@
+/********************************************************************************
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri/lib/umd';
+import * as theia from '@theia/plugin';
+import * as Converter from '../type-converters';
+import * as model from '../../api/model';
+import { DocumentsExtImpl } from '@theia/plugin-ext/src/plugin/documents';
+import { WorkspaceEditDto } from '@theia/plugin-ext/src/common';
+import { Position } from '../../api/plugin-api';
+import { createToken } from '../token-provider';
+import { Range } from '../types-impl';
+import { isObject } from '../../common/types';
+
+export class RenameAdapter {
+
+    static supportsResolving(provider: theia.RenameProvider): boolean {
+        return typeof provider.prepareRename === 'function';
+    }
+
+    constructor(
+        private readonly provider: theia.RenameProvider,
+        private readonly documents: DocumentsExtImpl
+    ) { }
+
+    provideRenameEdits(resource: URI, position: Position, newName: string): Promise<WorkspaceEditDto | undefined> {
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There is no document for ${resource}`));
+        }
+
+        const doc = document.document;
+        const pos = Converter.toPosition(position);
+
+        return Promise.resolve(
+            this.provider.provideRenameEdits(doc, pos, newName, createToken())
+        ).then(value => {
+            if (!value) {
+                return undefined;
+            }
+
+            return Converter.fromWorkspaceEdit(value);
+        }, error => {
+            const rejectReason = RenameAdapter.asMessage(error);
+            if (rejectReason) {
+                return <WorkspaceEditDto>{
+                    rejectReason,
+                    edits: undefined!
+                };
+            } else {
+                return Promise.reject<WorkspaceEditDto>(error);
+            }
+        });
+    }
+
+    resolveRenameLocation(resource: URI, position: Position): Promise<model.RenameLocation & model.Rejection | undefined> {
+        if (typeof this.provider.prepareRename !== 'function') {
+            return Promise.resolve(undefined);
+        }
+
+        const document = this.documents.getDocumentData(resource);
+        if (!document) {
+            return Promise.reject(new Error(`There is no document for ${resource}`));
+        }
+
+        const doc = document.document;
+        const pos = Converter.toPosition(position);
+
+        return Promise.resolve(
+            this.provider.prepareRename(doc, pos, createToken())
+        ).then(rangeOrLocation => {
+
+            let range: theia.Range | undefined;
+            let text: string;
+            if (rangeOrLocation && Range.isRange(rangeOrLocation)) {
+                range = rangeOrLocation;
+                text = doc.getText(rangeOrLocation);
+            } else if (rangeOrLocation && isObject(rangeOrLocation)) {
+                range = rangeOrLocation.range;
+                text = rangeOrLocation.placeholder;
+            }
+
+            if (!range) {
+                return undefined;
+            }
+            if (range.start.line > pos.line || range.end.line < pos.line) {
+                console.warn('INVALID rename location: position line must be within range start/end lines');
+                return undefined;
+            }
+            return {
+                range: Converter.fromRange(range)!,
+                text: text!
+            };
+        }, error => {
+            const rejectReason = RenameAdapter.asMessage(error);
+            if (rejectReason) {
+                return Promise.resolve(<model.RenameLocation & model.Rejection>{
+                    rejectReason,
+                    range: undefined!,
+                    text: undefined!
+                });
+            } else {
+                return Promise.reject(error);
+            }
+        });
+    }
+
+    /* tslint:disable-next-line:no-any */
+    private static asMessage(err: any): string | undefined {
+        if (typeof err === 'string') {
+            return err;
+        } else if (err instanceof Error && typeof err.message === 'string') {
+            return err.message;
+        } else {
+            return undefined;
+        }
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -500,6 +500,9 @@ export function createAPIFactory(
             registerFoldingRangeProvider(selector: theia.DocumentSelector, provider: theia.FoldingRangeProvider): theia.Disposable {
                 return languagesExt.registerFoldingRangeProvider(selector, provider);
             },
+            registerRenameProvider(selector: theia.DocumentSelector, provider: theia.RenameProvider): theia.Disposable {
+                return languagesExt.registerRenameProvider(selector, provider);
+            },
         };
 
         const plugins: typeof theia.plugins = {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5756,6 +5756,39 @@ declare module '@theia/plugin' {
         resolveDocumentLink?(link: DocumentLink, token: CancellationToken | undefined): ProviderResult<DocumentLink>;
     }
 
+
+    /**
+    * The rename provider interface defines the contract between extensions and
+    * the [rename](https://code.visualstudio.com/docs/editor/editingevolved#_rename-symbol)-feature.
+    */
+    export interface RenameProvider {
+
+        /**
+        * Provide an edit that describes changes that have to be made to one
+        * or many resources to rename a symbol to a different name.
+        *
+        * @param document The document in which the command was invoked.
+        * @param position The position at which the command was invoked.
+        * @param newName The new name of the symbol. If the given name is not valid, the provider must return a rejected promise.
+        * @param token A cancellation token.
+        * @return A workspace edit or a thenable that resolves to such. The lack of a result can be
+        * signaled by returning `undefined` or `null`.
+        */
+        provideRenameEdits(document: TextDocument, position: Position, newName: string, token: CancellationToken): ProviderResult<WorkspaceEdit>;
+
+        /**
+        * Optional function for resolving and validating a position *before* running rename. The result can
+        * be a range or a range and a placeholder text. The placeholder text should be the identifier of the symbol
+        * which is being renamed - when omitted the text in the returned range is used.
+        *
+        * @param document The document in which rename will be invoked.
+        * @param position The position at which rename will be invoked.
+        * @param token A cancellation token.
+        * @return The range or range and placeholder text of the identifier that is to be renamed. The lack of a result can signaled by returning `undefined` or `null`.
+        */
+        prepareRename?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Range | { range: Range, placeholder: string }>;
+    }
+
     export namespace languages {
         /**
          * Return the identifiers of all known languages.
@@ -6094,6 +6127,19 @@ declare module '@theia/plugin' {
         * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
         */
         export function registerFoldingRangeProvider(selector: DocumentSelector, provider: FoldingRangeProvider): Disposable;
+
+        /**
+        * Register a reference provider.
+        *
+        * Multiple providers can be registered for a language. In that case providers are sorted
+        * by their [score](#languages.match) and the best-matching provider is used. Failure
+        * of the selected provider will cause a failure of the whole operation.
+        *
+        * @param selector A selector that defines the documents this provider is applicable to.
+        * @param provider A rename provider.
+        * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+        */
+        export function registerRenameProvider(selector: DocumentSelector, provider: RenameProvider): Disposable;
     }
 
     /**


### PR DESCRIPTION
Implemented the part of Languages API that provides functionality to apply changes to one or many resources to rename a document symbol.

resolve https://github.com/theia-ide/theia/issues/3861

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
