### PR TITLE
support language specific preferences

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,3 +1,14 @@
 {
-   "typescript.tsdk": "node_modules/typescript/lib"
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "[typescript]": {
+    "editor.tabSize": 4
+  },
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.tabSize": 2
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,6 +44,9 @@
     "[json]": {
         "editor.tabSize": 2
     },
+    "[jsonc]": {
+        "editor.tabSize": 2
+    },
     "typescript.tsdk": "node_modules/typescript/lib",
     "files.insertFinalNewline": true
 }

--- a/packages/core/src/browser/preferences/test/mock-preference-provider.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-provider.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { PreferenceProvider, PreferenceProviderPriority } from '../';
+import { PreferenceScope } from '../preference-service';
 
 @injectable()
 export class MockPreferenceProvider extends PreferenceProvider {
@@ -26,8 +27,10 @@ export class MockPreferenceProvider extends PreferenceProvider {
         return this.prefs;
     }
     // tslint:disable-next-line:no-any
-    setPreference(key: string, value: any, resourceUri?: string): Promise<void> {
-        return Promise.resolve();
+    async setPreference(preferenceName: string, newValue: any, resourceUri?: string): Promise<void> {
+        const oldValue = this.prefs[preferenceName];
+        this.prefs[preferenceName] = newValue;
+        this.emitPreferencesChangedEvent([{ preferenceName, oldValue, newValue, scope: PreferenceScope.User, domain: [] }]);
     }
     canProvide(preferenceName: string, resourceUri?: string): { priority: number, provider: PreferenceProvider } {
         if (this.prefs[preferenceName] === undefined) {

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -17,6 +17,7 @@
 import { injectable } from 'inversify';
 import { PreferenceService, PreferenceChange } from '../';
 import { Emitter, Event } from '../../../common';
+import { OverridePreferenceName } from '../preference-contribution';
 
 @injectable()
 export class MockPreferenceService implements PreferenceService {
@@ -32,4 +33,10 @@ export class MockPreferenceService implements PreferenceService {
     set(preferenceName: string, value: any): Promise<void> { return Promise.resolve(); }
     ready: Promise<void> = Promise.resolve();
     readonly onPreferenceChanged: Event<PreferenceChange> = new Emitter<PreferenceChange>().event;
+    overridePreferenceName(options: OverridePreferenceName): string {
+        return options.preferenceName;
+    }
+    overridenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
+        return undefined;
+    }
 }

--- a/packages/core/src/common/strings.ts
+++ b/packages/core/src/common/strings.ts
@@ -27,10 +27,14 @@ export function* split(s: string, splitter: string): IterableIterator<string> {
     }
 }
 
-export function escapeInvisibleChars(value: string ): string  {
+export function escapeInvisibleChars(value: string): string {
     return value.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
 }
 
 export function unescapeInvisibleChars(value: string): string {
     return value.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+}
+
+export function escapeRegExpCharacters(value: string): string {
+    return value.replace(/[\-\\\{\}\*\+\?\|\^\$\.\[\]\(\)\#]/g, '\\$&');
 }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -28,6 +28,7 @@ import { isOSX } from '@theia/core/lib/common/os';
 export const editorPreferenceSchema: PreferenceSchema = {
     'type': 'object',
     'scope': 'resource',
+    'overridable': true,
     'properties': {
         'editor.tabSize': {
             'type': 'number',
@@ -65,12 +66,14 @@ export const editorPreferenceSchema: PreferenceSchema = {
                 'off'
             ],
             'default': 'on',
-            'description': 'Configure whether the editor should be auto saved.'
+            'description': 'Configure whether the editor should be auto saved.',
+            overridable: false
         },
         'editor.autoSaveDelay': {
             'type': 'number',
             'default': 500,
-            'description': 'Configure the auto save delay in milliseconds.'
+            'description': 'Configure the auto save delay in milliseconds.',
+            overridable: false
         },
         'editor.rulers': {
             'type': 'array',

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -18,7 +18,8 @@ import { RPCProtocol } from '../api/rpc-protocol';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { LogPart, KeysToAnyValues, KeysToKeysToAnyValue } from './types';
 import { CharacterPair, CommentRule, PluginAPIFactory, Plugin } from '../api/plugin-api';
-import { PreferenceSchema } from '@theia/core/lib/browser/preferences';
+// FIXME get rid of browser code in backend
+import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/browser/preferences';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
 
@@ -55,6 +56,7 @@ export interface PluginPackage {
  */
 export interface PluginPackageContribution {
     configuration?: PreferenceSchema;
+    configurationDefaults?: PreferenceSchemaProperties;
     languages?: PluginPackageLanguageContribution[];
     grammars?: PluginPackageGrammarsContribution[];
     viewsContainers?: { [location: string]: PluginPackageViewContainer[] };
@@ -347,6 +349,7 @@ export interface PluginModel {
  */
 export interface PluginContribution {
     configuration?: PreferenceSchema;
+    configurationDefaults?: PreferenceSchemaProperties;
     languages?: LanguageContribution[];
     grammars?: GrammarsContribution[];
     viewsContainers?: { [location: string]: ViewContainer[] };

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -119,6 +119,7 @@ export class TheiaPluginScanner implements PluginScanner {
             const config = this.readConfiguration(rawPlugin.contributes.configuration!, rawPlugin.packagePath);
             contributions.configuration = config;
         }
+        contributions.configurationDefaults = rawPlugin.contributes.configurationDefaults;
 
         if (rawPlugin.contributes!.languages) {
             const languages = this.readLanguages(rawPlugin.contributes.languages!, rawPlugin.packagePath);

--- a/packages/preferences/src/browser/preferences-frontend-application-contribution.ts
+++ b/packages/preferences/src/browser/preferences-frontend-application-contribution.ts
@@ -36,7 +36,7 @@ export class PreferencesFrontendApplicationContribution implements FrontendAppli
             fileMatch: ['.theia/settings.json', USER_PREFERENCE_URI.toString()],
             url: uri.toString()
         });
-        this.schemaProvider.onDidPreferencesChanged(() =>
+        this.schemaProvider.onDidPreferenceSchemaChanged(() =>
             this.inmemoryResources.update(uri, serializeSchema())
         );
     }


### PR DESCRIPTION
fix #1106 - language specific preferences
fix #3540 - `configurationDefault` vscode contribution point in order to provide default language specific preferences

![lang_preferences](https://user-images.githubusercontent.com/3082655/52478863-08484e80-2ba7-11e9-91e3-0a04e673c406.gif)
