### PR TITLE
install vscode extensions from npm tarballs

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-directory-handler.ts
@@ -29,7 +29,7 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
 
     accept(plugin: PluginDeployerEntry): boolean {
         console.debug(`Resolving "${plugin.id()}" as a VS Code extension...`);
-        return this.resolvePackage(plugin) || this.resolveFromSources(plugin) || this.resolveFromVSIX(plugin);
+        return this.resolvePackage(plugin) || this.resolveFromSources(plugin) || this.resolveFromVSIX(plugin) || this.resolveFromNpmTarball(plugin);
     }
 
     async handle(context: PluginDeployerDirectoryHandlerContext): Promise<void> {
@@ -46,6 +46,11 @@ export class PluginVsCodeDirectoryHandler implements PluginDeployerDirectoryHand
             return false;
         }
         const pluginPath = path.join(plugin.path(), 'extension');
+        return this.resolvePackage(plugin, { pluginPath, pck: this.requirePackage(pluginPath) });
+    }
+
+    protected resolveFromNpmTarball(plugin: PluginDeployerEntry): boolean {
+        const pluginPath = path.join(plugin.path(), 'package');
         return this.resolvePackage(plugin, { pluginPath, pck: this.requirePackage(pluginPath) });
     }
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -28,7 +28,11 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
     }
 
     accept(resolvedPlugin: PluginDeployerEntry): boolean {
-        return resolvedPlugin.isFile() && resolvedPlugin.path() !== null && resolvedPlugin.path().endsWith('.vsix');
+        if (!resolvedPlugin.isFile()) {
+            return false;
+        }
+        const pluginPath = resolvedPlugin.path();
+        return !!pluginPath && pluginPath.endsWith('.vsix') || pluginPath.endsWith('.tgz');
     }
 
     async handle(context: PluginDeployerFileHandlerContext): Promise<void> {


### PR DESCRIPTION
In order to support built-in vscode extensions republished under `@theia/vscode-bultin-` prefix to npm

Use `Deploy plugin by id` to verify. You have to reload a page to apply changes.

In order to get tarball url:

    npm view @theia/vscode-builtin-go dist.tarball
    https://registry.npmjs.org/@theia/vscode-builtin-go/-/vscode-builtin-go-0.1.0.tgz

