### PR TITLE
Duplicate keys when more than one tail decorator on a node

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -534,10 +534,10 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
         const style = (fontData: TreeDecoration.FontData | undefined) => this.applyFontStyles({}, fontData);
         return <React.Fragment>
-            {this.getDecorationData(node, 'tailDecorations').filter(notEmpty).reduce((acc, current) => acc.concat(current), []).map(decoration => {
+            {this.getDecorationData(node, 'tailDecorations').filter(notEmpty).reduce((acc, current) => acc.concat(current), []).map((decoration, index) => {
                 const { fontData, data, tooltip } = decoration;
                 const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS].join(' ');
-                return <div key={node.id + className} className={className} style={style(fontData)} title={tooltip}>
+                return <div key={node.id + className + index} className={className} style={style(fontData)} title={tooltip}>
                     {data}
                 </div>;
             })}


### PR DESCRIPTION
Signed-off-by: Nigel Westbury <nigelipse@miegel.org>

This fixes a problem that occurs when there is more than one trailing decorator on a node.  This problem does not show up with the core extensions because the only tail decorators added without custom rendering are the Git status indicators and these put at most one indicator on each node.

Without this fix we get duplicate key warnings and the tail decorators occasionally go haywire.

This is a very simple fix that does not entirely fix the problem.  Only the letter set as the data is added to the key.  It is possible that different extensions could use the same letter.  If you want a more thorough fix that copes with this too then I am happy to do that.  We could 1) add an id property to the decorator (making it optional for compatibility), or 2) we could combine data, font, color, and tooltip (if all of those are the same then they are the same indicator and we should remove the duplicate indicators), or 3) we could add a sequence number as in renderCaptionAffixes (though that would be less react-friendly).