### PR TITLE
Support for setting end of line character

### DIFF
--- a/packages/core/src/common/application-protocol.ts
+++ b/packages/core/src/common/application-protocol.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { OS } from './os';
+
 export const applicationPath = '/services/application';
 
 export const ApplicationServer = Symbol('ApplicationServer');
@@ -21,6 +23,7 @@ export const ApplicationServer = Symbol('ApplicationServer');
 export interface ApplicationServer {
     getExtensionsInfos(): Promise<ExtensionInfo[]>;
     getApplicationInfo(): Promise<ApplicationInfo | undefined>;
+    getBackendOS(): Promise<OS.Type>;
 }
 
 export interface ExtensionInfo {

--- a/packages/core/src/node/application-server.ts
+++ b/packages/core/src/node/application-server.ts
@@ -17,6 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { ApplicationServer, ExtensionInfo, ApplicationInfo } from '../common/application-protocol';
 import { ApplicationPackage } from '@theia/application-package';
+import { OS } from '../common/os';
 
 @injectable()
 export class ApplicationServerImpl implements ApplicationServer {
@@ -41,4 +42,7 @@ export class ApplicationServerImpl implements ApplicationServer {
         return Promise.resolve(undefined);
     }
 
+    async getBackendOS(): Promise<OS.Type> {
+        return OS.type();
+    }
 }

--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -37,6 +37,13 @@ export namespace EditorCommands {
     export const CONFIG_INDENTATION: Command = {
         id: 'textEditor.commands.configIndentation'
     };
+
+    export const CONFIG_EOL: Command = {
+        id: 'textEditor.commands.configEol',
+        category: EDITOR_CATEGORY,
+        label: 'Change End of Line Sequence'
+    };
+
     export const INDENT_USING_SPACES: Command = {
         id: 'textEditor.commands.indentUsingSpaces',
         category: EDITOR_CATEGORY,
@@ -102,6 +109,7 @@ export class EditorCommandContribution implements CommandContribution {
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(EditorCommands.SHOW_REFERENCES);
         registry.registerCommand(EditorCommands.CONFIG_INDENTATION);
+        registry.registerCommand(EditorCommands.CONFIG_EOL);
         registry.registerCommand(EditorCommands.INDENT_USING_SPACES);
         registry.registerCommand(EditorCommands.INDENT_USING_TABS);
         registry.registerCommand(EditorCommands.CHANGE_LANGUAGE, {

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -458,6 +458,21 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'type': 'boolean',
             'description': 'Reveal first change.',
             'default': true
+        },
+        'files.eol': {
+            'type': 'string',
+            'enum': [
+                '\n',
+                '\r\n',
+                'auto'
+            ],
+            'enumDescriptions': [
+                'LF',
+                'CRLF',
+                'Uses operating system specific end of line character.'
+            ],
+            'default': 'auto',
+            'description': 'The default end of line character.'
         }
     }
 };
@@ -533,7 +548,9 @@ export interface EditorConfiguration {
     'diffEditor.followsCaret'?: boolean
     'diffEditor.ignoreCharChanges'?: boolean
     'diffEditor.alwaysRevealFirst'?: boolean
+    'files.eol': EndOfLinePreference
 }
+export type EndOfLinePreference = '\n' | '\r\n' | 'auto';
 
 export type EditorPreferenceChange = PreferenceChangeEvent<EditorConfiguration>;
 

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -123,6 +123,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
     protected registerEditorCommandHandlers(): void {
         this.registry.registerHandler(EditorCommands.SHOW_REFERENCES.id, this.newShowReferenceHandler());
         this.registry.registerHandler(EditorCommands.CONFIG_INDENTATION.id, this.newConfigIndentationHandler());
+        this.registry.registerHandler(EditorCommands.CONFIG_EOL.id, this.newConfigEolHandler());
         this.registry.registerHandler(EditorCommands.INDENT_USING_SPACES.id, this.newConfigTabSizeHandler(true));
         this.registry.registerHandler(EditorCommands.INDENT_USING_TABS.id, this.newConfigTabSizeHandler(false));
     }
@@ -161,6 +162,42 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             placeholder: 'Select Action',
             fuzzyMatchLabel: true
         });
+    }
+
+    protected newConfigEolHandler(): MonacoEditorCommandHandler {
+        return {
+            execute: editor => this.configureEol(editor)
+        };
+    }
+
+    protected configureEol(editor: MonacoEditor): void {
+        const options = ['LF', 'CRLF'].map(lineEnding =>
+            new QuickOpenItem({
+                label: lineEnding,
+                run: (mode: QuickOpenMode) => {
+                    if (mode === QuickOpenMode.OPEN) {
+                        this.setEol(editor, lineEnding);
+                        return true;
+                    }
+                    return false;
+                }
+            })
+        );
+        this.quickOpenService.open({ onType: (_, acceptor) => acceptor(options) }, {
+            placeholder: 'Select End of Line Sequence',
+            fuzzyMatchLabel: true
+        });
+    }
+
+    protected setEol(editor: MonacoEditor, lineEnding: string): void {
+        const model = editor.document && editor.document.textEditorModel;
+        if (model) {
+            if (lineEnding === 'CRLF' || lineEnding === '\r\n') {
+                model.pushEOL(monaco.editor.EndOfLineSequence.CRLF);
+            } else {
+                model.pushEOL(monaco.editor.EndOfLineSequence.LF);
+            }
+        }
     }
 
     protected newConfigTabSizeHandler(useSpaces: boolean): MonacoEditorCommandHandler {

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -67,17 +67,18 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/editor/contrib/find/findController',
                 'vs/editor/contrib/rename/rename',
                 'vs/editor/contrib/snippet/snippetParser',
+                'vs/platform/configuration/common/configuration',
                 'vs/editor/browser/services/codeEditorService',
                 'vs/editor/browser/services/codeEditorServiceImpl'
             ], (css: any, html: any, commands: any, actions: any, registry: any, resolver: any, resolvedKeybinding: any,
                 keyCodes: any, editorExtensions: any, simpleServices: any, standaloneServices: any, quickOpen: any, quickOpenWidget: any, quickOpenModel: any,
                 filters: any, styler: any, platform: any, modes: any, suggest: any, suggestController: any, findController: any, rename: any, snippetParser: any,
-                codeEditorService: any, codeEditorServiceImpl: any) => {
+                configuration: any, codeEditorService: any, codeEditorServiceImpl: any) => {
                     const global: any = self;
                     global.monaco.commands = commands;
                     global.monaco.actions = actions;
                     global.monaco.keybindings = Object.assign({}, registry, resolver, resolvedKeybinding, keyCodes);
-                    global.monaco.services = Object.assign({}, simpleServices, standaloneServices, codeEditorService, codeEditorServiceImpl);
+                    global.monaco.services = Object.assign({}, simpleServices, standaloneServices, configuration, codeEditorService, codeEditorServiceImpl);
                     global.monaco.quickOpen = Object.assign({}, quickOpen, quickOpenWidget, quickOpenModel);
                     global.monaco.filters = filters;
                     global.monaco.theme = styler;

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -422,6 +422,7 @@ declare module monaco.keybindings {
 declare module monaco.services {
 
     export const ICodeEditorService: any;
+    export const IConfigurationService: any;
 
     export abstract class CodeEditorServiceImpl implements monaco.editor.ICodeEditorService {
         constructor(themeService: IStandaloneThemeService);


### PR DESCRIPTION
This PR adds a status bar item shwoing the current EOL mode of an editor. Adds a command to change it. Also it respects the 'files.eol' setting (with less precedence than a possible '.editorconfig', i.e. in case of Theia).
The default computation is now based on the backend's OS.

see #4069

