### PR TITLE
Added gitpod.yml to enable prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+ports:
+- port: 3000
+tasks:
+- init: yarn install
+  command: cd examples/browser && yarn start --hostname 0.0.0.0 ../..
+github:
+  prebuilds:
+    pullRequestsFromForks: true


### PR DESCRIPTION
Gitpod will prebuild workspaces effectively eliminating waiting for builds. It's a GitHub app and needs to be enabled on the repository. This PR adds the necessary gitpod config for it to work.