### PR TITLE
[plugin/workspace] fix #4565: implement saveAll

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -655,6 +655,7 @@ export interface TextEditorsMain {
     $tryApplyEdits(id: string, modelVersionId: number, edits: SingleEditOperation[], opts: ApplyEditsOptions): Promise<boolean>;
     $tryApplyWorkspaceEdit(workspaceEditDto: WorkspaceEditDto): Promise<boolean>;
     $tryInsertSnippet(id: string, template: string, selections: Range[], opts: UndoStopOptions): Promise<boolean>;
+    $saveAll(includeUntitled?: boolean): Promise<boolean>;
     // $getDiffInformation(id: string): Promise<editorCommon.ILineChange[]>;
 }
 

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -145,4 +145,8 @@ export class TextEditorsMainImpl implements TextEditorsMain {
         return Promise.resolve();
     }
 
+    $saveAll(includeUntitled?: boolean): Promise<boolean> {
+        return this.editorsAndDocuments.saveAll(includeUntitled);
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -411,6 +411,9 @@ export function createAPIFactory(
             findFiles(include: theia.GlobPattern, exclude?: theia.GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]> {
                 return workspaceExt.findFiles(include, exclude, maxResults, token);
             },
+            saveAll(includeUntitled?: boolean): PromiseLike<boolean> {
+                return editors.saveAll(includeUntitled);
+            },
             applyEdit(edit: theia.WorkspaceEdit): PromiseLike<boolean> {
                 return editors.applyWorkspaceEdit(edit);
             },

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -124,6 +124,10 @@ export class TextEditorsExtImpl implements TextEditorsExt {
         return this.proxy.$tryApplyWorkspaceEdit(dto);
     }
 
+    saveAll(includeUntitled?: boolean): PromiseLike<boolean> {
+        return this.proxy.$saveAll(includeUntitled);
+    }
+
 }
 
 export class TextEditorDecorationType implements theia.TextEditorDecorationType {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4085,6 +4085,14 @@ declare module '@theia/plugin' {
         export function findFiles(include: GlobPattern, exclude?: GlobPattern | null, maxResults?: number, token?: CancellationToken): PromiseLike<Uri[]>;
 
         /**
+         * Save all dirty files.
+         *
+         * @param includeUntitled Also save files that have been created during this session.
+         * @return A thenable that resolves when the files have been saved.
+         */
+        export function saveAll(includeUntitled?: boolean): PromiseLike<boolean>;
+
+        /**
          * Make changes to one or many resources or create, delete, and rename resources as defined by the given
          * [workspace edit](#WorkspaceEdit).
          *


### PR DESCRIPTION
Test: One should be able to rename something with go vscode extension.