### PR TITLE
Use problem manager to handle markers from plugins

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -104,7 +104,7 @@ export class ProblemWidget extends TreeWidget {
                     <i className={severityClass}></i>
                 </div>
                 <div className='owner'>
-                    {'[' + problemMarker.owner + ']'}
+                    {'[' + (problemMarker.data.source || problemMarker.owner) + ']'}
                 </div>
                 <div className='message'>{problemMarker.data.message}
                     {

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -10,6 +10,7 @@
     "@theia/editor": "^0.3.19",
     "@theia/file-search": "^0.3.19",
     "@theia/filesystem": "^0.3.19",
+    "@theia/markers": "^0.3.19",
     "@theia/messages": "^0.3.19",
     "@theia/monaco": "^0.3.19",
     "@theia/navigator": "^0.3.19",

--- a/packages/plugin-ext/src/api/model.ts
+++ b/packages/plugin-ext/src/api/model.ts
@@ -197,7 +197,7 @@ export interface MarkerData {
 }
 
 export interface RelatedInformation {
-    resource: UriComponents;
+    resource: string;
     message: string;
     startLineNumber: number;
     startColumn: number;

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -900,7 +900,7 @@ export interface LanguagesMain {
     $registerDocumentHighlightProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerQuickFixProvider(handle: number, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void;
     $clearDiagnostics(id: string): void;
-    $changeDiagnostics(id: string, delta: [UriComponents, MarkerData[]][]): void;
+    $changeDiagnostics(id: string, delta: [string, MarkerData[]][]): void;
     $registerDocumentFormattingSupport(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerRangeFormattingProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerOnTypeFormattingProvider(handle: number, selector: SerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;

--- a/packages/plugin-ext/src/plugin/languages/diagnostics.ts
+++ b/packages/plugin-ext/src/plugin/languages/diagnostics.ts
@@ -114,7 +114,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
         if (this.has(uri)) {
             this.fireDiagnosticChangeEvent(uri);
             this.diagnostics.delete(uri.toString());
-            this.proxy.$changeDiagnostics(this.name, [[uri, []]]);
+            this.proxy.$changeDiagnostics(this.name, [[uri.toString(), []]]);
         }
     }
 
@@ -204,7 +204,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
     }
 
     private sendChangesToEditor(uris: URI[]): void {
-        const markers: [URI, MarkerData[]][] = [];
+        const markers: [string, MarkerData[]][] = [];
         nextUri:
         for (const uri of uris) {
             const uriMarkers: MarkerData[] = [];
@@ -224,7 +224,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
                                         endLineNumber: lastMarker.endLineNumber,
                                         endColumn: lastMarker.endColumn
                                     });
-                                    markers.push([uri, uriMarkers]);
+                                    markers.push([uri.toString(), uriMarkers]);
                                     continue nextUri;
                                 }
                             }
@@ -232,10 +232,10 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
                     }
                 } else {
                     uriDiagnostics.forEach(diagnostic => uriMarkers.push(convertDiagnosticToMarkerData(diagnostic)));
-                    markers.push([uri, uriMarkers]);
+                    markers.push([uri.toString(), uriMarkers]);
                 }
             } else {
-                markers.push([uri, []]);
+                markers.push([uri.toString(), []]);
             }
         }
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -347,7 +347,7 @@ function convertRelatedInformation(diagnosticsRelatedInformation: theia.Diagnost
     const relatedInformation: model.RelatedInformation[] = [];
     for (const item of diagnosticsRelatedInformation) {
         relatedInformation.push({
-            resource: item.location.uri,
+            resource: item.location.uri.toString(),
             message: item.message,
             startLineNumber: item.location.range.start.line + 1,
             startColumn: item.location.range.start.character + 1,


### PR DESCRIPTION
This is a fix for https://github.com/theia-ide/theia/issues/4097. The problem was that markers from plugins were not pushed through the problem manager, but into the Monaco editor directly. 
My test case for this change is installing vscode-java via "Deploy plugin by id" and I used the typescript extension to make sure that theia extensions are not broken.
The problems view used to show the name of the diagnostics collections, but IMO this was wrong, since that seems to be a technical name: the plugin API even allows for it to be generated (that is what vscode-java does). Now the problems view shows the "source" attribute of the Diagnostic.