### PR TITLE
[preferences] fix preferences circular dependency

### DIFF
--- a/packages/core/src/browser/preferences/index.ts
+++ b/packages/core/src/browser/preferences/index.ts
@@ -18,3 +18,4 @@ export * from './preference-service';
 export * from './preference-proxy';
 export * from './preference-contribution';
 export * from './preference-provider';
+export * from './preference-scope';

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -17,7 +17,7 @@
 import * as Ajv from 'ajv';
 import { inject, injectable, interfaces, named, postConstruct } from 'inversify';
 import { ContributionProvider, bindContributionProvider, escapeRegExpCharacters, Emitter, Event } from '../../common';
-import { PreferenceScope } from './preference-service';
+import { PreferenceScope } from './preference-scope';
 import { PreferenceProvider, PreferenceProviderPriority, PreferenceProviderDataChange } from './preference-provider';
 
 // tslint:disable:no-any

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -19,7 +19,7 @@
 import { injectable } from 'inversify';
 import { Disposable, DisposableCollection, Emitter, Event } from '../../common';
 import { Deferred } from '../../common/promise-util';
-import { PreferenceScope } from './preference-service';
+import { PreferenceScope } from './preference-scope';
 
 export namespace PreferenceProviderPriority {
     export const NA = -1;

--- a/packages/core/src/browser/preferences/preference-scope.ts
+++ b/packages/core/src/browser/preferences/preference-scope.ts
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable:no-any
+
+export enum PreferenceScope {
+    Default,
+    User,
+    Workspace,
+    Folder
+}
+
+export namespace PreferenceScope {
+    export function is(scope: any): scope is PreferenceScope {
+        return typeof scope === 'number' && getScopes().findIndex(s => s === scope) >= 0;
+    }
+
+    export function getScopes(): PreferenceScope[] {
+        return Object.keys(PreferenceScope)
+            .filter(k => typeof PreferenceScope[k as any] === 'string')
+            .map(v => <PreferenceScope>Number(v));
+    }
+
+    export function getReversedScopes(): PreferenceScope[] {
+        return getScopes().reverse();
+    }
+
+    export function getScopeNames(scope?: PreferenceScope): string[] {
+        const names: string[] = [];
+        const allNames = Object.keys(PreferenceScope)
+            .filter(k => typeof PreferenceScope[k as any] === 'number');
+        if (scope) {
+            for (const name of allNames) {
+                if ((<any>PreferenceScope)[name] <= scope) {
+                    names.push(name);
+                }
+            }
+        }
+        return names;
+    }
+
+    export function fromString(strScope: string): PreferenceScope | undefined {
+        switch (strScope) {
+            case 'application':
+                return PreferenceScope.User;
+            case 'window':
+                return PreferenceScope.Workspace;
+            case 'resource':
+                return PreferenceScope.Folder;
+        }
+    }
+}

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -24,54 +24,9 @@ import { Deferred } from '../../common/promise-util';
 import { PreferenceProvider, PreferenceProviderDataChange, PreferenceProviderDataChanges } from './preference-provider';
 import { PreferenceSchemaProvider, OverridePreferenceName } from './preference-contribution';
 import URI from '../../common/uri';
+import { PreferenceScope } from './preference-scope';
 
-export enum PreferenceScope {
-    Default,
-    User,
-    Workspace,
-    Folder
-}
-
-export namespace PreferenceScope {
-    export function is(scope: any): scope is PreferenceScope {
-        return typeof scope === 'number' && getScopes().findIndex(s => s === scope) >= 0;
-    }
-
-    export function getScopes(): PreferenceScope[] {
-        return Object.keys(PreferenceScope)
-            .filter(k => typeof PreferenceScope[k as any] === 'string')
-            .map(v => <PreferenceScope>Number(v));
-    }
-
-    export function getReversedScopes(): PreferenceScope[] {
-        return getScopes().reverse();
-    }
-
-    export function getScopeNames(scope?: PreferenceScope): string[] {
-        const names: string[] = [];
-        const allNames = Object.keys(PreferenceScope)
-            .filter(k => typeof PreferenceScope[k as any] === 'number');
-        if (scope) {
-            for (const name of allNames) {
-                if ((<any>PreferenceScope)[name] <= scope) {
-                    names.push(name);
-                }
-            }
-        }
-        return names;
-    }
-
-    export function fromString(strScope: string): PreferenceScope | undefined {
-        switch (strScope) {
-            case 'application':
-                return PreferenceScope.User;
-            case 'window':
-                return PreferenceScope.Workspace;
-            case 'resource':
-                return PreferenceScope.Folder;
-        }
-    }
-}
+export { PreferenceScope };
 
 export interface PreferenceChange {
     readonly preferenceName: string;

--- a/packages/core/src/browser/preferences/test/mock-preference-provider.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-provider.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { PreferenceProvider, PreferenceProviderPriority } from '../';
-import { PreferenceScope } from '../preference-service';
+import { PreferenceScope } from '../preference-scope';
 
 @injectable()
 export class MockPreferenceProvider extends PreferenceProvider {


### PR DESCRIPTION
Fix circular dependencies present in `@theia/core/preferences` which affect the following files:
1. `preference-contribution`
2. `preference-provider`
3. `preference-service`

The issue is that all three files made use of `PreferenceScope` which was present in the 
`preference-service`. The fix includes moving both the `PreferenceScope` interface and namespace to a seperate file so that the coupling is avoided.

Circular dependencies are generally bad for a number of reasons including coupling,
prevent static linking and affect dependency injection among other reasons.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
