### PR TITLE
[WIP] Create frontend configuration providers

### DIFF
--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -73,9 +73,7 @@ export namespace ApplicationProps {
             config: {}
         },
         frontend: {
-            config: {
-                applicationName: 'Theia'
-            }
+            config: {}
         },
         generator: {
             config: {
@@ -103,11 +101,6 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
      * The default theme for the application. If not give, defaults to `dark`. If invalid theme is given, also defaults to `dark`.
      */
     readonly defaultTheme?: string;
-
-    /**
-     * The name of the application. `Theia` by default.
-     */
-    readonly applicationName: string;
 
 }
 

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -5,7 +5,9 @@
   "theia": {
     "frontend": {
       "config": {
-        "applicationName": "Theia Browser Example"
+        "core": {
+          "applicationName": "Theia Browser Example"
+        }
       }
     }
   },

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -6,7 +6,9 @@
     "target": "electron",
     "frontend": {
       "config": {
-        "applicationName": "Theia Electron Example"
+        "core": {
+          "applicationName": "Theia Electron Example"
+        }
       }
     }
   },

--- a/packages/core/src/browser/core-frontend-application-config.ts
+++ b/packages/core/src/browser/core-frontend-application-config.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (C) 2018 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { createConfigurationProvider } from './frontend-application-config-provider';
+
+export const CoreFrontendApplicationConfig = createConfigurationProvider('core', {
+    applicationName: 'Theia',
+});

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -25,7 +25,7 @@ import { FileSystemUtils } from '@theia/filesystem/lib/common/filesystem-utils';
 import { KeymapsCommands } from '@theia/keymaps/lib/browser';
 import { CommonCommands } from '@theia/core/lib/browser';
 import { ApplicationInfo, ApplicationServer } from '@theia/core/lib/common/application-protocol';
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { CoreFrontendApplicationConfig } from '@theia/core/lib/browser/core-frontend-application-config';
 
 @injectable()
 export class GettingStartedWidget extends ReactWidget {
@@ -34,7 +34,7 @@ export class GettingStartedWidget extends ReactWidget {
     static readonly LABEL = 'Getting Started';
 
     protected applicationInfo: ApplicationInfo | undefined;
-    protected applicationName = FrontendApplicationConfigProvider.get().applicationName;
+    protected applicationName = CoreFrontendApplicationConfig.get().applicationName;
 
     protected stat: FileStat | undefined;
     protected home: string | undefined;

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -28,7 +28,7 @@ import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise
 import { WorkspacePreferences } from './workspace-preferences';
 import * as jsoncparser from 'jsonc-parser';
 import * as Ajv from 'ajv';
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { CoreFrontendApplicationConfig } from '@theia/core/lib/browser/core-frontend-application-config';
 
 /**
  * The workspace service.
@@ -69,7 +69,7 @@ export class WorkspaceService implements FrontendApplicationContribution {
 
     @postConstruct()
     protected async init(): Promise<void> {
-        this.applicationName = FrontendApplicationConfigProvider.get().applicationName;
+        this.applicationName = CoreFrontendApplicationConfig.get().applicationName;
         const wpUriString = await this.getDefaultWorkspacePath();
         const wpStat = await this.toFileStat(wpUriString);
         await this.setWorkspace(wpStat);


### PR DESCRIPTION
Everytime someone wants to add properties inside the application configs
they would have to contribute to @theia/application-package.

This commit allows extensions to create scoped providers with their
own defaults.

Application `package.json` example:

```
frontend: {
	config: {
		core: {
			params...
		},
		some-ext: {
			more params...
		},
		...
	}
}
```

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

---

@kittaakos @vince-fugnitto I just saw @bogthe PR and wondered if this one would be useful.
This PR allows anyone to try and parse the configuration inside the application `package.json`.
Don't know if it helps, but its there.