### PR TITLE
Add ability to handle vscode.diff command and open diff editor

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -20,6 +20,7 @@ import { CommandService } from '@theia/core/lib/common/command';
 import TheiaURI from '@theia/core/lib/common/uri';
 import URI from 'vscode-uri';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { DiffService } from '@theia/workspace/lib/browser/diff-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { WebviewWidget } from '@theia/plugin-ext/lib/main/browser/webview/webview';
 import { ApplicationShell } from '@theia/core/lib/browser';
@@ -29,6 +30,11 @@ export namespace VscodeCommands {
     export const OPEN: Command = {
         id: 'vscode.open',
         label: 'VSCode open link'
+    };
+
+    export const DIFF: Command = {
+       id: 'vscode.diff',
+       label: 'VSCode diff'
     };
 
     export const SET_CONTEXT: Command = {
@@ -52,12 +58,23 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly shell: ApplicationShell;
     @inject(ResourceProvider)
     protected readonly resources: ResourceProvider;
+    @inject(DiffService)
+    protected readonly diffService: DiffService;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
             isVisible: () => false,
             execute: (resource: URI) => {
                 this.commandService.executeCommand('theia.open', new TheiaURI(resource));
+            }
+        });
+
+        commands.registerCommand(VscodeCommands.DIFF, {
+            isVisible: () => true,
+            // tslint:disable-next-line: no-any
+            execute: async uris => {
+                const [left, right] = uris;
+                await this.diffService.openDiffEditor(left, right);
             }
         });
 

--- a/packages/workspace/src/browser/diff-service.ts
+++ b/packages/workspace/src/browser/diff-service.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import {inject, injectable} from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { DiffUris } from '@theia/core/lib/browser/diff-uris';
+import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
+import { OpenerService } from '@theia/core/lib/browser';
+import { MessageService } from '@theia/core/lib/common/message-service';
+
+@injectable()
+export class DiffService {
+
+    @inject(FileSystem) protected readonly fileSystem: FileSystem;
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+    @inject(MessageService) protected readonly messageService: MessageService;
+
+    public async openDiffEditor(left: URI, right: URI) {
+        const [leftExists, rightExists] = await Promise.all([
+            this.fileSystem.exists(left.toString()),
+            this.fileSystem.exists(right.toString())
+        ]);
+        if (leftExists && rightExists) {
+            const [leftStat, rightStat] = await Promise.all([
+                this.fileSystem.getFileStat(left.toString()),
+                this.fileSystem.getFileStat(right.toString()),
+            ]);
+            if (leftStat && rightStat) {
+                if (!leftStat.isDirectory && !rightStat.isDirectory) {
+                    const uri = DiffUris.encode(left, right);
+                    const opener = await this.openerService.getOpener(uri);
+                    opener.open(uri);
+                } else {
+                    const details = (() => {
+                        if (leftStat.isDirectory && rightStat.isDirectory) {
+                            return 'Both resource were a directory.';
+                        } else {
+                            if (leftStat.isDirectory) {
+                                return `'${left.path.base}' was a directory.`;
+                            } else {
+                                return `'${right.path.base}' was a directory.`;
+                            }
+                        }
+                    });
+                    this.messageService.warn(`Directories cannot be compared. ${details()}`);
+                }
+            }
+        }
+    }
+}

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -16,7 +16,6 @@
 
 import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
 import { MenuContribution, MenuModelRegistry } from '@theia/core/lib/common/menu';
@@ -32,6 +31,7 @@ import { WorkspacePreferences } from './workspace-preferences';
 import { WorkspaceDeleteHandler } from './workspace-delete-handler';
 import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { FileSystemUtils } from '@theia/filesystem/lib/common';
+import { WorkspaceCompareHandler } from './workspace-compare-handler';
 
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
@@ -153,6 +153,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
     @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
     @inject(WorkspaceDeleteHandler) protected readonly deleteHandler: WorkspaceDeleteHandler;
     @inject(WorkspaceDuplicateHandler) protected readonly duplicateHandler: WorkspaceDuplicateHandler;
+    @inject(WorkspaceCompareHandler) protected readonly compareHandler: WorkspaceCompareHandler;
 
     registerCommands(registry: CommandRegistry): void {
         this.openerService.getOpeners().then(openers => {
@@ -242,43 +243,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
         }));
         registry.registerCommand(WorkspaceCommands.FILE_DUPLICATE, this.newMultiUriAwareCommandHandler(this.duplicateHandler));
         registry.registerCommand(WorkspaceCommands.FILE_DELETE, this.newMultiUriAwareCommandHandler(this.deleteHandler));
