### PR TITLE
'workspace.openTextDocument' API should take into account the contributed FileSystemProviders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.4.1
+- [plugin] `workspace.openTextDocument` API now respects the contributed `FileSystemProviders`
+
 ## v0.4.0
 - [application-manager] added support for pre-load HTML templates
 - [console] added support for console `when` contexts

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -991,6 +991,16 @@ export interface DebugMain {
     $customRequest(sessionId: string, command: string, args?: any): Promise<DebugProtocol.Response>;
 }
 
+export interface FileSystemExt {
+    $readFile(handle: number, resource: UriComponents, options?: { encoding?: string }): Promise<string>;
+    $writeFile(handle: number, resource: UriComponents, content: string, options?: { encoding?: string }): Promise<void>;
+}
+
+export interface FileSystemMain {
+    $registerFileSystemProvider(handle: number, scheme: string): void;
+    $unregisterProvider(handle: number): void;
+}
+
 export const PLUGIN_RPC_CONTEXT = {
     COMMAND_REGISTRY_MAIN: <ProxyIdentifier<CommandRegistryMain>>createProxyIdentifier<CommandRegistryMain>('CommandRegistryMain'),
     QUICK_OPEN_MAIN: createProxyIdentifier<QuickOpenMain>('QuickOpenMain'),
@@ -1012,7 +1022,8 @@ export const PLUGIN_RPC_CONTEXT = {
     STORAGE_MAIN: createProxyIdentifier<StorageMain>('StorageMain'),
     TASKS_MAIN: createProxyIdentifier<TasksMain>('TasksMain'),
     LANGUAGES_CONTRIBUTION_MAIN: createProxyIdentifier<LanguagesContributionMain>('LanguagesContributionMain'),
-    DEBUG_MAIN: createProxyIdentifier<DebugMain>('DebugMain')
+    DEBUG_MAIN: createProxyIdentifier<DebugMain>('DebugMain'),
+    FILE_SYSTEM_MAIN: createProxyIdentifier<FileSystemMain>('FileSystemMain')
 };
 
 export const MAIN_RPC_CONTEXT = {
@@ -1034,7 +1045,8 @@ export const MAIN_RPC_CONTEXT = {
     STORAGE_EXT: createProxyIdentifier<StorageExt>('StorageExt'),
     TASKS_EXT: createProxyIdentifier<TasksExt>('TasksExt'),
     LANGUAGES_CONTRIBUTION_EXT: createProxyIdentifier<LanguagesContributionExt>('LanguagesContributionExt'),
-    DEBUG_EXT: createProxyIdentifier<DebugExt>('DebugExt')
+    DEBUG_EXT: createProxyIdentifier<DebugExt>('DebugExt'),
+    FILE_SYSTEM_EXT: createProxyIdentifier<FileSystemExt>('FileSystemExt')
 };
 
 export interface TasksExt {

--- a/packages/plugin-ext/src/common/uri-components.ts
+++ b/packages/plugin-ext/src/common/uri-components.ts
@@ -27,8 +27,22 @@ export interface UriComponents {
 
 // some well known URI schemas
 export namespace Schemes {
-    export const File = 'file';
-    export const Untitled = 'untitled';
+    export const FILE = 'file';
+    export const UNTITLED = 'untitled';
+    export const HTTP: string = 'http';
+    export const HTTPS: string = 'https';
+    export const MAILTO: string = 'mailto';
+    export const DATA: string = 'data';
+    /**
+     * A schema is used for models that exist in memory
+     * only and that have no correspondence on a server or such.
+     */
+    export const IN_MEMORY: string = 'inmemory';
+    /** A schema is used for settings files. */
+    export const VSCODE: string = 'vscode';
+    /** A schema is used for internal private files. */
+    export const INTERNAL: string = 'private';
+    export const COMMAND: string = 'command';
 }
 
 export function theiaUritoUriComponents(uri: URI): UriComponents {

--- a/packages/plugin-ext/src/main/browser/editor/untitled-resource.ts
+++ b/packages/plugin-ext/src/main/browser/editor/untitled-resource.ts
@@ -17,18 +17,17 @@
 import { ResourceResolver, Resource } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { injectable } from 'inversify';
-import { Schemes } from '../../../common/uri-components';
-import { UriComponents } from '../../../common/uri-components';
+import { UriComponents, Schemes } from '../../../common/uri-components';
 
 const resources = new Map<string, UntitledResource>();
 let index = 0;
 @injectable()
 export class UntitledResourceResolver implements ResourceResolver {
     resolve(uri: URI): Resource | Promise<Resource> {
-        if (uri.scheme === Schemes.Untitled) {
+        if (uri.scheme === Schemes.UNTITLED) {
             return resources.get(uri.toString())!;
         }
-        throw new Error(`scheme ${uri.scheme} is not '${Schemes.Untitled}'`);
+        throw new Error(`scheme ${uri.scheme} is not '${Schemes.UNTITLED}'`);
     }
 }
 
@@ -59,6 +58,6 @@ export function createUntitledResource(content?: string, language?: string): Uri
             }
         }
     }
-    const resource = new UntitledResource(new URI().withScheme(Schemes.Untitled).withPath(`/Untitled-${index++}${extension ? extension : ''}`), content);
+    const resource = new UntitledResource(new URI().withScheme(Schemes.UNTITLED).withPath(`/Untitled-${index++}${extension ? extension : ''}`), content);
     return monaco.Uri.parse(resource.uri.toString());
 }

--- a/packages/plugin-ext/src/main/browser/file-system-main.ts
+++ b/packages/plugin-ext/src/main/browser/file-system-main.ts
@@ -1,0 +1,123 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { interfaces, injectable } from 'inversify';
+import Uri from 'vscode-uri';
+import { Disposable, ResourceResolver, DisposableCollection } from '@theia/core';
+import { Resource } from '@theia/core/lib/common/resource';
+import URI from '@theia/core/lib/common/uri';
+import { MAIN_RPC_CONTEXT, FileSystemMain, FileSystemExt } from '../../api/plugin-api';
+import { RPCProtocol } from '../../api/rpc-protocol';
+
+export class FileSystemMainImpl implements FileSystemMain, Disposable {
+
+    private readonly proxy: FileSystemExt;
+    private readonly resourceResolver: FSResourceResolver;
+    private readonly disposables = new Map<number, Disposable>();
+
+    constructor(rpc: RPCProtocol, container: interfaces.Container) {
+        this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.FILE_SYSTEM_EXT);
+        this.resourceResolver = container.get(FSResourceResolver);
+    }
+
+    async $registerFileSystemProvider(handle: number, scheme: string): Promise<void> {
+        this.disposables.set(handle, await this.resourceResolver.registerResourceProvider(handle, scheme, this.proxy));
+    }
+
+    $unregisterProvider(handle: number): void {
+        const disposable = this.disposables.get(handle);
+        if (disposable) {
+            disposable.dispose();
+            this.disposables.delete(handle);
+        }
+    }
+
+    dispose(): void {
+        this.disposables.forEach(d => d.dispose());
+    }
+}
+
+@injectable()
+export class FSResourceResolver implements ResourceResolver, Disposable {
+
+    // resource providers by schemas
+    private providers = new Map<string, FSResourceProvider>();
+    private toDispose = new DisposableCollection();
+
+    resolve(uri: URI): Resource {
+        const provider = this.providers.get(uri.scheme);
+        if (provider) {
+            return provider.get(uri);
+        }
+        throw new Error(`Unable to find a Resource Provider for scheme '${uri.scheme}'`);
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    registerResourceProvider(handle: number, scheme: string, proxy: FileSystemExt): Disposable {
+        if (this.providers.has(scheme)) {
+            throw new Error(`Resource Provider for scheme '${scheme}' is already registered`);
+        }
+
+        const provider = new FSResourceProvider(handle, proxy);
+        this.providers.set(scheme, provider);
+
+        const disposable = Disposable.create(() => {
+            provider.dispose();
+            this.providers.delete(scheme);
+        });
+        this.toDispose.push(disposable);
+        return disposable;
+    }
+}
+
+class FSResourceProvider implements Disposable {
+
+    private resourceCache = new Map<string, FSResource>();
+
+    constructor(private handle: number, private proxy: FileSystemExt) { }
+
+    get(uri: URI): Resource {
+        let resource = this.resourceCache.get(uri.toString());
+        if (!resource) {
+            resource = new FSResource(this.handle, uri, this.proxy);
+            this.resourceCache.set(uri.toString(), resource);
+        }
+        return resource;
+    }
+
+    dispose(): void {
+        this.resourceCache.clear();
+    }
+}
+
+/** Resource that delegates reading/saving a content to a plugin's FileSystemProvider. */
+export class FSResource implements Resource {
+
+    constructor(private handle: number, public uri: URI, private proxy: FileSystemExt) { }
+
+    readContents(options?: { encoding?: string }): Promise<string> {
+        return this.proxy.$readFile(this.handle, Uri.parse(this.uri.toString()), options);
+    }
+
+    saveContents(content: string, options?: { encoding?: string }): Promise<void> {
+        return this.proxy.$writeFile(this.handle, Uri.parse(this.uri.toString()), content, options);
+    }
+
+    dispose() { }
+}

--- a/packages/plugin-ext/src/main/browser/main-context.ts
+++ b/packages/plugin-ext/src/main/browser/main-context.ts
@@ -37,6 +37,7 @@ import { TasksMainImpl } from './tasks-main';
 import { StorageMainImpl } from './plugin-storage';
 import { LanguagesContributionMainImpl } from './languages-contribution-main';
 import { DebugMainImpl } from './debug/debug-main';
+import { FileSystemMainImpl } from './file-system-main';
 
 export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container): void {
     const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
@@ -100,4 +101,6 @@ export function setUpPluginApi(rpc: RPCProtocol, container: interfaces.Container
 
     const debugMain = new DebugMainImpl(rpc, connectionMain, container);
     rpc.set(PLUGIN_RPC_CONTEXT.DEBUG_MAIN, debugMain);
+
+    rpc.set(PLUGIN_RPC_CONTEXT.FILE_SYSTEM_MAIN, new FileSystemMainImpl(rpc, container));
 }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -57,6 +57,7 @@ import { PluginDebugSessionContributionRegistry } from './debug/plugin-debug-ses
 import { PluginDebugService } from './debug/plugin-debug-service';
 import { DebugService } from '@theia/debug/lib/common/debug-service';
 import { PluginSharedStyle } from './plugin-shared-style';
+import { FSResourceResolver } from './file-system-main';
 import { SelectionProviderCommandContribution } from './selection-provider-command';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -125,6 +126,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(TextContentResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(TextContentResourceResolver);
+    bind(FSResourceResolver).toSelf().inSingletonScope();
+    bind(ResourceResolver).toService(FSResourceResolver);
     bindContributionProvider(bind, MainPluginApiProvider);
 
     bind(LanguageClientContributionProviderImpl).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import URI from 'vscode-uri';
+import * as theia from '@theia/plugin';
+import { PLUGIN_RPC_CONTEXT, FileSystemExt, FileSystemMain } from '../api/plugin-api';
+import { RPCProtocol } from '../api/rpc-protocol';
+import { UriComponents, Schemes } from '../common/uri-components';
+import { Disposable } from './types-impl';
+
+export class FileSystemExtImpl implements FileSystemExt {
+
+    private readonly proxy: FileSystemMain;
+    private readonly usedSchemes = new Set<string>();
+    private readonly fsProviders = new Map<number, theia.FileSystemProvider>();
+
+    private handlePool: number = 0;
+
+    constructor(rpc: RPCProtocol) {
+        this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.FILE_SYSTEM_MAIN);
+        this.usedSchemes.add(Schemes.FILE);
+        this.usedSchemes.add(Schemes.UNTITLED);
+        this.usedSchemes.add(Schemes.VSCODE);
+        this.usedSchemes.add(Schemes.IN_MEMORY);
+        this.usedSchemes.add(Schemes.INTERNAL);
+        this.usedSchemes.add(Schemes.HTTP);
+        this.usedSchemes.add(Schemes.HTTPS);
+        this.usedSchemes.add(Schemes.MAILTO);
+        this.usedSchemes.add(Schemes.DATA);
+        this.usedSchemes.add(Schemes.COMMAND);
+    }
+
+    registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider): theia.Disposable {
+        if (this.usedSchemes.has(scheme)) {
+            throw new Error(`A provider for the scheme '${scheme}' is already registered`);
+        }
+
+        const handle = this.handlePool++;
+        this.usedSchemes.add(scheme);
+        this.fsProviders.set(handle, provider);
+
+        this.proxy.$registerFileSystemProvider(handle, scheme);
+
+        return new Disposable(() => {
+            this.usedSchemes.delete(scheme);
+            this.fsProviders.delete(handle);
+            this.proxy.$unregisterProvider(handle);
+        });
+    }
+
+    private checkProviderExists(handle: number): void {
+        if (!this.fsProviders.has(handle)) {
+            const err = new Error();
+            err.name = 'ENOPRO';
+            err.message = 'no provider';
+            throw err;
+        }
+    }
+
+    // forwarding calls
+
+    $readFile(handle: number, resource: UriComponents, options?: { encoding?: string }): Promise<string> {
+        this.checkProviderExists(handle);
+
+        return Promise.resolve(this.fsProviders.get(handle)!.readFile(URI.revive(resource))).then(data => {
+            const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+            const encoding = options === null ? undefined : options && options.encoding;
+            return buffer.toString(encoding);
+        }
+        );
+    }
+
+    $writeFile(handle: number, resource: UriComponents, content: string, options?: { encoding?: string }): Promise<void> {
+        this.checkProviderExists(handle);
+
+        const uri = URI.revive(resource);
+        const encoding = options === null ? undefined : options && options.encoding;
+        const buffer = new Buffer(content, encoding);
+        const opts = { create: true, overwrite: true };
+        return Promise.resolve(this.fsProviders.get(handle)!.writeFile(uri, buffer, opts));
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -97,7 +97,8 @@ import {
     ColorInformation,
     ColorPresentation,
     OperatingSystem,
-    WebviewPanelTargetArea
+    WebviewPanelTargetArea,
+    FileSystemError
 } from './types-impl';
 import { SymbolKind } from '../api/model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -121,6 +122,7 @@ import { ConnectionExtImpl } from './connection-ext';
 import { WebviewsExtImpl } from './webviews';
 import { TasksExtImpl } from './tasks/tasks';
 import { DebugExtImpl } from './node/debug/debug';
+import { FileSystemExtImpl } from './file-system';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -150,6 +152,7 @@ export function createAPIFactory(
     const tasksExt = rpc.set(MAIN_RPC_CONTEXT.TASKS_EXT, new TasksExtImpl(rpc));
     const connectionExt = rpc.set(MAIN_RPC_CONTEXT.CONNECTION_EXT, new ConnectionExtImpl(rpc));
     const languagesContributionExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_CONTRIBUTION_EXT, new LanguagesContributionExtImpl(rpc, connectionExt));
+    const fileSystemExt = rpc.set(MAIN_RPC_CONTEXT.FILE_SYSTEM_EXT, new FileSystemExtImpl(rpc));
     rpc.set(MAIN_RPC_CONTEXT.DEBUG_EXT, debugExt);
 
     return function (plugin: InternalPlugin): typeof theia {
@@ -414,9 +417,8 @@ export function createAPIFactory(
             registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
                 return workspaceExt.registerTextDocumentContentProvider(scheme, provider);
             },
-            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider, options?: { isCaseSensitive?: boolean, isReadonly?: boolean }): theia.Disposable {
-                // FIXME: to implement
-                return new Disposable(() => { });
+            registerFileSystemProvider(scheme: string, provider: theia.FileSystemProvider): theia.Disposable {
+                return fileSystemExt.registerFileSystemProvider(scheme, provider);
             },
             getWorkspaceFolder(uri: theia.Uri): theia.WorkspaceFolder | undefined {
                 return workspaceExt.getWorkspaceFolder(uri);
@@ -705,7 +707,8 @@ export function createAPIFactory(
             FoldingRange,
             FoldingRangeKind,
             OperatingSystem,
-            WebviewPanelTargetArea
+            WebviewPanelTargetArea,
+            FileSystemError
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1221,6 +1221,41 @@ export enum FileChangeType {
     Deleted = 3,
 }
 
+export class FileSystemError extends Error {
+
+    static FileExists(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'EntryExists', FileSystemError.FileExists);
+    }
+    static FileNotFound(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'EntryNotFound', FileSystemError.FileNotFound);
+    }
+    static FileNotADirectory(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'EntryNotADirectory', FileSystemError.FileNotADirectory);
+    }
+    static FileIsADirectory(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'EntryIsADirectory', FileSystemError.FileIsADirectory);
+    }
+    static NoPermissions(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'NoPermissions', FileSystemError.NoPermissions);
+    }
+    static Unavailable(messageOrUri?: string | URI): FileSystemError {
+        return new FileSystemError(messageOrUri, 'Unavailable', FileSystemError.Unavailable);
+    }
+
+    constructor(uriOrMessage?: string | URI, code?: string, terminator?: Function) {
+        super(URI.isUri(uriOrMessage) ? uriOrMessage.toString(true) : uriOrMessage);
+        this.name = code ? `${code} (FileSystemError)` : 'FileSystemError';
+
+        if (typeof Object.setPrototypeOf === 'function') {
+            Object.setPrototypeOf(this, FileSystemError.prototype);
+        }
+
+        if (typeof Error.captureStackTrace === 'function' && typeof terminator === 'function') {
+            Error.captureStackTrace(this, terminator);
+        }
+    }
+}
+
 export enum FileType {
     Unknown = 0,
     File = 1,

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -33,6 +33,7 @@ import URI from 'vscode-uri';
 import { FileStat } from '@theia/filesystem/lib/common';
 import { normalize } from '../common/paths';
 import { relative } from '../common/paths-util';
+import { Schemes } from '../common/uri-components';
 import { toWorkspaceFolder } from './type-converters';
 
 export class WorkspaceExtImpl implements WorkspaceExt {
@@ -156,7 +157,10 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     registerTextDocumentContentProvider(scheme: string, provider: theia.TextDocumentContentProvider): theia.Disposable {
-        if (scheme === 'file' || scheme === 'untitled' || this.documentContentProviders.has(scheme)) {
+        // `file` and `untitled` schemas are reserved by `workspace.openTextDocument` API:
+        // `file`-scheme for opening a file
+        // `untitled`-scheme for opening a new file that should be saved
+        if (scheme === Schemes.FILE || scheme === Schemes.UNTITLED || this.documentContentProviders.has(scheme)) {
             throw new Error(`Text Content Document Provider for scheme '${scheme}' is already registered`);
         }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -3661,6 +3661,60 @@ declare module '@theia/plugin' {
         size: number;
     }
 
+	/**
+	 * A type that filesystem providers should use to signal errors.
+	 *
+	 * This class has factory methods for common error-cases, like `EntryNotFound` when
+	 * a file or folder doesn't exist, use them like so: `throw vscode.FileSystemError.EntryNotFound(someUri);`
+	 */
+	export class FileSystemError extends Error {
+
+		/**
+		 * Create an error to signal that a file or folder wasn't found.
+		 * @param messageOrUri Message or uri.
+		 */
+		static FileNotFound(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Create an error to signal that a file or folder already exists, e.g. when
+		 * creating but not overwriting a file.
+		 * @param messageOrUri Message or uri.
+		 */
+		static FileExists(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Create an error to signal that a file is not a folder.
+		 * @param messageOrUri Message or uri.
+		 */
+		static FileNotADirectory(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Create an error to signal that a file is a folder.
+		 * @param messageOrUri Message or uri.
+		 */
+		static FileIsADirectory(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Create an error to signal that an operation lacks required permissions.
+		 * @param messageOrUri Message or uri.
+		 */
+		static NoPermissions(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Create an error to signal that the file system is unavailable or too busy to
+		 * complete a request.
+		 * @param messageOrUri Message or uri.
+		 */
+		static Unavailable(messageOrUri?: string | Uri): FileSystemError;
+
+		/**
+		 * Creates a new filesystem error.
+		 *
+		 * @param messageOrUri Message or uri.
+		 */
+		constructor(messageOrUri?: string | Uri);
+	}
+
     /**
      * Enumeration of file change types.
      */


### PR DESCRIPTION
The PR adds partial support of `workspace.registerFileSystemProvider` API, namely `workspace.openTextDocument` API now takes into account all the contributed `FileSystemProviders`. So a text document content can be fetched/written through a corresponding `FileSystemProvider` depending on the file URL scheme.

The sample plugin demonstrates the feature https://github.com/eclipse/che-theia-samples/pull/31
