### PR TITLE
Use PromiseLike instead of Thenable for theia-proposed.d.ts file.

### DIFF
--- a/packages/plugin/src/theia-proposed.d.ts
+++ b/packages/plugin/src/theia-proposed.d.ts
@@ -47,7 +47,7 @@ declare module '@theia/plugin' {
     export interface FileWillRenameEvent {
         readonly oldUri: Uri;
         readonly newUri: Uri;
-        waitUntil(thenable: Thenable<WorkspaceEdit>): void;
+        waitUntil(thenable: PromiseLike<WorkspaceEdit>): void;
     }
 
     /**


### PR DESCRIPTION
Use PromiseLike instead of Thenable for theia-proposed.d.ts file.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>


