### PR TITLE
[electron] URI decode the workspace path in location.hash

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -93,8 +93,8 @@ export class WorkspaceService implements FrontendApplicationContribution {
     protected getDefaultWorkspacePath(): MaybePromise<string | undefined> {
         // Prefer the workspace path specified as the URL fragment, if present.
         if (window.location.hash.length > 1) {
-            // Remove the leading #.
-            const wpPath = window.location.hash.substring(1);
+            // Remove the leading # and decode the URI.
+            const wpPath = decodeURI(window.location.hash.substring(1));
             return new URI().withPath(wpPath).withScheme('file').toString();
         } else {
             // Else, ask the server for its suggested workspace (usually the one


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Small fix to correctly decode the workspace URI during an electron window reload (or opening a new workspace in the same window) when the workspace path has spaces in it.
