### PR TITLE
Remove extra entry from changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - [monaco] fixed cross editor navigation
 - [monaco] fixed document-saving that took too long
 - [monaco] improved `MonacoWorkspace.fireWillSave` peformance
-- [plug-in] added `tasks.onDidStartTask` Plug-in API
 - [plugin] added `globalState` and `workspaceState` Plug-in API
 - [plugin] added `registerColorProvider` Plug-in API
 - [plugin] added `registerRenameProvider` Plug-in API


### PR DESCRIPTION
The new entry was added [here](https://github.com/theia-ide/theia/commit/61f2c4908386fbe7a0781d141a8ea5ef787893da#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR25)
So the old entry should be removed.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
