### PR TITLE
[electron] Default to running electron without cluster mode

### DIFF
--- a/packages/core/src/node/cluster/main.ts
+++ b/packages/core/src/node/cluster/main.ts
@@ -31,8 +31,8 @@ const args = yargs.option(MasterProcess.startupTimeoutOption, {
     type: 'number',
     default: BackendApplicationConfigProvider.get().startupTimeout || MasterProcess.defaultStartupTimeoutOption
 }).help(false).argv;
-const noCluster = args['cluster'] === false;
-const isMaster = !noCluster && cluster.isMaster;
+const useCluster = args['cluster'] === true;
+const isMaster = useCluster && cluster.isMaster;
 const development = process.env.NODE_ENV === 'development';
 
 const startupTimeout = args[MasterProcess.startupTimeoutOption] as number;


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

As discussed in the dev meeting, there are problems with cluster mode in electron and the plan is to remove it as it doesn't bring any speed increases.

This PR is a stop-gap solution to disable cluster mode by default when running electron in production.

Fixes #4349, #3242