### PR TITLE
Add 'tasks.taskExecutions' Plug-in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [cpp] fixed `CPP_CLANGD_COMMAND` and `CPP_CLANGD_ARGS` environment variables
 - [electron] open markdown links in the OS default browser
 - [plugin] added ability to display webview panel in 'left', 'right' and 'bottom' area
+- [plugin] added `tasks.taskExecutions` Plug-in API
 
 Breaking changes:
 - menus aligned with built-in VS Code menus [#4173](https://github.com/theia-ide/theia/pull/4173)

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -1041,6 +1041,7 @@ export interface TasksExt {
 
 export interface TasksMain {
     $registerTaskProvider(handle: number, type: string): void;
+    $taskExecutions(): Promise<TaskExecutionDto[]>;
     $unregister(handle: number): void;
     $terminateTask(id: number): void;
 }

--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -88,6 +88,14 @@ export class TasksMainImpl implements TasksMain {
         }
     }
 
+    async $taskExecutions() {
+        const runningTasks = await this.taskService.getRunningTasks();
+        return runningTasks.map(taskInfo => ({
+            id: taskInfo.taskId,
+            task: taskInfo.config
+        }));
+    }
+
     $terminateTask(id: number): void {
         this.taskService.kill(id);
     }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -620,6 +620,10 @@ export function createAPIFactory(
                 return tasksExt.registerTaskProvider(type, provider);
             },
 
+            get taskExecutions(): ReadonlyArray<theia.TaskExecution> {
+                return tasksExt.taskExecutions;
+            },
+
             onDidStartTask(listener, thisArg?, disposables?) {
                 return tasksExt.onDidStartTask(listener, thisArg, disposables);
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7140,6 +7140,11 @@ declare module '@theia/plugin' {
          */
         export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
 
+        /**
+         * The currently active task executions or an empty array.
+         */
+        export const taskExecutions: ReadonlyArray<TaskExecution>;
+
         /** Fires when a task starts. */
         export const onDidStartTask: Event<TaskStartEvent>;
 


### PR DESCRIPTION
'tasks.taskExecutions' Plug-in API will allow a plugin to get currently active task executions.

Closes: https://github.com/theia-ide/theia/issues/4372

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>