### PR TITLE
Use correct arguments in diff command handler

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -70,9 +70,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand(VscodeCommands.DIFF, {
             isVisible: () => false,
             // tslint:disable-next-line: no-any
-            execute: async uris => {
-                const [left, right] = uris;
-                await this.diffService.openDiffEditor(left, right);
+            execute: async (left: URI, right: URI) => {
+                await this.diffService.openDiffEditor(new TheiaURI(left), new TheiaURI(right));
             }
         });
 


### PR DESCRIPTION
This changes proposal fix the problem with incorrect using of arguments that pass into command handler during call `vscode.diff` command.

![kube-diff](https://user-images.githubusercontent.com/1968177/53870707-6b40d000-4003-11e9-8e44-170ef590034e.gif)

Related issue: https://github.com/eclipse/che/issues/12747

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
