### PR TITLE
Handle uncaught plugin local dir does not exist

### DIFF
--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -191,7 +191,7 @@ export class PluginDeployerImpl implements PluginDeployer {
             });
 
         });
-        return await Promise.all(waitPromises);
+        return Promise.all(waitPromises);
     }
 
     /**

--- a/packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts
+++ b/packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts
@@ -42,7 +42,8 @@ export class LocalDirectoryPluginDeployerResolver implements PluginDeployerResol
 
         // check directory exists
         if (!fs.existsSync(dirPath)) {
-            throw new Error('The directory referenced by ' + pluginResolverContext.getOriginId() + ' does not exist.');
+            console.warn(`The directory referenced by ${pluginResolverContext.getOriginId()} does not exist.`);
+            return;
 
         }
         // list all stuff from this directory


### PR DESCRIPTION
Fixes #4041 

- handle the uncaught exception `Error: The directory referenced by local-dir:../../plugins does not exist.`.
- remove unecessary `await`.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
