### PR TITLE
[ui/ux] update tab-bar styling

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -96,9 +96,10 @@
 
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
   padding-top: 6px;
+  padding-left: 10px;
   height: 16px;
   width: 16px;
-  background-size: 16px;
+  background-size: 13px;
   background-position: center;
   background-repeat: no-repeat;
 }
@@ -111,6 +112,11 @@
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon {
   background-size: 10px;
   background-image: var(--theia-icon-circle);
+}
+
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable.theia-mod-dirty > .p-TabBar-tabCloseIcon:hover {
+  background-size: 13px;
+  background-image: var(--theia-icon-close);
 }
 
 .p-TabBar.theia-app-centers .p-TabBar-tab > .p-TabBar-tabIcon.no-icon {


### PR DESCRIPTION
Fixes #2034

- display `x` (close icon) when hovering over the dirty editor marker (circle).

<div align='center'>

![closeicon](https://user-images.githubusercontent.com/40359487/53377855-80e23580-3931-11e9-80e2-91f565f7206c.gif)

</div>

- increase padding between editor name and (close / dirty) icons & adjust the `x` (close icon) size.


|Before|After (resize icon and increase left padding) |
|:---:|:---:|
|<img width="467" alt="screen shot 2019-02-25 at 7 21 50 pm" src="https://user-images.githubusercontent.com/40359487/53378187-b3d8f900-3932-11e9-8621-10205d665201.png">| <img width="464" alt="screen shot 2019-02-25 at 7 22 15 pm" src="https://user-images.githubusercontent.com/40359487/53378200-bf2c2480-3932-11e9-8f98-9a1805800af3.png">|


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
