### PR TITLE
Removed duplicate 'new build config' when triggering for the first time.

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations-ui.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations-ui.ts
@@ -127,10 +127,9 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
     /** Create a new build configuration with placeholder values.  */
     async createConfig(): Promise<void> {
         this.commandService.executeCommand(CommonCommands.OPEN_PREFERENCES.id, PreferenceScope.Workspace);
-        const configs = this.cppBuildConfigurations.getConfigs();
-        const newConfigs = configs.slice(0);
-        newConfigs.push({ name: '', directory: '' });
-        await this.preferenceService.set(CPP_BUILD_CONFIGURATIONS_PREFERENCE_KEY, newConfigs, PreferenceScope.Workspace);
+        const configs = this.cppBuildConfigurations.getConfigs().slice(0);
+        configs.push({ name: '', directory: '' });
+        await this.preferenceService.set(CPP_BUILD_CONFIGURATIONS_PREFERENCE_KEY, configs, PreferenceScope.Workspace);
     }
 
 }

--- a/packages/cpp/src/browser/cpp-preferences.ts
+++ b/packages/cpp/src/browser/cpp-preferences.ts
@@ -45,12 +45,7 @@ export const cppPreferencesSchema: PreferenceSchema = {
                 },
                 required: ['name', 'directory'],
             },
-            default: [
-                {
-                    name: '',
-                    directory: ''
-                }
-            ],
+            default: [],
         },
         'cpp.experimentalCommands': {
             description: 'Enable experimental commands mostly intended for Clangd developers.',


### PR DESCRIPTION
Fixes #4305

- removed duplicate `build config` when tiggering `Create Build Config` for the first time.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
