### PR TITLE
Introduce vscode.previeHtml command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.4.0
 - [plugin] added `tasks.onDidEndTask` Plug-in API
+- [plugin] Introduce `vscode.previeHtml` command support 
 - [cpp] fixed `CPP_CLANGD_COMMAND` and `CPP_CLANGD_ARGS` environment variables
 - [electron] open markdown links in the OS default browser
 - [plugin] added ability to display webview panel in 'left', 'right' and 'bottom' area

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -61,7 +61,7 @@
     "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
     "start": "export THEIA_DEFAULT_PLUGINS=local-dir:../../plugins && theia start",
     "start:debug": "yarn start --log-level=debug",
-    "test": "wdio --max-old-space-size=4096 wdio.conf.js",
+    "test": "wdio wdio.conf.js",
     "test-non-headless": "wdio wdio-non-headless.conf.js",
     "coverage:compile": "yarn build --config coverage-webpack.config.js",
     "coverage:remap": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-final.json --exclude 'frontend/index.js' && rimraf coverage/coverage.json",

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -115,7 +115,6 @@ export class WebviewWidget extends BaseWidget {
                     this.handleMessage(e);
                 };
                 newFrame.style.visibility = 'visible';
-                newFrame.contentWindow!.focus();
             }
         };
 
@@ -138,6 +137,10 @@ export class WebviewWidget extends BaseWidget {
         newFrame.contentDocument!.close();
 
         this.updateSandboxAttribute(newFrame);
+    }
+
+    focus() {
+      this.iframe.contentWindow!.focus();
     }
 
     private reloadFrame() {

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -87,6 +87,9 @@ export class WebviewsMainImpl implements WebviewsMain {
         this.views.set(viewId, view);
         this.shell.addWidget(view, { area: showOptions.area ? showOptions.area : 'main' });
         this.shell.activateWidget(view.id);
+        if (showOptions.preserveFocus) {
+            view.focus();
+        }
     }
     $disposeWebview(handle: string): void {
         const view = this.views.get(handle);

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -33,14 +33,8 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     private cache = new Map<number, theia.Command>();
     private delegatingCommandId: string;
 
-    // tslint:disable-next-line:no-any
-    private static EMPTY_HANDLER(...args: any[]): Promise<any> { return Promise.resolve(undefined); }
-
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
-
-        // register internal VS Code commands
-        this.registerCommand({ id: 'vscode.previewHtml' }, CommandRegistryImpl.EMPTY_HANDLER);
     }
 
     getConverter(): CommandsConverter {


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
For demonstrate how it work I used this sample of VS Code
https://github.com/Microsoft/vscode-extension-samples/tree/master/legacy-samples/previewhtml-sample 

![previewhtml](https://user-images.githubusercontent.com/1636592/53020981-d665a080-3460-11e9-8f03-f499f198ca64.gif)
