### PR TITLE
Remove global buttons styling in Theia core

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -109,7 +109,7 @@ body {
     border: none;
 }
 
-button, .theia-button {
+button.theia-button, .theia-button {
     border: none;
     color: var(--theia-ui-button-font-color);
     background-color: var(--theia-ui-button-color);
@@ -126,7 +126,7 @@ button, .theia-button {
     transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-button:hover, .theia-button:hover {
+button.theia-button:hover, .theia-button:hover {
   background-color: var(--theia-ui-button-color-hover);
 }
 
@@ -139,7 +139,7 @@ button.secondary:hover, .theia-button.secondary:hover {
   background-color: var(--theia-ui-button-color-secondary-hover);
 }
 
-button[disabled], .theia-button[disabled] {
+button.theia-button[disabled], .theia-button[disabled] {
   opacity: 0.6;
   color: var(--theia-ui-button-font-color-disabled);
   background-color: var(--theia-ui-button-color-disabled);


### PR DESCRIPTION
Fix #4430 by applying Theia style only for .theia-button instead of all buttons

Signed-off-by: Simon Delisle <simon.delisle@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
