### PR TITLE
[preview] Fix opening images, #4495

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -98,7 +98,7 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     canHandle(uri: URI): number {
         // It does not guard against directories. For instance, a folder with this name: `Hahahah.html`.
         // We could check with the FS, but then, this method would become async again.
-        const extension = uri.path.ext;
+        const extension = uri.toString().split('.').pop();
         if (extension) {
             return this.supportedExtensions.get(extension.toLocaleLowerCase()) || 0;
         }


### PR DESCRIPTION
Fixes #4495.

## Before

<img width="1552" alt="screenshot 2019-03-06 at 17 19 52" src="https://user-images.githubusercontent.com/599268/53896344-1d908b80-4034-11e9-9b36-a4dea727c006.png">

## After

<img width="1552" alt="screenshot 2019-03-06 at 19 30 51" src="https://user-images.githubusercontent.com/599268/53904448-65201300-4046-11e9-9d79-3e6598f5cc81.png">

Maybe we should also reset the background to white for image previews.

@kittaakos please have a look when you have time.