### PR TITLE
[plug-in] cache cleaning for all plugin's files and not only entrypoint

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -88,7 +88,13 @@ export class PluginHostRPC {
             loadPlugin(plugin: Plugin): void {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 try {
-                    delete require.cache[require.resolve(plugin.pluginPath)];
+                    // cleaning the cache for all files of that plug-in.
+                    Object.keys(require.cache).forEach(key => {
+                        if (key.startsWith(plugin.pluginFolder)) {
+                            // delete entry
+                            delete require.cache[key];
+                        }
+                    });
                     return require(plugin.pluginPath);
                 } catch (e) {
                     console.error(e);


### PR DESCRIPTION
Else some of the files may still have previous values while some others were correctly invalidated

Change-Id: I09f745145b05c041e8f0cd55e85a666617527d76
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
