### PR TITLE
[preferences] Escape \n and \r\n in preferences

### DIFF
--- a/packages/core/src/common/strings.ts
+++ b/packages/core/src/common/strings.ts
@@ -26,3 +26,11 @@ export function* split(s: string, splitter: string): IterableIterator<string> {
         start = end + splitter.length;
     }
 }
+
+export function escapeInvisibleChars(value: string ): string  {
+    return value.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+
+export function unescapeInvisibleChars(value: string): string {
+    return value.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+}

--- a/packages/preferences/src/browser/preferences-decorator.ts
+++ b/packages/preferences/src/browser/preferences-decorator.ts
@@ -17,6 +17,7 @@
 import { inject, injectable } from 'inversify';
 import { Tree, TreeDecorator, TreeDecoration, PreferenceProperty, PreferenceService } from '@theia/core/lib/browser';
 import { Emitter, Event, MaybePromise } from '@theia/core';
+import { escapeInvisibleChars } from '@theia/core/lib/common/strings';
 
 @injectable()
 export class PreferencesDecorator implements TreeDecorator {
@@ -50,7 +51,8 @@ export class PreferencesDecorator implements TreeDecorator {
                 tooltip: preferenceValue.description,
                 captionSuffixes: [
                     {
-                        data: storedValue !== undefined ? ': ' + storedValue : preferenceValue.default !== undefined ? ': ' + preferenceValue.default : undefined,
+                        data: storedValue !== undefined && typeof storedValue === 'string' ? ': ' + escapeInvisibleChars(storedValue) :
+                            preferenceValue.default !== undefined ? ': ' + preferenceValue.default : undefined,
                     },
                     {
                         data: ' ' + preferenceValue.description,
@@ -64,4 +66,5 @@ export class PreferencesDecorator implements TreeDecorator {
     decorations(tree: Tree): MaybePromise<Map<string, TreeDecoration.Data>> {
         return this.preferencesDecorations;
     }
+
 }

--- a/packages/preferences/src/browser/preferences-menu-factory.ts
+++ b/packages/preferences/src/browser/preferences-menu-factory.ts
@@ -18,6 +18,7 @@ import { injectable } from 'inversify';
 import { Menu } from '@phosphor/widgets';
 import { CommandRegistry } from '@phosphor/commands';
 import { PreferenceProperty } from '@theia/core/lib/browser';
+import { escapeInvisibleChars, unescapeInvisibleChars } from '@theia/core/lib/common/strings';
 
 @injectable()
 export class PreferencesMenuFactory {
@@ -29,13 +30,14 @@ export class PreferencesMenuFactory {
         if (property) {
             const enumConst = property.enum;
             if (enumConst) {
-                enumConst.forEach(enumValue => {
+                enumConst.map(escapeInvisibleChars)
+                .forEach(enumValue => {
                     const commandId = id + '-' + enumValue;
                     if (!commands.hasCommand(commandId)) {
                         commands.addCommand(commandId, {
                             label: enumValue,
-                            iconClass: savedPreference === enumValue || !savedPreference && property.default === enumValue ? 'fa fa-check' : '',
-                            execute: () => execute(id, enumValue)
+                            iconClass: escapeInvisibleChars(savedPreference) === enumValue || !savedPreference && property.default === enumValue ? 'fa fa-check' : '',
+                            execute: () => execute(id, unescapeInvisibleChars(enumValue))
                         });
                         menu.addItem({
                             type: 'command',


### PR DESCRIPTION
This PR is in relation to https://github.com/theia-ide/theia/pull/4110#issuecomment-456011435 and closes https://github.com/theia-ide/theia/issues/4087

This escapes `\n` and `\r\n` so that the literal values are shown in the ui and also retains the original values for the backend.

Signed-off-by: Uni Sayo <unibtc@gmail.com>