### PR TITLE
Fix changing of cpp build configuration

### DIFF
--- a/packages/cpp/src/browser/cpp-language-client-contribution.ts
+++ b/packages/cpp/src/browser/cpp-language-client-contribution.ts
@@ -89,10 +89,11 @@ export class CppLanguageClientContribution extends BaseLanguageClientContributio
     }
 
     async onActiveBuildConfigChanged(config: CppBuildConfiguration | undefined) {
-        // Restart clangd.  The new config will be picked up when
-        // createOptions will be called to send the initialize request
-        // to the new instance of clangd.
+        // Override the initializationOptions to put the new path to the build,
+        // then restart clangd.
         if (this.running) {
+            const lc = await this.languageClient;
+            lc.clientOptions.initializationOptions = this.createClangdConfigurationParams(config);
             this.restart();
         }
     }


### PR DESCRIPTION
Previously, to change build configuration, we were relying on the fact
that calling "this.restart()" in onActiveBuildConfigChanged would cause
a new LanguageClient to be instantiated.  This would call
createOptions(), where we would return new value of
compilationDatabasePath in the initializationOptions that are sent to
clangd.

However, since commit bfb235a0d7b ("[languages] fix leaking language
clients"), this.restart() does not create a new client, it re-uses the
existing one.  createOptions is not called and the old setting of
compilationDatabasePath is sent to clangd.  Therefore, the new build
configuration does not take effect.

This patch fixes it locally in the cpp package: we now go overwrite the
initializationOptions in the existing LanguageClient object, so that the
new value will be picked up when call restart.

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
