### PR TITLE
cpp: README changes

### DIFF
--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -10,7 +10,10 @@ To install Clangd on Ubuntu 18.04:
     $ sudo apt-get update && sudo apt-get install -y clang-tools-8
     $ sudo ln -s /usr/bin/clangd-8 /usr/bin/clangd
 
-See [here](https://clang.llvm.org/extra/clangd.html#id4) for detailed installation instructions.
+See [here](https://clang.llvm.org/extra/clangd.html#id4) for detailed
+installation instructions.
+
+## Getting accurate diagnostics
 
 To get accurate diagnostics, it helps to:
 
@@ -18,11 +21,9 @@ To get accurate diagnostics, it helps to:
    [`compile_commands.json`](https://clang.llvm.org/docs/JSONCompilationDatabase.html)
    file.
 2. Point Clangd to the build directory containing said `compile_commands.json`.
-3. Set path to Clangd executable.
-4. Set arguments to pass to clangd when starting the language server.
 
-\#2 can be done using the `cpp.buildConfigurations` preference. In your home
-or your project `.theia/settings.json`, define one or more build
+Step \#2 can be done using the `cpp.buildConfigurations` preference. In your
+home or your project `.theia/settings.json`, define one or more build
 configurations:
 
     {
@@ -35,27 +36,47 @@ configurations:
         }]
     }
 
-You can then select an active configuration using the
-`C/C++: Change Build Configuration` command from the command palette.
+You can then select an active configuration using the `C/C++: Change Build
+Configuration` command from the command palette.
 
-\#3 can be done either by:
+## Setting clangd executable path and arguments
 
-- Setting `CPP_CLANGD_COMMAND` environment variable
-- Adding `cpp.clangdExecutable` preference in your home or your project `.theia/settings.json`:
+The path of the clangd executable to use can be specified by either:
+
+- Setting the `CPP_CLANGD_COMMAND` environment variable
+- Setting the `cpp.clangdExecutable` preference in your home or your project
+  `.theia/settings.json`:
 
         {
             "cpp.clangdExecutable": "/path/to/my/clangd/executable"
         }
 
-- Adding clangd to system path. Default value of executable path is set to `clangd`
+- Adding clangd to system path. Default value of executable path is set to
+  `clangd`
 
-\#4 can be done either by:
+Similarly, the command-line arguments passed to clangd can be specified by
+either:
 
-- Setting `CPP_CLANGD_ARGS` environment variable
-- Adding `cpp.clangdArgs` preference in your home or your project `.theia/settings.json`:
+- Setting the `CPP_CLANGD_ARGS` environment variable
+- Setting the `cpp.clangdArgs` preference in your home or your project
+  `.theia/settings.json`:
 
         {
             "cpp.clangdArgs": "list of clangd arguments"
+        }
+
+## Getting cross-file references to work
+
+You may notice that by default, cross-references across source file boundaries
+don't work.  For example, doing a "Go To Definition" on a function defined in a
+different source file (different `.c` or `.cpp`) doesn't work, instead it sends
+you to the declaration of the function, typically in a header file.
+
+To get this working, you need to enable clangd's global index using the
+`--background-index` command-line argument.
+
+        {
+            "cpp.clangdArgs": "--background-index"
         }
 
 ## License


### PR DESCRIPTION
- Split the README in sections, to allow readers to jump to what they
  are looking for instead of reading the whole text.
- Mention clangd's --background-index switch

Change-Id: Iee7ee817218b18f8d643ed6ef876b25284e511f6
Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
