### PR TITLE
check that packages published to npm (#4083)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,9 @@
     "rebuild:electron:debug": "DEBUG=electron-rebuild && yarn rebuild:electron",
     "watch": "lerna run watch --scope \"@theia/!(example-)*\" --parallel",
     "publish": "yarn && yarn test && yarn publish:latest",
-    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes"
+    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish && yarn publish:check",
+    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes && yarn publish:check",
+    "publish:check": "node scripts/check-publish.js"
   },
   "workspaces": [
     "dev-packages/*",

--- a/scripts/check-publish.js
+++ b/scripts/check-publish.js
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2019 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+// @ts-check
+
+const path = require('path');
+const chalk = require('chalk').default;
+const cp = require('child_process');
+
+let code = 0;
+const workspaces = JSON.parse(JSON.parse(cp.execSync('yarn workspaces info --json').toString()).data);
+for (const name in workspaces) {
+    const workspace = workspaces[name];
+    const location = path.resolve(process.cwd(), workspace.location);
+    const packagePath = path.resolve(location, 'package.json');
+    const pck = require(packagePath);
+    if (!pck.private) {
+        const pckName = `${pck.name}@${pck.version}`;
+        if (cp.execSync(`npm view ${pckName} version --json`).toString().trim()) {
+            console.info(`${pckName}: published`);
+        } else {
+            console.error(`${pckName}: ${chalk.red('NOT')} published`);
+            code = 1;
+        }
+    }
+}
+process.exit(code);


### PR DESCRIPTION
in order to catch bogus deployments.

@svenefftinge @marcdumais-work can we merge it to try? It does not do anything to PR builds.

If it detects reliably missing packages (it does for me locally, tried with testnext tag), then we can try to change one thing at time and see what helps. I would like to try upgrading yarn version for travis first.