### PR TITLE
GH-4329: Implemented the select dialog.

### DIFF
--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -124,3 +124,7 @@ input {
     font-size: var(--theia-ui-font-size1);
     display: block;
 }
+
+.p-Widget.dialogOverlay select {
+    background: var(--theia-layout-color2);
+}


### PR DESCRIPTION
Closes: #4329.
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

Dummy select dialog In action:
```ts
const result = await new SelectDialog({
    items: [1, 2, 3, 4],
    label: item => `${item} blablabla`,
    title: 'Test Select Dialog',
}).open();
console.log(result);
```

![screencast 2019-02-13 16-02-25](https://user-images.githubusercontent.com/1405703/52721023-0caaa800-2fa9-11e9-8810-d8cb0ffc4d1c.gif)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->