### PR TITLE
Add gohtml to list of html highlighted file types

### DIFF
--- a/packages/textmate-grammars/src/browser/html.ts
+++ b/packages/textmate-grammars/src/browser/html.ts
@@ -28,7 +28,7 @@ export class HtmlContribution implements LanguageGrammarDefinitionContribution {
     registerTextmateLanguage(registry: TextmateRegistry) {
         monaco.languages.register({
             id: this.id,
-            extensions: ['.html', '.htm', '.shtml', '.xhtml', '.mdoc', '.jsp', '.asp', '.aspx', '.jshtm'],
+            extensions: ['.html', '.htm', '.shtml', '.xhtml', '.mdoc', '.jsp', '.asp', '.aspx', '.jshtm', '.gohtml'],
             aliases: ['HTML', 'htm', 'html', 'xhtml'],
             mimetypes: ['text/html', 'text/x-jshtm', 'text/template', 'text/ng-template'],
         });


### PR DESCRIPTION
The go function calls in go templates don't break the html syntax highlighting and I think having HTML syntax highlighting is better than no syntax highlighting.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
