### PR TITLE
GH-4324: Use the `resetBackground`  property for the mini-browser.

### DIFF
--- a/packages/mini-browser/src/browser/location-mapper-service.ts
+++ b/packages/mini-browser/src/browser/location-mapper-service.ts
@@ -105,10 +105,20 @@ export class HttpsLocationMapper implements LocationMapper {
 
 }
 
-export class MiniBrowserEndpoint extends Endpoint {
-    constructor() {
-        super({ path: 'mini-browser' });
+/**
+ * Location mapper for locations without a scheme.
+ */
+@injectable()
+export class LocationWithoutSchemeMapper implements LocationMapper {
+
+    canHandle(location: string): MaybePromise<number> {
+        return new URI(location).scheme === '' ? 1 : 0;
     }
+
+    map(location: string): MaybePromise<string> {
+        return `http://${location}`;
+    }
+
 }
 
 /**
@@ -133,4 +143,10 @@ export class FileLocationMapper implements LocationMapper {
         return new MiniBrowserEndpoint().getRestUrl().resolve(rawLocation).toString();
     }
 
+}
+
+export class MiniBrowserEndpoint extends Endpoint {
+    constructor() {
+        super({ path: 'mini-browser' });
+    }
 }

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -29,7 +29,14 @@ import { MiniBrowserOpenHandler } from './mini-browser-open-handler';
 import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
 import { MiniBrowser, MiniBrowserOptions } from './mini-browser';
 import { MiniBrowserProps, MiniBrowserContentFactory, MiniBrowserMouseClickTracker, MiniBrowserContent } from './mini-browser-content';
-import { LocationMapperService, FileLocationMapper, HttpLocationMapper, HttpsLocationMapper, LocationMapper } from './location-mapper-service';
+import {
+    LocationMapperService,
+    FileLocationMapper,
+    HttpLocationMapper,
+    HttpsLocationMapper,
+    LocationMapper,
+    LocationWithoutSchemeMapper,
+} from './location-mapper-service';
 
 import '../../src/browser/style/index.css';
 
@@ -68,6 +75,8 @@ export default new ContainerModule(bind => {
     bind(LocationMapper).to(FileLocationMapper).inSingletonScope();
     bind(LocationMapper).to(HttpLocationMapper).inSingletonScope();
     bind(LocationMapper).to(HttpsLocationMapper).inSingletonScope();
+    bind(LocationWithoutSchemeMapper).toSelf().inSingletonScope();
+    bind(LocationMapper).toService(LocationWithoutSchemeMapper);
     bind(LocationMapperService).toSelf().inSingletonScope();
 
     bind(MiniBrowserService).toDynamicValue(context => WebSocketConnectionProvider.createProxy(context.container, MiniBrowserServicePath)).inSingletonScope();

--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -30,6 +30,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser/fronten
 import { WidgetOpenerOptions } from '@theia/core/lib/browser/widget-open-handler';
 import { MiniBrowserService } from '../common/mini-browser-service';
 import { MiniBrowser, MiniBrowserProps } from './mini-browser';
+import { LocationMapperService } from './location-mapper-service';
 
 export namespace MiniBrowserCommands {
     export const PREVIEW: Command = {
@@ -57,6 +58,8 @@ export interface MiniBrowserOpenerOptions extends WidgetOpenerOptions, MiniBrows
 export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBrowser>
     implements FrontendApplicationContribution, CommandContribution, MenuContribution, TabBarToolbarContribution {
 
+    static PREVIEW_URI = new URI().withScheme('__minibrowser__preview__');
+
     /**
      * Instead of going to the backend with each file URI to ask whether it can handle the current file or not,
      * we have this map of extension and priority pairs that we populate at application startup.
@@ -82,6 +85,9 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     @inject(MiniBrowserService)
     protected readonly miniBrowserService: MiniBrowserService;
 
+    @inject(LocationMapperService)
+    protected readonly locationMapperService: LocationMapperService;
+
     onStart(): void {
         (async () => (await this.miniBrowserService.supportedFileExtensions()).forEach(entry => {
             const { extension, priority } = entry;
@@ -92,7 +98,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     canHandle(uri: URI): number {
         // It does not guard against directories. For instance, a folder with this name: `Hahahah.html`.
         // We could check with the FS, but then, this method would become async again.
-        const extension = uri.toString().split('.').pop();
+        const extension = uri.path.ext;
         if (extension) {
             return this.supportedExtensions.get(extension.toLocaleLowerCase()) || 0;
         }
@@ -114,6 +120,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         widget.setProps(props);
         return widget;
     }
+
     protected async options(uri?: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowserOpenerOptions & { widgetOptions: ApplicationShell.WidgetOptions }> {
         // Get the default options.
         let result = await this.defaultOptions();
@@ -253,18 +260,21 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
         }
     }
 
-    static PREVIEW_URI = new URI().withScheme('__minibrowser__preview__');
     async openPreview(startPage: string): Promise<MiniBrowser> {
-        return this.open(MiniBrowserOpenHandler.PREVIEW_URI, this.getOpenPreviewProps(startPage));
+        const props = await this.getOpenPreviewProps(await this.locationMapperService.map(startPage));
+        return this.open(MiniBrowserOpenHandler.PREVIEW_URI, props);
     }
-    protected getOpenPreviewProps(startPage: string): MiniBrowserOpenerOptions {
+
+    protected async getOpenPreviewProps(startPage: string): Promise<MiniBrowserOpenerOptions> {
+        const resetBackground = await this.resetBackground(new URI(startPage));
         return {
             name: 'Preview',
             startPage,
             toolbar: 'read-only',
             widgetOptions: {
                 area: 'right'
-            }
+            },
+            resetBackground
         };
     }
 

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -96,7 +96,6 @@
 }
 
 .theia-mini-browser-content-area {
-    background-color: white;
     position: relative;
     display: flex;
     height: 100%;


### PR DESCRIPTION
Instead of the hard-coded white background.

Closes: #4324
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
