### PR TITLE
[plug-in] rename method to get operating system

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -703,7 +703,7 @@ export interface DocumentsMain {
 
 export interface EnvMain {
     $getEnvVariable(envVarName: string): Promise<string | undefined>;
-    $getOsType(): Promise<theia.OSType>;
+    $getClientOperatingSystem(): Promise<theia.OperatingSystem>;
 }
 
 export interface PreferenceRegistryMain {

--- a/packages/plugin-ext/src/main/browser/env-main.ts
+++ b/packages/plugin-ext/src/main/browser/env-main.ts
@@ -20,7 +20,7 @@ import { RPCProtocol } from '../../api/rpc-protocol';
 import { EnvMain } from '../../api/plugin-api';
 import { QueryParameters } from '../../common/env';
 import { isWindows, isOSX } from '@theia/core';
-import { OSType } from '../../plugin/types-impl';
+import { OperatingSystem } from '../../plugin/types-impl';
 
 export class EnvMainImpl implements EnvMain {
     private envVariableServer: EnvVariablesServer;
@@ -33,14 +33,14 @@ export class EnvMainImpl implements EnvMain {
         return this.envVariableServer.getValue(envVarName).then(result => result ? result.value : undefined);
     }
 
-    async $getOsType(): Promise<OSType> {
+    async $getClientOperatingSystem(): Promise<OperatingSystem> {
         if (isWindows) {
-            return OSType.Windows;
+            return OperatingSystem.Windows;
         }
         if (isOSX) {
-            return OSType.OSX;
+            return OperatingSystem.OSX;
         }
-        return OSType.Linux;
+        return OperatingSystem.Linux;
     }
 }
 

--- a/packages/plugin-ext/src/plugin/env.ts
+++ b/packages/plugin-ext/src/plugin/env.ts
@@ -48,7 +48,7 @@ export class EnvExtImpl {
         this.queryParameters = queryParams;
     }
 
-    getOsType(): Promise<theia.OSType> {
-        return this.proxy.$getOsType();
+    getClientOperatingSystem(): Promise<theia.OperatingSystem> {
+        return this.proxy.$getClientOperatingSystem();
     }
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -93,7 +93,7 @@ import {
     Color,
     ColorInformation,
     ColorPresentation,
-    OSType,
+    OperatingSystem,
 } from './types-impl';
 import { SymbolKind } from '../api/model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -422,8 +422,8 @@ export function createAPIFactory(
             getQueryParameters(): QueryParameters {
                 return envExt.getQueryParameters();
             },
-            getOsType(): PromiseLike<theia.OSType> {
-                return envExt.getOsType();
+            getClientOperatingSystem(): PromiseLike<theia.OperatingSystem> {
+                return envExt.getClientOperatingSystem();
             }
 
         };
@@ -672,7 +672,7 @@ export function createAPIFactory(
             ColorPresentation,
             FoldingRange,
             FoldingRangeKind,
-            OSType
+            OperatingSystem
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1802,7 +1802,7 @@ export enum FoldingRangeKind {
 /**
  * Enumeration of the supported operating systems.
  */
-export enum OSType {
+export enum OperatingSystem {
     Windows = 'Windows',
     Linux = 'Linux',
     OSX = 'OSX'

--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -93,7 +93,7 @@ declare module '@theia/plugin' {
     /**
      * Enumeration of the supported operating systems.
      */
-    export enum OSType {
+    export enum OperatingSystem {
         Windows = 'Windows',
         Linux = 'Linux',
         OSX = 'OSX'
@@ -102,10 +102,10 @@ declare module '@theia/plugin' {
     export namespace env {
 
         /**
-         * Returns with the type of the operating system. If it is neither [Windows](isWindows) nor [OS X](isOSX), then
+         * Returns the type of the operating system on the client side (like browser'OS if using browser mode). If it is neither [Windows](isWindows) nor [OS X](isOSX), then
          * it always return with the `Linux` OS type.
          */
-        export function getOsType(): PromiseLike<OSType>;
+        export function getClientOperatingSystem(): PromiseLike<OperatingSystem>;
 
     }
 }


### PR DESCRIPTION
Following comments on https://github.com/theia-ide/theia/pull/4047 add 'client' in the name of the method to really know that  operating system is coming from client, not from server

Change-Id: I9ea879c600c68df86124711645ff4623188ea785
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
