### PR TITLE
Fix configuration contribution and workspace.getWorkspaceFolder implementation

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -156,6 +156,9 @@ export class HostedPluginReader implements BackendApplicationContribution {
             }
             return result;
         }
+        if (value === null) {
+            return value;
+        }
         if (typeof value === 'object') {
             const result: { [key: string]: any } = {};
             // tslint:disable-next-line:forin

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -355,7 +355,7 @@ export function createAPIFactory(
         };
 
         const workspace: typeof theia.workspace = {
-            get rootPath(): string | undefined {
+            get rootPath(): string | undefined {
                 return workspaceExt.rootPath;
             },
             get workspaceFolders(): theia.WorkspaceFolder[] | undefined {
@@ -430,7 +430,7 @@ export function createAPIFactory(
                 // FIXME: to implement
                 return new Disposable(() => { });
             },
-            getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | Uri | undefined {
+            getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | undefined {
                 return workspaceExt.getWorkspaceFolder(uri);
             },
             asRelativePath(pathOrUri: theia.Uri | string, includeWorkspace?: boolean): string | undefined {

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -33,6 +33,7 @@ import URI from 'vscode-uri';
 import { FileStat } from '@theia/filesystem/lib/common';
 import { normalize } from '../common/paths';
 import { relative } from '../common/paths-util';
+import { toWorkspaceFolder } from './type-converters';
 
 export class WorkspaceExtImpl implements WorkspaceExt {
 
@@ -198,7 +199,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
         return undefined;
     }
 
-    getWorkspaceFolder(uri: theia.Uri, resolveParent?: boolean): theia.WorkspaceFolder | URI | undefined {
+    getWorkspaceFolder(uri: theia.Uri, resolveParent?: boolean): theia.WorkspaceFolder | undefined {
         if (!this.folders || !this.folders.length) {
             return undefined;
         }
@@ -224,8 +225,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
             const folderPath = folder.uri.toString();
 
             if (resourcePath === folderPath) {
-                // return the input when the given uri is a workspace folder itself
-                return uri;
+                return toWorkspaceFolder(folder);
             }
 
             if (resourcePath.startsWith(folderPath)


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do
* Keep default `null` value of configuration properties (they were treated as `object` and converted to `{}`)
* `workspace.getWorkspaceFolder` implementation returns either WorkspaceFolder or undefined

[1] https://github.com/Microsoft/vscode/blob/1.31.1/src/vs/vscode.d.ts#L7387