### PR TITLE
[plugin] support multiple windows per a backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 Breaking changes:
 - [editor] computation of resource context keys moved to core [#4531](https://github.com/theia-ide/theia/pull/4531)
+- [plugin] support multiple windows per a backend [#4509](https://github.com/theia-ide/theia/issues/4509)
+  - Some plugin bindings are scoped per a connection now. Clients, who contribute/rebind these bindings, will need to scope them per a connection as well.
 
 ## v0.4.0
 - [application-manager] added support for pre-load HTML templates

--- a/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node-electron/plugin-ext-hosted-electron-backend-module.ts
@@ -16,13 +16,18 @@
 
 import { HostedInstanceManager, ElectronNodeHostedPluginRunner } from '../node/hosted-instance-manager';
 import { interfaces } from 'inversify';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 import { bindCommonHostedBackend } from '../node/plugin-ext-hosted-backend-module';
 import { PluginScanner } from '../../common/plugin-protocol';
 import { TheiaPluginScannerElectron } from './scanner-theia-electron';
 
+const hostedBackendConnectionModule = ConnectionContainerModule.create(({ bind }) => {
+    bind(HostedInstanceManager).to(ElectronNodeHostedPluginRunner);
+});
+
 export function bindElectronBackend(bind: interfaces.Bind): void {
     bindCommonHostedBackend(bind);
+    bind(ConnectionContainerModule).toConstantValue(hostedBackendConnectionModule);
 
-    bind(HostedInstanceManager).to(ElectronNodeHostedPluginRunner);
     bind(PluginScanner).to(TheiaPluginScannerElectron).inSingletonScope();
 }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (C) 2019 RedHat and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { ILogger } from '@theia/core';
+import { PluginDeployerHandler, PluginDeployerEntry, PluginMetadata } from '../../common/plugin-protocol';
+import { HostedPluginReader } from './plugin-reader';
+
+@injectable()
+export class HostedPluginDeployerHandler implements PluginDeployerHandler {
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    @inject(HostedPluginReader)
+    private readonly reader: HostedPluginReader;
+
+    /**
+     * Managed plugin metadata backend entries.
+     */
+    private readonly currentBackendPluginsMetadata: PluginMetadata[] = [];
+
+    /**
+     * Managed plugin metadata frontend entries.
+     */
+    private readonly currentFrontendPluginsMetadata: PluginMetadata[] = [];
+
+    getDeployedFrontendMetadata(): PluginMetadata[] {
+        return this.currentFrontendPluginsMetadata;
+    }
+
+    getDeployedBackendMetadata(): PluginMetadata[] {
+        return this.currentBackendPluginsMetadata;
+    }
+
+    async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void> {
+        for (const plugin of frontendPlugins) {
+            const metadata = await this.reader.getPluginMetadata(plugin.path());
+            if (metadata) {
+                this.currentFrontendPluginsMetadata.push(metadata);
+                this.logger.info(`Deploying frontend plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint.frontend || plugin.path()}"`);
+            }
+        }
+    }
+
+    async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void> {
+        for (const plugin of backendPlugins) {
+            const metadata = await this.reader.getPluginMetadata(plugin.path());
+            if (metadata) {
+                this.currentBackendPluginsMetadata.push(metadata);
+                this.logger.info(`Deploying backend plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint.backend || plugin.path()}"`);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
fix #4509

In order to verify:
- install any VS Code extension contributing language support (i used Go)
- disable auto save
- open several windows for the same file
- add different APIs to this file for different windows
- check that each window does not propose APIs from other windows (and has language support)

It's a breaking change: some plugin bindings are scoped per a connection now. Clients, who contribute/rebind these bindings, will need to scope them per a connection as well.