### PR TITLE
alt+shift+w closes all main area tabs

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -400,9 +400,19 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             }
         });
         commandRegistry.registerCommand(CommonCommands.CLOSE_ALL_TABS, {
-            isEnabled: (event?: Event) => this.findTabBar(event) !== undefined,
+            isEnabled: (event?: Event) => {
+                if (event) {
+                    return this.findTabBar(event) !== undefined;
+                } else {
+                    return this.shell.mainAreaTabBars.find(tb => tb.titles.length > 0) !== undefined;
+                }
+            },
             execute: (event?: Event) => {
-                this.shell.closeTabs(this.findTabArea(event)!);
+                if (event) {
+                    this.shell.closeTabs(this.findTabArea(event)!);
+                } else {
+                    this.shell.closeTabs('main');
+                }
             }
         });
         commandRegistry.registerCommand(CommonCommands.COLLAPSE_PANEL, {


### PR DESCRIPTION
Fixes #1999.

When invoked from the context menu, the command still closes the selected tab bar. When invoked via `alt + shift + W`, it closes all main area tabs.

Note that `alt + W` is unchanged: it closes the _current_ widget, regardless in which shell area it resides.