### PR TITLE
Save cycle fixes

### DIFF
--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -288,6 +288,11 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'default': false,
             'description': 'Enable format on manual save.'
         },
+        'editor.formatOnSaveTimeout': {
+            'type': 'number',
+            'default': 750,
+            'description': 'Timeout in milliseconds after which the formatting that is run on file save is cancelled.'
+        },
         'editor.formatOnType': {
             'type': 'boolean',
             'default': false,
@@ -560,7 +565,8 @@ export interface EditorConfiguration {
     'editor.autoClosingBrackets'?: boolean
     'editor.autoIndent'?: boolean
     'editor.formatOnType'?: boolean
-    'editor.formatOnSave'?: boolean
+    'editor.formatOnSave': boolean
+    'editor.formatOnSaveTimeout': number
     'editor.formatOnPaste'?: boolean
     'editor.dragAndDrop'?: boolean
     'editor.suggestOnTriggerCharacters'?: boolean

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -54,7 +54,8 @@ export class DocumentsMainImpl implements DocumentsMain {
             this.proxy.$acceptModelSaved(m.textEditorModel.uri);
         }));
         this.toDispose.push(modelService.onModelWillSave(onWillSaveModelEvent => {
-            onWillSaveModelEvent.waitUntil(new Promise<monaco.editor.IIdentifiedSingleEditOperation[]>(async resolve => {
+            onWillSaveModelEvent.waitUntil(new Promise<monaco.editor.IIdentifiedSingleEditOperation[]>(async (resolve, reject) => {
+                setTimeout(() => reject(new Error('Aborted onWillSaveTextDocument-event after 1750ms')), 1750);
                 const edits = await this.proxy.$acceptModelWillSave(onWillSaveModelEvent.model.textEditorModel.uri, onWillSaveModelEvent.reason);
                 const transformedEdits = edits.map((edit): monaco.editor.IIdentifiedSingleEditOperation =>
                 ({

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -81,34 +81,70 @@ export class DocumentsExtImpl implements DocumentsExt {
             this._onDidSaveTextDocument.fire(data.document);
         }
     }
-    $acceptModelWillSave(strUrl: UriComponents, reason: theia.TextDocumentSaveReason): Promise<SingleEditOperation[]> {
-        return new Promise<SingleEditOperation[]>((resolve, reject) => {
-            const uri = URI.revive(strUrl);
-            const uriString = uri.toString();
-            const data = this.editorsAndDocuments.getDocument(uriString);
-            if (data) {
-                const onWillSaveEvent: theia.TextDocumentWillSaveEvent = {
-                    document: data.document,
-                    reason: reason,
-                    /* tslint:disable:no-any */
-                    waitUntil: async (editsPromise: PromiseLike<theia.TextEdit[] | any>) => {
-                        const editsObjs = await editsPromise;
-                        if (this.isTextEditArray(editsObjs)) {
-                            const editOperations: SingleEditOperation[] = (editsObjs as theia.TextEdit[]).map(textEdit => Converter.fromTextEdit(textEdit));
-                            resolve(editOperations);
-                        } else {
-                            resolve([]);
-                        }
+
+    async $acceptModelWillSave(strUrl: UriComponents, reason: theia.TextDocumentSaveReason): Promise<SingleEditOperation[]> {
+        const uri = URI.revive(strUrl).toString();
+        const operations: SingleEditOperation[] = [];
+        let didTimeout = false;
+        const didTimeoutHandle = setTimeout(() => didTimeout = true, 1500);
+        try {
+            await this._onWillSaveTextDocument.sequence(async fireEvent => {
+                if (didTimeout) {
+                    return false;
+                }
+                try {
+                    const documentData = this.editorsAndDocuments.getDocument(uri);
+                    if (documentData) {
+                        const { document } = documentData;
+                        await this.fireTextDocumentWillSaveEvent({
+                            document, reason, fireEvent,
+                            accept: operation => operations.push(operation)
+                        });
                     }
-                };
-                this._onWillSaveTextDocument.fire(onWillSaveEvent);
-            }
-        });
+                } catch (e) {
+                    console.error(e);
+                }
+                return !didTimeout;
+            });
+        } finally {
+            clearTimeout(didTimeoutHandle);
+        }
+        return operations;
     }
 
-    isTextEditArray(obj: any): obj is theia.TextEdit[] {
-        return Array.isArray(obj) && obj.every((elem: any) => TextEdit.isTextEdit(elem));
+    // tslint:disable:no-any
+    protected async fireTextDocumentWillSaveEvent({
+        document, reason, fireEvent, accept
+    }: {
+            document: theia.TextDocument,
+            reason: theia.TextDocumentSaveReason,
+            fireEvent: (e: theia.TextDocumentWillSaveEvent) => any,
+            accept: (operation: SingleEditOperation) => void
+        }): Promise<void> {
+
+        const promises: PromiseLike<TextEdit[] | any>[] = [];
+        fireEvent(Object.freeze({
+            document, reason,
+            waitUntil(p: PromiseLike<TextEdit[] | any>) {
+                if (Object.isFrozen(promises)) {
+                    throw new Error('waitUntil can not be called async');
+                }
+                promises.push(p);
+            }
+        }));
+        Object.freeze(promises);
+
+        await Promise.all(promises).then(allEdits => allEdits.forEach(edits => {
+            if (Array.isArray(edits)) {
+                edits.forEach(edit => {
+                    if (TextEdit.isTextEdit(edit)) {
+                        accept(Converter.fromTextEdit(edit));
+                    }
+                });
+            }
+        }));
     }
+    // tslint:enable:no-any
 
     $acceptDirtyStateChanged(strUrl: UriComponents, isDirty: boolean): void {
         const uri = URI.revive(strUrl);


### PR DESCRIPTION
- align timeouts with VS Code: there is no general timeout anymore, each participant should take care, i.e. format on save, plugin host
- properly fire onWillSaveTextDocument event in the plugin host process, before it will resolve only for first listener or never resolve if there are no participants

fix #4463 