### PR TITLE
Fix conversion of OS paths to DebugProtocol Source paths

### DIFF
--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -21,7 +21,8 @@
     "p-debounce": "^1.0.0",
     "tar": "^4.0.0",
     "unzip-stream": "^0.3.0",
-    "vscode-debugprotocol": "^1.32.0"
+    "vscode-debugprotocol": "^1.32.0",
+    "vscode-uri": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/debug/src/browser/debug-resource.ts
+++ b/packages/debug/src/browser/debug-resource.ts
@@ -29,12 +29,12 @@ export class DebugResource implements Resource {
 
     dispose(): void { }
 
-    readContents(): Promise<string> {
+    async readContents(): Promise<string> {
         const { currentSession } = this.manager;
         if (!currentSession) {
             throw new Error(`There is no active debug session to load content '${this.uri}'`);
         }
-        const source = currentSession.toSource(this.uri);
+        const source = await currentSession.toSource(this.uri);
         if (!source) {
             throw new Error(`There is no source for '${this.uri}'`);
         }

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -29,6 +29,7 @@ import { DebugSessionConnection } from './debug-session-connection';
 import { IWebSocket } from 'vscode-ws-jsonrpc/lib/socket/socket';
 import { DebugAdapterPath } from '../common/debug-service';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { FileSystem } from '@theia/filesystem/lib/common';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -111,6 +112,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
     protected readonly outputChannelManager: OutputChannelManager;
     @inject(DebugPreferences)
     protected readonly debugPreferences: DebugPreferences;
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
 
     get(sessionId: string, options: DebugSessionOptions): DebugSession {
         const connection = new DebugSessionConnection(
@@ -130,7 +133,8 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
             this.editorManager,
             this.breakpoints,
             this.labelProvider,
-            this.messages);
+            this.messages,
+            this.fileSystem);
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {

--- a/packages/debug/src/browser/model/debug-source.ts
+++ b/packages/debug/src/browser/model/debug-source.ts
@@ -19,6 +19,7 @@ import { EditorManager, EditorOpenerOptions, EditorWidget } from '@theia/editor/
 import URI from '@theia/core/lib/common/uri';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { DebugSession } from '../debug-session';
+import Uri from 'vscode-uri';
 
 export class DebugSourceData {
     readonly raw: DebugProtocol.Source;
@@ -86,19 +87,6 @@ export class DebugSource extends DebugSourceData {
         if (raw.path.match(DebugSource.SCHEME_PATTERN)) {
             return new URI(raw.path);
         }
-        return new URI().withScheme('file').withPath(raw.path);
+        return new URI(Uri.file(raw.path));
     }
-    static toSource(uri: URI): DebugProtocol.Source {
-        if (uri.scheme === DebugSource.SCHEME) {
-            return {
-                name: uri.path.toString(),
-                sourceReference: Number(uri.query)
-            };
-        }
-        return {
-            name: uri.displayName,
-            path: uri.path.toString()
-        };
-    }
-
 }

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -48,6 +48,7 @@ import { PluginDebugSessionFactory } from './plugin-debug-session-factory';
 import { PluginWebSocketChannel } from '../../../common/connection';
 import { PluginDebugAdapterContributionRegistrator, PluginDebugService } from './plugin-debug-service';
 import { DebugSchemaUpdater } from '@theia/debug/lib/browser/debug-schema-updater';
+import { FileSystem } from '@theia/filesystem/lib/common';
 
 export class DebugMainImpl implements DebugMain {
     private readonly debugExt: DebugExt;
@@ -65,6 +66,7 @@ export class DebugMainImpl implements DebugMain {
     private readonly sessionContributionRegistrator: PluginDebugSessionContributionRegistrator;
     private readonly adapterContributionRegistrator: PluginDebugAdapterContributionRegistrator;
     private readonly debugSchemaUpdater: DebugSchemaUpdater;
+    private readonly fileSystem: FileSystem;
 
     private readonly toDispose = new Map<string, DisposableCollection>();
 
@@ -83,6 +85,7 @@ export class DebugMainImpl implements DebugMain {
         this.adapterContributionRegistrator = container.get(PluginDebugService);
         this.sessionContributionRegistrator = container.get(PluginDebugSessionContributionRegistry);
         this.debugSchemaUpdater = container.get(DebugSchemaUpdater);
+        this.fileSystem = container.get(FileSystem);
 
         this.breakpointsManager.onDidChangeBreakpoints(({ added, removed, changed }) => {
             // TODO can we get rid of all to reduce amount of data set each time, should not it be possible to recover on another side from deltas?
@@ -124,7 +127,8 @@ export class DebugMainImpl implements DebugMain {
             async (sessionId: string) => {
                 const connection = await this.connectionMain.ensureConnection(sessionId);
                 return new PluginWebSocketChannel(connection);
-            }
+            },
+            this.fileSystem
         );
 
         disposable.pushAll([

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -26,6 +26,7 @@ import { DebugSessionOptions } from '@theia/debug/lib/browser/debug-session-opti
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
 import { DebugSessionConnection } from '@theia/debug/lib/browser/debug-session-connection';
 import { IWebSocket } from 'vscode-ws-jsonrpc/lib/socket/socket';
+import { FileSystem } from '@theia/filesystem/lib/common';
 
 /**
  * Session factory for a client debug session that communicates with debug adapter contributed as plugin.
@@ -40,7 +41,8 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
         protected readonly messages: MessageClient,
         protected readonly outputChannelManager: OutputChannelManager,
         protected readonly debugPreferences: DebugPreferences,
-        protected readonly connectionFactory: (sessionId: string) => Promise<IWebSocket>
+        protected readonly connectionFactory: (sessionId: string) => Promise<IWebSocket>,
+        protected readonly fileSystem: FileSystem
     ) {
         super();
     }
@@ -59,6 +61,7 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
             this.editorManager,
             this.breakpoints,
             this.labelProvider,
-            this.messages);
+            this.messages,
+            this.fileSystem);
     }
 }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR fixes #4026 by ensuring conversion of paths between the debug adapter and the internal URIs are correct for both Windows and Unix.

This is done in two parts;

- New `withFile()` function on the `URI` object which internally uses `Uri.file()` to correctly parse Windows and Unix paths to URIs

- Usage of the `FileSystem.getFsPath()` function running on the backend to ensure paths being passed to the debug adapter are correct for the backend OS

Much of the PR was reworking classes and functions to enable an async call to an injected `FileSystem` object. One side effect of this is the static `DebugSource.toSource()` has had to be moved to be an instance function in an injectable class.

Tested on Mac and Windows.

cc @arekzaluski, @akosyakov 