### PR TITLE
[mini-browser] Better handle iframe errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - [workspace] added support for easier overriding of the `DefaultWorkspaceServer`
 - [workspace] added support for workspace `when` contexts
 - [workspace] fixed displaying the `Open With...` context menu only when more than one open handler is present
+- [mini-browser] improved handling of iframe errors and time-outs
 
 
 Breaking changes:

--- a/doc/Developing.md
+++ b/doc/Developing.md
@@ -46,7 +46,7 @@ For Windows instructions [click here](#building-on-windows).
 ## Prerequisites
  - Node.js `>= 8.x`, `< 9.x`.
    - Preferably, **use** version `8.11.4`, it has the [active LTS](https://github.com/nodejs/Release).
-   - Node.js `9.x` is untested. 
+   - Node.js `9.x` is untested.
    - Node.js `10.x` is **not** supported yet due to a known issue in [`nsfw`](https://github.com/theia-ide/theia/issues/2009).
  - [Yarn package manager](https://yarnpkg.com/en/docs/install) v1.7.0
  - git (If you would like to use the Git-extension too, you will need to have git version 2.11.0 or higher.)
@@ -90,11 +90,11 @@ Start your browser on https://localhost:3000.
 ### Run the browser example with Gitpod
 
 [Gitpod](http://gitpod.io/) is a Theia-based IDE for GitHub.
-You can start by prefixing any GitHub URL in the Theia repository with `gitpod.io#`:
-- Open http://gitpod.io#https://github.com/theia-ide/theia to start development with the master branch.
+You can start by prefixing any GitHub URL in the Theia repository with `gitpod.io/#`:
+- Open http://gitpod.io/#https://github.com/theia-ide/theia to start development with the master branch.
 - Gitpod will start a properly configured for Theia development workspace, clone and build the Theia repository.
 - After the build is finished, run from the terminal in Gitpod:
-    
+
         cd examples/browser \
         && yarn run start ../.. --hostname 0.0.0.0
 
@@ -216,7 +216,7 @@ Let assume you have to work for instance in the `@theia/navigator` extension. Bu
 
  - In VS Code: Start the debug tab and run the `Launch Backend` configuration.
  - Then run the `Launch Frontend` configuration.
- 
+
 ### Debug the Electron example's backend
 
  - In VS Code: Start the debug tab and run the `Launch Electron Backend` configuration.
@@ -330,7 +330,7 @@ You need to have the Xcode command line tools installed in order to build and ru
 If you already have Xcode installed, but you see the `xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance` error, you need to run the following command to fix it: `sudo xcode-select --switch /Library/Developer/CommandLineTools`.
 
 The solution is the same if you have updated to `10.14` (Mojave) and you can see the `gyp: No Xcode or CLT version detected!` error. More details [here](https://github.com/nodejs/node-gyp#on-macos).
- 
+
 ### Root privileges errors
 When trying to install with root privileges, you might encounter errors such as
 `cannot run in wd`.

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -125,6 +125,24 @@
     transition: opacity 0.8s;
 }
 
+.theia-mini-browser-load-indicator.theia-fade-out {
+    opacity: 0;
+}
+
+.theia-mini-browser-error-bar {
+    height: 19px;
+    padding-left: var(--theia-ui-padding);
+    background-color: var(--theia-warn-color0);
+    color: var(--theia-warn-font-color0);
+    font-size: var(--theia-statusBar-font-size);
+    z-index: 1000; /* Above the transparent overlay (`z-index: 999;`). */
+}
+
+.theia-mini-browser-error-bar span {
+    margin-top: 3px;
+    margin-left: var(--theia-ui-padding);
+}
+
 .theia-mini-browser-content-area iframe {
     flex-grow: 1;
     border: none; margin: 0; padding: 0;


### PR DESCRIPTION
Today, we don't handle iframe errors very well in Theia, as most of the time we hide them behind a forever-spinning load indicator overlay. (See #3589, #4102, https://github.com/gitpod-io/gitpod/issues/260.)

ToDo:

- [x] Hide the load indicator if the iframe sends a `'load'` event (was already the case)
- [x] Hide the load indicator if the iframe sends an `'error'` event (new with this PR)
- [x] Hide the load indicator if the iframe hasn't loaded after some time

This will make sure that we stop hiding an iframe that had errors. Most of the time, the browser will display more information on the error inside the iframe (e.g. CSP, content encoding, cross-origin, invalid address, etc.). However, in some cases (e.g. HTTP Mixed Content) the errored iframe will be completely blank.

Potential further improvements:

- [x] Insert a banner with an error message, between the Preview URL bar and the iframe, or at the bottom of the iframe
  - Showing something like "Error: iframe timed out", or the actual error if we have it
- [x] Add a fade-out animation when removing the load indicator
- ~~See if we can detect more iframe errors by polling `try { frame.contentWindow.document.readyState } catch (e) {  }`~~ (it detects errors, but also for sites that work)