### PR TITLE
update plugin-api to not return undefined workspace folders

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -354,10 +354,10 @@ export function createAPIFactory(
         };
 
         const workspace: typeof theia.workspace = {
-            get rootPath(): string | undefined {
+            get rootPath(): string | undefined {
                 return workspaceExt.rootPath;
             },
-            get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
+            get workspaceFolders(): theia.WorkspaceFolder[] {
                 return workspaceExt.workspaceFolders;
             },
             get name(): string | undefined {

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -42,7 +42,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     private workspaceFoldersChangedEmitter = new Emitter<theia.WorkspaceFoldersChangeEvent>();
     public readonly onDidChangeWorkspaceFolders: Event<theia.WorkspaceFoldersChangeEvent> = this.workspaceFoldersChangedEmitter.event;
 
-    private folders: theia.WorkspaceFolder[] | undefined;
+    private folders: theia.WorkspaceFolder[] = [];
     private documentContentProviders = new Map<string, theia.TextDocumentContentProvider>();
 
     constructor(rpc: RPCProtocol, private editorsAndDocuments: EditorsAndDocumentsExtImpl) {
@@ -55,7 +55,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         return folder && folder.uri.fsPath;
     }
 
-    get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
+    get workspaceFolders(): theia.WorkspaceFolder[] {
         return this.folders;
     }
 
@@ -199,7 +199,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     getWorkspaceFolder(uri: theia.Uri, resolveParent?: boolean): theia.WorkspaceFolder | URI | undefined {
-        if (!this.folders || !this.folders.length) {
+        if (!this.folders.length) {
             return undefined;
         }
 
@@ -238,7 +238,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     private hasFolder(uri: URI): boolean {
-        if (!this.folders) {
+        if (!this.folders.length) {
             return false;
         }
         return this.folders.some(folder => folder.uri.toString() === uri.toString());
@@ -266,7 +266,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         }
 
         if (typeof includeWorkspace === 'undefined') {
-            includeWorkspace = this.folders!.length > 1;
+            includeWorkspace = this.folders.length > 1;
         }
 
         let result = relative(folder.uri.fsPath, path);


### PR DESCRIPTION
- When plugins query the workspace.workspaceFolders, Theia plugin api returns `undefined` when there is no workspace open, or the opened workspace has not been resolved by WorkspaceService. And this is inconsistent with vsCode, where the extension host returns an empty array in such situation. This change aligns the return value of Theia plugin api with that of the vsCode extension host.

Signed-off-by: elaihau <liang.huang@ericsson.com>
