### PR TITLE
GH-3851 improve 'amend' experience

### DIFF
--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -663,6 +663,9 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
             <a className='toolbar-button' title='Unamend All Commits' onClick={this.unamendAll.bind(this)}>
                 <i className='fa fa-minus' />
             </a>
+            <a className='toolbar-button' title='Clear Amending Commits' onClick={this.clearAmending.bind(this)}>
+                <i className='fa fa-times' />
+            </a>
         </div>;
     }
 
@@ -1010,6 +1013,16 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
                 await new Promise(resolve => setTimeout(resolve, GitWidget.TRANSITION_TIME_MS));
             }
         }
+    }
+
+    readonly clearAmending = () => this.doClearAmending();
+    protected async doClearAmending() {
+        const repository = this.repositoryProvider.selectedRepository;
+        if (repository) {
+            await this.clearAmendingCommits(repository);
+        }
+        this.amendingCommits = [];
+        this.update();
     }
 
     protected confirm(path: string): Promise<boolean | undefined> {

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -179,10 +179,18 @@
 }
 
 .amendedCommitsOuterContainer {
-    overflow-y: auto;
     border-top: 1px dotted var(--theia-layout-color4);
     width: 100%;
-    min-height: 15px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 0;  /* must be zero to keep this at the bottom */
+    flex-shrink: 0;
+}
+
+.withMinHeight {
+    flex-shrink: 1;
+    min-height: 150px; /* height of three commits */
 }
 
 #theia-gitContainer .warn {
@@ -266,6 +274,11 @@
     max-height: 400px;
 }
 
+.no-grow-or-shrink {
+    flex-grow: 0;
+    flex-shrink: 0;
+}
+
 .flex-container-center {
     display: flex;
     align-items: center;
@@ -275,18 +288,6 @@
     position: relative;
     width: 100%;
     overflow: hidden;
-
-    margin-top: 0;
-    margin-bottom: 0;
-    padding-top: 0;
-    padding-bottom: 0;
-    border-top: 0;
-    border-bottom: 0;
-}
-
-.stationary-part {
-    position: relative;
-    width: 100%;
 
     margin-top: 0;
     margin-bottom: 0;

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -24,7 +24,8 @@
     padding-left: 19px;
 }
 
-.theia-git:focus, .theia-git :focus {
+.theia-git:focus,
+.theia-git :focus {
     outline: 0;
     box-shadow: none;
     border: none;
@@ -177,6 +178,13 @@
     flex-grow: 1;
 }
 
+.amendedCommitsOuterContainer {
+    overflow-y: auto;
+    border-top: 1px dotted var(--theia-layout-color4);
+    width: 100%;
+    min-height: 15px;
+}
+
 #theia-gitContainer .warn {
     background-color: var(--theia-error-color2) !important;
 }
@@ -185,11 +193,11 @@
     width: 100%;
 }
 
-.theia-git div:focus .theia-mod-selected{
+.theia-git div:focus .theia-mod-selected {
     background: var(--theia-accent-color3);
 }
 
-.theia-git .theia-mod-selected{
+.theia-git .theia-mod-selected {
     background: var(--theia-accent-color4);
 }
 
@@ -203,10 +211,24 @@
     display: flex;
     border-top: 1px solid var(--theia-layout-color4);
     width: 100%;
-    padding-top: 6px;
 }
 
-.theia-git-last-commit-container img {
+.theia-git-last-commit-and-button {
+    display: flex;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+}
+
+.theia-git-last-commit-avatar-and-text {
+    display: flex;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    padding-top: 2px;
+}
+
+.theia-git-last-commit-avatar-and-text img {
     width: 27px;
 }
 
@@ -247,6 +269,46 @@
 .flex-container-center {
     display: flex;
     align-items: center;
+}
+
+.scolling-container {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top: 0;
+    border-bottom: 0;
+}
+
+.stationary-part {
+    position: relative;
+    width: 100%;
+
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top: 0;
+    border-bottom: 0;
+}
+
+.fixed-height-commit-container {
+    position: relative;
+    width: 100%;
+    height: 32px;
+    overflow: hidden;
+    top: 0;
+
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top: 0;
+    border-bottom: 0;
 }
 
 .theia-git-commit-message-container textarea {
@@ -323,11 +385,11 @@
     -moz-user-select: none;
     -ms-user-select: none;
     -o-user-select: none;
- }
+}
 
- .no-select:focus {
+.no-select:focus {
     outline: none;
- }
+}
 
 .git-tab-icon {
     -webkit-mask: url('git.svg');
@@ -343,6 +405,10 @@
 .git-theia-header:hover {
     background-color: var(--theia-layout-color2);
     cursor: pointer;
+}
+
+.git-theia-header:hover>.git-change-list-buttons-container {
+    visibility: visible;
 }
 
 #theia-gitContainer .git-change-list-buttons-container {

--- a/packages/git/src/browser/style/index.css
+++ b/packages/git/src/browser/style/index.css
@@ -408,7 +408,7 @@
     cursor: pointer;
 }
 
-.git-theia-header:hover>.git-change-list-buttons-container {
+.git-theia-header:hover > .git-change-list-buttons-container {
     visibility: visible;
 }
 


### PR DESCRIPTION
This PR improves the user experience when using the 'Amend' button.

1. A list of the commits being amended is shown above the last commit.
2. There is an 'Unamend' button that reverses the previous 'Amend'
3. All commits being amended can be unamended using the '-' button in the section header
4. The movement of commits in the 'last commit' section and the 'commits being amended' section are animated so that the user readily sees how commits are moving between the sections.

In the screenshot below you will see how the view looks after pressing 'Amend' twice.

![amend](https://user-images.githubusercontent.com/87310/54164251-dbac7e80-4453-11e9-9f3a-29431a282c6b.jpg)
