### PR TITLE
[plug-in][java][preferences] Add files.exclude preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Breaking changes:
     - the type of `combinedSchema` property is changed from `PreferenceSchema` to `PreferenceDataSchema`.
     - the return type of `getCombinedSchema` function is changed from `PreferenceSchema` to `PreferenceDataSchema`.
   - `affects` function is added to `PreferenceChangeEvent` and `PreferenceChange` interface.
+- `navigator.exclude` preference is renamed to `files.exclude` [#4274](https://github.com/theia-ide/theia/pull/4274)
 
 
 ## v0.3.19

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -37,12 +37,19 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
                 '**/node_modules/**': true
             },
             'scope': 'resource'
+        },
+        'files.exclude': {
+            'type': 'object',
+            'default': { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
+            'description': 'Configure glob patterns for excluding files and folders.',
+            'scope': 'resource'
         }
     }
 };
 
 export interface FileSystemConfiguration {
     'files.watcherExclude': { [globPattern: string]: boolean };
+    'files.exclude': { [key: string]: boolean };
 }
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -26,21 +26,12 @@ export const FileNavigatorConfigSchema: PreferenceSchema = {
             type: 'boolean',
             description: 'Selects file under editing in the navigator.',
             default: true
-        },
-        'navigator.exclude': {
-            type: 'object',
-            description: `
-Configure glob patterns for excluding files and folders from the navigator. A resource that matches any of the enabled patterns, will be filtered out from the navigator. For more details about the exclusion patterns, see: \`man 5 gitignore\`.`,
-            default: {
-                '**/.git': true
-            }
         }
     }
 };
 
 export interface FileNavigatorConfiguration {
     'navigator.autoReveal': boolean;
-    'navigator.exclude': { [key: string]: boolean };
 }
 
 export const FileNavigatorPreferences = Symbol('NavigatorPreferences');


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

**The problem**
VS Code has `files.exclude` preference and some of VS Code extensions want to change value of this preference. In my case it is java-vscode extension. The last version of java-vscode extension  (0.38.0)  asks user to exclude some types of files (`.project`, `.classpath`) to hide them in **Files** view. To do that the extension wants to extend `files.exclude` preference, but Theia doesn't have such preference.

**Changes**
This PR offers to add `files.exclude` and makes it possible to hide excluded files/folders in **Files** view.

**Related issue**
https://github.com/theia-ide/theia/issues/4254

**Short demo**
![files_exclude](https://user-images.githubusercontent.com/1271546/52404790-88e94b00-2ad2-11e9-89ae-652995ed1bcf.gif)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
