### PR TITLE
Register show references command under the vscode known id.

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -29,8 +29,16 @@ export namespace EditorCommands {
      * Show editor references
      */
     export const SHOW_REFERENCES: Command = {
+        id: 'editor.action.showReferences'
+    };
+
+    /**
+     * Show editor references
+     */
+    export const SHOW_REFERENCES_DEPRECATED: Command = {
         id: 'textEditor.commands.showReferences'
     };
+
     /**
      * Change indentation configuration (i.e., indent using tabs / spaces, and how many spaces per tab)
      */
@@ -108,6 +116,7 @@ export class EditorCommandContribution implements CommandContribution {
 
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(EditorCommands.SHOW_REFERENCES);
+        registry.registerCommand(EditorCommands.SHOW_REFERENCES_DEPRECATED);
         registry.registerCommand(EditorCommands.CONFIG_INDENTATION);
         registry.registerCommand(EditorCommands.CONFIG_EOL);
         registry.registerCommand(EditorCommands.INDENT_USING_SPACES);

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -122,6 +122,7 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
 
     protected registerEditorCommandHandlers(): void {
         this.registry.registerHandler(EditorCommands.SHOW_REFERENCES.id, this.newShowReferenceHandler());
+        this.registry.registerHandler(EditorCommands.SHOW_REFERENCES_DEPRECATED.id, this.newShowReferenceHandler());
         this.registry.registerHandler(EditorCommands.CONFIG_INDENTATION.id, this.newConfigIndentationHandler());
         this.registry.registerHandler(EditorCommands.CONFIG_EOL.id, this.newConfigEolHandler());
         this.registry.registerHandler(EditorCommands.INDENT_USING_SPACES.id, this.newConfigTabSizeHandler(true));


### PR DESCRIPTION
Registers the show references command from monaco editor both under the old theia id and the vs code "standard" id. 
It's a fix for https://github.com/theia-ide/theia/issues/4084

This is untested code to illustrate what I have in mind.