### PR TITLE
Add config for new file name and extension

### DIFF
--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -109,15 +109,6 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
      */
     readonly applicationName: string;
 
-    /**
-     * The name of the newly created file. `Untitled` by default.
-     */
-    readonly newFileName?: string;
-
-    /**
-     * The extension of the newly created file. `.txt` by default.
-     */
-    readonly newFileExtension?: string;
 }
 
 /**

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -109,6 +109,15 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
      */
     readonly applicationName: string;
 
+    /**
+     * The name of the newly created file. `Untitled` by default.
+     */
+    readonly newFileName?: string;
+
+    /**
+     * The extension of the newly created file. `.txt` by default.
+     */
+    readonly newFileExtension?: string;
 }
 
 /**

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -25,7 +25,6 @@ import { FileSystem, FileStat } from '@theia/filesystem/lib/common/filesystem';
 import { FileDialogService } from '@theia/filesystem/lib/browser';
 import { SingleTextInputDialog, ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { OpenerService, OpenHandler, open, FrontendApplication } from '@theia/core/lib/browser';
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { WorkspaceService } from './workspace-service';
 import { MessageService } from '@theia/core/lib/common/message-service';
@@ -384,10 +383,9 @@ export class WorkspaceCommandContribution implements CommandContribution {
     }
 
     protected getDefaultFileConfig(): { fileName: string, fileExtension: string } {
-        const { newFileExtension, newFileName } = FrontendApplicationConfigProvider.get();
         return {
-            fileName: newFileName ? newFileName : 'Untitled',
-            fileExtension: newFileExtension ? newFileExtension : '.txt'
+            fileName: 'Untitled',
+            fileExtension: '.txt'
         };
     }
 


### PR DESCRIPTION
- You can now use `newFileName` and `newFileExtension` in package.json to specify the default file name and extension when creating a new file;