### PR TITLE
[debug] Debug adapter download script improvements

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -17,7 +17,9 @@
     "@theia/workspace": "^0.3.18",
     "@types/p-debounce": "^1.0.0",
     "jsonc-parser": "^2.0.2",
+    "mkdirp": "^0.5.0",
     "p-debounce": "^1.0.0",
+    "tar": "^4.0.0",
     "unzip-stream": "^0.3.0",
     "vscode-debugprotocol": "^1.32.0"
   },


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR introduces 3 enhancements to the debug adapter download script:

- Support for `.tar.gz` / `.tgz` packages for adapters using that format, e.g. [cpp-debug](https://github.com/eclipse/theia-cpp-extension/blob/master/packages/cpp-debug/package.json#L45)
- Added ability to change the target adapter output directory instead of the default `download`:

```json
    "adapters": {
        "node-debug": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/node-debug/1.29.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage",
        "node-debug2": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/node-debug2/1.29.2/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
    },
    "adapterDir": "adapters"
```
- Added ability to inject options for the HTTP request, e.g. to include a GitHub token for downloading/rate limiting:

```json
    "adapters": {
        "cdt-gdb-vscode": "https://github.com/theia-ide/cdt-gdb-vscode/releases/download/v0.0.34/cdt-gdb-vscode-0.0.34.tgz"
    },
    "requestOptions": {
        "headers": {
            "Authorization": "token <token>",
            "Accept": "application/vnd.github.v3.raw"
        }
    }
```

The PR introduces 2 new devDependencies for the `debug` package, however as these are already used by the `java` package, I am assuming this won't attract an eclipse CQ:

https://github.com/theia-ide/theia/blob/ecfa984f66eb84d9bcfbfd5136c1d38684db01ce/packages/java/package.json#L13
https://github.com/theia-ide/theia/blob/ecfa984f66eb84d9bcfbfd5136c1d38684db01ce/packages/java/package.json#L15

CC @marcdumais-work 