### PR TITLE
debug auto launch

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -21,6 +21,7 @@ import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });
+process.env['VSCODE_PID'] = process.env['THEIA_PARENT_PID'];
 
 const pluginsApiImpl = new Map<string, typeof theia>();
 const plugins = new Array<Plugin>();

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,6 +19,9 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
+/** Set up en as a default locale for VS Code extensions using vscode-nls */
+process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });
+
 const pluginsApiImpl = new Map<string, typeof theia>();
 const plugins = new Array<Plugin>();
 let defaultApi: typeof theia;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -162,7 +162,11 @@ export interface CommandRegistryExt {
 }
 
 export interface TerminalServiceExt {
-    $terminalClosed(id: number): void;
+    $terminalCreated(id: string, name: string): void;
+    $terminalNameChanged(id: string, name: string): void;
+    $terminalOpened(id: string, processId: number): void;
+    $terminalClosed(id: string): void;
+    $currentTerminalChanged(id: string | undefined): void;
 }
 
 export interface ConnectionMain {
@@ -184,7 +188,7 @@ export interface TerminalServiceMain {
      * Create new Terminal with Terminal options.
      * @param options - object with parameters to create new terminal.
      */
-    $createTerminal(options: theia.TerminalOptions): PromiseLike<number>;
+    $createTerminal(id: string, options: theia.TerminalOptions): Promise<string>;
 
     /**
      * Send text to the terminal by id.
@@ -192,26 +196,26 @@ export interface TerminalServiceMain {
      * @param text - text content.
      * @param addNewLine - in case true - add new line after the text, otherwise - don't apply new line.
      */
-    $sendText(id: number, text: string, addNewLine?: boolean): void;
+    $sendText(id: string, text: string, addNewLine?: boolean): void;
 
     /**
      * Show terminal on the UI panel.
      * @param id - terminal id.
      * @param preserveFocus - set terminal focus in case true value, and don't set focus otherwise.
      */
-    $show(id: number, preserveFocus?: boolean): void;
+    $show(id: string, preserveFocus?: boolean): void;
 
     /**
      * Hide UI panel where is located terminal widget.
      * @param id - terminal id.
      */
-    $hide(id: number): void;
+    $hide(id: string): void;
 
     /**
      * Distroy terminal.
      * @param id - terminal id.
      */
-    $dispose(id: number): void;
+    $dispose(id: string): void;
 }
 
 export interface AutoFocus {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -252,7 +252,7 @@ export interface MessageRegistryMain {
 }
 
 export interface StatusBarMessageRegistryMain {
-    $setMessage(text: string,
+    $setMessage(text: string | undefined,
         priority: number,
         alignment: theia.StatusBarAlignment,
         color: string | undefined,

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -153,7 +153,7 @@ export interface CommandRegistryMain {
     $registerCommand(command: theia.Command): void;
 
     $unregisterCommand(id: string): void;
-    $executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined>;
+    $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined>;
     $getCommands(): PromiseLike<string[]>;
 }
 

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -157,6 +157,31 @@ export interface PluginPackageLanguageContributionConfiguration {
 }
 
 export const PluginScanner = Symbol('PluginScanner');
+/**
+ * This scanner process package.json object and returns plugin metadata objects.
+ */
+export interface PluginScanner {
+    /**
+     * The type of plugin's API (engine name)
+     */
+    apiType: PluginEngine;
+
+    /**
+     * Creates plugin's model.
+     *
+     * @param {PluginPackage} plugin
+     * @returns {PluginModel}
+     */
+    getModel(plugin: PluginPackage): PluginModel;
+
+    /**
+     * Creates plugin's lifecycle.
+     *
+     * @returns {PluginLifecycle}
+     */
+    getLifecycle(plugin: PluginPackage): PluginLifecycle;
+}
+
 export const PluginDeployer = Symbol('PluginDeployer');
 
 /**
@@ -189,31 +214,6 @@ export interface PluginDeployerFileHandler {
     accept(pluginDeployerEntry: PluginDeployerEntry): boolean;
 
     handle(context: PluginDeployerFileHandlerContext): Promise<void>;
-}
-
-/**
- * This scanner process package.json object and returns plugin metadata objects.
- */
-export interface PluginScanner {
-    /**
-     * The type of plugin's API (engine name)
-     */
-    apiType: PluginEngine;
-
-    /**
-     * Creates plugin's model.
-     *
-     * @param {PluginPackage} plugin
-     * @returns {PluginModel}
-     */
-    getModel(plugin: PluginPackage): PluginModel;
-
-    /**
-     * Creates plugin's lifecycle.
-     *
-     * @returns {PluginLifecycle}
-     */
-    getLifecycle(plugin: PluginPackage): PluginLifecycle;
 }
 
 export interface PluginDeployerResolverInit {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as path from 'path';
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { MessageService, Command, Emitter, Event, UriSelection } from '@theia/core/lib/common';
@@ -26,6 +27,7 @@ import { HostedPluginServer } from '../../common/plugin-protocol';
 import { DebugConfiguration as HostedDebugConfig } from '../../common';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { HostedPluginPreferences } from './hosted-plugin-preferences';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 
 /**
  * Commands to control Hosted plugin instances.
@@ -171,12 +173,16 @@ export class HostedPluginManagerClient {
         this.isDebug = true;
 
         await this.start({ debugMode: this.hostedPluginPreferences['hosted-plugin.debugMode'] });
+        const outFiles = this.pluginLocation && [path.join(FileUri.fsPath(this.pluginLocation), '**', '*.js')];
         await this.debugSessionManager.start({
             configuration: {
                 type: 'node',
                 request: 'attach',
                 timeout: 30000,
-                name: 'Hosted Plugin'
+                name: 'Hosted Plugin',
+                smartStep: true,
+                sourceMaps: !!outFiles,
+                outFiles
             }
         });
     }

--- a/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
@@ -18,6 +18,7 @@ import { inject, injectable, named } from 'inversify';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as net from 'net';
+import * as path from 'path';
 import * as request from 'request';
 
 import URI from '@theia/core/lib/common/uri';
@@ -27,6 +28,8 @@ import { HostedPluginUriPostProcessor, HostedPluginUriPostProcessorSymbolName } 
 import { HostedPluginSupport } from './hosted-plugin';
 import { DebugConfiguration } from '../../common';
 import { environment } from '@theia/core';
+import { MetadataScanner } from './metadata-scanner';
+import { FileUri } from '@theia/core/lib/node/file-uri';
 const processTree = require('ps-tree');
 
 export const HostedInstanceManager = Symbol('HostedInstanceManager');
@@ -101,6 +104,9 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
 
     @inject(HostedPluginSupport)
     protected readonly hostedPluginSupport: HostedPluginSupport;
+
+    @inject(MetadataScanner)
+    protected readonly metadata: MetadataScanner;
 
     isRunning(): boolean {
         return this.isPluginRunnig;
@@ -223,13 +229,10 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
     }
 
     isPluginValid(uri: URI): boolean {
-        const packageJsonPath = uri.path.toString() + '/package.json';
-        if (fs.existsSync(packageJsonPath)) {
-            const packageJson = require(packageJsonPath);
-            const plugin = packageJson['theiaPlugin'];
-            if (plugin && (plugin['frontend'] || plugin['backend'])) {
-                return true;
-            }
+        const pckPath = path.join(FileUri.fsPath(uri), 'package.json');
+        if (fs.existsSync(pckPath)) {
+            const pck = require(pckPath);
+            return !!this.metadata.getScanner(pck);
         }
         return false;
     }

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -29,7 +29,7 @@ export class MetadataScanner {
         });
     }
 
-    public getPluginMetadata(plugin: PluginPackage): PluginMetadata {
+    getPluginMetadata(plugin: PluginPackage): PluginMetadata {
         const scanner = this.getScanner(plugin);
         return {
             host: 'main',
@@ -45,7 +45,7 @@ export class MetadataScanner {
      * @param {PluginPackage} plugin
      * @returns {PluginScanner}
      */
-    private getScanner(plugin: PluginPackage): PluginScanner {
+    getScanner(plugin: PluginPackage): PluginScanner {
         let scanner;
         if (plugin && plugin.engines) {
             const scanners = Object.keys(plugin.engines)

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -28,7 +28,9 @@ export class HostedPluginReader implements BackendApplicationContribution {
     @inject(ILogger)
     protected readonly logger: ILogger;
 
-    @inject(MetadataScanner) private readonly scanner: MetadataScanner;
+    @inject(MetadataScanner)
+    private readonly scanner: MetadataScanner;
+
     private plugin: PluginMetadata | undefined;
 
     @optional()
@@ -66,7 +68,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
         });
     }
 
-    public getPluginMetadata(path: string): PluginMetadata | undefined {
+    getPluginMetadata(path: string): PluginMetadata | undefined {
         if (!path.endsWith('/')) {
             path += '/';
         }
@@ -81,6 +83,10 @@ export class HostedPluginReader implements BackendApplicationContribution {
         const plugin: PluginPackage = JSON.parse(rawData);
         plugin.packagePath = path;
         const pluginMetadata = this.scanner.getPluginMetadata(plugin);
+        if (this.plugin && this.plugin.model && this.plugin.model.name === pluginMetadata.model.name) {
+            // prefer hosted plugin
+            return undefined;
+        }
         if (pluginMetadata.model.entryPoint.backend) {
             pluginMetadata.model.entryPoint.backend = resolve(path, pluginMetadata.model.entryPoint.backend);
         }

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -53,7 +53,7 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
         }
     }
     // tslint:disable-next-line:no-any
-    $executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined> {
+    $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
         try {
             return Promise.resolve(this.delegate.executeCommand(id, ...args));
         } catch (e) {

--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -29,7 +29,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
         this.delegate = container.get(StatusBar);
     }
 
-    $setMessage(text: string,
+    $setMessage(text: string | undefined,
                 priority: number,
                 alignment: number,
                 color: string | undefined,
@@ -37,7 +37,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
                 command: string | undefined): PromiseLike<string> {
         const id = this.uniqueId;
         const entry = {
-            text,
+            text: text || '',
             priority,
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color,

--- a/packages/plugin-ext/src/main/browser/terminal-main.ts
+++ b/packages/plugin-ext/src/main/browser/terminal-main.ts
@@ -14,93 +14,114 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { TerminalOptions } from '@theia/plugin';
-import { TerminalServiceMain, TerminalServiceExt, MAIN_RPC_CONTEXT } from '../../api/plugin-api';
 import { interfaces } from 'inversify';
+import { ApplicationShell, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { TerminalOptions } from '@theia/plugin';
+import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { TerminalWidget, TerminalWidgetOptions } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { TerminalServiceMain, TerminalServiceExt, MAIN_RPC_CONTEXT } from '../../api/plugin-api';
 import { RPCProtocol } from '../../api/rpc-protocol';
-import { ApplicationShell } from '@theia/core/lib/browser';
 
 /**
  * Plugin api service allows working with terminal emulator.
  */
 export class TerminalServiceMainImpl implements TerminalServiceMain {
 
-    private readonly terminalService: TerminalService;
+    private readonly terminals: TerminalService;
     private readonly shell: ApplicationShell;
-    protected readonly terminals = new Map<number, TerminalWidget>();
     private readonly extProxy: TerminalServiceExt;
-    private terminalNumber = 0;
-    private readonly TERM_ID_PREFIX = 'plugin-terminal-';
 
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
-        this.terminalService = container.get(TerminalService);
+        this.terminals = container.get(TerminalService);
         this.shell = container.get(ApplicationShell);
         this.extProxy = rpc.getProxy(MAIN_RPC_CONTEXT.TERMINAL_EXT);
+        this.terminals.onDidCreateTerminal(terminal => this.trackTerminal(terminal));
+        for (const terminal of this.terminals.all) {
+            this.trackTerminal(terminal);
+        }
+        this.terminals.onDidChangeCurrentTerminal(() => this.updateCurrentTerminal());
+        this.updateCurrentTerminal();
     }
 
-    async $createTerminal(options: TerminalOptions): Promise<number> {
-        const counter = this.terminalNumber++;
-        const termWidgetOptions: TerminalWidgetOptions = {
-            title: options.name,
-            shellPath: options.shellPath,
-            shellArgs: options.shellArgs,
-            cwd: options.cwd,
-            env: options.env,
-            destroyTermOnClose: true,
-            useServerTitle: false,
-            id: this.TERM_ID_PREFIX + counter,
-            attributes: options.attributes
-        };
-        let id: number;
+    protected updateCurrentTerminal(): void {
+        const { currentTerminal } = this.terminals;
+        this.extProxy.$currentTerminalChanged(currentTerminal && currentTerminal.id);
+    }
+
+    protected async trackTerminal(terminal: TerminalWidget): Promise<void> {
+        let name = terminal.title.label;
+        this.extProxy.$terminalCreated(terminal.id, name);
+        terminal.title.changed.connect(() => {
+            if (name !== terminal.title.label) {
+                name = terminal.title.label;
+                this.extProxy.$terminalNameChanged(terminal.id, name);
+            }
+        });
+        const updateProcessId = () => terminal.processId.then(
+            processId => this.extProxy.$terminalOpened(terminal.id, processId),
+            () => {/*no-op*/ }
+        );
+        updateProcessId();
+        terminal.onDidOpen(() => updateProcessId());
+        terminal.onTerminalDidClose(() => this.extProxy.$terminalClosed(terminal.id));
+    }
+
+    async $createTerminal(id: string, options: TerminalOptions): Promise<string> {
         try {
-            const termWidget = await this.terminalService.newTerminal(termWidgetOptions);
-            id = await termWidget.start();
-            this.terminals.set(id, termWidget);
-            termWidget.onTerminalDidClose(() => {
-                this.extProxy.$terminalClosed(id);
+            const terminal = await this.terminals.newTerminal({
+                id,
+                title: options.name,
+                shellPath: options.shellPath,
+                shellArgs: options.shellArgs,
+                cwd: options.cwd,
+                env: options.env,
+                destroyTermOnClose: true,
+                useServerTitle: false,
+                attributes: options.attributes
             });
+            terminal.start();
+            return terminal.id;
         } catch (error) {
             throw new Error('Failed to create terminal. Cause: ' + error);
         }
-        return id;
     }
 
-    $sendText(id: number, text: string, addNewLine?: boolean): void {
-        const termWidget = this.terminals.get(id);
-        if (termWidget) {
+    $sendText(id: string, text: string, addNewLine?: boolean): void {
+        const terminal = this.terminals.getById(id);
+        if (terminal) {
             text = text.replace(/\r?\n/g, '\r');
             if (addNewLine && text.charAt(text.length - 1) !== '\r') {
                 text += '\r';
             }
-            termWidget.sendText(text);
+            terminal.sendText(text);
         }
     }
 
-    $show(id: number, preserveFocus?: boolean): void {
-        const termWidget = this.terminals.get(id);
-        if (termWidget) {
-            this.terminalService.activateTerminal(termWidget);
+    $show(id: string, preserveFocus?: boolean): void {
+        const terminal = this.terminals.getById(id);
+        if (terminal) {
+            const options: WidgetOpenerOptions = {};
+            if (preserveFocus) {
+                options.mode = 'reveal';
+            }
+            this.terminals.open(terminal, options);
         }
     }
 
-    $hide(id: number): void {
-        const termWidget = this.terminals.get(id);
-        if (termWidget) {
-            if (termWidget.isVisible) {
-                const area = this.shell.getAreaFor(termWidget);
-                if (area) {
-                    this.shell.collapsePanel(area);
-                }
+    $hide(id: string): void {
+        const terminal = this.terminals.getById(id);
+        if (terminal && terminal.isVisible) {
+            const area = this.shell.getAreaFor(terminal);
+            if (area) {
+                this.shell.collapsePanel(area);
             }
         }
     }
 
-    $dispose(id: number): void {
-        const termWidget = this.terminals.get(id);
-        if (termWidget) {
-            termWidget.dispose();
+    $dispose(id: string): void {
+        const terminal = this.terminals.getById(id);
+        if (terminal) {
+            terminal.dispose();
         }
     }
 }

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -87,19 +87,19 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     }
 
     // tslint:disable-next-line:no-any
-    executeCommand<T>(id: string, args: any[]): PromiseLike<T | undefined> {
+    executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
         if (this.commands.has(id)) {
-            return this.executeLocalCommand(id, args);
+            return this.executeLocalCommand(id, ...args);
         } else {
-            return this.proxy.$executeCommand(id, args);
+            return this.proxy.$executeCommand(id, ...args);
         }
     }
 
     // tslint:disable-next-line:no-any
-    private executeLocalCommand<T>(id: string, args: any[]): PromiseLike<T> {
+    private executeLocalCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
         const handler = this.commands.get(id);
         if (handler) {
-            return Promise.resolve(handler(args));
+            return Promise.resolve(handler(...args));
         } else {
             return Promise.reject(new Error(`Command ${id} doesn't exist`));
         }
@@ -168,7 +168,7 @@ export class CommandsConverter {
         if (!actualCmd) {
             return Promise.resolve(undefined);
         }
-        return this.commands.executeCommand(actualCmd.id, actualCmd.arguments || []);
+        return this.commands.executeCommand(actualCmd.id, ...(actualCmd.arguments || []));
     }
 
     /**

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -266,7 +266,10 @@ export class DebugExtImpl implements DebugExt {
         const contribution = this.debuggersContributions.get(type);
         if (contribution) {
             if (contribution.adapterExecutableCommand) {
-                return await this.commandRegistryExt.executeCommand(contribution.adapterExecutableCommand, []) as DebugAdapterExecutable;
+                const executable = await this.commandRegistryExt.executeCommand<DebugAdapterExecutable>(contribution.adapterExecutableCommand);
+                if (executable) {
+                    return executable;
+                }
             } else {
                 const contributionPath = this.contributionPaths.get(type);
                 if (contributionPath) {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -155,7 +155,7 @@ export function createAPIFactory(
             },
             // tslint:disable-next-line:no-any
             executeCommand<T>(commandId: string, ...args: any[]): PromiseLike<T | undefined> {
-                return commandRegistry.executeCommand<T>(commandId, args);
+                return commandRegistry.executeCommand<T>(commandId, ...args);
             },
             // tslint:disable-next-line:no-any
             registerTextEditorCommand(command: theia.Command, callback: (textEditor: theia.TextEditor, edit: theia.TextEditorEdit, ...arg: any[]) => void): Disposable {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -167,13 +167,21 @@ export function createAPIFactory(
             }
         };
 
+        const { onDidChangeActiveTerminal, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
         const window: typeof theia.window = {
+            get activeTerminal() {
+                return terminalExt.activeTerminal;
+            },
             get activeTextEditor() {
                 return editors.getActiveEditor();
             },
             get visibleTextEditors() {
                 return editors.getVisibleTextEditors();
             },
+            get terminals() {
+                return terminalExt.terminals;
+            },
+            onDidChangeActiveTerminal,
             onDidChangeActiveTextEditor(listener, thisArg?, disposables?) {
                 return editors.onDidChangeActiveTextEditor(listener, thisArg, disposables);
             },
@@ -294,12 +302,8 @@ export function createAPIFactory(
             createTerminal(nameOrOptions: theia.TerminalOptions | (string | undefined), shellPath?: string, shellArgs?: string[]): theia.Terminal {
                 return terminalExt.createTerminal(nameOrOptions, shellPath, shellArgs);
             },
-            get onDidCloseTerminal(): theia.Event<theia.Terminal> {
-                return terminalExt.onDidCloseTerminal;
-            },
-            set onDidCloseTerminal(event: theia.Event<theia.Terminal>) {
-                terminalExt.onDidCloseTerminal = event;
-            },
+            onDidCloseTerminal,
+            onDidOpenTerminal,
             createTextEditorDecorationType(options: theia.DecorationRenderOptions): theia.TextEditorDecorationType {
                 return editors.createTextEditorDecorationType(options);
             },

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -263,8 +263,7 @@ class TreeViewExtImpl<T> extends Disposable {
             const treeItem = await this.treeDataProvider.getTreeItem(cachedElement);
 
             if (treeItem.command) {
-                this.commandRegistry.executeCommand(treeItem.command.id, treeItem.command.arguments ?
-                    treeItem.command.arguments : []);
+                this.commandRegistry.executeCommand(treeItem.command.id, ...(treeItem.command.arguments || []));
             }
         }
     }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2658,6 +2658,12 @@ declare module '@theia/plugin' {
     export namespace window {
 
         /**
+         * The currently active terminal or undefined. The active terminal is the one
+         * that currently has focus or most recently had focus.
+         */
+        export let activeTerminal: Terminal | undefined;
+
+        /**
          * The currently active editor or `undefined`. The active editor is the one
          * that currently has focus or, when none has focus, the one that has changed
          * input most recently.
@@ -2665,9 +2671,20 @@ declare module '@theia/plugin' {
         export let activeTextEditor: TextEditor | undefined;
 
         /**
+         * The currently opened terminals or an empty array.
+         */
+        export let terminals: ReadonlyArray<Terminal>;
+
+        /**
          * The currently visible editors or an empty array.
          */
         export let visibleTextEditors: TextEditor[];
+
+        /**
+         * An [event](#Event) which fires when the [active terminal](#window.activeTerminal) has changed.
+         * *Note* that the event also fires when the active terminal changes to `undefined`.
+         */
+        export const onDidChangeActiveTerminal: Event<Terminal | undefined>;
 
         /**
          * An [event](#Event) which fires when the [active editor](#window.activeTextEditor)
@@ -3023,6 +3040,12 @@ declare module '@theia/plugin' {
          * Event which fires when terminal did closed. Event value contains closed terminal definition.
          */
         export const onDidCloseTerminal: Event<Terminal>;
+
+        /**
+         * An [event](#Event) which fires when a terminal has been created,
+         * either through the createTerminal API or commands.
+         */
+        export const onDidOpenTerminal: Event<Terminal>;
 
         /**
          * Create new terminal with predefined options.
@@ -3904,8 +3927,8 @@ declare module '@theia/plugin' {
 		 * @return A thenable that resolves when the edit could be applied.
 		 */
 		export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
-        
-        
+
+
         /**
          * Register a filesystem provider for a given scheme, e.g. `ftp`.
          *

--- a/packages/terminal/src/browser/base/terminal-service.ts
+++ b/packages/terminal/src/browser/base/terminal-service.ts
@@ -13,6 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { Event } from '@theia/core/lib/common/event';
+import { WidgetOpenerOptions } from '@theia/core/lib/browser';
 import { TerminalWidgetOptions, TerminalWidget } from './terminal-widget';
 
 /**
@@ -20,6 +22,7 @@ import { TerminalWidgetOptions, TerminalWidget } from './terminal-widget';
  */
 export const TerminalService = Symbol('TerminalService');
 export interface TerminalService {
+
     /**
      * Create new terminal with predefined options.
      * @param options - terminal options.
@@ -28,7 +31,20 @@ export interface TerminalService {
 
     /**
      * Display new terminal widget.
-     * @param termWidget - widget to attach.
+     * @param terminal - widget to attach.
+     * @deprecated use #open
      */
-    activateTerminal(termWidget: TerminalWidget): void;
+    activateTerminal(terminal: TerminalWidget): void;
+
+    open(terminal: TerminalWidget, options?: WidgetOpenerOptions): void;
+
+    readonly all: TerminalWidget[];
+
+    getById(id: string): TerminalWidget | undefined;
+
+    readonly onDidCreateTerminal: Event<TerminalWidget>;
+
+    readonly currentTerminal: TerminalWidget | undefined;
+
+    readonly onDidChangeCurrentTerminal: Event<TerminalWidget | undefined>;
 }

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -22,27 +22,31 @@ import { BaseWidget } from '@theia/core/lib/browser';
  */
 export abstract class TerminalWidget extends BaseWidget {
 
+    abstract processId: Promise<number>;
+
     /**
      * Start terminal and return terminal id.
      * @param id - terminal id.
      */
-   abstract start(id?: number): Promise<number>;
+    abstract start(id?: number): Promise<number>;
 
-   /**
-    * Send text to the terminal server.
-    * @param text - text content.
-    */
-   abstract sendText(text: string): void;
+    /**
+     * Send text to the terminal server.
+     * @param text - text content.
+     */
+    abstract sendText(text: string): void;
 
-   /**
-    * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
-    */
-   abstract onTerminalDidClose: Event<TerminalWidget>;
+    abstract onDidOpen: Event<void>;
 
-   /**
-    * Cleat terminal output.
-    */
-   abstract clearOutput(): void;
+    /**
+     * Event which fires when terminal did closed. Event value contains closed terminal widget definition.
+     */
+    abstract onTerminalDidClose: Event<TerminalWidget>;
+
+    /**
+     * Cleat terminal output.
+     */
+    abstract clearOutput(): void;
 }
 
 /**

--- a/packages/terminal/src/common/base-terminal-protocol.ts
+++ b/packages/terminal/src/common/base-terminal-protocol.ts
@@ -21,6 +21,7 @@ export interface IBaseTerminalServerOptions { }
 
 export interface IBaseTerminalServer extends JsonRpcServer<IBaseTerminalClient> {
     create(IBaseTerminalServerOptions: object): Promise<number>;
+    getProcessId(id: number): Promise<number>;
     resize(id: number, cols: number, rows: number): Promise<void>;
     attach(id: number): Promise<number>;
     close(id: number): Promise<void>;

--- a/packages/terminal/src/node/base-terminal-server.ts
+++ b/packages/terminal/src/node/base-terminal-server.ts
@@ -50,6 +50,14 @@ export abstract class BaseTerminalServer implements IBaseTerminalServer {
         }
     }
 
+    async getProcessId(id: number): Promise<number> {
+        const terminal = this.processManager.get(id);
+        if (!(terminal instanceof TerminalProcess)) {
+            throw new Error(`terminal "${id}" does not exist`);
+        }
+        return terminal.pid;
+    }
+
     async close(id: number): Promise<void> {
         const term = this.processManager.get(id);
 


### PR DESCRIPTION
This PR fix issues to run and debug `debug-auto-launch` together with `debug-node` VS Code extensions.

Issues:
- fix #3992 - tolerate missing text fo status bar items
- fix #4010 - allow to debug VS Code extensions via the plugin-hosted extension, needed it to figure out why debug-auto-launch cannot load messages properly
- set up en as default locale for VS Code extension using vscode-nls
- set up VSCODE_PID as THEIA_PARENT_PID to allow `debug-auto-launch` to detect terminals spawned by Theia
- #4024 - support terminals related APIs on window, the same reason as previous
- #4030 - in hosted mode, allow the hosted plugin to override the installed plugin, needed during debugging `node-debug` via `node-debug`
- #4036 - in hosted mode, debug adapter executable were resolved against the hosted plugin, not proper one
- #4033 - command arguments were not spread properly, leading to bogus arguments

![debug-auto-launch](https://user-images.githubusercontent.com/3082655/51103517-4ab67f80-17e3-11e9-893c-17e201aaae45.gif)
