### PR TITLE
fix displayed values in the preference editor

### DIFF
--- a/packages/preferences/src/browser/preferences-decorator.ts
+++ b/packages/preferences/src/browser/preferences-decorator.ts
@@ -53,8 +53,7 @@ export class PreferencesDecorator implements TreeDecorator {
                 tooltip: preferenceValue.description,
                 captionSuffixes: [
                     {
-                        data: storedValue !== undefined && typeof storedValue === 'string' ? ': ' + escapeInvisibleChars(storedValue) :
-                            preferenceValue.default !== undefined ? ': ' + preferenceValue.default : undefined,
+                        data: `: ${this.getPreferenceDisplayValue(storedValue, preferenceValue.default)}`
                     },
                     {
                         data: ' ' + preferenceValue.description,
@@ -72,5 +71,16 @@ export class PreferencesDecorator implements TreeDecorator {
     setActiveFolder(folder: string) {
         this.activeFolderUri = folder;
         this.fireDidChangeDecorations(this.preferences);
+    }
+
+    // tslint:disable-next-line:no-any
+    private getPreferenceDisplayValue(storedValue: any, defaultValue: any): any {
+        if (storedValue !== undefined) {
+            if (typeof storedValue === 'string') {
+                return escapeInvisibleChars(storedValue);
+            }
+            return storedValue;
+        }
+        return defaultValue;
     }
 }


### PR DESCRIPTION
- preference values displayed in the tree of preference editor are broken by the commit https://github.com/theia-ide/theia/commit/57b8add5db31a2da5d8b501cdd0ed76609dbcb24. This change fixes the bug where preference values (if boolean or number) don't get updated after being edited.

Signed-off-by: elaihau <liang.huang@ericsson.com>

