### PR TITLE
[dialogs] fix bad vertical resizing behavior

### DIFF
--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -49,12 +49,12 @@
     background-color: var(--theia-ui-dialog-header-color);
     color: var(--theia-ui-dialog-header-font-color);
     padding: 0 calc(var(--theia-ui-padding)*2);
-    height: 28px;
+    min-height: 24px;
 }
 
 .p-Widget.dialogOverlay .dialogTitle i.closeButton {
     cursor: pointer;
-} 
+}
 
 .p-Widget.dialogOverlay .dialogContent {
     display: flex;
@@ -74,6 +74,7 @@
     align-content: right;
     flex-wrap: nowrap;
     justify-content: flex-end;
+    min-height: 21px;
 }
 
 input {
@@ -98,7 +99,7 @@ input {
     font-size: var(--theia-ui-font-size1);
     border-radius: 0;
     background: transparent;
-    outline: none;    
+    outline: none;
 }
 
 .p-Widget.dialogOverlay.hidden {

--- a/packages/filesystem/src/browser/style/file-dialog.css
+++ b/packages/filesystem/src/browser/style/file-dialog.css
@@ -41,7 +41,7 @@
 
 .dialogContent .theia-NavigationPanel,
 .dialogContent .theia-FiltersPanel {
-    height: 27px;
+    min-height: 27px;
 }
 
 .dialogContent .theia-FileNamePanel {


### PR DESCRIPTION
Before:
<img width="1113" alt="screenshot 2019-02-07 at 14 27 11" src="https://user-images.githubusercontent.com/372735/52415283-da9bd080-2ae6-11e9-9028-0107a766ac55.png">

After:
<img width="981" alt="screenshot 2019-02-07 at 14 40 44" src="https://user-images.githubusercontent.com/372735/52415287-de2f5780-2ae6-11e9-9529-92b17598e4a1.png">

