### PR TITLE
Add 'tasks.onDidEndTask' Plug-in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.3.20
+- [plugin] added `tasks.onDidEndTask` Plug-in API
+
+
 ## v0.3.19
 - [core] added `hostname` alias
 - [core] added new `editor.formatOnSave` preference, to format documents on manual save

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -1029,6 +1029,7 @@ export interface TasksExt {
     $provideTasks(handle: number): Promise<TaskDto[] | undefined>;
     $resolveTask(handle: number, task: TaskDto): Promise<TaskDto | undefined>;
     $onDidStartTask(execution: TaskExecutionDto): void;
+    $onDidEndTask(id: number): void;
 }
 
 export interface TasksMain {

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -24,7 +24,7 @@ import { DisposableCollection } from '@theia/core';
 import { TaskProviderRegistry, TaskResolverRegistry, TaskProvider, TaskResolver } from '@theia/task/lib/browser/task-contribution';
 import { interfaces } from 'inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import { TaskInfo } from '@theia/task/lib/common/task-protocol';
+import { TaskInfo, TaskExitedEvent } from '@theia/task/lib/common/task-protocol';
 import { TaskWatcher } from '@theia/task/lib/common/task-watcher';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TaskConfiguration } from '@theia/task/lib/common';
@@ -61,6 +61,12 @@ export class TasksMainImpl implements TasksMain {
                     id: event.taskId,
                     task: event.config
                 });
+            }
+        });
+
+        this.taskWatcher.onTaskExit((event: TaskExitedEvent) => {
+            if (event.ctx === this.workspaceRootUri) {
+                this.proxy.$onDidEndTask(event.taskId);
             }
         });
     }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -585,6 +585,10 @@ export function createAPIFactory(
 
             onDidStartTask(listener, thisArg?, disposables?) {
                 return tasksExt.onDidStartTask(listener, thisArg, disposables);
+            },
+
+            onDidEndTask(listener, thisArg?, disposables?) {
+                return tasksExt.onDidEndTask(listener, thisArg, disposables);
             }
         };
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7021,6 +7021,18 @@ declare module '@theia/plugin' {
         execution: TaskExecution;
     }
 
+    /**
+     * An event signaling the end of an executed task.
+     *
+     * This interface is not intended to be implemented.
+     */
+    interface TaskEndEvent {
+        /**
+         * The task item representing the task that finished.
+         */
+        execution: TaskExecution;
+    }
+
     export namespace tasks {
 
         /**
@@ -7034,6 +7046,9 @@ declare module '@theia/plugin' {
 
         /** Fires when a task starts. */
         export const onDidStartTask: Event<TaskStartEvent>;
+
+        /** Fires when a task ends. */
+        export const onDidEndTask: Event<TaskEndEvent>;
     }
 
     /**


### PR DESCRIPTION
Add ability to get event on plugin side when a task is terminated
Example:
```
theia.tasks.onDidEndTask(event => {
      const task = event.execution.task;

      console.log(`The task ${task.name} was terminated`);
});
```

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

