### PR TITLE
Register editor to location stack when 'onCurrentEditorChanged'

### DIFF
--- a/packages/editor/src/browser/editor-navigation-contribution.ts
+++ b/packages/editor/src/browser/editor-navigation-contribution.ts
@@ -98,6 +98,7 @@ export class EditorNavigationContribution implements Disposable, FrontendApplica
                 editor.onSelectionChanged(selection => this.onSelectionChanged(editor, selection)),
                 editor.onDocumentContentChanged(event => this.onDocumentContentChanged(editor, event))
             ]);
+            this.locationStack.register(NavigationLocation.create(editor, editor.selection));
         }
     }
 


### PR DESCRIPTION
Fixes #4388

- Previously, it wasn't clear when an editor would be registered to the `navigation location stack`.
This change adds the missing registration of an editor when `onCurrentEditorChanged`. Results in the quick file open are now more consistently added to the stack.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
