### PR TITLE
GH-4371: Unset the `global` Git `protocol.version` config on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,8 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH ;
 install: yarn && scripts/check_git_status.sh
 script:
+  # Unset the `protocol.version` in the `global` Git configuration. See: https://github.com/theia-ide/theia/issues/4371
+  - git config --global --unset protocol.version
   - travis_retry yarn test:theia ;
   - travis_retry yarn test:electron ;
   - travis_retry yarn test:browser ;


### PR DESCRIPTION
So that Git `< 2.18.1` will not try to use the unsupported protocol
when cloning repositories into the temp folder for the tests.

Closes #4371.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>