### PR TITLE
[file-search] add 'Clear Editor History' command

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -84,6 +84,14 @@ export namespace EditorCommands {
         category: EDITOR_CATEGORY,
         label: 'Go to Last Edit Location'
     };
+    /**
+     * Command that clears the editor navigation history.
+     */
+    export const CLEAR_EDITOR_HISTORY: Command = {
+        id: 'textEditor.commands.clear.history',
+        category: EDITOR_CATEGORY,
+        label: 'Clear Editor History'
+    };
 }
 
 @injectable()
@@ -121,6 +129,7 @@ export class EditorCommandContribution implements CommandContribution {
         registry.registerCommand(EditorCommands.GO_BACK);
         registry.registerCommand(EditorCommands.GO_FORWARD);
         registry.registerCommand(EditorCommands.GO_LAST_EDIT);
+        registry.registerCommand(EditorCommands.CLEAR_EDITOR_HISTORY);
 
         registry.registerCommand(CommonCommands.AUTO_SAVE, {
             isToggled: () => this.isAutoSaveOn(),

--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -69,6 +69,10 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
             execute: () => this.locationStack.reveal(this.locationStack.lastEditLocation()),
             isEnabled: () => !!this.locationStack.lastEditLocation()
         });
+        this.commandRegistry.registerHandler(EditorCommands.CLEAR_EDITOR_HISTORY.id, {
+            execute: () => this.locationStack.clearHistory(),
+            isEnabled: () => this.locationStack.locations().length > 0
+        });
     }
 
     async onStart(): Promise<void> {

--- a/packages/editor/src/browser/navigation/navigation-location-service.ts
+++ b/packages/editor/src/browser/navigation/navigation-location-service.ts
@@ -165,6 +165,15 @@ export class NavigationLocationService {
     }
 
     /**
+     * Clears the navigation history.
+     */
+    clearHistory(): void {
+        this.stack = [];
+        this.pointer = -1;
+        this._lastEditLocation = undefined;
+    }
+
+    /**
      * Reveals the location argument. If not given, reveals the `current location`. Does nothing, if the argument is `undefined`.
      */
     async reveal(location: NavigationLocation | undefined = this.currentLocation()): Promise<void> {


### PR DESCRIPTION
Fixes #4389

- If a user's recently opened editors list becomes large, there is no way to currently purge the list.
The command helps solve that issue by clearing the location stack, and resetting the pointer.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
