### PR TITLE
GH-4150: Replaced the platform-specific `export` with a CLI option.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,11 +58,11 @@
                 "--port=3000",
                 "--no-cluster",
                 "--app-project-path=${workspaceRoot}/examples/browser",
-                "--no-app-auto-install"
+                "--no-app-auto-install",
+                "--plugins=local-dir:plugins"
             ],
             "env": {
-                "NODE_ENV": "development",
-                "THEIA_DEFAULT_PLUGINS": "local-dir:plugins"
+                "NODE_ENV": "development"
             },
             "sourceMaps": true,
             "outFiles": [

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -59,7 +59,7 @@
     "clean": "theia clean && rimraf errorShots",
     "build": "theiaext compile && theia build --mode development",
     "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
-    "start": "export THEIA_DEFAULT_PLUGINS=local-dir:../../plugins && theia start",
+    "start": "theia start --plugins=local-dir:../../plugins",
     "start:debug": "yarn start --log-level=debug",
     "test": "wdio wdio.conf.js",
     "test-non-headless": "wdio wdio-non-headless.conf.js",

--- a/packages/plugin-ext/src/main/node/plugin-cli-contribution.ts
+++ b/packages/plugin-ext/src/main/node/plugin-cli-contribution.ts
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Argv, Arguments } from 'yargs';
+import { CliContribution } from '@theia/core/lib/node/cli';
+import { LocalDirectoryPluginDeployerResolver } from './resolvers/plugin-local-dir-resolver';
+
+@injectable()
+export class PluginCliContribution implements CliContribution {
+
+    static PLUGINS = 'plugins';
+
+    protected _localDir: string | undefined;
+
+    configure(conf: Argv): void {
+        conf.option(PluginCliContribution.PLUGINS, {
+            // tslint:disable-next-line:max-line-length
+            description: `Provides further refinement for the plugins. Example: --${PluginCliContribution.PLUGINS}=${LocalDirectoryPluginDeployerResolver.LOCAL_DIR}:path/to/your/plugins`,
+            type: 'string',
+            nargs: 1
+        });
+    }
+
+    setArguments(args: Arguments): void {
+        const arg = args[PluginCliContribution.PLUGINS];
+        if (arg && String(arg).startsWith(`${LocalDirectoryPluginDeployerResolver.LOCAL_DIR}:`)) {
+            this._localDir = arg;
+        }
+    }
+
+    localDir(): string | undefined {
+        return this._localDir;
+    }
+
+}

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -28,6 +28,7 @@ import { ProxyPluginDeployerEntry } from './plugin-deployer-proxy-entry-impl';
 import { PluginDeployerFileHandlerContextImpl } from './plugin-deployer-file-handler-context-impl';
 import { PluginDeployerDirectoryHandlerContextImpl } from './plugin-deployer-directory-handler-context-impl';
 import { ILogger } from '@theia/core';
+import { PluginCliContribution } from './plugin-cli-contribution';
 
 @injectable()
 export class PluginDeployerImpl implements PluginDeployer {
@@ -37,6 +38,9 @@ export class PluginDeployerImpl implements PluginDeployer {
 
     @inject(PluginDeployerHandler)
     protected readonly hostedPluginServer: PluginDeployerHandler;
+
+    @inject(PluginCliContribution)
+    protected readonly cliContribution: PluginCliContribution;
 
     /**
      * Deployer entries.
@@ -86,14 +90,17 @@ export class PluginDeployerImpl implements PluginDeployer {
         // check THEIA_DEFAULT_PLUGINS or THEIA_PLUGINS env var
         const defaultPluginsValue = process.env.THEIA_DEFAULT_PLUGINS || undefined;
         const pluginsValue = process.env.THEIA_PLUGINS || undefined;
+        // check the `--plugins` CLI option
+        const defaultPluginsValueViaCli = this.cliContribution.localDir();
 
         this.logger.debug('Found the list of default plugins ID on env:', defaultPluginsValue);
         this.logger.debug('Found the list of plugins ID on env:', pluginsValue);
+        this.logger.debug('Found the list of default plugins ID from CLI:', defaultPluginsValueViaCli);
 
         // transform it to array
         const defaultPluginIdList = defaultPluginsValue ? defaultPluginsValue.split(',') : [];
         const pluginIdList = pluginsValue ? pluginsValue.split(',') : [];
-        const pluginsList = defaultPluginIdList.concat(pluginIdList);
+        const pluginsList = defaultPluginIdList.concat(pluginIdList).concat(defaultPluginsValueViaCli ? defaultPluginsValueViaCli.split(',') : []);
 
         // skip if no plug-ins
         if (pluginsList.length === 0) {

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -16,7 +16,7 @@
 
 import { interfaces } from 'inversify';
 import { PluginApiContribution } from './plugin-service';
-import { BackendApplicationContribution } from '@theia/core/lib/node';
+import { BackendApplicationContribution, CliContribution } from '@theia/core/lib/node';
 import { PluginsKeyValueStorage } from './plugins-key-value-storage';
 import { PluginDeployerContribution } from './plugin-deployer-contribution';
 import {
@@ -33,6 +33,7 @@ import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
 import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
 import { PluginPathsServiceImpl } from './paths/plugin-paths-service';
 import { PluginServerHandler } from './plugin-server-handler';
+import { PluginCliContribution } from './plugin-cli-contribution';
 
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
@@ -65,4 +66,8 @@ export function bindMainBackend(bind: interfaces.Bind): void {
             ctx.container.get(PluginServer)
         )
     ).inSingletonScope();
+
+    bind(PluginCliContribution).toSelf().inSingletonScope();
+    bind(CliContribution).toService(PluginCliContribution);
+
 }

--- a/packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts
+++ b/packages/plugin-ext/src/main/node/resolvers/plugin-local-dir-resolver.ts
@@ -24,6 +24,8 @@ import * as path from 'path';
 @injectable()
 export class LocalDirectoryPluginDeployerResolver implements PluginDeployerResolver {
 
+    static LOCAL_DIR = 'local-dir';
+
     /**
      * Check all files/folder from the local-dir referenced and add them as plugins.
      */
@@ -31,11 +33,11 @@ export class LocalDirectoryPluginDeployerResolver implements PluginDeployerResol
 
         // get directory
         const localDirSetting = pluginResolverContext.getOriginId();
-        if (!localDirSetting.startsWith('local-dir')) {
+        if (!localDirSetting.startsWith(LocalDirectoryPluginDeployerResolver.LOCAL_DIR)) {
             return;
         }
         // remove prefix
-        let dirPath = localDirSetting.substring('local-dir'.length + 1);
+        let dirPath = localDirSetting.substring(LocalDirectoryPluginDeployerResolver.LOCAL_DIR.length + 1);
         if (!path.isAbsolute(dirPath)) {
             dirPath = path.resolve(process.cwd(), dirPath);
         }
@@ -60,6 +62,6 @@ export class LocalDirectoryPluginDeployerResolver implements PluginDeployerResol
         return Promise.resolve();
     }
     accept(pluginId: string): boolean {
-        return pluginId.startsWith('local-dir');
+        return pluginId.startsWith(LocalDirectoryPluginDeployerResolver.LOCAL_DIR);
     }
 }


### PR DESCRIPTION
So that Windows users can start the example application too.

Usage: `theia start --plugins=local-dir:/path/to/your/plugins`.

Closes: #4150.
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
