### PR TITLE
[cpp] update cpp build config status bar item

### DIFF
--- a/packages/cpp/src/browser/cpp-build-configurations-statusbar-element.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations-statusbar-element.ts
@@ -47,7 +47,8 @@ export class CppBuildConfigurationsStatusBarElement {
      */
     protected setCppBuildConfigElement(config: CppBuildConfiguration | undefined): void {
         this.statusBar.setElement(this.cppIdentifier, {
-            text: `$(wrench) C/C++ Build Config ${(config) ? config.name : ''}`,
+            text: `$(wrench) C/C++ ${config ? '(' + config.name + ')' : 'Build Config'}`,
+            tooltip: 'C/C++ Build Config',
             alignment: StatusBarAlignment.RIGHT,
             command: CPP_CHANGE_BUILD_CONFIGURATION.id,
             priority: 0.5,


### PR DESCRIPTION
Minor update to the cpp build config status bar to include tooltip and display the build config more easily while reducing vertical space. Previously the active build config was harder to identify and took too much space on the status bar.

| Active Config Before | Active Config After |
|:---:|:---:|
|![screenshot from 2019-02-13 17-47-44](https://user-images.githubusercontent.com/40359487/52749697-ec361a00-2fb7-11e9-961a-888932f339ad.png) |![screenshot from 2019-02-13 17-49-34](https://user-images.githubusercontent.com/40359487/52749680-e4767580-2fb7-11e9-9e4f-e64122c075da.png)|




Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
