### PR TITLE
don't pass user message actions over RPC

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -250,16 +250,19 @@ export interface PickOpenItem {
     picked?: boolean;
 }
 
+export enum MainMessageType {
+    Error,
+    Warning,
+    Info
+}
+
+export interface MainMessageOptions {
+    modal?: boolean
+    onCloseActionHandle?: number
+}
+
 export interface MessageRegistryMain {
-    $showInformationMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
-    $showWarningMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
-    $showErrorMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined>;
+    $showMessage(type: MainMessageType, message: string, options: MainMessageOptions, actions: string[]): PromiseLike<number | undefined>;
 }
 
 export interface StatusBarMessageRegistryMain {

--- a/packages/plugin-ext/src/main/browser/message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/message-registry-main.ts
@@ -15,9 +15,8 @@
  ********************************************************************************/
 
 import { interfaces } from 'inversify';
-import * as theia from '@theia/plugin';
 import { MessageService } from '@theia/core/lib/common/message-service';
-import { MessageRegistryMain } from '../../api/plugin-api';
+import { MessageRegistryMain, MainMessageType, MainMessageOptions } from '../../api/plugin-api';
 import { ModalNotification, MessageType } from './dialogs/modal-notification';
 
 export class MessageRegistryMainImpl implements MessageRegistryMain {
@@ -27,83 +26,29 @@ export class MessageRegistryMainImpl implements MessageRegistryMain {
         this.messageService = container.get(MessageService);
     }
 
-    $showInformationMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined> {
-        return this.showMessage(MessageType.Info, message, optionsOrFirstItem, ...items);
+    async $showMessage(type: MainMessageType, message: string, options: MainMessageOptions, actions: string[]): Promise<number | undefined> {
+        const action = await this.doShowMessage(type, message, options, actions);
+        const handle = action ? actions.indexOf(action) : undefined;
+        return handle === undefined && options.modal ? options.onCloseActionHandle : handle;
     }
 
-    $showWarningMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined> {
-        return this.showMessage(MessageType.Warning, message, optionsOrFirstItem, ...items);
-    }
-
-    $showErrorMessage(message: string,
-        optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-        items: string[] | theia.MessageItem[]): PromiseLike<string | theia.MessageItem | undefined> {
-        return this.showMessage(MessageType.Error, message, optionsOrFirstItem, ...items);
-    }
-
-    // tslint:disable-next-line:no-any
-    protected showMessage(type: MessageType, message: string, ...args: any[]): PromiseLike<string | theia.MessageItem | undefined> {
-        // tslint:disable-next-line:no-any
-        const actionsMap = new Map<string, any>();
-        const actionTitles: string[] = [];
-        const options: theia.MessageOptions = { modal: false };
-
-        let onCloseAction: string;
-        if (!!args && args.length > 0) {
-            const first = args[0];
-            if (first && first.modal) {
-                options.modal = true;
-            }
-            args.forEach(arg => {
-                if (!arg) {
-                    return;
-                }
-                let actionTitle: string;
-                if (typeof arg === 'string') {
-                    actionTitle = arg;
-                } else if (arg.title) {
-                    actionTitle = arg.title;
-                    actionsMap.set(actionTitle, arg);
-                    if (arg.isCloseAffordance) {
-                        onCloseAction = arg.title;
-                    }
-                } else {
-                    return;
-                }
-                actionTitles.push(actionTitle);
-            });
+    protected async doShowMessage(type: MainMessageType, message: string, options: MainMessageOptions, actions: string[]): Promise<string | undefined> {
+        if (options.modal) {
+            const messageType = type === MainMessageType.Error ? MessageType.Error :
+                type === MainMessageType.Warning ? MessageType.Warning :
+                    MessageType.Info;
+            const modalNotification = new ModalNotification();
+            return modalNotification.showDialog(messageType, message, actions);
         }
-
-        let promise: Promise<string | undefined>;
-
-        try {
-            if (options.modal) {
-                const modalNotification = new ModalNotification();
-                promise = modalNotification.showDialog(type, message, actionTitles)
-                    .then(result => result !== undefined ? result : onCloseAction);
-            } else {
-                switch (type) {
-                    case MessageType.Info:
-                        promise = this.messageService.info(message, ...actionTitles);
-                        break;
-                    case MessageType.Warning:
-                        promise = this.messageService.warn(message, ...actionTitles);
-                        break;
-                    case MessageType.Error:
-                        promise = this.messageService.error(message, ...actionTitles);
-                        break;
-                    default:
-                        return Promise.reject(new Error(`Message type '${type}' is not supported yet!`));
-                }
-            }
-        } catch (e) {
-            return Promise.reject(e);
+        switch (type) {
+            case MainMessageType.Info:
+                return this.messageService.info(message, ...actions);
+            case MainMessageType.Warning:
+                return this.messageService.warn(message, ...actions);
+            case MainMessageType.Error:
+                return this.messageService.error(message, ...actions);
         }
-
-        return Promise.resolve(promise.then(result => !!result && actionsMap.has(result) ? actionsMap.get(result) : result));
+        throw new Error(`Message type '${type}' is not supported yet!`);
     }
+
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -21,7 +21,7 @@ import { CommandRegistryImpl } from './command-registry';
 import { Emitter } from '@theia/core/lib/common/event';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { QuickOpenExtImpl } from './quick-open';
-import { MAIN_RPC_CONTEXT, Plugin as InternalPlugin, PluginManager, PluginAPIFactory } from '../api/plugin-api';
+import { MAIN_RPC_CONTEXT, Plugin as InternalPlugin, PluginManager, PluginAPIFactory, MainMessageType } from '../api/plugin-api';
 import { RPCProtocol } from '../api/rpc-protocol';
 import { MessageRegistryExt } from './message-registry';
 import { StatusBarMessageRegistryExt } from './status-bar-message-registry';
@@ -195,6 +195,9 @@ export function createAPIFactory(
         };
 
         const { onDidChangeActiveTerminal, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
+        const showInformationMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Info);
+        const showWarningMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Warning);
+        const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Error);
         const window: typeof theia.window = {
             get activeTerminal() {
                 return terminalExt.activeTerminal;
@@ -268,24 +271,9 @@ export function createAPIFactory(
             showWorkspaceFolderPick(options?: theia.WorkspaceFolderPickOptions): PromiseLike<theia.WorkspaceFolder | undefined> {
                 return workspaceExt.pickWorkspaceFolder(options);
             },
-            showInformationMessage(message: string,
-                optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-                // tslint:disable-next-line:no-any
-                ...items: any[]): PromiseLike<any> {
-                return messageRegistryExt.showInformationMessage(message, optionsOrFirstItem, items);
-            },
-            showWarningMessage(message: string,
-                optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-                // tslint:disable-next-line:no-any
-                ...items: any[]): PromiseLike<any> {
-                return messageRegistryExt.showWarningMessage(message, optionsOrFirstItem, items);
-            },
-            showErrorMessage(message: string,
-                optionsOrFirstItem: theia.MessageOptions | string | theia.MessageItem,
-                // tslint:disable-next-line:no-any
-                ...items: any[]): PromiseLike<any> {
-                return messageRegistryExt.showErrorMessage(message, optionsOrFirstItem, items);
-            },
+            showInformationMessage,
+            showWarningMessage,
+            showErrorMessage,
             showOpenDialog(options: theia.OpenDialogOptions): PromiseLike<Uri[] | undefined> {
                 return dialogsExt.showOpenDialog(options);
             },


### PR DESCRIPTION
fix #4455

Before user actions were passed over RPC, losing user data on the way. With this PR only minimal required information is passed and user action is preserved.

An example of a broken client before:
https://github.com/Microsoft/vscode-go/blob/7e79ee4f4aaf796e10d1a8246e217a9d6b6264fc/src/goInstallTools.ts#L466-L487