### PR TITLE
editorconfig: Apply properties to Monaco editor when opening/switching editor

### DIFF
--- a/packages/editorconfig/src/browser/editorconfig-document-manager.ts
+++ b/packages/editorconfig/src/browser/editorconfig-document-manager.ts
@@ -98,6 +98,7 @@ export class EditorconfigDocumentManager {
             const uri = editor.uri.toString();
             this.editorconfigServer.getConfig(uri).then(properties => {
                 this.properties[uri] = properties;
+                this.applyProperties(properties, editor);
             });
         }
     }


### PR DESCRIPTION
Since commit 260d79499823 ("[editorconfig] Don't apply all properties on
open"), the editorconfig settings are not applied to the Monaco editor.
For example, if my .editorconfig file says that *.py files should use
tabs with a tab width of 7, I would expect the Monaco editor to be set
to "tab" and a tab width of 7 when I open a .py file.  At the moment,
this does not happen.

The method that applies these properties to the Monaco editor is
applyProperties.  This method is however not called anywhere outside
tests (the commit mentioned above removed the only call).

I have added back the call, such that when an editor is created or the
current editor changes, we apply the settings from the .editorconfig to
the Monaco editor.

I verified that the behavior the commit mentioned above meant to fix is
kept.  That is, no modification is done to the file contents as a result
of just opening the file (or switching to and editor where it is open).
Even if I have "trim_trailing_whitespace = true" in my .editorconfig,
opening the file does not cause the trailing whitespaces to be trimmed.
Pressing ctrl-s, however, does (even if the editor doesn't appear as
"dirty").

Fixes #4308

Signed-off-by: Simon Marchi <simon.marchi@efficios.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
