### PR TITLE
Show the `X` on the closeable tab-bars only if current or has the hover.

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -37,7 +37,7 @@
   height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
   min-width: 35px;
   line-height: var(--theia-private-horizontal-tab-height);
-  padding: 0px 8px;
+  padding: 0px 2px 0px 4px;
   background: var(--theia-layout-color3);
 }
 
@@ -95,14 +95,17 @@
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
-  margin-left: 4px;
   padding-top: 6px;
   height: 16px;
   width: 16px;
-  background-image: var(--theia-icon-close);
   background-size: 16px;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:hover > .p-TabBar-tabCloseIcon,
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon {
+  background-image: var(--theia-icon-close);
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon {


### PR DESCRIPTION
Otherwise hide them, so that the UI does not feel too noisy.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

-----
For reviewers:

I was not able to find the corresponding ticket, but I think someone mentioned earlier, the UI feels too busy with all those close `X` icons. I second it. I was reading the tab-bar code anyway, so here is a proposal to adjust them.

Show the `X` (Close) icon on the horizontal tab-bar item:
 - if the tab-bar is the current,
 - or has the hover.

Otherwise, it is hidden. 

Before:
<img width="769" alt="screen shot 2019-02-24 at 20 18 46" src="https://user-images.githubusercontent.com/1405703/53304149-8167c700-3872-11e9-85df-cdeda3182c87.png">

After:
<img width="795" alt="screen shot 2019-02-24 at 20 16 53" src="https://user-images.githubusercontent.com/1405703/53304150-89276b80-3872-11e9-8fc7-2cdf64d2bd8e.png">

In action:
![screencast 2019-02-24 20-17-03](https://user-images.githubusercontent.com/1405703/53304155-947a9700-3872-11e9-8fd5-3b3e2835fab7.gif)

Same behavior for all tab-bars per their container:
![screencast 2019-02-24 20-24-24](https://user-images.githubusercontent.com/1405703/53304163-a52b0d00-3872-11e9-8bdd-c6b52745a080.gif)

Note:
 - no changes regarding the dirty ones.
 - the mouse cursor is missing from the screencasts, no idea what went wrong.
 - please link the GH issue if you find it. Thanks!


<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
