### PR TITLE
Ability to proceed runInTerminal request in sidecar container

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -36,6 +36,7 @@ import { DebugSessionOptions, InternalDebugSessionOptions } from './debug-sessio
 import { DebugConfiguration } from '../common/debug-common';
 import { SourceBreakpoint } from './breakpoint/breakpoint-marker';
 import { FileSystem } from '@theia/filesystem/lib/common';
+import { TerminalWidgetOptions } from '@theia/terminal/lib/browser/base/terminal-widget';
 
 export enum DebugState {
     Inactive,
@@ -367,7 +368,11 @@ export class DebugSession implements CompositeTreeElement {
     }
 
     protected async runInTerminal({ arguments: { title, cwd, args, env } }: DebugProtocol.RunInTerminalRequest): Promise<DebugProtocol.RunInTerminalResponse['body']> {
-        const terminal = await this.terminalServer.newTerminal({ title, cwd, shellPath: args[0], shellArgs: args.slice(1), env });
+        return this.doRunInTerminal({ title, cwd, shellPath: args[0], shellArgs: args.slice(1), env });
+    }
+
+    protected async doRunInTerminal(options: TerminalWidgetOptions): Promise<DebugProtocol.RunInTerminalResponse['body']> {
+        const terminal = await this.terminalServer.newTerminal(options);
         this.terminalServer.activateTerminal(terminal);
         const processId = await terminal.start();
         return { processId };

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -740,6 +740,13 @@ export interface PreferenceChangeExt {
     preferenceName: string,
     newValue: any
 }
+
+export interface TerminalOptionsExt {
+    attributes?: {
+        [key: string]: string;
+    }
+}
+
 export interface PreferenceRegistryExt {
     $acceptConfigurationChanged(data: { [key: string]: any }, eventData: PreferenceChangeExt): void;
 }
@@ -983,6 +990,7 @@ export interface DebugExt {
     $getConfigurationSnippets(debugType: string): Promise<IJSONSchemaSnippet[]>;
     $createDebugSession(debugConfiguration: theia.DebugConfiguration): Promise<string>;
     $terminateDebugSession(sessionId: string): Promise<void>;
+    $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined>;
 }
 
 export interface DebugMain {

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -115,6 +115,7 @@ export class DebugMainImpl implements DebugMain {
     async $registerDebuggerContribution(description: DebuggerDescription): Promise<void> {
         const disposable = new DisposableCollection();
         this.toDispose.set(description.type, disposable);
+        const terminalOptionsExt = await this.debugExt.$getTerminalCreationOptions(description.type);
 
         const debugSessionFactory = new PluginDebugSessionFactory(
             this.terminalService,
@@ -128,7 +129,8 @@ export class DebugMainImpl implements DebugMain {
                 const connection = await this.connectionMain.ensureConnection(sessionId);
                 return new PluginWebSocketChannel(connection);
             },
-            this.fileSystem
+            this.fileSystem,
+            terminalOptionsExt
         );
 
         disposable.pushAll([

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -20,7 +20,8 @@ import { RPCProtocol } from '../../../api/rpc-protocol';
 import {
     PLUGIN_RPC_CONTEXT as Ext,
     DebugMain,
-    DebugExt
+    DebugExt,
+    TerminalOptionsExt
 } from '../../../api/plugin-api';
 import * as theia from '@theia/plugin';
 import uuid = require('uuid');
@@ -225,6 +226,14 @@ export class DebugExtImpl implements DebugExt {
     async $getConfigurationSnippets(debugType: string): Promise<IJSONSchemaSnippet[]> {
         const contribution = this.debuggersContributions.get(debugType);
         return contribution && contribution.configurationSnippets || [];
+    }
+
+    async $getTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined> {
+        return this.doGetTerminalCreationOptions(debugType);
+    }
+
+    async doGetTerminalCreationOptions(debugType: string): Promise<TerminalOptionsExt | undefined> {
+        return undefined;
     }
 
     async $provideDebugConfigurations(debugType: string, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration[]> {


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### Reference issue
https://github.com/eclipse/che/issues/12771

Method overriding is implemented in https://github.com/eclipse/che-theia/pull/107