### PR TITLE
Fix minor scrollbar issues for the command palette

### DIFF
--- a/packages/core/src/browser/style/scrollbars.css
+++ b/packages/core/src/browser/style/scrollbars.css
@@ -138,7 +138,7 @@
 /* Make horizontal scrollbar, decorations overview ruler and vertical scrollbar arrows opaque */
 .vs .monaco-scrollable-element > .scrollbar,
 .vs-dark .monaco-scrollable-element > .scrollbar,
-.decorationsOverviewRuler, {
+.decorationsOverviewRuler {
     background: var(--theia-scrollbar-rail-color);
 }
 
@@ -157,8 +157,16 @@
     background: var(--theia-scrollbar-active-thumb-color) !important;
 }
 
+.monaco-scrollable-element > .visible.scrollbar.vertical:hover > .slider {
+    background: var(--theia-scrollbar-thumb-color) !important;
+}
+
 .monaco-scrollable-element > .scrollbar.vertical > .slider {
     width: var(--theia-scrollbar-width) !important;
+}
+
+.monaco-scrollable-element > .scrollbar.vertical > .slider.active {
+    background: var(--theia-scrollbar-active-thumb-color) !important;
 }
 
 .monaco-scrollable-element > .scrollbar.horizontal > .slider {


### PR DESCRIPTION
Fixes #4408
Fixes #4409 

- Fix issue on dark themes where the `command palette` scrollbar is completely black when in the
active state, making it difficult to see.
- Fix issue where the scrollbar in the `command palette` is difficult to find. Now when a user hovers over the scrollbar area, the scrollbar is displayed.
- Fix minor typo in the `scrollbar.css` with an extra comma.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
