### PR TITLE
[core] Return a proper Window object when possible

### DIFF
--- a/packages/core/src/browser/http-open-handler.ts
+++ b/packages/core/src/browser/http-open-handler.ts
@@ -31,9 +31,8 @@ export class HttpOpenHandler implements OpenHandler {
         return uri.scheme.startsWith('http') ? 500 : 0;
     }
 
-    open(uri: URI): undefined {
-        this.windowService.openNewWindow(uri.toString(true), { external: true });
-        return undefined;
+    open(uri: URI): Window | undefined {
+        return this.windowService.openNewWindow(uri.toString(true), { external: true });
     }
 
 }

--- a/packages/core/src/browser/window/test/mock-window-service.ts
+++ b/packages/core/src/browser/window/test/mock-window-service.ts
@@ -18,5 +18,5 @@ import { WindowService } from '../window-service';
 
 @injectable()
 export class MockWindowService implements WindowService {
-    openNewWindow(): void { }
+    openNewWindow() { return undefined; }
 }

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -31,18 +31,19 @@ export interface WindowService {
      * In a browser, opening a new Theia tab or open a link is the same thing.
      * But in Electron, we want to open links in a browser, not in Electron.
      */
-    openNewWindow(url: string, options?: NewWindowOptions): void;
+    openNewWindow(url: string, options?: NewWindowOptions): Window | undefined;
 
 }
 
 @injectable()
 export class DefaultWindowService implements WindowService {
 
-    openNewWindow(url: string): void {
+    openNewWindow(url: string): Window {
         const newWindow = window.open(url);
         if (newWindow === null) {
             throw new Error('Cannot open a new window for URL: ' + url);
         }
+        return newWindow;
     }
 
 }

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -21,12 +21,13 @@ import { WindowService, NewWindowOptions } from '../../browser/window/window-ser
 @injectable()
 export class ElectronWindowService implements WindowService {
 
-    openNewWindow(url: string, { external }: NewWindowOptions = {}): void {
+    openNewWindow(url: string, { external }: NewWindowOptions = {}): undefined {
         if (external) {
             ipcRenderer.send('open-external', url);
         } else {
             ipcRenderer.send('create-new-window', url);
         }
+        return undefined;
     }
 
 }


### PR DESCRIPTION
I had changed a bit the return value of some
`WindowService.openNewWindow` functions.

The API didn't change, although the actual returned values aren't the
same. This commit fixes it.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

Not a big change, just something that @elaihau noticed, so here's the fix, if anyone else also think it might be better with this commit.
