### PR TITLE
[ci] run canary publish second time without actual publishing to npm

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,11 @@
   "command": {
     "run": {
       "stream": true
+    },
+    "publish": {
+      "forcePublish": true,
+      "skipGit": true,
+      "registry": "https://registry.npmjs.org/"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,8 +62,9 @@
     "rebuild:electron:debug": "DEBUG=electron-rebuild && yarn rebuild:electron",
     "watch": "lerna run watch --scope \"@theia/!(example-)*\" --parallel",
     "publish": "yarn && yarn test && yarn publish:latest",
-    "publish:latest": "lerna publish --registry=https://registry.npmjs.org/ --skip-git --force-publish && yarn publish:check",
-    "publish:next": "lerna publish --registry=https://registry.npmjs.org/ --exact --canary=next --npm-tag=next --force-publish --skip-git --yes && yarn publish:check",
+    "publish:latest": "lerna publish && yarn publish:check",
+    "publish:next": "yarn next:publish && yarn next:publish --skip-npm && yarn publish:check",
+    "next:publish": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "publish:check": "node scripts/check-publish.js"
   },
   "workspaces": [

--- a/scripts/check-publish.js
+++ b/scripts/check-publish.js
@@ -31,7 +31,7 @@ for (const name in workspaces) {
         if (cp.execSync(`npm view ${pckName} version --json`).toString().trim()) {
             console.info(`${pckName}: published`);
         } else {
-            console.error(`${pckName}: ${chalk.red('NOT')} published`);
+            console.error(`(${chalk.red('ERR')}) ${pckName}: ${chalk.red('NOT')} published`);
             code = 1;
         }
     }


### PR DESCRIPTION
Otherwise lerna resets package.json files and publish check is done against previous versions.

BTW I've run `next:check` npm script against `next` tag and found that `typescript` extension was not published properly yesterday:
```
@theia/typescript@0.4.0-next.73d23a46: NOT published
@theia/userstorage@0.4.0-next.73d23a46: published
@theia/variable-resolver@0.4.0-next.73d23a46: published
@theia/workspace@0.4.0-next.73d23a46: published
```