### PR TITLE
Add schema support for tasks.json

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -26,6 +26,7 @@ import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { TaskContribution, TaskResolverRegistry, TaskProviderRegistry } from './task-contribution';
 import { TaskService } from './task-service';
 import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
+import { TaskSchemaUpdater } from './task-schema-updater';
 
 export namespace TaskCommands {
     const TASK_CATEGORY = 'Task';
@@ -74,6 +75,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     @inject(TaskService)
     protected readonly taskService: TaskService;
 
+    @inject(TaskSchemaUpdater)
+    protected readonly schemaUpdater: TaskSchemaUpdater;
+
     onStart(): void {
         this.contributionProvider.getContributions().forEach(contrib => {
             if (contrib.registerResolvers) {
@@ -83,6 +87,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
                 contrib.registerProviders(this.taskProviderRegistry);
             }
         });
+        this.schemaUpdater.update();
     }
 
     registerCommands(registry: CommandRegistry): void {

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -27,6 +27,7 @@ import { createCommonBindings } from '../common/task-common-module';
 import { TaskServer, taskPath } from '../common/task-protocol';
 import { TaskWatcher } from '../common/task-watcher';
 import { bindProcessTaskModule } from './process/process-task-frontend-module';
+import { TaskSchemaUpdater } from './task-schema-updater';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();
@@ -50,6 +51,7 @@ export default new ContainerModule(bind => {
     bind(TaskProviderRegistry).toSelf().inSingletonScope();
     bind(TaskResolverRegistry).toSelf().inSingletonScope();
     bindContributionProvider(bind, TaskContribution);
+    bind(TaskSchemaUpdater).toSelf().inSingletonScope();
 
     bindProcessTaskModule(bind);
 });

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -1,0 +1,118 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { injectable, inject } from 'inversify';
+import { JsonSchemaStore } from '@theia/core/lib/browser/json-schema-store';
+import { InMemoryResources, deepClone } from '@theia/core/lib/common';
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import URI from '@theia/core/lib/common/uri';
+import { TaskService } from './task-service';
+
+@injectable()
+export class TaskSchemaUpdater {
+    @inject(JsonSchemaStore)
+    protected readonly jsonSchemaStore: JsonSchemaStore;
+
+    @inject(InMemoryResources)
+    protected readonly inmemoryResources: InMemoryResources;
+
+    @inject(TaskService)
+    protected readonly taskService: TaskService;
+
+    async update(): Promise<void> {
+
+        const taskSchema = {
+            properties: {
+                tasks: {
+                    type: 'array',
+                    items: {
+                        ...deepClone(taskConfigurationSchema)
+                    }
+                }
+            }
+        };
+        const taskTypes = await this.taskService.getRegisteredTaskTypes();
+        taskSchema.properties.tasks.items.oneOf![0].allOf![0].properties!.type.enum = taskTypes;
+        const taskSchemaUrl = new URI('vscode://task/tasks.json');
+        const contents = JSON.stringify(taskSchema);
+        try {
+            this.inmemoryResources.update(taskSchemaUrl, contents);
+        } catch (e) {
+            this.inmemoryResources.add(taskSchemaUrl, contents);
+            this.jsonSchemaStore.registerSchema({
+                fileMatch: ['tasks.json'],
+                url: taskSchemaUrl.toString()
+            });
+        }
+    }
+}
+
+const taskConfigurationSchema: IJSONSchema = {
+    oneOf: [
+        {
+            'allOf': [
+                {
+                    type: 'object',
+                    required: ['type', 'label'],
+                    properties: {
+                        label: {
+                            type: 'string',
+                            description: 'A unique string that identifies the task that is also used as task\'s user interface label'
+                        },
+                        type: {
+                            type: 'string',
+                            enum: ['shell', 'process'],
+                            default: 'shell',
+                            description: 'Determines what type of process will be used to execute the task. Only shell types will have output shown on the user interface'
+                        },
+                        cwd: {
+                            type: 'string',
+                            description: 'The directory in which the command will be executed'
+                        },
+                        command: {
+                            type: 'string',
+                            description: 'The actual command or script to execute'
+                        },
+                        args: {
+                            type: 'array',
+                            description: 'A list of strings, each one being one argument to pass to the command',
+                            items: {
+                                type: 'string'
+                            }
+                        },
+                        windows: {
+                            type: 'object',
+                            'description': 'Windows specific command configuration overrides command and args',
+                            properties: {
+                                command: {
+                                    type: 'string',
+                                    description: 'The actual command or script to execute'
+                                },
+                                args: {
+                                    type: 'array',
+                                    description: 'A list of strings, each one being one argument to pass to the command',
+                                    items: {
+                                        type: 'string'
+                                    }
+                                },
+                            }
+                        }
+
+                    }
+                }
+            ]
+        }
+    ]
+};

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -155,6 +155,11 @@ export class TaskService implements TaskConfigurationClient {
         return this.taskServer.getTasks(this.getContext());
     }
 
+    /** Returns an array of task types that are registered, including the default types */
+    getRegisteredTaskTypes(): Promise<string[]> {
+        return this.taskServer.getRegisteredTaskTypes();
+    }
+
     /**
      * Get the last executed task.
      *

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -65,6 +65,10 @@ export interface TaskServer extends JsonRpcServer<TaskClient> {
 
     /** removes the client that has disconnected */
     disconnectClient(client: TaskClient): void;
+
+    /** Returns the list of default and registered task runners */
+    getRegisteredTaskTypes(): Promise<string[]>
+
 }
 
 /** Event sent when a task has concluded its execution */

--- a/packages/task/src/node/task-runner.ts
+++ b/packages/task/src/node/task-runner.ts
@@ -63,4 +63,8 @@ export class TaskRunnerRegistry {
         const runner = this.runners.get(type);
         return runner ? runner : this.defaultRunner;
     }
+
+    getRunnerTypes(): string[] {
+        return [...this.runners.keys()];
+    }
 }

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -67,6 +67,10 @@ export class TaskServerImpl implements TaskServer {
         return taskInfo;
     }
 
+    async getRegisteredTaskTypes(): Promise<string[]> {
+        return this.runnerRegistry.getRunnerTypes();
+    }
+
     protected fireTaskExitedEvent(event: TaskExitedEvent) {
         this.logger.debug(log => log('task has exited:', event));
 


### PR DESCRIPTION
Provides configuration assistance for tasks.json.

Adds schema for task configurations. It enhances task-server to be able to collect information about task types.

fixes #1098