### PR TITLE
Add ability to specify container for webview panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [plugin] added `tasks.onDidEndTask` Plug-in API
 - [cpp] fixed `CPP_CLANGD_COMMAND` and `CPP_CLANGD_ARGS` environment variables
 - [electron] open markdown links in the OS default browser
+- [plugin] added ability to display webview panel in 'left', 'right' and 'bottom' area
 
 Breaking changes:
 - menus aligned with built-in VS Code menus [#4173](https://github.com/theia-ide/theia/pull/4173)

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -915,11 +915,6 @@ export interface WebviewPanelViewState {
     readonly position: number;
 }
 
-export interface WebviewPanelShowOptions {
-    readonly viewColumn?: number;
-    readonly preserveFocus?: boolean;
-}
-
 export interface WebviewsExt {
     $onMessage(handle: string, message: any): void;
     $onDidChangeWebviewPanelViewState(handle: string, newState: WebviewPanelViewState): void;
@@ -936,11 +931,11 @@ export interface WebviewsMain {
     $createWebviewPanel(handle: string,
         viewType: string,
         title: string,
-        showOptions: WebviewPanelShowOptions,
+        showOptions: theia.WebviewPanelShowOptions,
         options: theia.WebviewPanelOptions & theia.WebviewOptions | undefined,
         pluginLocation: UriComponents): void;
     $disposeWebview(handle: string): void;
-    $reveal(handle: string, showOptions: WebviewPanelShowOptions): void;
+    $reveal(handle: string, showOptions: theia.WebviewPanelShowOptions): void;
     $setTitle(handle: string, value: string): void;
     $setIconPath(handle: string, value: { light: string, dark: string } | string | undefined): void;
     $setHtml(handle: string, value: string): void;

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { WebviewsMain, WebviewPanelShowOptions, MAIN_RPC_CONTEXT, WebviewsExt } from '../../api/plugin-api';
+import { WebviewsMain, MAIN_RPC_CONTEXT, WebviewsExt } from '../../api/plugin-api';
 import { interfaces } from 'inversify';
 import { RPCProtocol } from '../../api/rpc-protocol';
 import { UriComponents } from '../../common/uri-components';
-import { WebviewOptions, WebviewPanelOptions } from '@theia/plugin';
+import { WebviewOptions, WebviewPanelOptions, WebviewPanelShowOptions } from '@theia/plugin';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { WebviewWidget } from './webview/webview';
@@ -85,7 +85,7 @@ export class WebviewsMainImpl implements WebviewsMain {
             this.onCloseView(viewId);
         });
         this.views.set(viewId, view);
-        this.shell.addWidget(view, { area: 'main' });
+        this.shell.addWidget(view, { area: showOptions.area ? showOptions.area : 'main' });
         this.shell.activateWidget(view.id);
     }
     $disposeWebview(handle: string): void {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -97,6 +97,7 @@ import {
     ColorInformation,
     ColorPresentation,
     OperatingSystem,
+    WebviewPanelTargetArea
 } from './types-impl';
 import { SymbolKind } from '../api/model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -312,7 +313,7 @@ export function createAPIFactory(
             },
             createWebviewPanel(viewType: string,
                 title: string,
-                showOptions: theia.ViewColumn | { viewColumn: theia.ViewColumn, preserveFocus?: boolean },
+                showOptions: theia.ViewColumn | theia.WebviewPanelShowOptions,
                 options: theia.WebviewPanelOptions & theia.WebviewOptions): theia.WebviewPanel {
                 return webviewExt.createWebview(viewType, title, showOptions, options, Uri.file(plugin.pluginPath));
             },
@@ -712,7 +713,8 @@ export function createAPIFactory(
             ColorPresentation,
             FoldingRange,
             FoldingRangeKind,
-            OperatingSystem
+            OperatingSystem,
+            WebviewPanelTargetArea
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -254,4 +254,64 @@ describe('Type converters:', () => {
             assert.deepEqual(result, taskDtoWithCommandLine);
         });
     });
+
+    describe('Webview Panel Show Options:', () => {
+        it('should create options from view column ', () => {
+            const viewColumn = types.ViewColumn.Five;
+
+            const showOptions: theia.WebviewPanelShowOptions = {
+                area: types.WebviewPanelTargetArea.Main,
+                viewColumn: types.ViewColumn.Four,
+                preserveFocus: false
+            };
+
+            // when
+            const result: theia.WebviewPanelShowOptions = Converter.toWebviewPanelShowOptions(viewColumn);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, showOptions);
+        });
+
+        it('should create options from given "WebviewPanelShowOptions" object ', () => {
+            const incomingObject: theia.WebviewPanelShowOptions = {
+                area: types.WebviewPanelTargetArea.Main,
+                viewColumn: types.ViewColumn.Five,
+                preserveFocus: true
+            };
+
+            const showOptions: theia.WebviewPanelShowOptions = {
+                area: types.WebviewPanelTargetArea.Main,
+                viewColumn: types.ViewColumn.Four,
+                preserveFocus: true
+            };
+
+            // when
+            const result: theia.WebviewPanelShowOptions = Converter.toWebviewPanelShowOptions(incomingObject);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, showOptions);
+        });
+
+        it('should set default "main" area', () => {
+            const incomingObject: theia.WebviewPanelShowOptions = {
+                viewColumn: types.ViewColumn.Five,
+                preserveFocus: false
+            };
+
+            const showOptions: theia.WebviewPanelShowOptions = {
+                area: types.WebviewPanelTargetArea.Main,
+                viewColumn: types.ViewColumn.Four,
+                preserveFocus: false
+            };
+
+            // when
+            const result: theia.WebviewPanelShowOptions = Converter.toWebviewPanelShowOptions(incomingObject);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, showOptions);
+        });
+    });
 });

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -54,6 +54,23 @@ export function fromViewColumn(column?: theia.ViewColumn): number {
     return ACTIVE_GROUP;
 }
 
