### PR TITLE
vscode built-in menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 # Change Log
 
-## v0.3.20
+## v0.4.0
 - [plugin] added `tasks.onDidEndTask` Plug-in API
 - [cpp] fixed `CPP_CLANGD_COMMAND` and `CPP_CLANGD_ARGS` environment variables
 
+Breaking changes:
+- menus aligned with built-in VS Code menus [#4173](https://github.com/theia-ide/theia/pull/4173)
+  - navigator context menu group changes:
+    - `1_open` and `4_new` replaced by `navigation` group
+    - `6_workspace` renamed to `2_workspace` group
+    - `5_diff` renamed to `3_compare` group
+    - `6_find` renamed to `4_search` group
+    - `2_clipboard` renamed to `5_cutcopypaste` group
+    - `3_move` and `7_actions` replaced by `navigation` group
+  - editor context menu group changes:
+    - `2_cut_copy_paste` renamed to `9_cutcopypaste` group
 
 ## v0.3.19
 - [core] added `hostname` alias

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -178,6 +178,13 @@ export class CompositeMenuNode implements MenuNode {
     public addNode(node: MenuNode): Disposable {
         this._children.push(node);
         this._children.sort((m1, m2) => {
+            // The navigation group is special as it will always be sorted to the top/beginning of a menu.
+            if (CompositeMenuNode.isNavigationGroup(m1)) {
+                return -1;
+            }
+            if (CompositeMenuNode.isNavigationGroup(m2)) {
+                return 1;
+            }
             if (m1.sortString < m2.sortString) {
                 return -1;
             } else if (m1.sortString > m2.sortString) {
@@ -212,6 +219,10 @@ export class CompositeMenuNode implements MenuNode {
 
     get isSubmenu(): boolean {
         return this.label !== undefined;
+    }
+
+    static isNavigationGroup(node: MenuNode): node is CompositeMenuNode {
+        return node instanceof CompositeMenuNode && node.id === 'navigation';
     }
 }
 

--- a/packages/debug/src/browser/view/debug-stack-frames-widget.ts
+++ b/packages/debug/src/browser/view/debug-stack-frames-widget.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject, postConstruct, interfaces, Container } from 'inversify';
-import { MenuPath } from '@theia/core';
+import { MenuPath, SelectionService } from '@theia/core';
 import { TreeNode, NodeProps, SelectableTreeNode } from '@theia/core/lib/browser';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { DebugStackFramesSource, LoadMoreStackFrames } from './debug-stack-frames-source';
@@ -47,6 +47,9 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
 
     @inject(DebugViewModel)
     protected readonly viewModel: DebugViewModel;
+
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
 
     @inject(DebugCallStackItemTypeKey)
     protected readonly debugCallStackItemTypeKey: DebugCallStackItemTypeKey;
@@ -88,13 +91,23 @@ export class DebugStackFramesWidget extends SourceTreeWidget {
         }
         this.updatingSelection = true;
         try {
+            let selection: string | number | undefined;
             const node = this.model.selectedNodes[0];
             if (TreeElementNode.is(node)) {
                 if (node.element instanceof DebugStackFrame) {
                     node.element.thread.currentFrame = node.element;
                     this.debugCallStackItemTypeKey.set('stackFrame');
+                    const source = node.element.source;
+                    if (source) {
+                        if (source.inMemory) {
+                            selection = source.raw.path || source.raw.sourceReference;
+                        } else {
+                            selection = source.uri.toString();
+                        }
+                    }
                 }
             }
+            this.selectionService.selection = selection;
         } finally {
             this.updatingSelection = false;
         }

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -17,6 +17,7 @@
 import { injectable, inject, postConstruct, interfaces, Container } from 'inversify';
 import { MenuPath } from '@theia/core';
 import { TreeNode, NodeProps, SelectableTreeNode } from '@theia/core/lib/browser';
+import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { DebugThreadsSource } from './debug-threads-source';
 import { DebugSession } from '../debug-session';
@@ -51,6 +52,9 @@ export class DebugThreadsWidget extends SourceTreeWidget {
 
     @inject(DebugViewModel)
     protected readonly viewModel: DebugViewModel;
+
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
 
     @inject(DebugCallStackItemTypeKey)
     protected readonly debugCallStackItemTypeKey: DebugCallStackItemTypeKey;
@@ -91,6 +95,7 @@ export class DebugThreadsWidget extends SourceTreeWidget {
         }
         this.updatingSelection = true;
         try {
+            let selection: number | undefined;
             const node = this.model.selectedNodes[0];
             if (TreeElementNode.is(node)) {
                 if (node.element instanceof DebugSession) {
@@ -99,8 +104,10 @@ export class DebugThreadsWidget extends SourceTreeWidget {
                 } else if (node.element instanceof DebugThread) {
                     node.element.session.currentThread = node.element;
                     this.debugCallStackItemTypeKey.set('thread');
+                    selection = node.element.raw.id;
                 }
             }
+            this.selectionService.selection = selection;
         } finally {
             this.updatingSelection = false;
         }

--- a/packages/editor/src/browser/editor-menu.ts
+++ b/packages/editor/src/browser/editor-menu.ts
@@ -21,10 +21,16 @@ import { EditorCommands } from './editor-command';
 
 export const EDITOR_CONTEXT_MENU: MenuPath = ['editor_context_menu'];
 
+/**
+ * Editor context menu default groups should be aligned
+ * with VS Code default groups: https://code.visualstudio.com/api/references/contribution-points#contributes.menus
+ */
 export namespace EditorContextMenu {
-    export const UNDO_REDO = [...EDITOR_CONTEXT_MENU, '1_undo'];
-    export const CUT_COPY_PASTE = [...EDITOR_CONTEXT_MENU, '2_cut_copy_paste'];
     export const NAVIGATION = [...EDITOR_CONTEXT_MENU, 'navigation'];
+    export const MODIFICATION = [...EDITOR_CONTEXT_MENU, '1_modification'];
+    export const CUT_COPY_PASTE = [...EDITOR_CONTEXT_MENU, '9_cutcopypaste'];
+    export const COMMANDS = [...EDITOR_CONTEXT_MENU, 'z_commands'];
+    export const UNDO_REDO = [...EDITOR_CONTEXT_MENU, '1_undo'];
 }
 
 export namespace EditorMainMenu {

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -20,7 +20,7 @@ import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { injectable, inject } from 'inversify';
 import { GitDiffWidget, GIT_DIFF } from './git-diff-widget';
 import { open, OpenerService } from '@theia/core/lib/browser';
-import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
+import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { GitQuickOpenService } from '../git-quick-open-service';
 import { FileSystem } from '@theia/filesystem/lib/common';
@@ -62,7 +62,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
     }
 
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '5_diff'], {
+        menus.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: GitDiffCommands.OPEN_FILE_DIFF.id
         });
     }

--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -17,7 +17,7 @@
 import { MenuModelRegistry, CommandRegistry, Command, SelectionService } from '@theia/core';
 import { AbstractViewContribution, OpenViewArguments } from '@theia/core/lib/browser';
 import { injectable, inject, postConstruct } from 'inversify';
-import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
+import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import URI from '@theia/core/lib/common/uri';
 import { GitHistoryWidget } from './git-history-widget';
@@ -95,7 +95,7 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
     }
 
     registerMenus(menus: MenuModelRegistry): void {
-        menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '5_history'], {
+        menus.registerMenuAction(NavigatorContextMenu.SEARCH, {
             commandId: GitHistoryCommands.OPEN_FILE_HISTORY.id,
             label: GIT_HISTORY_LABEL
         });

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -47,15 +47,33 @@ export namespace FileNavigatorCommands {
 
 export const NAVIGATOR_CONTEXT_MENU: MenuPath = ['navigator-context-menu'];
 
+/**
+ * Navigator context menu default groups should be aligned
+ * with VS Code default groups: https://code.visualstudio.com/api/references/contribution-points#contributes.menus
+ */
 export namespace NavigatorContextMenu {
-    export const OPEN = [...NAVIGATOR_CONTEXT_MENU, '1_open'];
-    export const OPEN_WITH = [...OPEN, 'open_with'];
-    export const CLIPBOARD = [...NAVIGATOR_CONTEXT_MENU, '2_clipboard'];
-    export const MOVE = [...NAVIGATOR_CONTEXT_MENU, '3_move'];
-    export const NEW = [...NAVIGATOR_CONTEXT_MENU, '4_new'];
-    export const DIFF = [...NAVIGATOR_CONTEXT_MENU, '5_diff'];
-    export const WORKSPACE = [...NAVIGATOR_CONTEXT_MENU, '6_workspace'];
-    export const ACTIONS = [...NAVIGATOR_CONTEXT_MENU, '7_actions'];
+    export const NAVIGATION = [...NAVIGATOR_CONTEXT_MENU, 'navigation'];
+    /** @deprecated use NAVIGATION */
+    export const OPEN = NAVIGATION;
+    /** @deprecated use NAVIGATION */
+    export const NEW = NAVIGATION;
+
+    export const WORKSPACE = [...NAVIGATOR_CONTEXT_MENU, '2_workspace'];
+
+    export const COMPARE = [...NAVIGATOR_CONTEXT_MENU, '3_compare'];
+    /** @deprecated use COMPARE */
+    export const DIFF = COMPARE;
+
+    export const SEARCH = [...NAVIGATOR_CONTEXT_MENU, '4_search'];
+    export const CLIPBOARD = [...NAVIGATOR_CONTEXT_MENU, '5_cutcopypaste'];
+
+    export const MODIFICATION = [...NAVIGATOR_CONTEXT_MENU, '7_modification'];
+    /** @deprecated use MODIFICATION */
+    export const MOVE = MODIFICATION;
+    /** @deprecated use MODIFICATION */
+    export const ACTIONS = MODIFICATION;
+
+    export const OPEN_WITH = [...NAVIGATION, 'open_with'];
 }
 
 @injectable()
@@ -131,7 +149,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             order: '5'
         });
 
-        registry.registerMenuAction(NavigatorContextMenu.OPEN, {
+        registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
             commandId: CommonCommands.OPEN.id
         });
         registry.registerSubmenu(NavigatorContextMenu.OPEN_WITH, 'Open With');
@@ -157,33 +175,34 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             commandId: CommonCommands.PASTE.id
         });
 
-        registry.registerMenuAction(NavigatorContextMenu.MOVE, {
+        registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: WorkspaceCommands.FILE_RENAME.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.MOVE, {
+        registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: WorkspaceCommands.FILE_DELETE.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.MOVE, {
+        registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: WorkspaceCommands.FILE_DUPLICATE.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.MOVE, {
+        registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: FileDownloadCommands.DOWNLOAD.id,
             label: 'Download',
-            order: 'z' // Should be the last item in the "move" menu group.
+            order: 'z1' // Should be the last item in the "move" menu group.
         });
 
-        registry.registerMenuAction(NavigatorContextMenu.NEW, {
+        registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
             commandId: WorkspaceCommands.NEW_FILE.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.NEW, {
+        registry.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
             commandId: WorkspaceCommands.NEW_FOLDER.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.DIFF, {
+        registry.registerMenuAction(NavigatorContextMenu.COMPARE, {
             commandId: WorkspaceCommands.FILE_COMPARE.id
         });
-        registry.registerMenuAction(NavigatorContextMenu.ACTIONS, {
+        registry.registerMenuAction(NavigatorContextMenu.MODIFICATION, {
             commandId: FileNavigatorCommands.COLLAPSE_ALL.id,
-            label: 'Collapse All'
+            label: 'Collapse All',
+            order: 'z2'
         });
 
         this.workspacePreferences.ready.then(() => {

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -32,26 +32,12 @@ let pluginApiFactory: PluginAPIFactory;
 export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIFactory, plugin: Plugin) => {
     const vscode = apiFactory(plugin);
 
-    // register the commands that are in the package.json file
-    const contributes: any = plugin.rawModel.contributes;
-    if (contributes && contributes.commands) {
-        contributes.commands.forEach((commandItem: any) => {
-            let commandLabel: string;
-            if (commandItem.category) { // if VS Code command has category we will add it before title, so label will looks like 'category: title'
-                commandLabel = commandItem.category + ': ' + commandItem.title;
-            } else {
-                commandLabel = commandItem.title;
-            }
-            vscode.commands.registerCommand({ id: commandItem.command, label: commandLabel });
-        });
-    }
-
     // replace command API as it will send only the ID as a string parameter
     const registerCommand = vscode.commands.registerCommand;
     vscode.commands.registerCommand = function (command: any, handler?: <T>(...args: any[]) => T | Thenable<T>): any {
         // use of the ID when registering commands
         if (typeof command === 'string' && handler) {
-            return registerCommand({ id: command }, handler);
+            return vscode.commands.registerHandler(command, handler);
         }
         return registerCommand(command, handler);
     };

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -151,8 +151,11 @@ export interface PluginManagerExt {
 
 export interface CommandRegistryMain {
     $registerCommand(command: theia.Command): void;
-
     $unregisterCommand(id: string): void;
+
+    $registerHandler(id: string): void;
+    $unregisterHandler(id: string): void;
+
     $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined>;
     $getCommands(): PromiseLike<string[]>;
     $getKeyBinding(commandId: string): PromiseLike<theia.CommandKeyBinding[] | undefined>;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -59,6 +59,7 @@ export interface PluginPackageContribution {
     grammars?: PluginPackageGrammarsContribution[];
     viewsContainers?: { [location: string]: PluginPackageViewContainer[] };
     views?: { [location: string]: PluginPackageView[] };
+    commands?: PluginPackageCommand | PluginPackageCommand[];
     menus?: { [location: string]: PluginPackageMenu[] };
     keybindings?: PluginPackageKeybinding[];
     debuggers?: PluginPackageDebuggersContribution[];
@@ -74,6 +75,13 @@ export interface PluginPackageViewContainer {
 export interface PluginPackageView {
     id: string;
     name: string;
+}
+
+export interface PluginPackageCommand {
+    command: string;
+    title: string;
+    category?: string;
+    icon?: string | { light: string; dark: string; };
 }
 
 export interface PluginPackageMenu {
@@ -340,6 +348,7 @@ export interface PluginContribution {
     grammars?: GrammarsContribution[];
     viewsContainers?: { [location: string]: ViewContainer[] };
     views?: { [location: string]: View[] };
+    commands?: PluginCommand[]
     menus?: { [location: string]: Menu[] };
     keybindings?: Keybinding[];
     debuggers?: DebuggerContribution[];
@@ -448,6 +457,15 @@ export interface View {
     id: string;
     name: string;
 }
+
+export interface PluginCommand {
+    command: string;
+    title: string;
+    category?: string;
+    iconUrl?: IconUrl;
+}
+
+export type IconUrl = string | { light: string; dark: string; };
 
 /**
  * Menu contribution

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -39,7 +39,11 @@ import {
     PluginPackageMenu,
     PluginPackageDebuggersContribution,
     DebuggerContribution,
-    SnippetContribution
+    SnippetContribution,
+    PluginPackageCommand,
+    PluginCommand,
+    IconUrl,
+    getPluginId
 } from '../../../common/plugin-protocol';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -152,6 +156,12 @@ export class TheiaPluginScanner implements PluginScanner {
             });
         }
 
+        const pluginCommands = rawPlugin.contributes.commands;
+        if (pluginCommands) {
+            const commands = Array.isArray(pluginCommands) ? pluginCommands : [pluginCommands];
+            contributions.commands = commands.map(command => this.readCommand(command, rawPlugin));
+        }
+
         if (rawPlugin.contributes!.menus) {
             contributions.menus = {};
 
@@ -172,6 +182,25 @@ export class TheiaPluginScanner implements PluginScanner {
 
         contributions.snippets = this.readSnippets(rawPlugin);
         return contributions;
+    }
+
+    protected readCommand({ command, title, category, icon }: PluginPackageCommand, pck: PluginPackage): PluginCommand {
+        let iconUrl: IconUrl | undefined;
+        if (icon) {
+            if (typeof icon === 'string') {
+                iconUrl = this.toPluginUrl(pck, icon);
+            } else {
+                iconUrl = {
+                    light: this.toPluginUrl(pck, icon.light),
+                    dark: this.toPluginUrl(pck, icon.dark)
+                };
+            }
+        }
+        return { command, title, category, iconUrl };
+    }
+
+    protected toPluginUrl(pck: PluginPackage, relativePath: string): string {
+        return path.join('hostedPlugin', getPluginId(pck), relativePath);
     }
 
     protected readSnippets(pck: PluginPackage): SnippetContribution[] | undefined {

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -24,7 +24,8 @@ import { KeybindingRegistry } from '@theia/core/lib/browser';
 
 export class CommandRegistryMainImpl implements CommandRegistryMain {
     private proxy: CommandRegistryExt;
-    private disposables = new Map<string, Disposable>();
+    private readonly commands = new Map<string, Disposable>();
+    private readonly handlers = new Map<string, Disposable>();
     private delegate: CommandRegistry;
     private keyBinding: KeybindingRegistry;
 
@@ -35,26 +36,36 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
     }
 
     $registerCommand(command: theia.Command): void {
-        this.disposables.set(
-            command.id,
-            this.delegate.registerCommand(command, {
-                // tslint:disable-next-line:no-any
-                execute: (...args: any[]) => {
-                    this.proxy.$executeCommand(command.id, ...args);
-                },
-                // Always enabled - a command can be executed programmatically or via the commands palette.
-                isEnabled() { return true; },
-                // Visibility rules are defined via the `menus` contribution point.
-                isVisible() { return true; }
-            }));
+        this.commands.set(command.id, this.delegate.registerCommand(command));
     }
     $unregisterCommand(id: string): void {
-        const dis = this.disposables.get(id);
-        if (dis) {
-            dis.dispose();
-            this.disposables.delete(id);
+        const command = this.commands.get(id);
+        if (command) {
+            command.dispose();
+            this.commands.delete(id);
         }
     }
+
+    $registerHandler(id: string): void {
+        this.handlers.set(id, this.delegate.registerHandler(id, {
+            // tslint:disable-next-line:no-any
+            execute: (...args: any[]) => {
+                this.proxy.$executeCommand(id, ...args);
+            },
+            // Always enabled - a command can be executed programmatically or via the commands palette.
+            isEnabled() { return true; },
+            // Visibility rules are defined via the `menus` contribution point.
+            isVisible() { return true; }
+        }));
+    }
+    $unregisterHandler(id: string): void {
+        const handler = this.handlers.get(id);
+        if (handler) {
+            handler.dispose();
+            this.handlers.delete(id);
+        }
+    }
+
     // tslint:disable-next-line:no-any
     $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
         try {

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
@@ -30,6 +30,8 @@ import 'mocha';
 import * as sinon from 'sinon';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { QuickCommandService } from '@theia/core/lib/browser';
+import { PluginSharedStyle } from '../plugin-shared-style';
+import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 disableJSDOM();
 
@@ -57,6 +59,10 @@ before(() => {
         bind(MenusContributionPointHandler).toSelf();
         // tslint:disable-next-line:no-any mock QuickCommandService
         bind(QuickCommandService).toConstantValue({} as any);
+        // tslint:disable-next-line:no-any mock TabBarToolbarRegistry
+        bind(TabBarToolbarRegistry).toConstantValue({} as any);
+        // tslint:disable-next-line:no-any mock PluginSharedStyle
+        bind(PluginSharedStyle).toConstantValue({} as any);
     });
 
     testContainer.load(module);

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
@@ -19,7 +19,7 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
 
 import { Container, ContainerModule } from 'inversify';
-import { ILogger, MessageClient, MessageService, MenuPath, MenuAction, CommandRegistry, bindContributionProvider, CommandContribution } from '@theia/core';
+import { ILogger, MessageClient, MessageService, MenuPath, MenuAction, CommandRegistry, bindContributionProvider, CommandContribution, SelectionService } from '@theia/core';
 import { MenuModelRegistry } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { MockMenuModelRegistry } from '@theia/core/lib/common/test/mock-menu';
@@ -63,6 +63,7 @@ before(() => {
         bind(TabBarToolbarRegistry).toConstantValue({} as any);
         // tslint:disable-next-line:no-any mock PluginSharedStyle
         bind(PluginSharedStyle).toConstantValue({} as any);
+        bind(SelectionService).toSelf().inSingletonScope();
     });
 
     testContainer.load(module);

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -49,12 +49,6 @@ export class MenusContributionPointHandler {
     @inject(PluginSharedStyle)
     protected readonly style: PluginSharedStyle;
 
-    /**
-     * Handles the `menus` contribution point.
-     * In VSCode, a menu can have more than one item for the same command. Each item may have it's own visibility rules.
-     * In Theia, a menu can't have more than one item for the same command.
-     * So, several handlers for the same command are registered to support different visibility rules for a menu item in different contexts.
-     */
     handle(contributions: PluginContribution): void {
         const allMenus = contributions.menus;
         if (!allMenus) {

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -16,12 +16,15 @@
 
 import { injectable, inject } from 'inversify';
 import { MenuPath, ILogger, CommandRegistry } from '@theia/core';
-import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { EDITOR_CONTEXT_MENU, EditorWidget } from '@theia/editor/lib/browser';
 import { MenuModelRegistry } from '@theia/core/lib/common';
+import { BuiltinThemeProvider } from '@theia/core/lib/browser/theming';
+import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { QuickCommandService } from '@theia/core/lib/browser/quick-open/quick-command-service';
 import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-views-main';
-import { PluginContribution, Menu } from '../../../common';
+import { PluginContribution, Menu, PluginCommand } from '../../../common';
+import { PluginSharedStyle } from '../plugin-shared-style';
 
 @injectable()
 export class MenusContributionPointHandler {
@@ -37,6 +40,12 @@ export class MenusContributionPointHandler {
 
     @inject(QuickCommandService)
     protected readonly quickCommandService: QuickCommandService;
+
+    @inject(TabBarToolbarRegistry)
+    protected readonly tabBarToolbar: TabBarToolbarRegistry;
+
+    @inject(PluginSharedStyle)
+    protected readonly style: PluginSharedStyle;
 
     // menu location to command IDs
     protected readonly registeredMenus: Map<string, Set<string>> = new Map();
@@ -59,6 +68,8 @@ export class MenusContributionPointHandler {
                         this.quickCommandService.pushCommandContext(menu.command, menu.when);
                     }
                 }
+            } else if (location === 'editor/title') {
+                this.registerEditorTitleActions(allMenus[location], contributions);
             } else if (allMenus.hasOwnProperty(location)) {
                 const menuPath = MenusContributionPointHandler.parseMenuPath(location);
                 if (!menuPath) {
@@ -73,6 +84,44 @@ export class MenusContributionPointHandler {
                 });
             }
         }
+    }
+
+    protected registerEditorTitleActions(actions: Menu[], contributions: PluginContribution): void {
+        if (!contributions.commands || !actions.length) {
+            return;
+        }
+        const commands = new Map(contributions.commands.map(c => [c.command, c] as [string, PluginCommand]));
+        for (const action of actions) {
+            const pluginCommand = commands.get(action.command);
+            if (pluginCommand) {
+                this.registerEditorTitleAction(action, pluginCommand);
+            }
+        }
+    }
+
+    protected editorTitleActionId = 0;
+    protected registerEditorTitleAction(action: Menu, pluginCommand: PluginCommand): void {
+        const id = pluginCommand.command;
+        const command = '__editor.title.' + id;
+        const tooltip = pluginCommand.title;
+        const iconClass = 'plugin-editor-title-action-' + this.editorTitleActionId++;
+        const { group, when } = action;
+
+        const { iconUrl } = pluginCommand;
+        const darkIconUrl = typeof iconUrl === 'object' ? iconUrl.dark : iconUrl;
+        const lightIconUrl = typeof iconUrl === 'object' ? iconUrl.light : iconUrl;
+        this.style.insertRule('.' + iconClass, theme => `
+            width: 16px;
+            height: 16px;
+            background: no-repeat url("${theme.id === BuiltinThemeProvider.lightTheme.id ? lightIconUrl : darkIconUrl}");
+        `);
+
+        this.commands.registerCommand({ id: command, iconClass }, {
+            execute: widget => widget instanceof EditorWidget && this.commands.executeCommand(id, widget.editor.uri),
+            isEnabled: widget => widget instanceof EditorWidget,
+            isVisible: widget => widget instanceof EditorWidget
+        });
+        this.tabBarToolbar.registerItem({ id, command, tooltip, group, when });
     }
 
     protected static parseMenuPath(value: string): MenuPath | undefined {

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -56,6 +56,7 @@ import { DebugSessionContributionRegistry } from '@theia/debug/lib/browser/debug
 import { PluginDebugSessionContributionRegistry } from './debug/plugin-debug-session-contribution-registry';
 import { PluginDebugService } from './debug/plugin-debug-service';
 import { DebugService } from '@theia/debug/lib/common/debug-service';
+import { PluginSharedStyle } from './plugin-shared-style';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindHostedPluginPreferences(bind);
@@ -111,6 +112,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         return provider.createProxy<PluginServer>(pluginServerJsonRpcPath);
     }).inSingletonScope();
 
+    bind(PluginSharedStyle).toSelf().inSingletonScope();
     bind(ViewRegistry).toSelf().inSingletonScope();
     bind(MenusContributionPointHandler).toSelf().inSingletonScope();
 

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { ThemeService, Theme } from '@theia/core/lib/browser/theming';
+
+@injectable()
+export class PluginSharedStyle {
+
+    protected style: HTMLStyleElement;
+    protected readonly rules: {
+        selector: string;
+        body: (theme: Theme) => string
+    }[] = [];
+
+    constructor() {
+        this.update();
+        ThemeService.get().onThemeChange(() => this.update());
+    }
+
+    protected readonly toUpdate = new DisposableCollection();
+    protected update(): void {
+        this.toUpdate.dispose();
+
+        const style = this.style = document.createElement('style');
+        style.type = 'text/css';
+        style.media = 'screen';
+        document.getElementsByTagName('head')[0].appendChild(style);
+        this.toUpdate.push(Disposable.create(() =>
+            document.getElementsByTagName('head')[0].removeChild(style)
+        ));
+
+        for (const rule of this.rules) {
+            this.doInsertRule(rule);
+        }
+    }
+
+    insertRule(selector: string, body: (theme: Theme) => string): Disposable {
+        const rule = { selector, body };
+        this.rules.push(rule);
+        this.doInsertRule(rule);
+        return Disposable.create(() => {
+            const index = this.rules.indexOf(rule);
+            if (index !== -1) {
+                this.rules.splice(index, 1);
+                this.deleteRule(selector);
+            }
+        });
+    }
+    protected doInsertRule({ selector, body }: {
+        selector: string;
+        body: (theme: Theme) => string
+    }): void {
+        const sheet = (<CSSStyleSheet>this.style.sheet);
+        const cssBody = body(ThemeService.get().getCurrentTheme());
+        sheet.insertRule(selector + ' { ' + cssBody + ' }', 0);
+    }
+
+    deleteRule(selector: string): void {
+        const sheet = (<CSSStyleSheet>this.style.sheet);
+        const rules = sheet.rules || sheet.cssRules || [];
+        for (let i = rules.length - 1; i >= 0; i--) {
+            const rule = rules[i];
+            // tslint:disable-next-line:no-any
+            if ((<any>rule).selectorText.indexOf(selector) !== -1) {
+                sheet.deleteRule(i);
+            }
+        }
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -27,7 +27,8 @@ export type Handler = <T>(...args: any[]) => T | PromiseLike<T>;
 export class CommandRegistryImpl implements CommandRegistryExt {
 
     private proxy: CommandRegistryMain;
-    private commands = new Map<string, Handler>();
+    private readonly commands = new Set<string>();
+    private readonly handlers = new Map<string, Handler>();
     private converter: CommandsConverter;
     private cache = new Map<number, theia.Command>();
     private delegatingCommandId: string;
@@ -39,7 +40,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
 
         // register internal VS Code commands
-        this.registerHandler('vscode.previewHtml', CommandRegistryImpl.EMPTY_HANDLER);
+        this.registerCommand({ id: 'vscode.previewHtml' }, CommandRegistryImpl.EMPTY_HANDLER);
     }
 
     getConverter(): CommandsConverter {
@@ -60,26 +61,29 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         if (this.commands.has(command.id)) {
             throw new Error(`Command ${command.id} already exist`);
         }
-        if (handler) {
-            this.commands.set(command.id, handler);
-        }
+        this.commands.add(command.id);
         this.proxy.$registerCommand(command);
 
-        return Disposable.create(() => {
+        const toDispose: Disposable[] = [];
+        if (handler) {
+            toDispose.push(this.registerHandler(command.id, handler));
+        }
+        toDispose.push(Disposable.create(() => {
             this.commands.delete(command.id);
             this.proxy.$unregisterCommand(command.id);
-        });
-
+        }));
+        return Disposable.from(...toDispose);
     }
 
     registerHandler(commandId: string, handler: Handler): Disposable {
-        if (this.commands.has(commandId)) {
-            throw new Error(`Command ${commandId} already has handler`);
+        if (this.handlers.has(commandId)) {
+            throw new Error(`Command "${commandId}" already has handler`);
         }
-        this.commands.set(commandId, handler);
+        this.proxy.$registerHandler(commandId);
+        this.handlers.set(commandId, handler);
         return Disposable.create(() => {
-            this.commands.delete(commandId);
-            this.proxy.$unregisterCommand(commandId);
+            this.handlers.delete(commandId);
+            this.proxy.$unregisterHandler(commandId);
         });
     }
 
@@ -89,7 +93,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
 
     // tslint:disable-next-line:no-any
     $executeCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
-        if (this.commands.has(id)) {
+        if (this.handlers.has(id)) {
             return this.executeLocalCommand(id, ...args);
         } else {
             return Promise.reject(`Command: ${id} does not exist.`);
@@ -98,7 +102,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
 
     // tslint:disable-next-line:no-any
     executeCommand<T>(id: string, ...args: any[]): PromiseLike<T | undefined> {
-        if (this.commands.has(id)) {
+        if (this.handlers.has(id)) {
             return this.executeLocalCommand(id, ...args);
         } else {
             return this.proxy.$executeCommand(id, ...args);
@@ -111,7 +115,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
 
     // tslint:disable-next-line:no-any
     private executeLocalCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
-        const handler = this.commands.get(id);
+        const handler = this.handlers.get(id);
         if (handler) {
             const result = id === this.delegatingCommandId ?
                 handler(this, ...args)

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2003,6 +2003,8 @@ declare module '@theia/plugin' {
          *
          * @param commandId a given command id
          * @param handler a command handler
+         *
+         * Throw if a handler for the given command identifier is already registered.
          */
         export function registerHandler(commandId: string, handler: (...args: any[]) => any): Disposable;
 

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -18,7 +18,7 @@ import { AbstractViewContribution, KeybindingRegistry, LabelProvider, CommonMenu
 import { SearchInWorkspaceWidget } from './search-in-workspace-widget';
 import { injectable, inject, postConstruct } from 'inversify';
 import { CommandRegistry, MenuModelRegistry, SelectionService, Command } from '@theia/core';
-import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
+import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -120,7 +120,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
 
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
-        menus.registerMenuAction([...NAVIGATOR_CONTEXT_MENU, '6_find'], {
+        menus.registerMenuAction(NavigatorContextMenu.SEARCH, {
             commandId: SearchInWorkspaceCommands.FIND_IN_FOLDER.id
         });
         menus.registerMenuAction(CommonMenus.EDIT_FIND, {

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -47,7 +47,7 @@ export namespace TerminalMenus {
     export const TERMINAL = [...MAIN_MENU_BAR, '7_terminal'];
     export const TERMINAL_NEW = [...TERMINAL, '1_terminal'];
     export const TERMINAL_TASKS = [...TERMINAL, '2_terminal'];
-    export const TERMINAL_NAVIGATOR_CONTEXT_MENU = ['navigator-context-menu', '4_new'];
+    export const TERMINAL_NAVIGATOR_CONTEXT_MENU = ['navigator-context-menu', 'navigation'];
 }
 
 export namespace TerminalCommands {
@@ -200,7 +200,8 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
             order: '1'
         });
         menus.registerMenuAction(TerminalMenus.TERMINAL_NAVIGATOR_CONTEXT_MENU, {
-            commandId: TerminalCommands.TERMINAL_CONTEXT.id
+            commandId: TerminalCommands.TERMINAL_CONTEXT.id,
+            order: 'z'
         });
     }
 


### PR DESCRIPTION
fix https://github.com/theia-ide/theia/issues/4004
VS Code docs: https://code.visualstudio.com/api/references/contribution-points#contributes.menus

This PR alignes Theia menus with VS Code built-in menus:
- `navigator` menu group is always sorted to the top
- each menu command receives a current selected resource as first argument, Theia core URIs translated to VS Code URIs
- supported menus:
  - `explorer/context`
  - `editor/context`
  - `editor/title`
  - `debug/callstack/context`
  - `view/item/context`

Out of scope, since there are not corresponding implementations in Theia:
- SCM menus: https://github.com/theia-ide/theia/issues/4171
- `editor/title/context` menu: https://github.com/theia-ide/theia/issues/4161
- `view/title` https://github.com/theia-ide/theia/issues/4174
- `ALT` commands https://github.com/theia-ide/theia/issues/4162

Testing:
One can test against this VS Code extension: https://github.com/akosyakov/vscode-menus

There is no API breaking changes, but menu constants were renamed. Is it a case for major release? @marcdumais-work @svenefftinge 

<img width="1179" alt="screen shot 2019-01-28 at 10 29 47" src="https://user-images.githubusercontent.com/3082655/51826802-321c8e00-22e8-11e9-8fdf-0eb198df0f1c.png">

Location of built-in explorer groups in Theia and VS Code:
<img width="1134" alt="screen shot 2019-01-28 at 11 39 10" src="https://user-images.githubusercontent.com/3082655/51830979-5c267e00-22f1-11e9-84ff-a99553f42223.png">
