### PR TITLE
Support additional preload HTML elements

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { AbstractGenerator } from './abstract-generator';
+import { existsSync, readFileSync } from 'fs';
 
 export class FrontendGenerator extends AbstractGenerator {
 
@@ -27,6 +28,20 @@ export class FrontendGenerator extends AbstractGenerator {
         }
     }
 
+    protected compileIndexPreload(frontendModules: Map<string, string>): string {
+        const template = this.pck.props.generator.config.preloadTemplate;
+        if (!template) {
+            return '';
+        }
+
+        // Support path to html file
+        if (existsSync(template)) {
+            return readFileSync(template).toString();
+        }
+
+        return template;
+    }
+
     protected compileIndexHtml(frontendModules: Map<string, string>): string {
         return `<!DOCTYPE html>
 <html>
@@ -36,7 +51,7 @@ export class FrontendGenerator extends AbstractGenerator {
 </head>
 
 <body>
-  <div class="theia-preload"></div>
+  <div class="theia-preload">${this.compileIndexPreload(frontendModules)}</div>
 </body>
 
 </html>`;

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -57,6 +57,10 @@ export interface ApplicationProps extends NpmRegistryProps {
      */
     readonly backend: Readonly<{ config: BackendApplicationConfig }>;
 
+    /**
+     * Generator specific properties.
+     */
+    readonly generator: Readonly<{ config: GeneratorConfig }>;
 }
 export namespace ApplicationProps {
 
@@ -71,6 +75,11 @@ export namespace ApplicationProps {
         frontend: {
             config: {
                 applicationName: 'Theia'
+            }
+        },
+        generator: {
+            config: {
+                preloadTemplate: ''
             }
         }
     };
@@ -113,5 +122,17 @@ export interface BackendApplicationConfig extends ApplicationConfig {
      * For more details, see [`startupTimeoutOption`](MasterProcess#startupTimeoutOption).
      */
     readonly startupTimeout?: number;
+
+}
+
+/**
+ * Configuration for the generator.
+ */
+export interface GeneratorConfig {
+
+    /**
+     * Template to use for extra preload content markup (file path or HTML)
+     */
+    readonly preloadTemplate: string;
 
 }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR adds the ability to specify further HTML elements to be injected into the `preload` element statically declared in the frontend generator.

This enables a developer to create more complex load screens by adding additional markup to an html file and referencing it in the application package.json file:

```json
"theia": {
    generator: {
        config: {
            preloadTemplate: "preload.html"
        }
    }
}
```

Or by specifying the extra markup directly in the application package.json file:

```json
"theia": {
    generator: {
        config: {
            "preloadTemplate": "<div class='more-preload'></div>"
        }
    }
}
```
