### PR TITLE
[mini-browser] Fix 6px gap above the load-indicator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.4.0
 - [plugin] added `tasks.onDidEndTask` Plug-in API
-- [plugin] Introduce `vscode.previeHtml` command support 
+- [plugin] Introduce `vscode.previewHtml` command support
 - [cpp] fixed `CPP_CLANGD_COMMAND` and `CPP_CLANGD_ARGS` environment variables
 - [electron] open markdown links in the OS default browser
 - [plugin] added ability to display webview panel in 'left', 'right' and 'bottom' area
@@ -31,7 +31,7 @@ Breaking changes:
     - `debug.stop` renamed to `workbench.action.debug.stop`
     - `debug.editor.showHover` renamed to `editor.debug.action.showDebugHover`
 - multi-root workspace support for preferences [#3247](https://github.com/theia-ide/theia/pull/3247)
-  - `PreferenceProvider` 
+  - `PreferenceProvider`
     - is changed from a regular class to an abstract class.
     - the `fireOnDidPreferencesChanged` function is deprecated. `emitPreferencesChangedEvent` function should be used instead. `fireOnDidPreferencesChanged` will be removed with the next major release.
   - `PreferenceServiceImpl`

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -113,7 +113,7 @@
 
 .theia-mini-browser-load-indicator {
     position: absolute;
-    top: 6px;
+    top: 0;
     right: 0;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
There is a gap above the mini-browser load indicator, that is visible when the preview background is set to white:

<img width="516" alt="screenshot 2019-02-20 at 14 57 51" src="https://user-images.githubusercontent.com/599268/53096651-f019ed00-351f-11e9-81a7-85f21eaae2ed.png">

This pull request fixes it.

Drive-by fix: Typo and trailing whitespace in `CHANGELOG.md` (but this fix isn't worth mentioning there).