+export function toWebviewPanelShowOptions(options: theia.ViewColumn | theia.WebviewPanelShowOptions): theia.WebviewPanelShowOptions {
+    if (typeof options === 'object') {
+        const showOptions = options as theia.WebviewPanelShowOptions;
+        return {
+            area: showOptions.area ? showOptions.area : types.WebviewPanelTargetArea.Main,
+            viewColumn: showOptions.viewColumn ? fromViewColumn(showOptions.viewColumn) : undefined,
+            preserveFocus: showOptions.preserveFocus ? showOptions.preserveFocus : false
+        };
+    }
+
+    return {
+        area: types.WebviewPanelTargetArea.Main,
+        viewColumn: fromViewColumn(options as theia.ViewColumn),
+        preserveFocus: false
+    };
+}
+
 export function toSelection(selection: Selection): types.Selection {
     const { selectionStartLineNumber, selectionStartColumn, positionLineNumber, positionColumn } = selection;
     const start = new types.Position(selectionStartLineNumber - 1, selectionStartColumn - 1);

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1810,3 +1810,11 @@ export enum OperatingSystem {
     Linux = 'Linux',
     OSX = 'OSX'
 }
+
+/** The areas of the application shell where webview panel can reside. */
+export enum WebviewPanelTargetArea {
+    Main = 'main',
+    Left = 'left',
+    Right = 'right',
+    Bottom = 'bottom'
+}

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2554,6 +2554,36 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * The areas of the application shell where webview panel can reside.
+     */
+    export enum WebviewPanelTargetArea {
+        Main = 'main',
+        Left = 'left',
+        Right = 'right',
+        Bottom = 'bottom'
+    }
+
+    /**
+     * Settings to determine where webview panel will be reside
+     */
+    export interface WebviewPanelShowOptions {
+        /**
+         * Target area where webview panel will be resided. Shows in the 'WebviewPanelTargetArea.Main' area if undefined.
+         */
+        area?: WebviewPanelTargetArea;
+
+        /**
+         * Editor View column to show the panel in. Shows in the current `viewColumn` if undefined.
+         */
+        viewColumn?: number;
+
+        /**
+         * When `true`, the webview will not take focus.
+         */
+        preserveFocus?: boolean;
+    }
+
+    /**
      * A panel that contains a webview.
      */
     interface WebviewPanel {
@@ -2582,6 +2612,10 @@ declare module '@theia/plugin' {
          */
         readonly options: WebviewPanelOptions;
 
+        /**
+         * Settings to determine where webview panel will be reside
+         */
+        readonly showOptions?: WebviewPanelShowOptions;
         /**
          * Editor position of the panel. This property is only set if the webview is in
          * one of the editor view columns.
@@ -2614,15 +2648,16 @@ declare module '@theia/plugin' {
         readonly onDidDispose: Event<void>;
 
         /**
-         * Show the webview panel in a given column.
+         * Show the webview panel according to a given options.
          *
          * A webview panel may only show in a single column at a time. If it is already showing, this
          * method moves it to a new column.
          *
+         * @param area target area where webview panel will be resided. Shows in the 'WebviewPanelTargetArea.Main' area if undefined.
          * @param viewColumn View column to show the panel in. Shows in the current `viewColumn` if undefined.
          * @param preserveFocus When `true`, the webview will not take focus.
          */
-        reveal(viewColumn?: ViewColumn, preserveFocus?: boolean): void;
+        reveal(area?: WebviewPanelTargetArea, viewColumn?: ViewColumn, preserveFocus?: boolean): void;
 
         /**
          * Dispose of the webview panel.
@@ -2983,12 +3018,12 @@ declare module '@theia/plugin' {
          *
          * @param viewType Identifies the type of the webview panel.
          * @param title Title of the panel.
-         * @param showOptions Where to show the webview in the editor. If preserveFocus is set, the new webview will not take focus.
+         * @param showOptions where webview panel will be reside. If preserveFocus is set, the new webview will not take focus.
          * @param options Settings for the new panel.
          *
          * @return New webview panel.
          */
-        export function createWebviewPanel(viewType: string, title: string, showOptions: ViewColumn | { viewColumn: ViewColumn, preserveFocus?: boolean }, options?: WebviewPanelOptions & WebviewOptions): WebviewPanel;
+        export function createWebviewPanel(viewType: string, title: string, showOptions: ViewColumn | WebviewPanelShowOptions, options?: WebviewPanelOptions & WebviewOptions): WebviewPanel;
 
         /**
          * Registers a webview panel serializer.


### PR DESCRIPTION
The changes allow to specify container for webview panel and attach it to the Left, Right or Bottom pane as well as to default 'main' area.

Closes: https://github.com/theia-ide/theia/issues/4257
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
