### PR TITLE
[plug-in] Implement inspect configuration method of Preferences API

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -51,7 +51,7 @@ import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from './label-provider';
 import {
     PreferenceProviderProvider, PreferenceProvider, PreferenceScope, PreferenceService,
-    PreferenceServiceImpl, bindPreferenceSchemaProvider
+    PreferenceServiceImpl, bindPreferenceSchemaProvider, PreferenceSchemaProvider
 } from './preferences';
 import { ContextMenuRenderer } from './context-menu-renderer';
 import { ThemingCommandContribution, ThemeService, BuiltinThemeProvider } from './theming';
@@ -193,7 +193,12 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(PreferenceProvider).toSelf().inSingletonScope().whenTargetNamed(PreferenceScope.User);
     bind(PreferenceProvider).toSelf().inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);
-    bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => ctx.container.getNamed(PreferenceProvider, scope));
+    bind(PreferenceProviderProvider).toFactory(ctx => (scope: PreferenceScope) => {
+        if (scope === PreferenceScope.Default) {
+            return ctx.container.get(PreferenceSchemaProvider);
+        }
+        return ctx.container.getNamed(PreferenceProvider, scope);
+    });
     bind(PreferenceServiceImpl).toSelf().inSingletonScope();
     bind(PreferenceService).toService(PreferenceServiceImpl);
     bind(FrontendApplicationContribution).toService(PreferenceServiceImpl);

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -25,8 +25,17 @@ import { PreferenceProvider } from './preference-provider';
 import { PreferenceSchemaProvider } from './preference-contribution';
 
 export enum PreferenceScope {
+    Default,
     User,
     Workspace
+}
+
+export namespace PreferenceScope {
+    export function getScopes(): PreferenceScope[] {
+        return Object.keys(PreferenceScope)
+            .filter(k => typeof PreferenceScope[k as any] === 'string')
+            .map(v => <PreferenceScope>Number(v));
+    }
 }
 
 export interface PreferenceChangedEvent {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -65,11 +65,15 @@ import { SymbolInformation } from 'vscode-languageserver-types';
 
 export interface PluginInitData {
     plugins: PluginMetadata[];
-    preferences: { [key: string]: any };
+    preferences: PreferenceData;
     globalState: KeysToKeysToAnyValue;
     workspaceState: KeysToKeysToAnyValue;
     env: EnvInit;
     extApi?: ExtPluginApi[];
+}
+
+export interface PreferenceData {
+    [scope: number]: any;
 }
 
 export interface Plugin {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -54,7 +54,7 @@ export interface PluginPackage {
  * This interface describes a package.json contribution section object.
  */
 export interface PluginPackageContribution {
-    configuration: PreferenceSchema;
+    configuration?: PreferenceSchema;
     languages?: PluginPackageLanguageContribution[];
     grammars?: PluginPackageGrammarsContribution[];
     viewsContainers?: { [location: string]: PluginPackageViewContainer[] };

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -24,13 +24,14 @@ import { MAIN_RPC_CONTEXT, ConfigStorage, PluginManagerExt } from '../../api/plu
 import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../api/rpc-protocol';
 import { ILogger, ContributionProvider } from '@theia/core';
-import { PreferenceServiceImpl } from '@theia/core/lib/browser';
+import { PreferenceServiceImpl, PreferenceProviderProvider } from '@theia/core/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { PluginContributionHandler } from '../../main/browser/plugin-contribution-handler';
 import { getQueryParameters } from '../../main/browser/env-main';
 import { ExtPluginApi, MainPluginApiProvider } from '../../common/plugin-ext-api-contribution';
 import { PluginPathsService } from '../../main/common/plugin-paths-protocol';
 import { StoragePathService } from '../../main/browser/storage-path-service';
+import { getPreferences } from '../../main/browser/preference-registry-main';
 import { PluginServer } from '../../common/plugin-protocol';
 import { KeysToKeysToAnyValue } from '../../common/types';
 
@@ -59,6 +60,9 @@ export class HostedPluginSupport {
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
+
+    @inject(PreferenceProviderProvider)
+    protected readonly preferenceProviderProvider: PreferenceProviderProvider;
 
     private theiaReadyPromise: Promise<any>;
     private frontendExtManagerProxy: PluginManagerExt;
@@ -119,7 +123,7 @@ export class HostedPluginSupport {
                 const hostedExtManager = worker.rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
                 hostedExtManager.$init({
                     plugins: initData.plugins,
-                    preferences: this.preferenceServiceImpl.getPreferences(),
+                    preferences: getPreferences(this.preferenceProviderProvider),
                     globalState: initData.globalStates,
                     workspaceState: initData.workspaceStates,
                     env: { queryParams: getQueryParameters() },
@@ -153,7 +157,7 @@ export class HostedPluginSupport {
                     const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
                     hostedExtManager.$init({
                         plugins: plugins,
-                        preferences: this.preferenceServiceImpl.getPreferences(),
+                        preferences: getPreferences(this.preferenceProviderProvider),
                         globalState: initData.globalStates,
                         workspaceState: initData.workspaceStates,
                         env: { queryParams: getQueryParameters() },

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -25,6 +25,8 @@ import { EnvExtImpl } from '../../../plugin/env';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
 import { ExtPluginApi } from '../../../common/plugin-ext-api-contribution';
 import { createDebugExtStub } from './debug-stub';
+import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-documents';
+import { WorkspaceExtImpl } from '../../../plugin/workspace';
 
 // tslint:disable-next-line:no-any
 const ctx = self as any;
@@ -47,7 +49,9 @@ function initialize(contextPath: string, pluginMetadata: PluginMetadata): void {
     ctx.importScripts('/context/' + contextPath);
 }
 const envExt = new EnvExtImpl(rpc);
-const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc);
+const editorsAndDocuments = new EditorsAndDocumentsExtImpl(rpc);
+const workspaceExt = new WorkspaceExtImpl(rpc, editorsAndDocuments);
+const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
 
 const pluginManager = new PluginManagerExtImpl({
@@ -124,7 +128,10 @@ const apiFactory = createAPIFactory(
     pluginManager,
     envExt,
     debugExt,
-    preferenceRegistryExt);
+    preferenceRegistryExt,
+    editorsAndDocuments,
+    workspaceExt
+);
 let defaultApi: typeof theia;
 
 const handler = {
@@ -147,6 +154,8 @@ const handler = {
 ctx['theia'] = new Proxy(Object.create(null), handler);
 
 rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, pluginManager);
+rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocuments);
+rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
 rpc.set(MAIN_RPC_CONTEXT.PREFERENCE_REGISTRY_EXT, preferenceRegistryExt);
 
 function isElectron() {

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -22,6 +22,8 @@ import { EnvExtImpl } from '../../plugin/env';
 import { PreferenceRegistryExtImpl } from '../../plugin/preference-registry';
 import { ExtPluginApi } from '../../common/plugin-ext-api-contribution';
 import { DebugExtImpl } from '../../plugin/node/debug/debug';
+import { EditorsAndDocumentsExtImpl } from '../../plugin/editors-and-documents';
+import { WorkspaceExtImpl } from '../../plugin/workspace';
 
 /**
  * Handle the RPC calls.
@@ -39,9 +41,13 @@ export class PluginHostRPC {
     initialize() {
         const envExt = new EnvExtImpl(this.rpc);
         const debugExt = new DebugExtImpl(this.rpc);
-        const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc);
+        const editorsAndDocumentsExt = new EditorsAndDocumentsExtImpl(this.rpc);
+        const workspaceExt = new WorkspaceExtImpl(this.rpc, editorsAndDocumentsExt);
+        const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
         this.pluginManager = this.createPluginManager(envExt, preferenceRegistryExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
+        this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
+        this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
         this.rpc.set(MAIN_RPC_CONTEXT.PREFERENCE_REGISTRY_EXT, preferenceRegistryExt);
 
         PluginHostRPC.apiFactory = createAPIFactory(
@@ -49,7 +55,10 @@ export class PluginHostRPC {
             this.pluginManager,
             envExt,
             debugExt,
-            preferenceRegistryExt);
+            preferenceRegistryExt,
+            editorsAndDocumentsExt,
+            workspaceExt
+        );
     }
 
     // tslint:disable-next-line:no-any

--- a/packages/plugin-ext/src/main/browser/plugin-worker.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-worker.ts
@@ -23,15 +23,15 @@ export class PluginWorker {
     private worker: Worker;
     public readonly rpc: RPCProtocol;
     constructor() {
-        const emmitter = new Emitter();
+        const emitter = new Emitter();
         this.worker = new (require('../../hosted/browser/worker/worker-main'));
         this.worker.onmessage = message => {
-            emmitter.fire(message.data);
+            emitter.fire(message.data);
         };
         this.worker.onerror = e => console.error(e);
 
         this.rpc = new RPCProtocolImpl({
-            onMessage: emmitter.event,
+            onMessage: emitter.event,
             send: (m: {}) => {
                 this.worker.postMessage(m);
             }

--- a/packages/plugin-ext/src/main/browser/preference-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/preference-registry-main.ts
@@ -17,28 +17,47 @@
 import {
     PreferenceService,
     PreferenceServiceImpl,
-    PreferenceScope
+    PreferenceScope,
+    PreferenceChange,
+    PreferenceProviderProvider
 } from '@theia/core/lib/browser/preferences';
 import { interfaces } from 'inversify';
 import {
     MAIN_RPC_CONTEXT,
     PreferenceRegistryExt,
     PreferenceRegistryMain,
+    PreferenceData,
 } from '../../api/plugin-api';
 import { RPCProtocol } from '../../api/rpc-protocol';
 import { ConfigurationTarget } from '../../plugin/types-impl';
 
+export function getPreferences(preferenceProviderProvider: PreferenceProviderProvider): PreferenceData {
+    return PreferenceScope.getScopes().reduce((result, scope) => {
+        const provider = preferenceProviderProvider(scope);
+        result[scope] = provider.getPreferences();
+        return result;
+    }, {} as PreferenceData);
+}
+
 export class PreferenceRegistryMainImpl implements PreferenceRegistryMain {
     private proxy: PreferenceRegistryExt;
     private preferenceService: PreferenceService;
+    private readonly preferenceProviderProvider: PreferenceProviderProvider;
 
     constructor(prc: RPCProtocol, container: interfaces.Container) {
         this.proxy = prc.getProxy(MAIN_RPC_CONTEXT.PREFERENCE_REGISTRY_EXT);
         this.preferenceService = container.get(PreferenceService);
+        this.preferenceProviderProvider = container.get(PreferenceProviderProvider);
         const preferenceServiceImpl = container.get(PreferenceServiceImpl);
 
         preferenceServiceImpl.onPreferenceChanged(e => {
-            this.proxy.$acceptConfigurationChanged(preferenceServiceImpl.getPreferences(), e);
+            const data = getPreferences(this.preferenceProviderProvider);
+            const eventData: PreferenceChange = {
+                preferenceName: e.preferenceName,
+                newValue: e.newValue,
+                oldValue: e.oldValue
+            };
+            this.proxy.$acceptConfigurationChanged(data, eventData);
         });
     }
 
@@ -61,10 +80,13 @@ export class PreferenceRegistryMainImpl implements PreferenceRegistryMain {
             return arg ? PreferenceScope.User : PreferenceScope.Workspace;
         }
 
-        if (arg === ConfigurationTarget.User) {
-            return PreferenceScope.User;
-        } else {
-            return PreferenceScope.Workspace;
+        switch (arg) {
+            case ConfigurationTarget.Global:
+                return PreferenceScope.User;
+            case ConfigurationTarget.Workspace:
+                return PreferenceScope.Workspace;
+            default:
+                return PreferenceScope.Workspace;
         }
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -123,7 +123,10 @@ export function createAPIFactory(
     pluginManager: PluginManager,
     envExt: EnvExtImpl,
     debugExt: DebugExtImpl,
-    preferenceRegistryExt: PreferenceRegistryExtImpl): PluginAPIFactory {
+    preferenceRegistryExt: PreferenceRegistryExtImpl,
+    editorsAndDocumentsExt: EditorsAndDocumentsExtImpl,
+    workspaceExt: WorkspaceExtImpl
+): PluginAPIFactory {
 
     const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
     const quickOpenExt = rpc.set(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT, new QuickOpenExtImpl(rpc));
@@ -132,10 +135,8 @@ export function createAPIFactory(
     const windowStateExt = rpc.set(MAIN_RPC_CONTEXT.WINDOW_STATE_EXT, new WindowStateExtImpl());
     const notificationExt = rpc.set(MAIN_RPC_CONTEXT.NOTIFICATION_EXT, new NotificationExtImpl(rpc));
     const statusBarExt = new StatusBarExtImpl(rpc);
-    const editorsAndDocuments = rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, new EditorsAndDocumentsExtImpl(rpc));
-    const editors = rpc.set(MAIN_RPC_CONTEXT.TEXT_EDITORS_EXT, new TextEditorsExtImpl(rpc, editorsAndDocuments));
-    const documents = rpc.set(MAIN_RPC_CONTEXT.DOCUMENTS_EXT, new DocumentsExtImpl(rpc, editorsAndDocuments));
-    const workspaceExt = rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, new WorkspaceExtImpl(rpc, editorsAndDocuments));
+    const editors = rpc.set(MAIN_RPC_CONTEXT.TEXT_EDITORS_EXT, new TextEditorsExtImpl(rpc, editorsAndDocumentsExt));
+    const documents = rpc.set(MAIN_RPC_CONTEXT.DOCUMENTS_EXT, new DocumentsExtImpl(rpc, editorsAndDocumentsExt));
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = new OutputChannelRegistryExt(rpc);

--- a/packages/plugin-ext/src/plugin/preferences/configuration.ts
+++ b/packages/plugin-ext/src/plugin/preferences/configuration.ts
@@ -1,0 +1,115 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WorkspaceExtImpl } from '../workspace';
+import { isObject } from '../../common/types';
+import cloneDeep = require('lodash.clonedeep');
+
+/* tslint:disable:no-any */
+
+export class Configuration {
+
+    private configuration: ConfigurationModel | undefined;
+
+    constructor(
+        private defaultConfiguration: ConfigurationModel,
+        private userConfiguration: ConfigurationModel,
+        private workspaceConfiguration: ConfigurationModel = new ConfigurationModel(),
+    ) { }
+
+    getValue(section?: string): any {
+        return this.getCombined().getValue(section);
+    }
+
+    inspect<C>(key: string, workspace: WorkspaceExtImpl): {
+        default: C,
+        user: C,
+        workspace: C | undefined,
+        value: C,
+    } {
+        const combinedConfiguration = this.getCombined();
+        return {
+            default: this.defaultConfiguration.getValue(key),
+            user: this.userConfiguration.getValue(key),
+            workspace: workspace ? this.workspaceConfiguration.getValue(key) : void 0,
+            value: combinedConfiguration.getValue(key)
+        };
+    }
+
+    private getCombined(): ConfigurationModel {
+        if (!this.configuration) {
+            this.configuration = this.defaultConfiguration.merge(this.userConfiguration, this.workspaceConfiguration);
+        }
+        return this.configuration;
+    }
+
+}
+
+export class ConfigurationModel {
+
+    constructor(
+        private contents: any = {},
+        private keys: string[] = [],
+    ) { }
+
+    getValue(section?: string): any {
+        if (!section) {
+            return this.contents;
+        }
+
+        const path = section.split('.');
+        let current = this.contents;
+        for (let i = 0; i < path.length; i++) {
+            if (typeof current !== 'object' || current === null) {
+                return undefined;
+            }
+            current = current[path[i]];
+        }
+        return current;
+    }
+
+    merge(...others: ConfigurationModel[]): ConfigurationModel {
+        const contents = cloneDeep(this.contents);
+        const allKeys = [...this.keys];
+
+        for (const other of others) {
+            this.mergeContents(contents, other.contents);
+            this.mergeKeys(allKeys, other.keys);
+        }
+        return new ConfigurationModel(contents, allKeys);
+    }
+
+    private mergeContents(source: any, target: any): void {
+        for (const key of Object.keys(target)) {
+            if (key in source) {
+                if (isObject(source[key]) && isObject(target[key])) {
+                    this.mergeContents(source[key], target[key]);
+                    continue;
+                }
+            }
+            source[key] = cloneDeep(target[key]);
+        }
+    }
+
+    private mergeKeys(source: string[], target: string[]): void {
+        for (const key of target) {
+            if (source.indexOf(key) === -1) {
+                source.push(key);
+            }
+        }
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -578,8 +578,11 @@ export enum OverviewRulerLane {
 }
 
 export enum ConfigurationTarget {
-    User = 0,
-    Workspace = 1
+    Global = 1,
+    Workspace,
+    WorkspaceFolder,
+    Default,
+    Memory
 }
 
 export class RelativePattern {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3462,11 +3462,15 @@ declare module '@theia/plugin' {
         /**
          * Global configuration
          */
-        User = 0,
+        Global = 1,
         /**
          * Workspace configuration
          */
-        Workspace = 1
+        Workspace = 2,
+        /**
+         * Workspace folder configuration
+         */
+        WorkspaceFolder = 3
     }
 
     /**
@@ -3813,18 +3817,18 @@ declare module '@theia/plugin' {
         export const onDidChangeTextDocument: Event<TextDocumentChangeEvent>;
 
         /**
-		 * An event that is emitted when a [text document](#TextDocument) will be saved to disk.
-		 *
-		 * *Note 1:* Subscribers can delay saving by registering asynchronous work. For the sake of data integrity the editor
-		 * might save without firing this event. For instance when shutting down with dirty files.
-		 *
-		 * *Note 2:* Subscribers are called sequentially and they can [delay](#TextDocumentWillSaveEvent.waitUntil) saving
-		 * by registering asynchronous work. Protection against misbehaving listeners is implemented as such:
-		 *  * there is an overall time budget that all listeners share and if that is exhausted no further listener is called
-		 *  * listeners that take a long time or produce errors frequently will not be called anymore
-		 *
-		 * The current thresholds are 1.5 seconds as overall time budget and a listener can misbehave 3 times before being ignored.
-		 */
+         * An event that is emitted when a [text document](#TextDocument) will be saved to disk.
+         *
+         * *Note 1:* Subscribers can delay saving by registering asynchronous work. For the sake of data integrity the editor
+         * might save without firing this event. For instance when shutting down with dirty files.
+         *
+         * *Note 2:* Subscribers are called sequentially and they can [delay](#TextDocumentWillSaveEvent.waitUntil) saving
+         * by registering asynchronous work. Protection against misbehaving listeners is implemented as such:
+         *  * there is an overall time budget that all listeners share and if that is exhausted no further listener is called
+         *  * listeners that take a long time or produce errors frequently will not be called anymore
+         *
+         * The current thresholds are 1.5 seconds as overall time budget and a listener can misbehave 3 times before being ignored.
+         */
         export const onWillSaveTextDocument: Event<TextDocumentWillSaveEvent>;
 
         /**
@@ -3930,21 +3934,21 @@ declare module '@theia/plugin' {
         export function findFiles(include: GlobPattern, exclude?: GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
 
         /**
-		 * Make changes to one or many resources or create, delete, and rename resources as defined by the given
-		 * [workspace edit](#WorkspaceEdit).
-		 *
-		 * All changes of a workspace edit are applied in the same order in which they have been added. If
-		 * multiple textual inserts are made at the same position, these strings appear in the resulting text
-		 * in the order the 'inserts' were made. Invalid sequences like 'delete file a' -> 'insert text in file a'
-		 * cause failure of the operation.
-		 *
-		 * When applying a workspace edit that consists only of text edits an 'all-or-nothing'-strategy is used.
-		 * A workspace edit with resource creations or deletions aborts the operation, e.g. consective edits will
-		 * not be attempted, when a single edit fails.
-		 *
-		 * @param edit A workspace edit.
-		 * @return A thenable that resolves when the edit could be applied.
-		 */
+         * Make changes to one or many resources or create, delete, and rename resources as defined by the given
+         * [workspace edit](#WorkspaceEdit).
+         *
+         * All changes of a workspace edit are applied in the same order in which they have been added. If
+         * multiple textual inserts are made at the same position, these strings appear in the resulting text
+         * in the order the 'inserts' were made. Invalid sequences like 'delete file a' -> 'insert text in file a'
+         * cause failure of the operation.
+         *
+         * When applying a workspace edit that consists only of text edits an 'all-or-nothing'-strategy is used.
+         * A workspace edit with resource creations or deletions aborts the operation, e.g. consective edits will
+         * not be attempted, when a single edit fails.
+         *
+         * @param edit A workspace edit.
+         * @return A thenable that resolves when the edit could be applied.
+         */
         export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
 
 


### PR DESCRIPTION

This PR adds the implementation of `inspect` method without the support of multi-root workspaces.

resolves https://github.com/theia-ide/theia/issues/2289

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>


<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
