### PR TITLE
quick palette fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 - [editor] computation of resource context keys moved to core [#4531](https://github.com/theia-ide/theia/pull/4531)
 - [plugin] support multiple windows per a backend [#4509](https://github.com/theia-ide/theia/issues/4509)
   - Some plugin bindings are scoped per a connection now. Clients, who contribute/rebind these bindings, will need to scope them per a connection as well.
+- [quick-open] disable separate fuzzy matching by default [#4549](https://github.com/theia-ide/theia/pull/4549)
 
 ## v0.4.0
 - [application-manager] added support for pre-load HTML templates

--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -20,14 +20,20 @@ import { MessageType } from '../../common/message-service-protocol';
 
 export type QuickOpenOptions = Partial<QuickOpenOptions.Resolved>;
 export namespace QuickOpenOptions {
+    export interface FuzzyMatchOptions {
+        /**
+         * Default: `false`
+         */
+        enableSeparateSubstringMatching?: boolean
+    }
     export interface Resolved {
         readonly prefix: string;
         readonly placeholder: string;
         readonly ignoreFocusOut: boolean;
 
-        readonly fuzzyMatchLabel: boolean;
-        readonly fuzzyMatchDetail: boolean;
-        readonly fuzzyMatchDescription: boolean;
+        readonly fuzzyMatchLabel: boolean | FuzzyMatchOptions;
+        readonly fuzzyMatchDetail: boolean | FuzzyMatchOptions;
+        readonly fuzzyMatchDescription: boolean | FuzzyMatchOptions;
         readonly fuzzySort: boolean;
 
         /** The amount of first symbols to be ignored by quick open widget (e.g. don't affect matching). */

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -91,8 +91,12 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
         }
         return {
             placeholder,
-            fuzzyMatchLabel: true,
-            fuzzyMatchDescription: true,
+            fuzzyMatchLabel: {
+                enableSeparateSubstringMatching: true
+            },
+            fuzzyMatchDescription: {
+                enableSeparateSubstringMatching: true
+            },
             showItemsWithoutHighlight: true,
             onClose: () => {
                 this.isOpen = false;

--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -141,16 +141,16 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
     private cancelIndicator = new CancellationTokenSource();
 
     public async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
+        this.cancelIndicator.cancel();
+        this.cancelIndicator = new CancellationTokenSource();
+        const token = this.cancelIndicator.token;
+
         const roots = this.workspaceService.tryGetRoots();
         if (roots.length === 0) {
             return;
         }
 
         this.currentLookFor = lookFor;
-        this.cancelIndicator.cancel();
-        this.cancelIndicator = new CancellationTokenSource();
-
-        const token = this.cancelIndicator.token;
         const alreadyCollected = new Set<string>();
         const recentlyUsedItems: QuickOpenItem[] = [];
 
@@ -158,35 +158,47 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
         for (const location of locations) {
             const uriString = location.uri.toString();
             if (location.uri.scheme === 'file' && !alreadyCollected.has(uriString) && fuzzy.test(lookFor, uriString)) {
-                recentlyUsedItems.push(await this.toItem(location.uri, { groupLabel: recentlyUsedItems.length === 0 ? 'recently opened' : undefined, showBorder: false }));
+                const item = await this.toItem(location.uri, { groupLabel: recentlyUsedItems.length === 0 ? 'recently opened' : undefined, showBorder: false });
+                if (token.isCancellationRequested) {
+                    return;
+                }
+                recentlyUsedItems.push(item);
                 alreadyCollected.add(uriString);
             }
         }
         if (lookFor.length > 0) {
             const handler = async (results: string[]) => {
-                if (!token.isCancellationRequested) {
-                    const fileSearchResultItems: QuickOpenItem[] = [];
-                    for (const fileUri of results) {
-                        if (!alreadyCollected.has(fileUri)) {
-                            fileSearchResultItems.push(await this.toItem(fileUri));
-                            alreadyCollected.add(fileUri);
-                        }
-                    }
-
-                    // Create a copy of the file search results and sort.
-                    const sortedResults = fileSearchResultItems.slice();
-                    sortedResults.sort((a, b) => this.compareItems(a, b));
-
-                    // Extract the first element, and re-add it to the array with the group label.
-                    const first = sortedResults[0];
-                    sortedResults.shift();
-                    if (first) {
-                        sortedResults.unshift(await this.toItem(first.getUri()!, { groupLabel: 'file results', showBorder: true }));
-                    }
-
-                    // Return the recently used items, followed by the search results.
-                    acceptor([...recentlyUsedItems, ...sortedResults]);
+                if (token.isCancellationRequested) {
+                    return;
                 }
+                const fileSearchResultItems: QuickOpenItem[] = [];
+                for (const fileUri of results) {
+                    if (!alreadyCollected.has(fileUri)) {
+                        const item = await this.toItem(fileUri);
+                        if (token.isCancellationRequested) {
+                            return;
+                        }
+                        fileSearchResultItems.push(item);
+                        alreadyCollected.add(fileUri);
+                    }
+                }
+
+                // Create a copy of the file search results and sort.
+                const sortedResults = fileSearchResultItems.slice();
+                sortedResults.sort((a, b) => this.compareItems(a, b));
+
+                // Extract the first element, and re-add it to the array with the group label.
+                const first = sortedResults[0];
+                sortedResults.shift();
+                if (first) {
+                    const item = await this.toItem(first.getUri()!, { groupLabel: 'file results', showBorder: true });
+                    if (token.isCancellationRequested) {
+                        return;
+                    }
+                    sortedResults.unshift(item);
+                }
+                // Return the recently used items, followed by the search results.
+                acceptor([...recentlyUsedItems, ...sortedResults]);
             };
             this.fileSearchService.find(lookFor, {
                 rootUris: roots.map(r => r.uri),

--- a/packages/file-search/src/common/file-search-service.ts
+++ b/packages/file-search/src/common/file-search-service.ts
@@ -40,5 +40,6 @@ export namespace FileSearchService {
         useGitIgnore?: boolean
         /** when `undefined`, no excludes will apply, when empty array, default excludes will apply */
         defaultIgnorePatterns?: string[]
+        includePatterns?: string[]
     }
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -244,9 +244,10 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
         if (this.options.skipPrefix) {
             lookFor = lookFor.substr(this.options.skipPrefix);
         }
-        const labelHighlights = this.options.fuzzyMatchLabel ? this.matchesFuzzy(lookFor, item.getLabel()) : item.getLabelHighlights();
-        const descriptionHighlights = this.options.fuzzyMatchDescription ? this.matchesFuzzy(lookFor, item.getDescription()) : item.getDescriptionHighlights();
-        const detailHighlights = this.options.fuzzyMatchDetail ? this.matchesFuzzy(lookFor, item.getDetail()) : item.getDetailHighlights();
+        const { fuzzyMatchLabel, fuzzyMatchDescription, fuzzyMatchDetail } = this.options;
+        const labelHighlights = fuzzyMatchLabel ? this.matchesFuzzy(lookFor, item.getLabel(), fuzzyMatchLabel) : item.getLabelHighlights();
+        const descriptionHighlights = fuzzyMatchDescription ? this.matchesFuzzy(lookFor, item.getDescription(), fuzzyMatchDescription) : item.getDescriptionHighlights();
+        const detailHighlights = fuzzyMatchDetail ? this.matchesFuzzy(lookFor, item.getDetail(), fuzzyMatchDetail) : item.getDetailHighlights();
         if ((lookFor && !labelHighlights && !descriptionHighlights && !detailHighlights)
             && !this.options.showItemsWithoutHighlight) {
             return undefined;
@@ -256,11 +257,12 @@ export class MonacoQuickOpenControllerOptsImpl implements MonacoQuickOpenControl
         return entry;
     }
 
-    protected matchesFuzzy(lookFor: string, value: string | undefined): monaco.quickOpen.IHighlight[] | undefined {
+    protected matchesFuzzy(lookFor: string, value: string | undefined, options?: QuickOpenOptions.FuzzyMatchOptions | boolean): monaco.quickOpen.IHighlight[] | undefined {
         if (!lookFor || !value) {
             return undefined;
         }
-        return monaco.filters.matchesFuzzy(lookFor, value, true);
+        const enableSeparateSubstringMatching = typeof options === 'object' && options.enableSeparateSubstringMatching;
+        return monaco.filters.matchesFuzzy(lookFor, value, enableSeparateSubstringMatching);
     }
 
     getAutoFocus(lookFor: string): monaco.quickOpen.IAutoFocus {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -377,7 +377,7 @@ export interface QuickOpenMain {
 
 export interface WorkspaceMain {
     $pickWorkspaceFolder(options: WorkspaceFolderPickOptionsMain): Promise<theia.WorkspaceFolder | undefined>;
-    $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes: string | false,
+    $startFileSearch(includePattern: string, includeFolder: string | undefined, excludePatternOrDisregardExcludes: string | false,
         maxResults: number | undefined, token: theia.CancellationToken): PromiseLike<UriComponents[]>;
     $registerTextDocumentContentProvider(scheme: string): Promise<void>;
     $unregisterTextDocumentContentProvider(scheme: string): void;

--- a/packages/plugin-ext/src/main/browser/workspace-main.ts
+++ b/packages/plugin-ext/src/main/browser/workspace-main.ts
@@ -152,22 +152,24 @@ export class WorkspaceMainImpl implements WorkspaceMain {
         });
     }
 
-    async $startFileSearch(includePattern: string, excludePatternOrDisregardExcludes?: string | false,
-        maxResults?: number, token?: theia.CancellationToken): Promise<UriComponents[]> {
-        const opts: FileSearchService.Options = { rootUris: this.roots.map(r => r.uri) };
+    async $startFileSearch(includePattern: string, includeFolderUri: string | undefined, excludePatternOrDisregardExcludes?: string | false,
+        maxResults?: number): Promise<UriComponents[]> {
+        const rootUris = includeFolderUri ? [includeFolderUri] : this.roots.map(r => r.uri);
+        const opts: FileSearchService.Options = { rootUris };
+        if (includePattern) {
+            opts.includePatterns = [includePattern];
+        }
         if (typeof excludePatternOrDisregardExcludes === 'string') {
             if (excludePatternOrDisregardExcludes === '') { // default excludes
                 opts.defaultIgnorePatterns = [];
             } else {
                 opts.defaultIgnorePatterns = [excludePatternOrDisregardExcludes];
             }
-        } else {
-            opts.defaultIgnorePatterns = undefined; // no excludes
         }
         if (typeof maxResults === 'number') {
             opts.limit = maxResults;
         }
-        const uriStrs = await this.fileSearchService.find(includePattern, opts);
+        const uriStrs = await this.fileSearchService.find('', opts);
         return uriStrs.map(uriStr => Uri.parse(uriStr));
     }
 

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -117,11 +117,13 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | null, maxResults?: number,
         token: CancellationToken = CancellationToken.None): PromiseLike<URI[]> {
         let includePattern: string;
+        let includeFolderUri: string | undefined;
         if (include) {
             if (typeof include === 'string') {
                 includePattern = include;
             } else {
                 includePattern = include.pattern;
+                includeFolderUri = URI.file(include.base).toString();
             }
         } else {
             includePattern = '';
@@ -144,7 +146,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
             return Promise.resolve([]);
         }
 
-        return this.proxy.$startFileSearch(includePattern, excludePatternOrDisregardExcludes, maxResults, token)
+        return this.proxy.$startFileSearch(includePattern, includeFolderUri, excludePatternOrDisregardExcludes, maxResults, token)
             .then(data => Array.isArray(data) ? data.map(URI.revive) : []);
     }
 


### PR DESCRIPTION
fix #4537

- By default quick palette won't do separate fuzzy matching anymore. For most clients it produces bogus result.
- Fixed race condition in file search.
- Matching based on relative paths for file search instead of absolute, see https://github.com/theia-ide/theia/issues/4537#issuecomment-472320500
- Use a root URI as a CWD for rigrep to make it reliable and limit the search scope, see https://github.com/theia-ide/theia/pull/4549#discussion_r265179122

See https://github.com/theia-ide/theia/pull/4549#issuecomment-472428269 for how to reproduce.