### PR TITLE
Obtain information about selected objects in either explorer or editor

### DIFF
--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -57,6 +57,7 @@ import { PluginDebugSessionContributionRegistry } from './debug/plugin-debug-ses
 import { PluginDebugService } from './debug/plugin-debug-service';
 import { DebugService } from '@theia/debug/lib/common/debug-service';
 import { PluginSharedStyle } from './plugin-shared-style';
+import { SelectionProviderCommandContribution } from './selection-provider-command';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindHostedPluginPreferences(bind);
@@ -67,6 +68,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(HostedPluginWatcher).toSelf().inSingletonScope();
     bind(HostedPluginLogViewer).toSelf().inSingletonScope();
     bind(HostedPluginManagerClient).toSelf().inSingletonScope();
+    bind(SelectionProviderCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(SelectionProviderCommandContribution);
 
     bind(FrontendApplicationContribution).to(HostedPluginInformer).inSingletonScope();
     bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/selection-provider-command.ts
+++ b/packages/plugin-ext/src/main/browser/selection-provider-command.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
+import { inject, injectable } from 'inversify';
+import { UriAwareCommandHandler, UriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import URI from '@theia/core/lib/common/uri';
+import { SelectionService } from '@theia/core';
+import { theiaUritoUriComponents } from '../../common/uri-components';
+
+export namespace SelectionProviderCommands {
+    export const GET_SELECTED_CONTEXT: Command = {
+        id: 'theia.plugin.workspace.selectedContext'
+    };
+}
+
+@injectable()
+export class SelectionProviderCommandContribution implements CommandContribution {
+
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(SelectionProviderCommands.GET_SELECTED_CONTEXT, this.newMultiUriAwareCommandHandler({
+            isEnabled: () => true,
+            isVisible: () => false,
+            execute: (selectedUris: URI[]) => selectedUris.map(uri => theiaUritoUriComponents(uri))
+        }));
+    }
+
+    protected newMultiUriAwareCommandHandler(handler: UriCommandHandler<URI[]>): UriAwareCommandHandler<URI[]> {
+        return new UriAwareCommandHandler(this.selectionService, handler, { multi: true });
+    }
+}


### PR DESCRIPTION
This changes proposal adds new command to have an ability to obtain information (in our case lists of paths) about selected files or directories in editor or explorer view. This code is needed for task plugin which implements besides theia.

Related issue: #4043 