### PR TITLE
Follow up on plugins life-cycle / per connection scoped.

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -621,6 +621,7 @@ export interface ServerPluginRunner {
     onMessage(jsonMessage: any): void;
     setClient(client: HostedPluginClient): void;
     setDefault(defaultRunner: ServerPluginRunner): void;
+    clientClosed(): void;
 
     /**
      * Provides additional metadata.

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -148,7 +148,7 @@ export class HostedPluginSupport {
                 Object.keys(pluginsPerHost).forEach(hostKey => {
                     const plugins: PluginMetadata[] = pluginsPerHost[hostKey];
                     let pluginID = hostKey;
-                    if (plugins.length === 1) {
+                    if (plugins.length >= 1) {
                         pluginID = getPluginId(plugins[0].model);
                     }
                     const rpc = this.createServerRpc(pluginID, hostKey);

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -53,6 +53,10 @@ export class HostedPluginProcess implements ServerPluginRunner {
         this.client = client;
     }
 
+    public clientClosed(): void {
+
+    }
+
     public setDefault(defaultRunner: ServerPluginRunner): void {
 
     }

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -63,6 +63,7 @@ export class HostedPluginSupport {
         this.isPluginProcessRunning = false;
         this.terminatePluginServer();
         this.isPluginProcessRunning = false;
+        this.pluginRunners.forEach(runner => runner.clientClosed());
     }
 
     runPlugin(plugin: PluginModel): void {

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -30,7 +30,7 @@ import { WorkspaceExtImpl } from '../../plugin/workspace';
  */
 export class PluginHostRPC {
 
-    private static apiFactory: PluginAPIFactory;
+    private apiFactory: PluginAPIFactory;
 
     private pluginManager: PluginManagerExtImpl;
 
@@ -50,7 +50,7 @@ export class PluginHostRPC {
         this.rpc.set(MAIN_RPC_CONTEXT.WORKSPACE_EXT, workspaceExt);
         this.rpc.set(MAIN_RPC_CONTEXT.PREFERENCE_REGISTRY_EXT, preferenceRegistryExt);
 
-        PluginHostRPC.apiFactory = createAPIFactory(
+        this.apiFactory = createAPIFactory(
             this.rpc,
             this.pluginManager,
             envExt,
@@ -62,23 +62,33 @@ export class PluginHostRPC {
     }
 
     // tslint:disable-next-line:no-any
-    static initialize(contextPath: string, plugin: Plugin): any {
+    initContext(contextPath: string, plugin: Plugin): any {
         console.log('PLUGIN_HOST(' + process.pid + '): initializing(' + contextPath + ')');
         try {
             const backendInit = require(contextPath);
-            backendInit.doInitialization(PluginHostRPC.apiFactory, plugin);
+            backendInit.doInitialization(this.apiFactory, plugin);
         } catch (e) {
             console.error(e);
         }
     }
 
+    /*
+     * Stop the given context by calling the plug-in manager.
+     * note: stopPlugin can also be invoked through RPC proxy.
+     */
+    stopContext(): PromiseLike<void> {
+        return this.pluginManager.$stopPlugin('');
+    }
+
     // tslint:disable-next-line:no-any
     createPluginManager(envExt: EnvExtImpl, preferencesManager: PreferenceRegistryExtImpl, rpc: any): PluginManagerExtImpl {
         const { extensionTestsPath } = process.env;
+        const self = this;
         const pluginManager = new PluginManagerExtImpl({
             loadPlugin(plugin: Plugin): void {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 try {
+                    delete require.cache[require.resolve(plugin.pluginPath)];
                     return require(plugin.pluginPath);
                 } catch (e) {
                     console.error(e);
@@ -107,7 +117,7 @@ export class PluginHostRPC {
                             rawModel: plg.source
                         };
 
-                        PluginHostRPC.initialize(backendInitPath, plugin);
+                        self.initContext(backendInitPath, plugin);
 
                         result.push(plugin);
                     } else {


### PR DESCRIPTION
Follow-up of the https://github.com/theia-ide/theia/pull/4521 PR that introduced per connection scoped on plug-ins

Runners need now to be notified when client is disconnected and the usage of static needs to be removed to ensure we get correct instances every time.