-        registry.registerCommand(WorkspaceCommands.FILE_COMPARE, this.newMultiUriAwareCommandHandler({
-            isVisible: uris => uris.length === 2,
-            isEnabled: uris => uris.length === 2,
-            execute: async uris => {
-                const [left, right] = uris;
-                const [leftExists, rightExists] = await Promise.all([
-                    this.fileSystem.exists(left.toString()),
-                    this.fileSystem.exists(right.toString())
-                ]);
-                if (leftExists && rightExists) {
-                    const [leftStat, rightStat] = await Promise.all([
-                        this.fileSystem.getFileStat(left.toString()),
-                        this.fileSystem.getFileStat(right.toString()),
-                    ]);
-                    if (leftStat && rightStat) {
-                        if (!leftStat.isDirectory && !rightStat.isDirectory) {
-                            const uri = DiffUris.encode(left, right);
-                            const opener = await this.openerService.getOpener(uri);
-                            opener.open(uri);
-                        } else {
-                            const details = (() => {
-                                if (leftStat.isDirectory && rightStat.isDirectory) {
-                                    return 'Both resource were a directory.';
-                                } else {
-                                    if (leftStat.isDirectory) {
-                                        return `'${left.path.base}' was a directory.`;
-                                    } else {
-                                        return `'${right.path.base}' was a directory.`;
-                                    }
-                                }
-                            });
-                            this.messageService.warn(`Directories cannot be compared. ${details()}`);
-                        }
-                    }
-                }
-            }
-        }));
+        registry.registerCommand(WorkspaceCommands.FILE_COMPARE, this.newMultiUriAwareCommandHandler(this.compareHandler));
         this.preferences.ready.then(() => {
             registry.registerCommand(WorkspaceCommands.ADD_FOLDER, this.newMultiUriAwareCommandHandler({
                 isEnabled: () => this.workspaceService.isMultiRootWorkspaceOpened,

--- a/packages/workspace/src/browser/workspace-compare-handler.ts
+++ b/packages/workspace/src/browser/workspace-compare-handler.ts
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { UriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { DiffService } from './diff-service';
+
+@injectable()
+export class WorkspaceCompareHandler implements UriCommandHandler<URI[]> {
+
+    @inject(DiffService) protected readonly diffService: DiffService;
+
+    /**
+     * Determine if the command is visible.
+     *
+     * @param uris URIs of selected resources.
+     * @returns `true` if the command is visible.
+     */
+    isVisible(uris: URI[]): boolean {
+        return uris.length === 2;
+    }
+
+    /**
+     * Determine if the command is enabled.
+     *
+     * @param uris URIs of selected resources.
+     * @returns `true` if the command is enabled.
+     */
+    isEnabled(uris: URI[]): boolean {
+        return uris.length === 2;
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param uris URIs of selected resources.
+     */
+    async execute(uris: URI[]): Promise<void> {
+        const [left, right] = uris;
+        await this.diffService.openDiffEditor(left, right);
+    }
+}

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -42,6 +42,8 @@ import { QuickOpenWorkspace } from './quick-open-workspace';
 import { WorkspaceDeleteHandler } from './workspace-delete-handler';
 import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { WorkspaceUtils } from './workspace-utils';
+import { WorkspaceCompareHandler } from './workspace-compare-handler';
+import { DiffService } from './diff-service';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -72,6 +74,8 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(MenuContribution).to(FileMenuContribution).inSingletonScope();
     bind(WorkspaceDeleteHandler).toSelf().inSingletonScope();
     bind(WorkspaceDuplicateHandler).toSelf().inSingletonScope();
+    bind(WorkspaceCompareHandler).toSelf().inSingletonScope();
+    bind(DiffService).toSelf().inSingletonScope();
 
     bind(WorkspaceStorageService).toSelf().inSingletonScope();
     rebind(StorageService).toService(WorkspaceStorageService);


### PR DESCRIPTION
This changes proposal adds ability to handle `vscode.diff` command and open diff editor between to paths given as arguments into command.

Simple sample how this works:
![diff](https://user-images.githubusercontent.com/1968177/52641884-8461cf80-2ee2-11e9-87e7-71101736d27c.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>