### PR TITLE
[startup] Delay menus and commands until contributions have started

### DIFF
--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -274,14 +274,7 @@ export class FrontendApplication {
             }
         }
 
-        /**
-         * FIXME:
-         * - decouple commands & menus
-         * - consider treat commands, keybindings and menus as frontend application contributions
-         */
-        this.commands.onStart();
-        this.keybindings.onStart();
-        this.menus.onStart();
+        // Bring up contributions and await their onStart functions
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.onStart) {
                 try {
@@ -293,6 +286,15 @@ export class FrontendApplication {
                 }
             }
         }
+
+        /**
+         * FIXME:
+         * - decouple commands & menus
+         * - consider treat commands, keybindings and menus as frontend application contributions
+         */
+        this.commands.onStart();
+        this.keybindings.onStart();
+        this.menus.onStart();
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

In our use case for Theia, we have the need to delay the menus and commands being available until our extensions have fully loaded.
Specifically, one of our extensions provides login functionality and we don't want to display the electron menus until the user has logged in (otherwise functionality will be available).

We have confirmed this change has the desired effect of delaying the menu and command startup until the contributions have loaded (the login contribution doesn't complete until login is successful).

We haven't seen any side effects from this change, but it is possible the startup order is in this order on purpose.

Any feedback/comments welcome, especially if there is a better way to achieve this.

