### PR TITLE
GH-4136: Ignore the `.cache` folder when checking hoisted dependencies.

### DIFF
--- a/dev-packages/cli/src/check-hoisting.ts
+++ b/dev-packages/cli/src/check-hoisting.ts
@@ -34,6 +34,11 @@ interface Diagnostic {
 
 type DiagnosticMap = Map<string, Diagnostic[]>;
 
+/**
+ * Folders to skip inside the `node_modules` when checking the hoisted dependencies. Such as the `.bin` and `.cache` folders.
+ */
+const toSkip = ['.bin', '.cache'];
+
 function collectIssues(): DiagnosticMap {
     console.log('🔍  Analyzing hoisted dependencies in the Theia extensions...');
     const root = process.cwd();
@@ -45,7 +50,7 @@ function collectIssues(): DiagnosticMap {
         const extensionPath = path.join(packages, extension);
         const nodeModulesPath = path.join(extensionPath, 'node_modules');
         if (fs.existsSync(nodeModulesPath)) {
-            for (const dependency of fs.readdirSync(nodeModulesPath).filter(name => name !== '.bin')) {
+            for (const dependency of fs.readdirSync(nodeModulesPath).filter(name => toSkip.indexOf(name) === -1)) {
                 const dependencyPath = path.join(nodeModulesPath, dependency);
                 const version = versionOf(dependencyPath);
                 let message = `Dependency '${dependency}' ${version ? `[${version}] ` : ''}was not hoisted to the root 'node_modules' folder.`;


### PR DESCRIPTION
We have ignored the `.bin` folder previously,
now we have to ignore the `.cache` folder too.

Closes: #4136.
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

For reviewers:

Without this fix, the Travis build log contains the followings:
```
$ theia check:hoisted -s
🔍  Analyzing hoisted dependencies in the Theia extensions...
📖  Summary:
The following dependency issues were detected in '@theia/bunyan':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/callhierarchy':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/console':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/core':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/home/travis/build/theia-ide/theia/node_modules/ajv'.
The following dependency issues were detected in '@theia/cpp':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/debug':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/debug-nodejs':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/editor':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/editor-preview':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/editorconfig':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/extension-manager':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/file-search':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/filesystem':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/getting-started':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/git':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/java':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/java-debug':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/json':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/keymaps':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/home/travis/build/theia-ide/theia/node_modules/ajv'.
The following dependency issues were detected in '@theia/languages':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/markers':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/merge-conflicts':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/messages':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/metrics':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/mini-browser':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/monaco':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/navigator':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/outline-view':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/output':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/plugin':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/plugin-ext':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/plugin-ext-vscode':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/preferences':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/preview':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/process':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/python':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/search-in-workspace':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/task':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/terminal':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/textmate-grammars':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/tslint':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/typescript':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/userstorage':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/variable-resolver':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
The following dependency issues were detected in '@theia/workspace':
 - error: Dependency '.cache' was not hoisted to the root 'node_modules' folder.
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/home/travis/build/theia-ide/theia/node_modules/ajv'.
⚠️  This is a reminder to fix the dependency issues.
```

With the fix it should be:
```
🔍  Analyzing hoisted dependencies in the Theia extensions...
📖  Summary:
The following dependency issues were detected in '@theia/core':
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/Users/akos.kitta/git/theia/node_modules/ajv'.
The following dependency issues were detected in '@theia/keymaps':
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/Users/akos.kitta/git/theia/node_modules/ajv'.
The following dependency issues were detected in '@theia/workspace':
 - error: Dependency 'ajv' [6.5.4] was not hoisted to the root 'node_modules' folder. The same dependency already exists with version 6.5.3 at '/Users/akos.kitta/git/theia/node_modules/ajv'.
⚠️  This is a reminder to fix the dependency issues.
```