### PR TITLE
Fire onDidChangeVisibleTextEditors on editors change

### DIFF
--- a/packages/plugin-ext/src/plugin/editors-and-documents.ts
+++ b/packages/plugin-ext/src/plugin/editors-and-documents.ts
@@ -125,7 +125,7 @@ export class EditorsAndDocumentsExtImpl implements EditorsAndDocumentsExt {
             this._onDidAddDocuments.fire(addedDocuments);
         }
 
-        if (delta.removedDocuments || delta.addedDocuments) {
+        if ((delta.removedEditors && delta.removedEditors.length > 0) || (delta.addedEditors && delta.addedEditors.length > 0)) {
             this._onDidChangeVisibleTextEditors.fire(this.allEditors());
         }
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Before we fired `onDidChangeVisibleTextEditors` on documents change what is wrong. This PR fixes that problem and reacts on editors change now.

Resolves: https://github.com/theia-ide/theia/issues/4221
