### PR TITLE
GH-4461: From now on, no `electron-store` will be created by the workers

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -126,13 +126,15 @@ const electron = require('electron');
 const { join, resolve } = require('path');
 const { isMaster } = require('cluster');
 const { fork } = require('child_process');
-const Storage = require('electron-store');
-const electronStore = new Storage();
 const { app, shell, BrowserWindow, ipcMain, Menu } = electron;
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
 
 if (isMaster) {
+
+    const Storage = require('electron-store');
+    const electronStore = new Storage();
+
     app.on('ready', () => {
         const { screen } = electron;
 


### PR DESCRIPTION
Having one for the `isMaster` process is sufficient.

Closes: #4461

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----
For reviewers: #4370 was most likely tested and verified in debug mode, [without the clusters](https://github.com/theia-ide/theia/blob/6381e063982ac87755e69fa5851cbe57b902d12f/.vscode/launch.json#L32).