### PR TITLE
Add ability to pass argument for 'mini-browser.openUrl' command

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -170,7 +170,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
             isVisible: widget => !!this.getSourceUri(widget)
         });
         commands.registerCommand(MiniBrowserCommands.OPEN_URL, {
-            execute: () => this.openUrl()
+            execute: (arg?: string) => this.openUrl(arg)
         });
     }
 
@@ -243,8 +243,8 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         return uri;
     }
 
-    protected async openUrl(): Promise<void> {
-        const url = await this.quickInputService.open({
+    protected async openUrl(arg?: string): Promise<void> {
+        const url = arg ? arg : await this.quickInputService.open({
             prompt: 'URL to open',
             placeHolder: 'Type a URL'
         });


### PR DESCRIPTION
Ability to pass argument for 'mini-browser.openUrl' command will allow to open URL in the Preview Tab without asking user to enter this one.
It would be very useful for plugin side, for example.

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

