### PR TITLE
Fix host plugin run to remove --port arg of theia run

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-instance-manager.ts
@@ -244,9 +244,9 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
         if (environment.electron.is()) {
             command = ['yarn', 'theia', 'start'];
         } else {
-            command = processArguments.filter(arg => {
-                // remove --port= argument if set
-                if (arg.startsWith('--port=')) {
+            command = processArguments.filter((arg, index, args) => {
+                // remove --port=X and --port X arguments if set
+                if (arg.startsWith('--port') || args[index - 1] === '--port') {
                     return;
                 } else {
                     return arg;


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

Remove `--port 4444` in addition to the previously removal support for `--port=4444`

Fixes: https://github.com/theia-ide/theia/issues/4361
