### PR TITLE
[java] Misc improvements

### DIFF
--- a/packages/java/src/browser/java-client-contribution.ts
+++ b/packages/java/src/browser/java-client-contribution.ts
@@ -96,7 +96,7 @@ export class JavaClientContribution extends BaseLanguageClientContribution {
         this.statusBarTimeout = window.setTimeout(() => {
             this.statusBar.removeElement(this.statusNotificationName);
             this.statusBarTimeout = undefined;
-        }, 5000);
+        }, 500);
     }
 
     protected showActionableMessage(message: ActionableMessage): void {


### PR DESCRIPTION
fixes #1078

how to test:
- just create a java file not included in a proper java project and open it 
- when you try to call any language feature e.g. content assist, the LS should warn you about an incomplete classpath
- you should be able to ignore it, which has to set the severity of this message to ignore in settings
- reload the browser to verify, that the message is not shown on restart of the LS