### PR TITLE
Improve `git pull` & `git push` quick-open-items

### DIFF
--- a/packages/git/src/browser/git-quick-open-service.ts
+++ b/packages/git/src/browser/git-quick-open-service.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { QuickOpenItem, QuickOpenMode, QuickOpenModel } from '@theia/core/lib/browser/quick-open/quick-open-model';
 import { QuickOpenService, QuickOpenOptions } from '@theia/core/lib/browser/quick-open/quick-open-service';
-import { Git, Repository, Branch, BranchType, Tag } from '../common';
+import { Git, Repository, Branch, BranchType, Tag, Remote } from '../common';
 import { GitRepositoryProvider } from './git-repository-provider';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import URI from '@theia/core/lib/common/uri';
@@ -115,7 +115,11 @@ export class GitQuickOpenService {
                     this.gitErrorHandler.handleError(error);
                 }
             };
-            const items = remotes.map(remote => new GitQuickOpenItem(remote, execute));
+            const items = remotes.map(remote => {
+                const toLabel = () => remote.name;
+                const toDescription = () => remote.fetch;
+                return new GitQuickOpenItem(remote.name, execute, toLabel, toDescription);
+            });
             this.open(items, 'Pick a remote to fetch from:');
         }
     }
@@ -123,7 +127,7 @@ export class GitQuickOpenService {
     async performDefaultGitAction(action: GitAction): Promise<void> {
         const repository = this.getRepository();
         const remote = await this.getRemotes();
-        const defaultRemote = remote[0];
+        const defaultRemote = remote[0].name;
         if (repository) {
             try {
                 if (action === GitAction.PULL) {
@@ -150,7 +154,11 @@ export class GitQuickOpenService {
                     this.gitErrorHandler.handleError(error);
                 }
             };
-            const items = remotes.map(remote => new GitQuickOpenItem(remote, execute));
+            const items = remotes.map(remote => {
+                const toLabel = () => remote.name;
+                const toDescription = () => remote.push;
+                return new GitQuickOpenItem(remote.name, execute, toLabel, toDescription);
+            });
             const branchName = currentBranch ? `'${currentBranch.name}' ` : '';
             this.open(items, `Pick a remote to push the currently active branch ${branchName}to:`);
         }
@@ -160,10 +168,10 @@ export class GitQuickOpenService {
         const repository = this.getRepository();
         if (repository) {
             const remotes = await this.getRemotes();
-            const defaultRemote = remotes[0]; // I wish I could use assignment destructuring here. (GH-413)
-            const executeRemote = async (remoteItem: GitQuickOpenItem<string>) => {
+            const defaultRemote = remotes[0].name; // I wish I could use assignment destructuring here. (GH-413)
+            const executeRemote = async (remoteItem: GitQuickOpenItem<Remote>) => {
                 // The first remote is the default.
-                if (remoteItem.ref === defaultRemote) {
+                if (remoteItem.ref.name === defaultRemote) {
                     try {
                         await this.git.pull(repository, { remote: remoteItem.getLabel() });
                     } catch (error) {
@@ -174,7 +182,7 @@ export class GitQuickOpenService {
                     const branches = await this.getBranches();
                     const executeBranch = async (branchItem: GitQuickOpenItem<Branch>) => {
                         try {
-                            await this.git.pull(repository, { remote: remoteItem.ref, branch: branchItem.ref.nameWithoutRemote });
+                            await this.git.pull(repository, { remote: remoteItem.ref.name, branch: branchItem.ref.nameWithoutRemote });
                         } catch (error) {
                             this.gitErrorHandler.handleError(error);
                         }
@@ -187,7 +195,11 @@ export class GitQuickOpenService {
                     this.open(branchItems, 'Select the branch to pull the changes from:');
                 }
             };
-            const remoteItems = remotes.map(remote => new GitQuickOpenItem(remote, executeRemote));
+            const remoteItems = remotes.map(remote => {
+                const toLabel = () => remote.name;
+                const toDescription = () => remote.fetch;
+                return new GitQuickOpenItem(remote, executeRemote, toLabel, toDescription);
+            });
             this.open(remoteItems, 'Pick a remote to pull the branch from:');
         }
     }
@@ -356,10 +368,10 @@ export class GitQuickOpenService {
         return this.repositoryProvider.selectedRepository;
     }
 
-    private async getRemotes(): Promise<string[]> {
+    private async getRemotes(): Promise<Remote[]> {
         const repository = this.getRepository();
         try {
-            return repository ? await this.git.remote(repository) : [];
+            return repository ? await this.git.remote(repository, { verbose: true }) : [];
         } catch (error) {
             this.gitErrorHandler.handleError(error);
             return [];

--- a/packages/git/src/common/git-model.ts
+++ b/packages/git/src/common/git-model.ts
@@ -192,6 +192,28 @@ export namespace Repository {
 }
 
 /**
+ * Representation of a Git remote.
+ */
+export interface Remote {
+
+    /**
+     * The name of the remote.
+     */
+    readonly name: string,
+
+    /**
+     * The remote fetch url.
+     */
+    readonly fetch: string,
+
+    /**
+     * The remote git url.
+     */
+    readonly push: string,
+
+}
+
+/**
  * The branch type. Either local or remote.
  * The order matters.
  */

--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -16,7 +16,7 @@
 
 import { ChildProcess } from 'child_process';
 import { Disposable } from '@theia/core';
-import { Repository, WorkingDirectoryStatus, Branch, GitResult, GitError, GitFileStatus, GitFileChange, CommitWithChanges, GitFileBlame } from './git-model';
+import { Repository, WorkingDirectoryStatus, Branch, GitResult, GitError, GitFileStatus, GitFileChange, CommitWithChanges, GitFileBlame, Remote as RemoteModel } from './git-model';
 
 /**
  * The WS endpoint path to the Git service.
@@ -546,6 +546,18 @@ export namespace Git {
 
         }
 
+        /**
+         * Options for the `git remote` command.
+         */
+        export interface Remote {
+
+            /**
+             * Be more verbose and get remote url for `fetch` and `push` actions.
+             */
+            readonly verbose?: true,
+
+        }
+
     }
 
 }
@@ -691,11 +703,19 @@ export interface Git extends Disposable {
     show(repository: Repository, uri: string, options?: Git.Options.Show): Promise<string>;
 
     /**
-     * It resolves to an array of configured remotes for the given repository.
+     * It resolves to an array of configured remotes names for the given repository.
      *
-     * @param repository the repository to get the remotes.
+     * @param repository the repository to get the remote names.
      */
     remote(repository: Repository): Promise<string[]>;
+
+    /**
+     * It resolves to an array of configured remote objects for the given Git action.
+     *
+     * @param repository the repository to get the remote objects.
+     * @param options `git remote` command refinements.
+     */
+    remote(repository: Repository, options: { verbose: true }): Promise<RemoteModel[]>;
 
     /**
      * Executes the Git command and resolves to the result. If an executed Git command exits with a code that is not in the `successExitCodes` or an error not in `expectedErrors`,


### PR DESCRIPTION
Updated `git pull` and `git push` quick open items to now also display remote uri, instead
of simply displaying the remote name.

- create new method `getRemoteUris` to not break api, and provide more information than the standard `getRemotes` which only returns the remote name.

<div align='center'>

<img width="1049" alt="screen shot 2019-01-29 at 5 43 26 pm" src="https://user-images.githubusercontent.com/40359487/51945758-89585680-23ed-11e9-94ed-ec86df4321e2.png">

</div>


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
