### PR TITLE
GH-4253: Dropped the `path` and `name` when loading with `file-loader`.

### DIFF
--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -102,7 +102,7 @@ module.exports = {
                 test: /\\.(jpg|png|gif)$/,
                 loader: 'file-loader',
                 options: {
-                    name: '[path][name].[hash].[ext]',
+                    name: '[hash].[ext]',
                 }
             },
             {


### PR DESCRIPTION
So that a bundled electron application can pick up the images.

Closes: #4253.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

I have verified this with the `browser` and `electron` examples in development mode from the Theia repository. Also, I have manually applied this change to the generated `webpack.config.js` file in `theia-apps/theia-electron`, bundled the application and verified whether the spinning GIF is there or not; it was available. Please review.

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->