### PR TITLE
[plug-in] Allow to grab extra metadata for remote plug-ins

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -538,15 +538,19 @@ export interface HostedPluginClient {
     log(logPart: LogPart): void;
 }
 
+export const PluginDeployerHandler = Symbol('PluginDeployerHandler');
+export interface PluginDeployerHandler {
+    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
+    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
+}
+
 export const HostedPluginServer = Symbol('HostedPluginServer');
 export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
     getHostedPlugin(): Promise<PluginMetadata | undefined>;
 
     getDeployedMetadata(): Promise<PluginMetadata[]>;
     getDeployedFrontendMetadata(): Promise<PluginMetadata[]>;
-    deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void>;
     getDeployedBackendMetadata(): Promise<PluginMetadata[]>;
-    deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void>;
 
     getExtPluginAPI(): Promise<ExtPluginApi[]>;
 
@@ -590,4 +594,9 @@ export interface ServerPluginRunner {
     onMessage(jsonMessage: any): void;
     setClient(client: HostedPluginClient): void;
     setDefault(defaultRunner: ServerPluginRunner): void;
+
+    /**
+     * Provides additional metadata.
+     */
+    getExtraPluginMetadata(): Promise<PluginMetadata[]>;
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -20,7 +20,7 @@ import { injectable, inject } from 'inversify';
 import { ILogger, ConnectionErrorHandler } from '@theia/core/lib/common';
 import { Emitter } from '@theia/core/lib/common/event';
 import { createIpcEnv } from '@theia/core/lib/node/messaging/ipc-protocol';
-import { HostedPluginClient, ServerPluginRunner } from '../../common/plugin-protocol';
+import { HostedPluginClient, ServerPluginRunner, PluginMetadata } from '../../common/plugin-protocol';
 import { RPCProtocolImpl } from '../../api/rpc-protocol';
 import { MAIN_RPC_CONTEXT } from '../../api/plugin-api';
 
@@ -139,4 +139,9 @@ export class HostedPluginProcess implements ServerPluginRunner {
 
         return childProcess;
     }
+
+    async getExtraPluginMetadata(): Promise<PluginMetadata[]> {
+        return [];
+    }
+
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, multiInject, postConstruct, optional } from 'inversify';
 import { ILogger, ConnectionErrorHandler } from '@theia/core/lib/common';
-import { HostedPluginClient, PluginModel, ServerPluginRunner } from '../../common/plugin-protocol';
+import { HostedPluginClient, PluginModel, ServerPluginRunner, PluginMetadata } from '../../common/plugin-protocol';
 import { LogPart } from '../../common/types';
 import { HostedPluginProcess } from './hosted-plugin-process';
 
@@ -95,6 +95,10 @@ export class HostedPluginSupport {
             this.hostedPluginProcess.runPluginServer();
             this.isPluginProcessRunning = true;
         }
+    }
+
+    public async getExtraPluginMetadata(): Promise<PluginMetadata[]> {
+        return [].concat.apply([], await Promise.all(this.pluginRunners.map(runner => runner.getExtraPluginMetadata())));
     }
 
     public sendLog(logPart: LogPart): void {

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -26,14 +26,18 @@ import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginSupport } from './hosted-plugin';
 import { TheiaPluginScanner } from './scanners/scanner-theia';
 import { HostedPluginsManager, HostedPluginsManagerImpl } from './hosted-plugins-manager';
-import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath } from '../../common/plugin-protocol';
+import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath, PluginDeployerHandler } from '../../common/plugin-protocol';
 import { GrammarsReader } from './scanners/grammars-reader';
 import { HostedPluginProcess } from './hosted-plugin-process';
 import { ExtPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 
 export function bindCommonHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginReader).toSelf().inSingletonScope();
-    bind(HostedPluginServer).to(HostedPluginServerImpl).inSingletonScope();
+
+    bind(HostedPluginServerImpl).toSelf().inSingletonScope();
+    bind(HostedPluginServer).toService(HostedPluginServerImpl);
+    bind(PluginDeployerHandler).toService(HostedPluginServerImpl);
+
     bind(HostedPluginSupport).toSelf().inSingletonScope();
     bind(MetadataScanner).toSelf().inSingletonScope();
     bind(HostedPluginsManager).to(HostedPluginsManagerImpl).inSingletonScope();

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -20,7 +20,7 @@ import { injectable, optional, multiInject, inject } from 'inversify';
 import {
     PluginDeployerResolver, PluginDeployerFileHandler, PluginDeployerDirectoryHandler,
     PluginDeployerEntry, PluginDeployer, PluginDeployerResolverInit, PluginDeployerFileHandlerContext,
-    PluginDeployerDirectoryHandlerContext, HostedPluginServer, PluginDeployerEntryType,
+    PluginDeployerDirectoryHandlerContext, PluginDeployerEntryType, PluginDeployerHandler,
 } from '../../common/plugin-protocol';
 import { PluginDeployerEntryImpl } from './plugin-deployer-entry-impl';
 import { PluginDeployerResolverContextImpl, PluginDeployerResolverInitImpl } from './plugin-deployer-resolver-context-impl';
@@ -35,8 +35,8 @@ export class PluginDeployerImpl implements PluginDeployer {
     @inject(ILogger)
     protected readonly logger: ILogger;
 
-    @inject(HostedPluginServer)
-    protected readonly hostedPluginServer: HostedPluginServer;
+    @inject(PluginDeployerHandler)
+    protected readonly hostedPluginServer: PluginDeployerHandler;
 
     /**
      * Deployer entries.


### PR DESCRIPTION
- Adds a new interface `PluginDeployerHandler` for deploying metadata
- Adds method to grab metadata

Change-Id: I65f2ee2c7848aa8b4424eabcdd632d42c81e00d0
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
