### PR TITLE
Pass the DOM element as first argument to context menu command handlers

### DIFF
--- a/packages/core/src/browser/menu/browser-context-menu-renderer.ts
+++ b/packages/core/src/browser/menu/browser-context-menu-renderer.ts
@@ -22,11 +22,11 @@ import { BrowserMainMenuFactory } from './browser-menu-plugin';
 @injectable()
 export class BrowserContextMenuRenderer implements ContextMenuRenderer {
 
-    constructor( @inject(BrowserMainMenuFactory) private menuFactory: BrowserMainMenuFactory) {
+    constructor(@inject(BrowserMainMenuFactory) private menuFactory: BrowserMainMenuFactory) {
     }
 
     render(menuPath: MenuPath, anchor: Anchor, onHide?: () => void): void {
-        const contextMenu = this.menuFactory.createContextMenu(menuPath);
+        const contextMenu = this.menuFactory.createContextMenu(menuPath, anchor);
         const { x, y } = anchor instanceof MouseEvent ? { x: anchor.clientX, y: anchor.clientY } : anchor;
         if (onHide) {
             contextMenu.aboutToClose.connect(() => onHide());

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable, inject, optional, postConstruct } from 'inversify';
-import { ArrayExt, find, toArray } from '@phosphor/algorithm';
+import { ArrayExt, find, toArray, each } from '@phosphor/algorithm';
 import { Signal } from '@phosphor/signaling';
 import {
     BoxLayout, BoxPanel, DockLayout, DockPanel, FocusTracker, Layout, Panel, SplitLayout,
@@ -745,6 +745,34 @@ export class ApplicationShell extends Widget {
     }
 
     /**
+     * Find the widget that contains the given HTML element. The returned widget may be one
+     * that is managed by the application shell, or one that is embedded in another widget and
+     * not directly managed by the shell, or a tab bar.
+     */
+    findWidgetForElement(element: HTMLElement): Widget | undefined {
+        let widgetNode: HTMLElement | null = element;
+        while (widgetNode && !widgetNode.classList.contains('p-Widget')) {
+            widgetNode = widgetNode.parentElement;
+        }
+        if (widgetNode) {
+            return this.findWidgetForNode(widgetNode, this);
+        }
+        return undefined;
+    }
+
+    private findWidgetForNode(widgetNode: HTMLElement, widget: Widget): Widget | undefined {
+        if (widget.node === widgetNode) {
+            return widget;
+        }
+        let result: Widget | undefined;
+        each(widget.children(), child => {
+            result = this.findWidgetForNode(widgetNode, child);
+            return !result;
+        });
+        return result;
+    }
+
+    /**
      * The current widget in the application shell. The current widget is the last widget that
      * was active and not yet closed. See the remarks to `activeWidget` on what _active_ means.
      */
@@ -1133,20 +1161,35 @@ export class ApplicationShell extends Widget {
      * undefined if the widget does not reside directly in the shell.
      */
     getAreaFor(widget: Widget): ApplicationShell.Area | undefined {
-        const title = widget.title;
-        const mainPanelTabBar = this.mainPanel.findTabBar(title);
-        if (mainPanelTabBar) {
-            return 'main';
-        }
-        const bottomPanelTabBar = this.bottomPanel.findTabBar(title);
-        if (bottomPanelTabBar) {
-            return 'bottom';
-        }
-        if (ArrayExt.firstIndexOf(this.leftPanelHandler.tabBar.titles, title) > -1) {
-            return 'left';
-        }
-        if (ArrayExt.firstIndexOf(this.rightPanelHandler.tabBar.titles, title) > -1) {
-            return 'right';
+        if (widget instanceof TabBar) {
+            if (find(this.mainPanel.tabBars(), tb => tb === widget)) {
+                return 'main';
+            }
+            if (find(this.bottomPanel.tabBars(), tb => tb === widget)) {
+                return 'bottom';
+            }
+            if (this.leftPanelHandler.tabBar === widget) {
+                return 'left';
+            }
+            if (this.rightPanelHandler.tabBar === widget) {
+                return 'right';
+            }
+        } else {
+            const title = widget.title;
+            const mainPanelTabBar = this.mainPanel.findTabBar(title);
+            if (mainPanelTabBar) {
+                return 'main';
+            }
+            const bottomPanelTabBar = this.bottomPanel.findTabBar(title);
+            if (bottomPanelTabBar) {
+                return 'bottom';
+            }
+            if (ArrayExt.firstIndexOf(this.leftPanelHandler.tabBar.titles, title) > -1) {
+                return 'left';
+            }
+            if (ArrayExt.firstIndexOf(this.rightPanelHandler.tabBar.titles, title) > -1) {
+                return 'right';
+            }
         }
         return undefined;
     }

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -26,7 +26,7 @@ export class ElectronContextMenuRenderer implements ContextMenuRenderer {
     }
 
     render(menuPath: MenuPath, anchor: Anchor, onHide?: () => void): void {
-        const menu = this.menuFactory.createContextMenu(menuPath);
+        const menu = this.menuFactory.createContextMenu(menuPath, anchor);
         menu.popup({});
         if (onHide) {
             onHide();


### PR DESCRIPTION
Fixes #1923.

When commands are called via context menu, their handlers get the DOM node that was right-clicked as first argument.

When commands are called via keybinding, the handlers fall back to the previous behavior of using the global `shell.currentWidget`.