### PR TITLE
Implement URIs transferring via rpc channel

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { CommandContribution, CommandRegistry, Command } from '@theia/core';
 import { CommandService } from '@theia/core/lib/common/command';
-import theiaURI from '@theia/core/lib/common/uri';
+import TheiaURI from '@theia/core/lib/common/uri';
 import URI from 'vscode-uri';
 
 export namespace VscodeCommands {
@@ -36,7 +36,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand(VscodeCommands.OPEN, {
             isVisible: () => false,
             execute: (resource: URI) => {
-                this.commandService.executeCommand('theia.open', new theiaURI(resource));
+                this.commandService.executeCommand('theia.open', new TheiaURI(resource));
             }
         });
     }


### PR DESCRIPTION
This PR introduced mechanism to transfer specified objects via json rpc channel.
This allows using of objects in commands arguments according to their specifications.
For now added support for Theia URI and VSCode URI objects.

Fixes: https://github.com/theia-ide/theia/issues/3936

Signed-off-by: Mykola Morhun <mmorhun@redhat.com>
