### PR TITLE
[filesystem] Run only one file watching process

### DIFF
--- a/packages/filesystem/src/node/filesystem-backend-module.ts
+++ b/packages/filesystem/src/node/filesystem-backend-module.ts
@@ -45,7 +45,7 @@ export function bindFileSystemWatcherServer(bind: interfaces.Bind): void {
             });
         });
     } else {
-        bind(FileSystemWatcherServerClient).toSelf();
+        bind(FileSystemWatcherServerClient).toSelf().inSingletonScope();
         bind(FileSystemWatcherServer).toService(FileSystemWatcherServerClient);
     }
 }


### PR DESCRIPTION
`FileSystemWatcherServerClient` is not bound as a singleton, issue is
that for each instance of that class, a new process is created.

So the backend would usually have one file watching process opened, no
frontends.  Then, for each new frontend, 2 more processes are created
for file watching.

With this commit, everyone should use the same watcher process.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->