### PR TITLE
GH-4395: Made the Git env variable validation less aggressive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,6 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH ;
 install: yarn && scripts/check_git_status.sh
 script:
-  # Unset the `protocol.version` in the `global` Git configuration. See: https://github.com/theia-ide/theia/issues/4371
-  - git config --global --unset protocol.version
   - travis_retry yarn test:theia ;
   - travis_retry yarn test:electron ;
   - travis_retry yarn test:browser ;
@@ -109,8 +107,6 @@ jobs:
     env: CXX=c++
     before_script: skip
     script:
-      # Unset the `protocol.version` in the `global` Git configuration.
-      - git config --global --unset protocol.version
       - travis_retry yarn test:theia ;
   - stage: deploy
     if: NOT type IN (cron, pull_request)

--- a/examples/browser/wdio.base.conf.js
+++ b/examples/browser/wdio.base.conf.js
@@ -261,7 +261,7 @@ function makeConfig(headless) {
             try {
                 result = browser.execute("return window.__coverage__;");
             } catch (error) {
-                console.error(`Error retreiving the coverage: ${error}`);
+                console.error(`Error retrieving the coverage: ${error}`);
                 return;
             }
             try {

--- a/packages/git/src/node/dugite-git-watcher.slow-spec.ts
+++ b/packages/git/src/node/dugite-git-watcher.slow-spec.ts
@@ -51,11 +51,6 @@ describe('git-watcher-slow', () => {
         repository = { localUri };
 
         await git!.clone('https://github.com/TypeFox/find-git-exec.git', { localUri });
-
-        // This test has different bindings than other Git tests. We want to check the `watcher` here.
-        // Watching repository changes will initialize Git, so we need to get rid of the env variables here after the clone.
-        delete process.env.LOCAL_GIT_DIRECTORY;
-        delete process.env.GIT_EXEC_PATH;
     });
 
     after(function () {

--- a/packages/git/src/node/test/binding-helper.ts
+++ b/packages/git/src/node/test/binding-helper.ts
@@ -46,8 +46,6 @@ export function initializeBindings(): { container: Container, bind: interfaces.B
  * For testing only.
  */
 export async function createGit(bindingOptions: GitBindingOptions = GitBindingOptions.Default): Promise<Git> {
-    delete process.env.LOCAL_GIT_DIRECTORY;
-    delete process.env.GIT_EXEC_PATH;
     const { container, bind } = initializeBindings();
     bindGit(bind, {
         bindManager(binding: interfaces.BindingToSyntax<{}>): interfaces.BindingWhenOnSyntax<{}> {


### PR DESCRIPTION
This is an interim solution.

Rules:
 - Fails when the env variable was set, and we try to set another value.
 - Passes when the env variable was set, and we try to re-set the same.

Managing the external Git location via env vars is getting complicated:
 - `dugite` manages the non-embedded Git locations with env variables.
 - We have switched to connection scope DI-bindings for `DugiteGit`.

Closes #4395.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

This PR also contains the revert changes of #4371.
Q: OK, but why?
A: Travis does not set the default Git `protocol.version` to `2` anymore. And [this comment](
https://github.com/theia-ide/theia/issues/4395#issuecomment-465977089) mentions the non-zero exit code as part of #4395.

See: https://travis-ci.community/t/got-to-fail-carthage-outdated-command-because-of-git-protocol-version/2359/