### PR TITLE
support ignored globs & limit in file search & plugin-ext

### DIFF
--- a/packages/file-search/src/common/file-search-service.ts
+++ b/packages/file-search/src/common/file-search-service.ts
@@ -38,6 +38,7 @@ export namespace FileSearchService {
         fuzzyMatch?: boolean
         limit?: number
         useGitIgnore?: boolean
+        /** when `undefined`, no excludes will apply, when empty array, default excludes will apply */
         defaultIgnorePatterns?: string[]
     }
 }

--- a/packages/file-search/src/node/file-search-service-impl.spec.ts
+++ b/packages/file-search/src/node/file-search-service-impl.spec.ts
@@ -81,23 +81,41 @@ describe('search-service', function () {
 
     describe('search with glob', () => {
         it('should support file searches with globs', async () => {
-            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1')).toString();
+            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1/sub2')).toString();
 
             const matches = await service.find('**/*oo.*', { rootUris: [rootUri] });
             expect(matches).to.be.not.undefined;
-            expect(matches.length).to.eq(3);
+            expect(matches.length).to.eq(1);
         });
 
         it('should support file searches with globs without the prefixed or trailing star (*)', async () => {
-            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1')).toString();
+            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1/sub2')).toString();
 
             const trailingMatches = await service.find('*oo', { rootUris: [rootUri] });
             expect(trailingMatches).to.be.not.undefined;
-            expect(trailingMatches.length).to.eq(3);
+            expect(trailingMatches.length).to.eq(1);
 
             const prefixedMatches = await service.find('oo*', { rootUris: [rootUri] });
             expect(prefixedMatches).to.be.not.undefined;
-            expect(prefixedMatches.length).to.eq(3);
+            expect(prefixedMatches.length).to.eq(1);
+        });
+    });
+
+    describe('search with ignored patterns', () => {
+        it('should ignore strings passed through the search options', async () => {
+            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1/sub2')).toString();
+
+            const matches = await service.find('**/*oo.*', { rootUris: [rootUri], defaultIgnorePatterns: ['foo'] });
+            expect(matches).to.be.not.undefined;
+            expect(matches.length).to.eq(0);
+        });
+
+        it('should ignore globs passed through the search options', async () => {
+            const rootUri = FileUri.create(path.resolve(__dirname, '../../test-resources/subdir1/sub2')).toString();
+
+            const matches = await service.find('**/*oo.*', { rootUris: [rootUri], defaultIgnorePatterns: ['*fo*'] });
+            expect(matches).to.be.not.undefined;
+            expect(matches.length).to.eq(0);
         });
     });
 });

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -32,13 +32,13 @@ export class FileSearchServiceImpl implements FileSearchService {
         @inject(RawProcessFactory) protected readonly rawProcessFactory: RawProcessFactory) { }
 
     async find(searchPattern: string, options: FileSearchService.Options, cancellationToken?: CancellationToken): Promise<string[]> {
+        if (options.defaultIgnorePatterns && options.defaultIgnorePatterns.length === 0) { // default excludes
+            options.defaultIgnorePatterns.push('.git');
+        }
         const opts = {
             fuzzyMatch: true,
             limit: Number.MAX_SAFE_INTEGER,
             useGitIgnore: true,
-            defaultIgnorePatterns: [
-                '.git'
-            ],
             ...options
         };
         const args: string[] = this.getSearchArgs(opts);

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -156,7 +156,13 @@ export class WorkspaceMainImpl implements WorkspaceMain {
         maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
         const opts: FileSearchService.Options = { rootUris: this.roots.map(r => r.uri) };
         if (typeof excludePatternOrDisregardExcludes === 'string') {
-            opts.defaultIgnorePatterns = [excludePatternOrDisregardExcludes];
+            if (excludePatternOrDisregardExcludes === '') { // default excludes
+                opts.defaultIgnorePatterns = [];
+            } else {
+                opts.defaultIgnorePatterns = [excludePatternOrDisregardExcludes];
+            }
+        } else {
+            opts.defaultIgnorePatterns = undefined; // no excludes
         }
         if (typeof maxResults === 'number') {
             opts.limit = maxResults;

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -154,7 +154,14 @@ export class WorkspaceMainImpl implements WorkspaceMain {
 
     async $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes?: string | false,
         maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
-        const uriStrs = await this.fileSearchService.find(includePattern, { rootUris: this.roots.map(r => r.uri) });
+        const opts: FileSearchService.Options = { rootUris: this.roots.map(r => r.uri) };
+        if (typeof excludePatternOrDisregardExcludes === 'string') {
+            opts.defaultIgnorePatterns = [excludePatternOrDisregardExcludes];
+        }
+        if (typeof maxResults === 'number') {
+            opts.limit = maxResults;
+        }
+        const uriStrs = await this.fileSearchService.find(includePattern, opts);
         return uriStrs.map(uriStr => Uri.parse(uriStr));
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -417,7 +417,7 @@ export function createAPIFactory(
                 ignoreDeleteEvents?: boolean): theia.FileSystemWatcher {
                 return workspaceExt.createFileSystemWatcher(globPattern, ignoreCreateEvents, ignoreChangeEvents, ignoreDeleteEvents);
             },
-            findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
+            findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
                 return workspaceExt.findFiles(include, exclude, maxResults, token);
             },
             applyEdit(edit: theia.WorkspaceEdit): PromiseLike<boolean> {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -355,7 +355,7 @@ export function createAPIFactory(
         };
 
         const workspace: typeof theia.workspace = {
-            get rootPath(): string | undefined {
+            get rootPath(): string | undefined {
                 return workspaceExt.rootPath;
             },
             get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
@@ -418,7 +418,7 @@ export function createAPIFactory(
                 return workspaceExt.createFileSystemWatcher(globPattern, ignoreCreateEvents, ignoreChangeEvents, ignoreDeleteEvents);
             },
             findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
-                return workspaceExt.findFiles(include, undefined, maxResults, token);
+                return workspaceExt.findFiles(include, exclude, maxResults, token);
             },
             applyEdit(edit: theia.WorkspaceEdit): PromiseLike<boolean> {
                 return editors.applyWorkspaceEdit(edit);

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -112,7 +112,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         });
     }
 
-    findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | undefined, maxResults?: number,
+    findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | null, maxResults?: number,
         token: CancellationToken = CancellationToken.None): PromiseLike<URI[]> {
         let includePattern: string;
         if (include) {
@@ -127,7 +127,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
         let excludePatternOrDisregardExcludes: string | false;
         if (exclude === undefined) {
-            excludePatternOrDisregardExcludes = false;
+            excludePatternOrDisregardExcludes = ''; // default excludes
         } else if (exclude) {
             if (typeof exclude === 'string') {
                 excludePatternOrDisregardExcludes = exclude;
@@ -135,7 +135,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
                 excludePatternOrDisregardExcludes = exclude.pattern;
             }
         } else {
-            excludePatternOrDisregardExcludes = false;
+            excludePatternOrDisregardExcludes = false; // no excludes
         }
 
         if (token && token.isCancellationRequested) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4028,7 +4028,7 @@ declare module '@theia/plugin' {
          * @return A thenable that resolves to an array of resource identifiers. Will return no results if no
          * [workspace folders](#workspace.workspaceFolders) are opened.
          */
-        export function findFiles(include: GlobPattern, exclude?: GlobPattern | undefined, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
+        export function findFiles(include: GlobPattern, exclude?: GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
 
         /**
          * Make changes to one or many resources or create, delete, and rename resources as defined by the given


### PR DESCRIPTION
- in current Theia, passing "ignored globs" or "limit" to plugins-api from plugins does not work, as the data is dropped before reaching the file search service. This change ensures the data goes through and handled by the service.

Signed-off-by: elaihau <liang.huang@ericsson.com>


- vscode.workspace.findFiles() supports passing either a GlobPattern, undefined, or null to represent the pattern to ignore, while in theia, passing null is not allowed. This change aligned the theia plugin api with that of vscode.

Signed-off-by: elaihau <liang.huang@ericsson.com>