### PR TITLE
WIP register Monaco command used by vscode extensions

### DIFF
--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -28,6 +28,7 @@ export interface MonacoEditorCommandHandler {
 @injectable()
 export class MonacoCommandRegistry {
 
+    /* @deprecated Monaco command is registered as it is, without prefixing */
     public static MONACO_COMMAND_PREFIX = 'monaco.';
 
     constructor(
@@ -36,20 +37,18 @@ export class MonacoCommandRegistry {
         @inject(SelectionService) protected readonly selectionService: SelectionService
     ) { }
 
+    /* @deprecated Monaco command is registered as it is, without prefixing */
     protected prefix(command: string): string {
-        return MonacoCommandRegistry.MONACO_COMMAND_PREFIX + command;
+        return command;
     }
 
     validate(command: string): string | undefined {
-        const monacoCommand = this.prefix(command);
-        return this.commands.commandIds.indexOf(monacoCommand) !== -1 ? monacoCommand : undefined;
+        const monacoCommand = this.commands.getCommand(command);
+        return monacoCommand && monacoCommand.label ? monacoCommand.id : undefined;
     }
 
     registerCommand(command: Command, handler: MonacoEditorCommandHandler): void {
-        this.commands.registerCommand({
-            ...command,
-            id: this.prefix(command.id)
-        }, this.newHandler(handler));
+        this.commands.registerCommand(command, this.newHandler(handler));
     }
 
     registerHandler(command: string, handler: MonacoEditorCommandHandler): void {

--- a/packages/monaco/src/browser/monaco-command-service.ts
+++ b/packages/monaco/src/browser/monaco-command-service.ts
@@ -49,6 +49,9 @@ export class MonacoCommandService implements ICommandService {
             ));
         }
     }
+    getDelegate(): ICommandService | undefined {
+        return this.delegate;
+    }
 
     // tslint:disable-next-line:no-any
     executeCommand(commandId: any, ...args: any[]): monaco.Promise<any> {

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -83,6 +83,8 @@ export namespace MonacoCommands {
             const label = command.label;
             const iconClass = iconClasses.get(id);
             ACTIONS.push({ id, label, iconClass });
+        } else {
+            ACTIONS.push({ id });
         }
     }
 }
