### PR TITLE
Apply typehierarchy styling to only typehierarchy

### DIFF
--- a/packages/typehierarchy/src/browser/style/index.css
+++ b/packages/typehierarchy/src/browser/style/index.css
@@ -19,11 +19,11 @@
     color: var(--theia-ui-font-color1);
 }
 
-.theia-caption-suffix {
+.theia-type-hierarchy-tree .theia-caption-suffix {
     padding-left: 10px !important;
 }
 
-.theia-caption-prefix {
+.theia-type-hierarchy-tree .theia-caption-prefix {
     padding-right: 5px !important;
     padding-left: 1px !important;
 }


### PR DESCRIPTION
Fixes #4554

Previously, the `typehierarchy` extension would describe styling which
were set globally instead of solely for the `typehierarchy` widget.
This meant that any other component using the `theia-caption-suffix`
would be styled incorrectly.

The fix was to simply specify the styling solely for the `typehierarchy` class.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
