### PR TITLE
[plug-in] Fix some signatures

### DIFF
--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -48,6 +48,14 @@ declare module '@theia/plugin' {
          * dispose all provided disposables.
          */
         static from(...disposableLikes: { dispose: () => any }[]): Disposable;
+
+        /**
+        * Creates a new Disposable calling the provided function
+        * on dispose.
+        * @param callOnDispose Function that disposes something.
+        */
+        constructor(callOnDispose: Function);
+
     }
 
     export type PluginType = 'frontend' | 'backend';
@@ -193,7 +201,7 @@ declare module '@theia/plugin' {
          */
         readonly character: number;
 
-        constructor(line: number, char: number);
+        constructor(line: number, character: number);
 
         /**
          * Check if this position is before `other`.
@@ -325,11 +333,11 @@ declare module '@theia/plugin' {
          * Create a new position from coordinates.
          *
          * @param startLine a zero based line value
-         * @param startChar a zero based character value
+         * @param startCharacter a zero based character value
          * @param endLine a zero based line value
-         * @param endChar a zero based character value
+         * @param endCharacter a zero based character value
          */
-        constructor(startLine: number, startChar: number, endLine: number, endChar: number);
+        constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number);
 
         /**
          * Check if a position or a range is in this range.
@@ -405,11 +413,11 @@ declare module '@theia/plugin' {
          * Create a selection from coordinates.
          *
          * @param anchorLine a zero based line value
-         * @param anchorChar a zero based character value
+         * @param anchorCharacter a zero based character value
          * @param activeLine a zero based line value
-         * @param activeChar a zero based character value
+         * @param activeCharacter a zero based character value
          */
-        constructor(anchorLine: number, anchorChar: number, activeLine: number, activeChar: number);
+        constructor(anchorLine: number, anchorCharacter: number, activeLine: number, activeCharacter: number);
     }
 
     /**
@@ -1066,7 +1074,7 @@ declare module '@theia/plugin' {
          * @param options The undo/redo behavior around this edit. By default, undo stops will be created before and after this edit.
          * @return A promise that resolves with a value indicating if the edits could be applied.
          */
-        edit(callback: (editBuilder: TextEditorEdit) => void, options?: { undoStopBefore: boolean; undoStopAfter: boolean; }): Promise<boolean>;
+        edit(callback: (editBuilder: TextEditorEdit) => void, options?: { undoStopBefore: boolean; undoStopAfter: boolean; }): PromiseLike<boolean>;
 
         /**
          * Insert a [snippet](#SnippetString) and put the editor into snippet mode. "Snippet mode"
@@ -1079,7 +1087,7 @@ declare module '@theia/plugin' {
          * @return A promise that resolves with a value indicating if the snippet could be inserted. Note that the promise does not signal
          * that the snippet is completely filled-in or accepted.
          */
-        insertSnippet(snippet: SnippetString, location?: Position | Range | Position[] | Range[], options?: { undoStopBefore: boolean; undoStopAfter: boolean; }): Promise<boolean>;
+        insertSnippet(snippet: SnippetString, location?: Position | Range | Position[] | Range[], options?: { undoStopBefore: boolean; undoStopAfter: boolean; }): PromiseLike<boolean>;
 
         /**
          * Adds a set of decorations to the text editor. If a set of decorations already exists with
@@ -2821,7 +2829,7 @@ declare module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showInformationMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
+        export function showInformationMessage<T extends MessageItem>(message: string, ...items: T[]): PromiseLike<T | undefined>;
 
         /**
          * Show an information message.
@@ -2840,7 +2848,7 @@ declare module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showWarningMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
+        export function showWarningMessage(message: string, ...items: string[]): PromiseLike<string | undefined>;
 
         /**
          * Show a warning message.
@@ -2878,7 +2886,7 @@ declare module '@theia/plugin' {
          * @param items A set of items that will be rendered as actions in the message.
          * @return A promise that resolves to the selected item or `undefined` when being dismissed.
          */
-        export function showErrorMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): PromiseLike<T | undefined>;
+        export function showErrorMessage(message: string, ...items: string[]): PromiseLike<string | undefined>;
 
         /**
          * Show an error message.
@@ -3184,7 +3192,7 @@ declare module '@theia/plugin' {
          *
          * **NOTE:** [TreeDataProvider](#TreeDataProvider) is required to implement [getParent](#TreeDataProvider.getParent) method to access this API.
          */
-        reveal(element: T, options?: { select?: boolean }): PromiseLike<void>;
+        reveal(element: T, options?: { select?: boolean, focus?: boolean, expand?: boolean | number }): PromiseLike<void>;
     }
 
     /**
@@ -3806,7 +3814,7 @@ declare module '@theia/plugin' {
 		 *
 		 * The current thresholds are 1.5 seconds as overall time budget and a listener can misbehave 3 times before being ignored.
 		 */
-		export const onWillSaveTextDocument: Event<TextDocumentWillSaveEvent>;
+        export const onWillSaveTextDocument: Event<TextDocumentWillSaveEvent>;
 
         /**
          * An event that is emitted when a [text document](#TextDocument) is saved to disk.
@@ -3830,7 +3838,7 @@ declare module '@theia/plugin' {
          * @param uri Identifies the resource to open.
          * @return A promise that resolves to a [document](#TextDocument).
          */
-        export function openTextDocument(uri: Uri): Promise<TextDocument | undefined>;
+        export function openTextDocument(uri: Uri): PromiseLike<TextDocument | undefined>;
 
         /**
          * A short-hand for `openTextDocument(Uri.file(fileName))`.
@@ -3839,7 +3847,7 @@ declare module '@theia/plugin' {
          * @param fileName A name of a file on disk.
          * @return A promise that resolves to a [document](#TextDocument).
          */
-        export function openTextDocument(fileName: string): Promise<TextDocument | undefined>;
+        export function openTextDocument(fileName: string): PromiseLike<TextDocument | undefined>;
 
         /**
          * Opens an untitled text document. The editor will prompt the user for a file
@@ -3849,7 +3857,7 @@ declare module '@theia/plugin' {
          * @param options Options to control how the document will be created.
          * @return A promise that resolves to a [document](#TextDocument).
          */
-        export function openTextDocument(options?: { language?: string; content?: string; }): Promise<TextDocument | undefined>;
+        export function openTextDocument(options?: { language?: string; content?: string; }): PromiseLike<TextDocument | undefined>;
 
         /**
          * Get a workspace configuration object.
@@ -3926,7 +3934,7 @@ declare module '@theia/plugin' {
 		 * @param edit A workspace edit.
 		 * @return A thenable that resolves when the edit could be applied.
 		 */
-		export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
+        export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
 
 
         /**
@@ -4234,10 +4242,11 @@ declare module '@theia/plugin' {
         /**
          * Creates a new parameter information object.
          *
-         * @param label A label string.
+         * @param label A label string or inclusive start and exclusive end offsets within its containing signature label.
          * @param documentation A doc string.
          */
-        constructor(label: string, documentation?: string | MarkdownString);
+        constructor(label: string | [number, number], documentation?: string | MarkdownString);
+
     }
 
     /**


### PR DESCRIPTION
Align some names with vscode one when it's duplicated
Update all Thenable to PromiseLike
showInformationMessage/showWarningMessage/showErrorMessage fix invalid parameter
remove tab characters

Change-Id: Ia018a12939bff612eb346de2abb6939389e9972a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
