### PR TITLE
Align TaskDto with TaskConfiguration

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -829,7 +829,7 @@ export interface TaskDto {
     label: string;
     source?: string;
     // tslint:disable-next-line:no-any
-    properties?: { [key: string]: any };
+    [key: string]: any;
 }
 
 export interface TaskExecutionDto {

--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -175,54 +175,55 @@ describe('Type converters:', () => {
         const command = 'yarn';
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
+        const additionalProperty = 'some property';
 
         const shellTaskDto: ProcessTaskDto = {
-            type: type,
-            label: label,
+            type,
+            label,
             source,
-            command: command,
-            args: args,
-            cwd: cwd,
+            command,
+            args,
+            cwd,
             options: {},
-            properties: {}
+            additionalProperty
         };
 
         const shellPluginTask: theia.Task = {
             name: label,
             source,
             definition: {
-                type: type
+                type,
+                additionalProperty
             },
             execution: {
-                command: command,
-                args: args,
+                command,
+                args,
                 options: {
-                    cwd: cwd
+                    cwd
                 }
             }
         };
 
         const taskDtoWithCommandLine: ProcessTaskDto = {
-            type: type,
-            label: label,
+            type,
+            label,
             source,
-            command: command,
-            args: args,
-            cwd: cwd,
-            options: {},
-            properties: {}
+            command,
+            args,
+            cwd,
+            options: {}
         };
 
         const pluginTaskWithCommandLine: theia.Task = {
             name: label,
             source,
             definition: {
-                type: type
+                type
             },
             execution: {
                 commandLine: 'yarn run build',
                 options: {
-                    cwd: cwd
+                    cwd
                 }
             }
         };

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -527,10 +527,10 @@ export function fromTask(task: theia.Task): TaskDto | undefined {
     }
 
     taskDto.type = taskDefinition.type;
-    taskDto.properties = {};
-    for (const key in taskDefinition) {
-        if (key !== 'type' && taskDefinition.hasOwnProperty(key)) {
-            taskDto.properties[key] = taskDefinition[key];
+    const { type, ...properties } = taskDefinition;
+    for (const key in properties) {
+        if (properties.hasOwnProperty(key)) {
+            taskDto[key] = properties[key];
         }
     }
 
@@ -556,11 +556,12 @@ export function toTask(taskDto: TaskDto): theia.Task {
         throw new Error('Task should be provided for converting');
     }
 
+    const { type, label, source, command, args, options, windows, cwd, ...properties } = taskDto;
     const result = {} as theia.Task;
-    result.name = taskDto.label;
-    result.source = taskDto.source;
+    result.name = label;
+    result.source = source;
 
-    const taskType = taskDto.type;
+    const taskType = type;
     const taskDefinition: theia.TaskDefinition = {
         type: taskType
     };
@@ -575,7 +576,6 @@ export function toTask(taskDto: TaskDto): theia.Task {
         result.execution = getShellExecution(taskDto as ProcessTaskDto);
     }
 
-    const properties = taskDto.properties;
     if (!properties) {
         return result;
     }


### PR DESCRIPTION
We use [properties](https://github.com/theia-ide/theia/blob/master/packages/plugin-ext/src/api/plugin-api.ts#L832) of TaskDto object for additional task type specific properties.
TaskConfiguration of theia uses [this one](https://github.com/theia-ide/theia/blob/master/packages/task/src/common/task-protocol.ts#L36) and TaskConfiguration of che-theia uses [the same](https://github.com/eclipse/che-theia/blob/master/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts#L133)
So, my proposal is to align TaskDto with TaskConfiguration of theia and che-theia. 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>