### PR TITLE
[plug-in] 4084 show refs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [electron] open markdown links in the OS default browser
 - [plugin] added ability to display webview panel in 'left', 'right' and 'bottom' area
 - [plugin] added `tasks.taskExecutions` Plug-in API
+- [plugin] the "Command" interface has been split into two: "CommandDescription" and "Command". "Command" has been
+made compatible with the "Command" interface in vscode. This is not a breaking change, currently, but fields in those interfaces
+have been deprecated and will be removed in the future.
 
 Breaking changes:
 - menus aligned with built-in VS Code menus [#4173](https://github.com/theia-ide/theia/pull/4173)

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -153,7 +153,7 @@ export interface PluginManagerExt {
 }
 
 export interface CommandRegistryMain {
-    $registerCommand(command: theia.Command): void;
+    $registerCommand(command: theia.CommandDescription): void;
     $unregisterCommand(id: string): void;
 
     $registerHandler(id: string): void;

--- a/packages/plugin-ext/src/main/browser/command-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/command-registry-main.ts
@@ -35,7 +35,7 @@ export class CommandRegistryMainImpl implements CommandRegistryMain {
         this.keyBinding = container.get(KeybindingRegistry);
     }
 
-    $registerCommand(command: theia.Command): void {
+    $registerCommand(command: theia.CommandDescription): void {
         this.commands.set(command.id, this.delegate.registerCommand(command));
     }
     $unregisterCommand(id: string): void {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -70,7 +70,6 @@ import { TypeDefinitionAdapter } from './languages/type-definition';
 import { CodeActionAdapter } from './languages/code-action';
 import { LinkProviderAdapter } from './languages/link-provider';
 import { CodeLensAdapter } from './languages/lens';
-import { CommandRegistryImpl } from './command-registry';
 import { OutlineAdapter } from './languages/outline';
 import { ReferenceAdapter } from './languages/reference';
 import { WorkspaceSymbolAdapter } from './languages/workspace-symbol';
@@ -109,7 +108,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     private callId = 0;
     private adaptersMap = new Map<number, Adapter>();
 
-    constructor(rpc: RPCProtocol, private readonly documents: DocumentsExtImpl, private readonly commands: CommandRegistryImpl) {
+    constructor(rpc: RPCProtocol, private readonly documents: DocumentsExtImpl) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.LANGUAGES_MAIN);
         this.diagnostics = new Diagnostics(rpc);
     }
@@ -401,7 +400,7 @@ export class LanguagesExtImpl implements LanguagesExt {
 
     // ### Code Lens Provider begin
     registerCodeLensProvider(selector: theia.DocumentSelector, provider: theia.CodeLensProvider): theia.Disposable {
-        const callId = this.addNewAdapter(new CodeLensAdapter(provider, this.documents, this.commands.getConverter()));
+        const callId = this.addNewAdapter(new CodeLensAdapter(provider, this.documents));
         const eventHandle = typeof provider.onDidChangeCodeLenses === 'function' ? this.nextCallId() : undefined;
         this.proxy.$registerCodeLensSupport(callId, this.transformDocumentSelector(selector), eventHandle);
         let result = this.createDisposable(callId);

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -67,7 +67,7 @@ export class CodeActionAdapter {
                 }
                 if (CodeActionAdapter._isCommand(candidate)) {
                     result.push({
-                        title: candidate.label || '',
+                        title: candidate.title || '',
                         command: Converter.toInternalCommand(candidate)
                     });
                 } else {
@@ -98,7 +98,7 @@ export class CodeActionAdapter {
 
     // tslint:disable-next-line:no-any
     private static _isCommand(smth: any): smth is theia.Command {
-        return typeof (<theia.Command>smth).id === 'string';
+        return typeof (<theia.Command>smth).command === 'string' || typeof (<theia.Command>smth).id === 'string';
     }
 
     // tslint:disable-next-line:no-any

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -21,7 +21,6 @@ import { CodeLensSymbol } from '../../api/model';
 import * as Converter from '../type-converters';
 import { ObjectIdentifier } from '../../common/object-identifier';
 import { createToken } from '../token-provider';
-import { CommandsConverter } from '../command-registry';
 
 /** Adapts the calls from main to extension thread for providing/resolving the code lenses. */
 export class CodeLensAdapter {
@@ -34,7 +33,6 @@ export class CodeLensAdapter {
     constructor(
         private readonly provider: theia.CodeLensProvider,
         private readonly documents: DocumentsExtImpl,
-        private readonly commands: CommandsConverter
     ) { }
 
     provideCodeLenses(resource: URI): Promise<CodeLensSymbol[] | undefined> {
@@ -49,9 +47,10 @@ export class CodeLensAdapter {
             if (Array.isArray(lenses)) {
                 return lenses.map(lens => {
                     const id = this.cacheId++;
+                    console.log(lens);
                     const lensSymbol = ObjectIdentifier.mixin({
                         range: Converter.fromRange(lens.range)!,
-                        command: this.commands.toInternal(lens.command)
+                        command: lens.command ? Converter.toInternalCommand(lens.command) : undefined
                     }, id);
                     this.cache.set(id, lens);
                     return lensSymbol;
@@ -76,7 +75,7 @@ export class CodeLensAdapter {
 
         return resolve.then(newLens => {
             newLens = newLens || lens;
-            symbol.command = this.commands.toInternal(newLens.command || CodeLensAdapter.BAD_CMD);
+            symbol.command = Converter.toInternalCommand(newLens.command ? newLens.command : CodeLensAdapter.BAD_CMD);
             return symbol;
         });
     }

--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -25,7 +25,7 @@ import { createToken } from '../token-provider';
 /** Adapts the calls from main to extension thread for providing/resolving the code lenses. */
 export class CodeLensAdapter {
 
-    private static readonly BAD_CMD: theia.Command = { id: 'missing', label: '<<MISSING COMMAND>>' };
+    private static readonly BAD_CMD: theia.Command = { command: 'missing', title: '<<MISSING COMMAND>>' };
 
     private cacheId = 0;
     private cache = new Map<number, theia.CodeLens>();
@@ -47,7 +47,6 @@ export class CodeLensAdapter {
             if (Array.isArray(lenses)) {
                 return lenses.map(lens => {
                     const id = this.cacheId++;
-                    console.log(lens);
                     const lensSymbol = ObjectIdentifier.mixin({
                         range: Converter.fromRange(lens.range)!,
                         command: lens.command ? Converter.toInternalCommand(lens.command) : undefined

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -144,7 +144,7 @@ export function createAPIFactory(
     const statusBarMessageRegistryExt = new StatusBarMessageRegistryExt(rpc);
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = new OutputChannelRegistryExt(rpc);
-    const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry));
+    const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
     const webviewExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEWS_EXT, new WebviewsExtImpl(rpc));
     const tasksExt = rpc.set(MAIN_RPC_CONTEXT.TASKS_EXT, new TasksExtImpl(rpc));

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -155,7 +155,7 @@ export function createAPIFactory(
     return function (plugin: InternalPlugin): typeof theia {
         const commands: typeof theia.commands = {
             // tslint:disable-next-line:no-any
-            registerCommand(command: theia.Command, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): Disposable {
+            registerCommand(command: theia.CommandDescription, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): Disposable {
                 return commandRegistry.registerCommand(command, handler, thisArg);
             },
             // tslint:disable-next-line:no-any

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -263,7 +263,7 @@ class TreeViewExtImpl<T> extends Disposable {
             const treeItem = await this.treeDataProvider.getTreeItem(cachedElement);
 
             if (treeItem.command) {
-                this.commandRegistry.executeCommand(treeItem.command.id, ...(treeItem.command.arguments || []));
+                this.commandRegistry.executeCommand((treeItem.command.command || treeItem.command.id)!, ...(treeItem.command.arguments || []));
             }
         }
     }

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -24,7 +24,7 @@ import URI from 'vscode-uri';
 
 const SIDE_GROUP = -2;
 const ACTIVE_GROUP = -1;
-import { SymbolInformation, Range as R, Position as P, SymbolKind as S } from 'vscode-languageserver-types';
+import { SymbolInformation, Range as R, Position as P, SymbolKind as S, Location as L } from 'vscode-languageserver-types';
 
 export function toViewColumn(ep?: EditorPosition): theia.ViewColumn | undefined {
     if (typeof ep !== 'number') {
@@ -418,12 +418,70 @@ export function fromDocumentHighlight(documentHighlight: theia.DocumentHighlight
     };
 }
 
-export function toInternalCommand(command: theia.Command): model.Command {
-    return {
-        id: command.command ? command.command : command.id,
-        title: command.title ? command.title : command.label || ' ',
-        tooltip: command.tooltip,
-        arguments: command.arguments
+export function toInternalCommand(external: theia.Command): model.Command {
+    // we're deprecating Command.id, so it has to be optional.
+    // Existing code will have compiled against a non - optional version of the field, so asserting it to exist is ok
+    // tslint:disable-next-line: no-any
+    return KnownCommands.map((external.command || external.id)!, external.arguments, (mappedId: string, mappedArgs: any[]) =>
+        ({
+            id: mappedId,
+            title: external.title || external.label || ' ',
+            tooltip: external.tooltip,
+            arguments: mappedArgs
+        }));
+}
+
+export namespace KnownCommands {
+    // tslint:disable: no-any
+    const mappings: { [id: string]: [string, (args: any[] | undefined) => any[] | undefined] } = {};
+    mappings['editor.action.showReferences'] = ['textEditor.commands.showReferences', createConversionFunction(
+        (uri: URI) => uri.toString(),
+        fromPositionToP,
+        toArrayConversion(fromLocationToL))];
+
+    export function map<T>(id: string, args: any[] | undefined, toDo: (mappedId: string, mappedArgs: any[] | undefined) => T): T {
+        if (mappings[id]) {
+            return toDo(mappings[id][0], mappings[id][1](args));
+        } else {
+            return toDo(id, args);
+        }
+    }
+
+    type conversionFunction = ((parameter: any) => any) | undefined;
+    function createConversionFunction(...conversions: conversionFunction[]): (args: any[] | undefined) => any[] | undefined {
+        return function (args: any[] | undefined): any[] | undefined {
+            if (!args) {
+                return args;
+            }
+            return args.map(function (arg: any, index: number): any {
+                if (index < conversions.length) {
+                    const conversion = conversions[index];
+                    if (conversion) {
+                        return conversion(arg);
+                    }
+                }
+                return arg;
+            });
+        };
+    }
+    // tslint:enable: no-any
+    function fromPositionToP(p: theia.Position): P {
+        return P.create(p.line, p.character);
+    }
+
+    function fromRangeToR(r: theia.Range): R {
+        return R.create(fromPositionToP(r.start), fromPositionToP(r.end));
+    }
+
+    function fromLocationToL(l: theia.Location): L {
+        return L.create(l.uri.toString(), fromRangeToR(l.range));
+    }
+
+}
+
+function toArrayConversion<T, U>(f: (a: T) => U): (a: T[]) => U[] {
+    return function (a: T[]) {
+        return a.map(f);
     };
 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -157,12 +157,13 @@ declare module '@theia/plugin' {
         export let all: Plugin<any>[];
     }
 
+
     /**
-     * A command is a unique identifier of a function
-     * which can be executed by a user via a keyboard shortcut,
-     * a menu action or directly.
-     */
-    export interface Command {
+ * A command is a unique identifier of a function
+ * which can be executed by a user via a keyboard shortcut,
+ * a menu action or directly.
+ */
+    export interface CommandDescription {
         /**
          * A unique identifier of this command.
          */
@@ -172,29 +173,44 @@ declare module '@theia/plugin' {
          */
         label?: string;
         /**
-         * A tooltip for for command, when represented in the UI.
-         */
+          * A tooltip for for command, when represented in the UI.
+          */
         tooltip?: string;
         /**
          * An icon class of this command.
          */
         iconClass?: string;
+    }
+    /**
+     * Command represents a particular invocation of a registered command.
+     */
+    export interface Command {
+        /**
+         * The identifier of the actual command handler.
+         */
+        command?: string;
+        /**
+        * Title of the command invocation, like "Add local varible 'foo'".
+        */
+        title?: string;
+        /**
+          * A tooltip for for command, when represented in the UI.
+          */
+        tooltip?: string;
         /**
          * Arguments that the command handler should be
          * invoked with.
          */
         arguments?: any[];
 
-        // Title and command fields are needed to make Command object similar to Command from vscode API
-
         /**
-         * Title of the command, like "save".
+         * @deprecated use command instead
          */
-        title?: string;
+        id?: string;
         /**
-         * The identifier of the actual command handler.
+         * @deprecated use title instead
          */
-        command?: string;
+        label?: string;
     }
 
     /**
@@ -1996,7 +2012,7 @@ declare module '@theia/plugin' {
          *
          * Throw if a command is already registered for the given command identifier.
          */
-        export function registerCommand(command: Command, handler?: (...args: any[]) => any, thisArg?: any): Disposable;
+        export function registerCommand(command: CommandDescription, handler?: (...args: any[]) => any, thisArg?: any): Disposable;
 
         /**
          * Register the given handler for the given command identifier.


### PR DESCRIPTION
Fixes #4084. 
1. Separates the "Command" objects used in the Theia plugin API  for registration  of commands and invocation of commands into two separate interfaces: CommandRegistration and Command. The "Command" interface is compatible with the related vscode API interface. The unnecessary fields in the separated interfaces have been made deprecated. They will be removed after a period of deprecation. The new code should be compatible with the old version.
2. Introduces "KnownCommands" where well known command invocations can be mapped to other command ids and parameters can be converted.
3.  Removed "CommandConverter", as I don't think it is needed.
