### PR TITLE
Update tabbar padding

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -37,7 +37,7 @@
   height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
   min-width: 35px;
   line-height: var(--theia-private-horizontal-tab-height);
-  padding: 0px 2px 0px 4px;
+  padding: 0px 8px;
   background: var(--theia-layout-color3);
 }
 
@@ -94,6 +94,7 @@
   line-height: 1.7;
 }
 
+
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
   padding-top: 6px;
   padding-left: 10px;
@@ -103,6 +104,11 @@
   background-position: center;
   background-repeat: no-repeat;
 }
+
+.p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable {
+  padding-right: 2px;
+}
+
 
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable:hover > .p-TabBar-tabCloseIcon,
 .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-current > .p-TabBar-tabCloseIcon {


### PR DESCRIPTION
- Fixes issue addressed by the following comment https://github.com/theia-ide/theia/pull/4420#issuecomment-468263493
- Reset the general tab padding to `8px`.
- Adjust the tab padding of `closable` tabs.

<div align='center'>

![screenshot from 2019-02-28 09-04-09](https://user-images.githubusercontent.com/40359487/53572100-72199f80-3b38-11e9-8d94-35076e00985a.png)


</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
