### PR TITLE
delay hosted plugins' initialization

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -152,6 +152,7 @@ export class HostedPluginSupport {
                         pluginID = getPluginId(plugins[0].model);
                     }
                     const rpc = this.createServerRpc(pluginID, hostKey);
+                    setUpPluginApi(rpc, container);
                     const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
                     hostedExtManager.$init({
                         plugins: plugins,
@@ -161,7 +162,6 @@ export class HostedPluginSupport {
                         env: { queryParams: getQueryParameters() },
                         extApi: initData.pluginAPIs
                     }, confStorage);
-                    setUpPluginApi(rpc, container);
                     this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(rpc, container));
                     this.backendExtManagerProxy = hostedExtManager;
                 });

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -58,9 +58,6 @@ export class HostedPluginSupport {
     @inject(PluginServer)
     protected readonly pluginServer: PluginServer;
 
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
     @inject(PreferenceProviderProvider)
     protected readonly preferenceProviderProvider: PreferenceProviderProvider;
 
@@ -72,8 +69,9 @@ export class HostedPluginSupport {
         @inject(PreferenceServiceImpl) private readonly preferenceServiceImpl: PreferenceServiceImpl,
         @inject(PluginPathsService) private readonly pluginPathsService: PluginPathsService,
         @inject(StoragePathService) private readonly storagePathService: StoragePathService,
+        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
     ) {
-        this.theiaReadyPromise = Promise.all([this.preferenceServiceImpl.ready]);
+        this.theiaReadyPromise = Promise.all([this.preferenceServiceImpl.ready, this.workspaceService.roots]);
 
         this.storagePathService.onStoragePathChanged(path => {
             this.updateStoragePath(path);

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -67,10 +67,7 @@ export class WorkspaceMainImpl implements WorkspaceMain {
 
         this.inPluginFileSystemWatcherManager = new InPluginFileSystemWatcherManager(this.proxy, container);
 
-        this.workspaceService.roots.then(roots => {
-            this.processWorkspaceFoldersChanged(roots);
-        });
-
+        this.processWorkspaceFoldersChanged(this.workspaceService.tryGetRoots());
         this.workspaceService.onWorkspaceChanged(roots => {
             this.processWorkspaceFoldersChanged(roots);
         });
@@ -81,13 +78,13 @@ export class WorkspaceMainImpl implements WorkspaceMain {
             return;
         }
         this.roots = roots;
+        this.proxy.$onWorkspaceFoldersChanged({ roots });
 
         await this.storagePathService.updateStoragePath(roots);
 
         const keyValueStorageWorkspacesData = await this.pluginServer.keyValueStorageGetAll(false);
         this.storageProxy.$updatePluginsWorkspaceData(keyValueStorageWorkspacesData);
 
-        this.proxy.$onWorkspaceFoldersChanged({ roots });
     }
 
     private isAnyRootChanged(roots: FileStat[]): boolean {


### PR DESCRIPTION
setup plugin api before plugins are started
    
- in current Theia code plugins are loaded and activated before the plugin api becomes ready. This change fixes this problem.
    
Signed-off-by: elaihau <liang.huang@ericsson.com>


delay hosted plugins' initialization
    
- When plugins query the `workspace.workspaceFolders`, Theia plugin api returns `undefined` when there is no workspace open, or the opened workspace has not been resolved by `WorkspaceService`. And this is inconsistent with vsCode, where the extension host is not started until the `initialize` function of `WorkspaceService` returns. This change delays the initialization and loading of plugins to ensure workspace root(s) are resolved beforehand.
    
Signed-off-by: elaihau <liang.huang@ericsson.com>
