### PR TITLE
remove the wrong filter for container views

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -132,8 +132,7 @@ export class PluginContributionHandler {
                 if (contributions.viewsContainers!.hasOwnProperty(location)) {
                     const viewContainers = contributions.viewsContainers[location];
                     viewContainers.forEach(container => {
-                        const views = !contributions.views || !contributions.views[container.id] ? [] :
-                            contributions.views[container.id].filter(view => view.id === container.id);
+                        const views = contributions.views && contributions.views[container.id] ? contributions.views[container.id] : [];
                         this.viewRegistry.registerViewContainer(location, container, views);
                     });
                 }

--- a/packages/plugin-ext/src/main/browser/view/view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/view-registry.ts
@@ -82,7 +82,7 @@ export class ViewRegistry {
 
     private addTreeViewWidget(viewsContainerId: string, viewId: string, treeViewWidget: TreeViewWidget) {
         const containerWidget = this.containerWidgets.get(viewsContainerId);
-        if (containerWidget && containerWidget.hasView(viewId) && !containerWidget.hasWidget(treeViewWidget)) {
+        if (containerWidget && containerWidget.hasView(viewId)) {
             containerWidget.addWidget(viewId, treeViewWidget);
         }
     }

--- a/packages/plugin-ext/src/main/browser/view/views-container-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/views-container-widget.ts
@@ -63,15 +63,11 @@ export class ViewsContainerWidget extends Widget {
         return this.sections.has(viewId);
     }
 
-    public hasWidget(viewWidget: TreeViewWidget): boolean {
-        return this.childrenId.indexOf(viewWidget.id) !== -1;
-    }
-
     public addWidget(viewId: string, viewWidget: TreeViewWidget) {
         const section = this.sections.get(viewId);
-        if (section) {
-            this.childrenId.push(viewWidget.id);
+        if (section && this.childrenId.indexOf(viewId) === -1) {
             section.addViewWidget(viewWidget);
+            this.childrenId.push(viewId);
             this.updateDimensions();
         }
     }


### PR DESCRIPTION
Remove the wrong filter for container views.  It was added after the code refactoring commit.  And it does not affect the samples work.

These changes were tested with 
https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools

Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
