### PR TITLE
[ts] restore version only when workspace & preferences are ready

### DIFF
--- a/packages/typescript/src/browser/typescript-client-contribution.ts
+++ b/packages/typescript/src/browser/typescript-client-contribution.ts
@@ -153,7 +153,8 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
         }
         return versions[0];
     }
-    getVersions(): Promise<TypescriptVersion[]> {
+    async getVersions(): Promise<TypescriptVersion[]> {
+        await Promise.all([this.preferences.ready, this.workspace.ready]);
         return this.versionService.getVersions(this.versionOptions);
     }
     protected get versionOptions(): TypescriptVersionOptions {


### PR DESCRIPTION
fix #4194

In order to test:
- add timeouts into preferences initialization;
- debug version restoration;
- check that proper workspace roots and preference values are used.