### PR TITLE
[editorconfig] Don't apply all properties on open

### DIFF
--- a/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.spec.ts
@@ -46,8 +46,6 @@ describe('Editorconfig document manager', function () {
         const stubIndentStyle = sinon.stub(documentManager, 'ensureIndentStyle');
         const stubIndentSize = sinon.stub(documentManager, 'ensureIndentSize');
         const stubEndOfLine = sinon.stub(documentManager, 'ensureEndOfLine');
-        const stubTrimTrailingWhitespace = sinon.stub(documentManager, 'ensureTrimTrailingWhitespace');
-        const stubEndsWithNewLine = sinon.stub(documentManager, 'ensureEndsWithNewLine');
 
         const properties = {
             indent_style: 'space',
@@ -63,8 +61,6 @@ describe('Editorconfig document manager', function () {
         expect(stubIndentStyle.called).to.be.true;
         expect(stubIndentSize.called).to.be.true;
         expect(stubEndOfLine.called).to.be.true;
-        expect(stubTrimTrailingWhitespace.called).to.be.true;
-        expect(stubEndsWithNewLine.called).to.be.true;
     });
 
     it('Should handle `tab_width` property when `indent_size` is set to `tab`', () => {
@@ -106,8 +102,6 @@ describe('Editorconfig document manager', function () {
         const stubIndentStyle = sinon.stub(documentManager, 'ensureIndentStyle');
         const stubIndentSize = sinon.stub(documentManager, 'ensureIndentSize');
         const stubEndOfLine = sinon.stub(documentManager, 'ensureEndOfLine');
-        const stubTrimTrailingWhitespace = sinon.stub(documentManager, 'ensureTrimTrailingWhitespace');
-        const stubEndsWithNewLine = sinon.stub(documentManager, 'ensureEndsWithNewLine');
 
         const properties = {} as KnownProps;
 
@@ -116,8 +110,6 @@ describe('Editorconfig document manager', function () {
         expect(stubIndentStyle.called).to.be.false;
         expect(stubIndentSize.called).to.be.false;
         expect(stubEndOfLine.called).to.be.false;
-        expect(stubTrimTrailingWhitespace.called).to.be.false;
-        expect(stubEndsWithNewLine.called).to.be.false;
     });
 
 });

--- a/packages/editorconfig/src/browser/editorconfig-document-manager.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.ts
@@ -98,7 +98,6 @@ export class EditorconfigDocumentManager {
             const uri = editor.uri.toString();
             this.editorconfigServer.getConfig(uri).then(properties => {
                 this.properties[uri] = properties;
-                this.applyProperties(properties, editor);
             });
         }
     }
@@ -120,14 +119,6 @@ export class EditorconfigDocumentManager {
 
         if (this.isSet(properties.end_of_line)) {
             this.ensureEndOfLine(editor, properties);
-        }
-
-        if (this.isSet(properties.trim_trailing_whitespace)) {
-            this.ensureTrimTrailingWhitespace(editor, properties);
-        }
-
-        if (this.isSet(properties.insert_final_newline)) {
-            this.ensureEndsWithNewLine(editor, properties);
         }
     }
 
@@ -202,17 +193,6 @@ export class EditorconfigDocumentManager {
     }
 
     /**
-     * trim_trailing_whitespace: set to true to remove any whitespace characters
-     * preceding newline characters and false to ensure it doesn't.
-     */
-    ensureTrimTrailingWhitespace(editor: MonacoEditor, properties: KnownProps): void {
-        const edits = this.getEditsTrimmingTrailingWhitespaces(editor, properties);
-        if (edits.length > 0) {
-            editor.document.textEditorModel.applyEdits(edits);
-        }
-    }
-
-    /**
      * Returns array of edits trimming trailing whitespaces for the whole document.
      *
      * @param editor editor
@@ -246,24 +226,6 @@ export class EditorconfigDocumentManager {
         }
 
         return edits;
-    }
-
-    /**
-     * insert_final_newline: set to true to ensure file ends with a newline
-     * when saving and false to ensure it doesn't.
-     */
-    ensureEndsWithNewLine(editor: MonacoEditor, properties: KnownProps): void {
-        const edit = this.getEditInsertingFinalNewLine(editor, properties);
-        if (edit) {
-            // remember cursor position
-            const cursor = editor.cursor;
-
-            // apply edit
-            editor.document.textEditorModel.applyEdits([edit]);
-
-            // restore cursor position
-            editor.cursor = cursor;
-        }
     }
 
     /**

--- a/packages/editorconfig/src/common/editorconfig-interface.ts
+++ b/packages/editorconfig/src/common/editorconfig-interface.ts
@@ -22,7 +22,7 @@ export const EditorconfigService = Symbol('EditorconfigService');
 export interface EditorconfigService {
 
     /**
-     * Finds an apropriate editorconfgig properties for a file.
+     * Finds an apropriate editorconfig properties for a file.
      */
     getConfig(uri: string): Promise<KnownProps>;
 


### PR DESCRIPTION
`trim_trailing_whitespace` and `insert_final_newline` should not
be applied on open.
See https://github.com/editorconfig/editorconfig/wiki/Plugin-Guidelines

Fixes theia-ide/theia#2667

Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>