### PR TITLE
[languages] fix clash in language server session ids

### DIFF
--- a/packages/languages/src/node/languages-backend-contribution.ts
+++ b/packages/languages/src/node/languages-backend-contribution.ts
@@ -35,12 +35,12 @@ export class LanguagesBackendContribution implements MessagingService.Contributi
     @inject(ContributionProvider) @named(LanguageServerContribution)
     protected readonly contributors: ContributionProvider<LanguageServerContribution>;
 
-    protected readonly ids = new Map<string, number>();
+    protected nextId: number = 1;
     protected readonly sessions = new Map<string, any>();
 
     async create(contributionId: string, startParameters: any): Promise<string> {
-        const id = (this.ids.get(contributionId) || 0) + 1;
-        this.ids.set(contributionId, id);
+        const id = this.nextId;
+        this.nextId++;
         const sessionId = String(id);
         this.sessions.set(sessionId, startParameters);
         return sessionId;


### PR DESCRIPTION
Fixes an issue where language server sessions ids clashed when starting multiple language servers.
The issue was encourented when attempting to start the `cpp` language server which could not properly
find the `cpp.clangdExecutable` since the `startParameters` were overwritten.

**Example**:
The issue can be seen in the following example. Let's assume there are two language servers, A and B.
Language server A creates it's session id as 1, then B creates it's session id as 1 which essentially
overwrites the previous session information. When it comes time to configurate the language server
and start it with its `startParams` we query the sessions to get the values. In this case, the proper
values of A have already been overwritten and we can no longer properly start the LS.

In the example of `cpp`, we attempt to tell the language server where `clangd` is located, but since
we also have TypeScript who registers a session, the values for `cpp` have been overwritten and we
can no longer start the LS.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
