### PR TITLE
[plug-in] ensure uniqueness of status bar entries

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -4,7 +4,8 @@
     "await-promise": {
       "severity": "warning",
       "options": [
-        "Thenable"
+        "Thenable",
+        "PromiseLike"
       ]
     },
     "no-implicit-dependencies": {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -257,12 +257,13 @@ export interface MessageRegistryMain {
 }
 
 export interface StatusBarMessageRegistryMain {
-    $setMessage(text: string | undefined,
+    $setMessage(id: string,
+        text: string | undefined,
         priority: number,
         alignment: theia.StatusBarAlignment,
         color: string | undefined,
         tooltip: string | undefined,
-        command: string | undefined): PromiseLike<string>;
+        command: string | undefined): PromiseLike<void>;
     $update(id: string, message: string): void;
     $dispose(id: string): void;
 }

--- a/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
+++ b/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
@@ -13,13 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import {Disposable, StatusBarAlignment} from './types-impl';
-import {StatusBarItem} from '@theia/plugin';
+import { Disposable, StatusBarAlignment } from './types-impl';
+import { StatusBarItem } from '@theia/plugin';
 import {
     PLUGIN_RPC_CONTEXT as Ext, StatusBarMessageRegistryMain
 } from '../api/plugin-api';
-import {RPCProtocol} from '../api/rpc-protocol';
-import {StatusBarItemImpl} from './status-bar/status-bar-item';
+import { RPCProtocol } from '../api/rpc-protocol';
+import { StatusBarItemImpl } from './status-bar/status-bar-item';
 
 export class StatusBarMessageRegistryExt {
 
@@ -31,14 +31,12 @@ export class StatusBarMessageRegistryExt {
 
     // tslint:disable-next-line:no-any
     setStatusBarMessage(text: string, arg?: number | PromiseLike<any>): Disposable {
-        let id: string;
-        this.proxy.$setMessage(text, 0, 1, undefined, undefined, undefined).then((messageId: string) => {
-            id = messageId;
-        });
-        let handle: NodeJS.Timer;
+        const id = StatusBarItemImpl.nextId();
+        this.proxy.$setMessage(id, text, 0, 1, undefined, undefined, undefined);
+        let handle: NodeJS.Timer | undefined;
 
         if (typeof arg === 'number') {
-            handle = setTimeout(() => this.dispose(id), <number>arg);
+            handle = setTimeout(() => this.dispose(id), arg);
         } else if (typeof arg !== 'undefined') {
             arg.then(() => this.dispose(id), () => this.dispose(id));
         }
@@ -52,9 +50,6 @@ export class StatusBarMessageRegistryExt {
     }
 
     private dispose(id: string): void {
-        if (!id) {
-            return;
-        }
         this.proxy.$dispose(id);
     }
 

--- a/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
+++ b/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts
@@ -17,9 +17,12 @@ import * as theia from '@theia/plugin';
 import { ThemeColor, StatusBarAlignment } from '../types-impl';
 import { StatusBarMessageRegistryMain } from '../../api/plugin-api';
 import { VS_COLORS } from './vscolor-const';
+import { UUID } from '@phosphor/coreutils/lib/uuid';
 
 export class StatusBarItemImpl implements theia.StatusBarItem {
-    private _messageId: string;
+
+    private readonly id = StatusBarItemImpl.nextId();
+
     private _alignment: StatusBarAlignment;
     private _priority: number;
 
@@ -94,9 +97,7 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
         if (this._timeoutHandle) {
             clearTimeout(this._timeoutHandle);
         }
-        if (this._messageId) {
-            this._proxy.$dispose(this._messageId);
-        }
+        this._proxy.$dispose(this.id);
         this._isVisible = false;
     }
 
@@ -104,28 +105,20 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
         if (!this._isVisible) {
             return;
         }
-
-        if (this._messageId) {
-            this._proxy.$dispose(this._messageId);
-        }
-
         if (this._timeoutHandle) {
             clearTimeout(this._timeoutHandle);
         }
-
         // Defer the update so that multiple changes to setters don't cause a redraw each
         this._timeoutHandle = setTimeout(() => {
             this._timeoutHandle = undefined;
 
             // Set to status bar
-            this._proxy.$setMessage(this.text,
+            this._proxy.$setMessage(this.id, this.text,
                 this.priority,
                 this.alignment,
                 this.getColor(),
                 this.tooltip,
-                this.command).then((id: string) => {
-                    this._messageId = id;
-                });
+                this.command);
         }, 0);
     }
 
@@ -140,4 +133,9 @@ export class StatusBarItemImpl implements theia.StatusBarItem {
     public dispose(): void {
         this.hide();
     }
+
+    static nextId(): string {
+        return StatusBarItemImpl.ID_PREFIX + ':' + UUID.uuid4();
+    }
+    static ID_PREFIX = 'plugin-status-bar-item';
 }

--- a/packages/plugin-ext/src/plugin/statusBar.ts
+++ b/packages/plugin-ext/src/plugin/statusBar.ts
@@ -19,6 +19,7 @@ import { CancellationToken, Progress, ProgressOptions } from '@theia/plugin';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { Event, Emitter } from '@theia/core/lib/common/event';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { StatusBarItemImpl } from './status-bar/status-bar-item';
 
 export class StatusBarExtImpl implements StatusBarExt {
     private readonly proxy: StatusBarMessageRegistryMain;
@@ -30,7 +31,8 @@ export class StatusBarExtImpl implements StatusBarExt {
     ): Promise<R> {
         const message = options.title ? '$(refresh~spin) ' + options.title : '';
         const token = new CancellationTokenImpl(this.onCancel);
-        const id = await this.proxy.$setMessage(message, 1, 1, undefined, undefined, undefined);
+        const id = StatusBarItemImpl.nextId();
+        await this.proxy.$setMessage(id, message, 1, 1, undefined, undefined, undefined);
         const promise = task(new ProgressCallback(id, message, this.proxy), token);
         await promise;
         this.proxy.$dispose(id);


### PR DESCRIPTION
fix #4032, fix #4027

here `messageid` provided asynchronously:
https://github.com/theia-ide/theia/blob/603fe22b3b7e4a941775b97dba5528358a3fc8d2/packages/plugin-ext/src/plugin/status-bar/status-bar-item.ts#L108-L129

If second update happens (in another tick), before the previous is resolved then a new entry is created without removing previous. PR makes sure that ID is generated synchronously.