### PR TITLE
align debug commands with VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ Breaking changes:
     - `3_move` and `7_actions` replaced by `navigation` group
   - editor context menu group changes:
     - `2_cut_copy_paste` renamed to `9_cutcopypaste` group
+- [debug] align commands with VS Code [#4204](https://github.com/theia-ide/theia/issues/4204)
+    - `debug.breakpoint.toggle` renamed to `editor.debug.action.toggleBreakpoint`
+    - `debug.start` renamed to `workbench.action.debug.start`
+    - `debug.thread.continue` renamed to `workbench.action.debug.continue`
+    - `debug.start.noDebug` renamed to `workbench.action.debug.run`
+    - `debug.thread.pause` renamed to `workbench.action.debug.pause`
+    - `debug.thread.stepin` renamed to `workbench.action.debug.stepInto`
+    - `debug.thread.stepout` renamed to `workbench.action.debug.stepOut`
+    - `debug.thread.next` renamed to `workbench.action.debug.stepOver`
+    - `debug.stop` renamed to `workbench.action.debug.stop`
+    - `debug.editor.showHover` renamed to `editor.debug.action.showDebugHover`
 
 ## v0.3.19
 - [core] added `hostname` alias

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -55,17 +55,17 @@ export namespace DebugCommands {
     const DEBUG_CATEGORY = 'Debug';
 
     export const START: Command = {
-        id: 'debug.start',
+        id: 'workbench.action.debug.start',
         category: DEBUG_CATEGORY,
         label: 'Start Debugging',
         iconClass: 'fa fa-play'
     };
     export const START_NO_DEBUG: Command = {
-        id: 'debug.start.noDebug',
+        id: 'workbench.action.debug.run',
         label: 'Debug: Start Without Debugging'
     };
     export const STOP: Command = {
-        id: 'debug.stop',
+        id: 'workbench.action.debug.stop',
         category: DEBUG_CATEGORY,
         label: 'Stop Debugging',
         iconClass: 'fa fa-stop'
@@ -86,31 +86,31 @@ export namespace DebugCommands {
     };
 
     export const STEP_OVER: Command = {
-        id: 'debug.thread.next',
+        id: 'workbench.action.debug.stepOver',
         category: DEBUG_CATEGORY,
         label: 'Step Over',
         iconClass: 'fa fa-arrow-right'
     };
     export const STEP_INTO: Command = {
-        id: 'debug.thread.stepin',
+        id: 'workbench.action.debug.stepInto',
         category: DEBUG_CATEGORY,
         label: 'Step Into',
         iconClass: 'fa fa-arrow-down'
     };
     export const STEP_OUT: Command = {
-        id: 'debug.thread.stepout',
+        id: 'workbench.action.debug.stepOut',
         category: DEBUG_CATEGORY,
         label: 'Step Out',
         iconClass: 'fa fa-arrow-up'
     };
     export const CONTINUE: Command = {
-        id: 'debug.thread.continue',
+        id: 'workbench.action.debug.continue',
         category: DEBUG_CATEGORY,
         label: 'Continue',
         iconClass: 'fa fa-play-circle'
     };
     export const PAUSE: Command = {
-        id: 'debug.thread.pause',
+        id: 'workbench.action.debug.pause',
         category: DEBUG_CATEGORY,
         label: 'Pause',
         iconClass: 'fa fa-pause'
@@ -129,7 +129,7 @@ export namespace DebugCommands {
     };
 
     export const TOGGLE_BREAKPOINT: Command = {
-        id: 'debug.breakpoint.toggle',
+        id: 'editor.debug.action.toggleBreakpoint',
         category: DEBUG_CATEGORY,
         label: 'Toggle Breakpoint',
     };
@@ -179,7 +179,7 @@ export namespace DebugCommands {
         label: 'Remove All Breakpoints',
     };
     export const SHOW_HOVER = {
-        id: 'debug.editor.showHover',
+        id: 'editor.debug.action.showDebugHover',
         label: 'Debug: Show Hover'
     };
 


### PR DESCRIPTION
fix #4204

I've checked that:
- Monaco does not contribute such VS Code commands
- VS Code extensions cannot pass any arguments or expect results from them

Because of it, replacing constants should be safe.

It is a breaking change, but i doubt that anyone is using them outside of Theia repo. @thegecko?

Anyway, since we did other breaking changes already for `^0.4.0`, i've listed these changes as well in the changelog.

`Start Debugging and Stop on Entry` is a command contributed by `node-debug` VS Code extension and implemented via calling `workbench.action.debug.start` command:
![stop_on_entry](https://user-images.githubusercontent.com/3082655/52055968-369fab80-2561-11e9-900d-016220766259.gif)