@@ -239,9 +241,96 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
     }
 
     protected registerMonacoActionCommands(): void {
+        const missingMonacoCommands = new Set([
+            'undo',
+            'redo',
+            // https://code.visualstudio.com/docs/getstarted/keybindings#_basic-editing
+            'editor.action.clipboardCutAction',
+            'editor.action.clipboardCopyAction',
+            'editor.action.deleteLines',
+            'editor.action.insertLineAfter',
+            'editor.action.insertLineBefore',
+            'editor.action.moveLinesDownAction',
+            'editor.action.moveLinesUpAction',
+            'editor.action.copyLinesDownAction',
+            'editor.action.copyLinesUpAction',
+            'editor.action.addSelectionToNextFindMatch',
+            'editor.action.moveSelectionToNextFindMatch',
+            'cursorUndo',
+            'editor.action.insertCursorAtEndOfEachLineSelected',
+            'editor.action.selectHighlights',
+            'editor.action.changeAll',
+            'expandLineSelection',
+            'editor.action.insertCursorBelow',
+            'editor.action.insertCursorAbove',
+            'editor.action.jumpToBracket',
+            'editor.action.indentLines',
+            'editor.action.outdentLines',
+            'cursorHome',
+            'cursorEnd',
+            'cursorBottom',
+            'cursorTop',
+            'scrollLineDown',
+            'scrollLineUp',
+            'scrollPageDown',
+            'scrollPageUp',
+            'editor.fold',
+            'editor.unfold',
+            'editor.foldRecursively',
+            'editor.unfoldRecursively',
+            'editor.foldAll',
+            'editor.unfoldAll',
+            'editor.action.addCommentLine',
+            'editor.action.removeCommentLine',
+            'editor.action.commentLine',
+            'editor.action.blockComment',
+            'actions.find',
+            'editor.action.startFindReplaceAction',
+            'editor.action.nextMatchFindAction',
+            'editor.action.previousMatchFindAction',
+            'editor.action.selectAllMatches',
+            'toggleFindCaseSensitive',
+            'toggleFindRegex',
+            'toggleFindWholeWord',
+            'editor.action.toggleTabFocusMode',
+            // Should be reimplemented by plugin extension, not part of Monaco
+            // 'toggleRenderWhitespace',
+            // 'editor.action.toggleWordWrap',
+            // 'workbench.action.editor.changeLanguageMode',
+            // https://code.visualstudio.com/docs/getstarted/keybindings#_rich-languages-editing
+            'editor.action.triggerSuggest',
+            'editor.action.triggerParameterHints',
+            'editor.action.formatDocument',
+            'editor.action.formatSelection',
+            'editor.action.showHover',
+            // Requier Monaco upgrade
+            // 'editor.action.revealDefinition',
+            // 'editor.action.peekDefinition',
+            // 'editor.action.revealDefinitionAside',
+            'editor.action.quickFix',
+            'editor.action.referenceSearch.trigger',
+            'editor.action.rename',
+            'editor.action.inPlaceReplace.down',
+            'editor.action.inPlaceReplace.up',
+            'editor.action.smartSelect.grow',
+            'editor.action.smartSelect.shrink',
+            'editor.action.trimTrailingWhitespace',
+        ]);
         for (const action of MonacoCommands.ACTIONS) {
+            missingMonacoCommands.delete(action.id);
             const handler = this.newMonacoActionHandler(action);
             this.registry.registerCommand(action, handler);
+        }
+        for (const id of missingMonacoCommands) {
+            const command = monaco.commands.CommandsRegistry.getCommand(id);
+            if (command) {
+                missingMonacoCommands.delete(id);
+                const handler = this.newCommandHandler(id);
+                this.registry.registerCommand({ id }, handler);
+            }
+        }
+        if (missingMonacoCommands.size) {
+            console.error('Missing VS Code commands', JSON.stringify([...missingMonacoCommands], undefined, 2));
         }
     }
     protected newMonacoActionHandler(action: MonacoCommand): MonacoEditorCommandHandler {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -35,6 +35,7 @@ import {
     EditorMouseEvent
 } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from './monaco-editor-model';
+import { MonacoCommandService } from './monaco-command-service';
 
 import IEditorConstructionOptions = monaco.editor.IEditorConstructionOptions;
 import IModelDeltaDecoration = monaco.editor.IModelDeltaDecoration;
@@ -362,7 +363,11 @@ export class MonacoEditor implements TextEditor {
     }
 
     get commandService(): monaco.commands.ICommandService {
-        return this.editor._commandService;
+        const commandService = this.editor._commandService;
+        if (commandService instanceof MonacoCommandService) {
+            return commandService.getDelegate() || commandService;
+        }
+        return commandService;
     }
 
     get instantiationService(): monaco.instantiation.IInstantiationService {

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -277,6 +277,16 @@ declare module monaco.commands {
         executeCommand(commandId: string, ...args: any[]): monaco.Promise<any>;
     }
 
+    export interface ICommand {
+        id: string;
+    }
+
+    export interface ICommandRegistry {
+        getCommand(id: string): ICommand | undefined;
+    }
+
+    export const CommandsRegistry: ICommandRegistry;
+
 }
 
 declare module monaco.actions {


### PR DESCRIPTION
fix #4247

This PR registers Monaco commands used by VS Code extensions via by-passing the global command registry and calling the internal Monaco registry. The drawback of this approach that not all Monaco commands are exposed, i.e. `editor.action.findReferences` is not exposed with it. One has to expose them explicitly by listing here: https://github.com/theia-ide/theia/pull/4275/files#diff-50091b54c279f7fa9bf0acce18541c06R244

An alternative is to change the plugin system that it invokes internal Monaco editor command service first, and if it not present falls back to global command registry. In this case there should not be need to list commands explicitly. @svenefftinge Would it be the better approach?

This PR does not implement require conversions between VS Code and Monaco types, they have to be implemented in the plugin extension.

