### PR TITLE
breakpoint widget focus context should be enabled only when a widget is visible

### DIFF
--- a/packages/debug/src/browser/debug-keybinding-contexts.ts
+++ b/packages/debug/src/browser/debug-keybinding-contexts.ts
@@ -54,7 +54,7 @@ export class BreakpointWidgetInputFocusContext implements KeybindingContext {
 
     isEnabled(): boolean {
         const model = this.editors.model;
-        return !!model && this.isFocused(model);
+        return !!model && !!model.breakpointWidget.position && this.isFocused(model);
     }
 
     protected isFocused(model: DebugEditorModel): boolean {


### PR DESCRIPTION
fix #4443