### PR TITLE
Replace files.eol preferences with LF and CRLF

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -462,17 +462,12 @@ export const editorPreferenceSchema: PreferenceSchema = {
         'files.eol': {
             'type': 'string',
             'enum': [
-                '\n',
-                '\r\n',
-                'auto'
-            ],
-            'enumDescriptions': [
                 'LF',
                 'CRLF',
-                'Uses operating system specific end of line character.'
+                'auto'
             ],
             'default': 'auto',
-            'description': 'The default end of line character.'
+            'description': 'The default end of line character. LF(\\n), CRLF(\\r\\n)'
         }
     }
 };
@@ -550,7 +545,7 @@ export interface EditorConfiguration {
     'diffEditor.alwaysRevealFirst'?: boolean
     'files.eol': EndOfLinePreference
 }
-export type EndOfLinePreference = '\n' | '\r\n' | 'auto';
+export type EndOfLinePreference = 'LF' | 'CRLF' | 'auto';
 
 export type EditorPreferenceChange = PreferenceChangeEvent<EditorConfiguration>;
 

--- a/packages/monaco/src/browser/monaco-editor-provider.ts
+++ b/packages/monaco/src/browser/monaco-editor-provider.ts
@@ -75,7 +75,7 @@ export class MonacoEditorProvider {
                     if (creationOptions) {
                         const eol = this.getEOL();
                         creationOptions.files = {
-                            eol
+                            eol: eol === 'CRLF' ? '\r\n' : '\n'
                         };
                     }
                     return creationOptions;
@@ -87,12 +87,10 @@ export class MonacoEditorProvider {
 
     protected getEOL(): EndOfLinePreference {
         const eol = this.editorPreferences['files.eol'];
-        if (eol) {
-            if (eol !== 'auto') {
+        if (eol && eol !== 'auto') {
                 return eol;
-            }
         }
-        return this.isWindowsBackend ? '\r\n' : '\n';
+        return this.isWindowsBackend ? 'CRLF' : 'LF';
     }
 
     protected async getModel(uri: URI, toDispose: DisposableCollection): Promise<MonacoEditorModel> {


### PR DESCRIPTION
This is in relation to https://github.com/theia-ide/theia/issues/4087 Currently, the preferences widget parses the `\n` and `\r\n` which is why only `auto` is available from the choices. 

Primarily, i thought of simply escaping both values (`\\n`, `\\r\\n`) which technically will work and will show up as `\n` and `\r\n` from the choices.  However, choosing any of the two, it gets stored on the settings file as `"files.eol": "\\n"` or `"files.eol": "\\r\\n"` . So I decided to just use LF and CRLF and just converts them to their corresponding values during file creation.

Signed-off-by: Uni Sayo <unibtc@gmail.com>

