### PR TITLE
fixes for configuration VS Code API tests 

### DIFF
--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -125,8 +125,30 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
             }
         }
         for (const property of props) {
-            this.preferences[property] = this.combinedSchema.properties[property].default;
+            this.preferences[property] = this.getDefaultValue(this.combinedSchema.properties[property]);
         }
+    }
+
+    protected getDefaultValue(property: PreferenceDataProperty): any {
+        if (property.default) {
+            return property.default;
+        }
+        const type = Array.isArray(property.type) ? property.type[0] : property.type;
+        switch (type) {
+            case 'boolean':
+                return false;
+            case 'integer':
+            case 'number':
+                return 0;
+            case 'string':
+                return '';
+            case 'array':
+                return [];
+            case 'object':
+                return {};
+        }
+        // tslint:disable-next-line:no-null-keyword
+        return null;
     }
 
     protected updateValidate(): void {

--- a/packages/plugin-ext/src/plugin/preference-registry.ts
+++ b/packages/plugin-ext/src/plugin/preference-registry.ts
@@ -25,7 +25,7 @@ import {
     PreferenceData
 } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
-import { isObject } from '../common/types';
+import { isObject, mixin } from '../common/types';
 import { PreferenceChange } from '@theia/core/lib/browser';
 import { Configuration, ConfigurationModel } from './preferences/configuration';
 import { WorkspaceExtImpl } from './workspace';
@@ -179,7 +179,12 @@ export class PreferenceRegistryExtImpl implements PreferenceRegistryExt {
                 return configInspect;
             }
         };
-        return configuration;
+
+        if (typeof preferences === 'object') {
+            mixin(configuration, preferences, false);
+        }
+
+        return Object.freeze(configuration);
     }
 
     private toReadonlyValue(data: any): any {


### PR DESCRIPTION
fix #4258 - align default preference values with vscode by type
fix #4259 - configuration should support read-only index access 