### PR TITLE
Fix 'onDidSelectItem' behavior for Quick Pick widget

### DIFF
--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -74,13 +74,13 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
                 description: i.description,
                 detail: i.detail,
                 run: mode => {
-                    if (mode === QuickOpenMode.PREVIEW) {
+                    if (mode === QuickOpenMode.OPEN) {
                         this.proxy.$onItemSelected(i.handle);
-                    } else if (mode === QuickOpenMode.OPEN) {
                         this.doResolve(i.handle);
                         this.cleanUp();
+                        return true;
                     }
-                    return true;
+                    return false;
                 }
             }));
         }


### PR DESCRIPTION
Invoke `onDidSelectItem` method  when  Quick Pick widget is in `OPEN` mode

Current state - `onDidSelectItem` is invoked immediately after opening the Quick Pick widget.
At this step Quick Pick widget is in `PREVIEW` mode and first item gets selection by default.

Fixes: https://github.com/theia-ide/theia/issues/4046

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

