### PR TITLE
[process/task] Normalize task types and processes

### DIFF
--- a/packages/core/src/node/messaging/test/test-web-socket-channel.ts
+++ b/packages/core/src/node/messaging/test/test-web-socket-channel.ts
@@ -35,9 +35,9 @@ export class TestWebSocketChannel extends WebSocketChannel {
         socket.on('close', (code, reason) =>
             this.fireClose(code, reason)
         );
-        socket.on('message', data =>
-            this.handleMessage(JSON.parse(data.toString()))
-        );
+        socket.on('message', data => {
+            this.handleMessage(JSON.parse(data.toString()));
+        });
         socket.on('open', () =>
             this.open(path)
         );

--- a/packages/debug/src/node/debug-adapter-factory.ts
+++ b/packages/debug/src/node/debug-adapter-factory.ts
@@ -55,8 +55,8 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
 
         // FIXME: propagate onError + onExit
         return {
-            input: process.input,
-            output: process.output,
+            input: process.inputStream,
+            output: process.outputStream,
             dispose: () => process.kill()
         };
     }

--- a/packages/file-search/src/node/file-search-service-impl.ts
+++ b/packages/file-search/src/node/file-search-service-impl.ts
@@ -108,12 +108,12 @@ export class FileSearchServiceImpl implements FileSearchService {
                 // TODO: why not just child_process.spawn, theia process are supposed to be used for user processes like tasks and terminals, not internal
                 const process = this.rawProcessFactory({ command: rgPath, args, options: { cwd } });
                 process.onError(reject);
-                process.output.on('close', resolve);
+                process.outputStream.on('close', resolve);
                 token.onCancellationRequested(() => process.kill());
 
                 const lineReader = readline.createInterface({
-                    input: process.output,
-                    output: process.input
+                    input: process.outputStream,
+                    output: process.inputStream
                 });
                 lineReader.on('line', line => {
                     if (token.isCancellationRequested) {

--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -78,7 +78,7 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
 
         const process = await this.spawnProcessAsync(command, args, options);
         const [outSock, inSock] = await Promise.all([outSocket, inSocket]);
-        return createProcessSocketConnection(process.process, outSock, inSock);
+        return createProcessSocketConnection(process.process!, outSock, inSock);
     }
 
     /**
@@ -92,7 +92,7 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
 
     protected async createProcessStreamConnectionAsync(command: string, args?: string[], options?: cp.SpawnOptions): Promise<IConnection> {
         const process = await this.spawnProcessAsync(command, args, options);
-        return createStreamConnection(process.output, process.input, () => process.kill());
+        return createStreamConnection(process.outputStream, process.inputStream, () => process.kill());
     }
 
     /**
@@ -100,14 +100,14 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
      */
     protected spawnProcess(command: string, args?: string[], options?: cp.SpawnOptions): RawProcess {
         const rawProcess = this.processFactory({ command, args, options });
-        rawProcess.process.once('error', this.onDidFailSpawnProcess.bind(this));
-        rawProcess.process.stderr.on('data', this.logError.bind(this));
+        rawProcess.onError(this.onDidFailSpawnProcess.bind(this));
+        rawProcess.errorStream.on('data', this.logError.bind(this));
         return rawProcess;
     }
 
     protected spawnProcessAsync(command: string, args?: string[], options?: cp.SpawnOptions): Promise<RawProcess> {
         const rawProcess = this.processFactory({ command, args, options });
-        rawProcess.process.stderr.on('data', this.logError.bind(this));
+        rawProcess.errorStream.on('data', this.logError.bind(this));
         return new Promise<RawProcess>((resolve, reject) => {
             rawProcess.onError((error: ProcessErrorEvent) => {
                 this.onDidFailSpawnProcess(error);

--- a/packages/process/src/node/dev-null-stream.ts
+++ b/packages/process/src/node/dev-null-stream.ts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import stream = require('stream');
+
+/**
+ * A Node stream like `/dev/null`.
+ *
+ * Writing goes to a black hole, reading returns `EOF`.
+ */
+export class DevNullStream extends stream.Duplex {
+    // tslint:disable-next-line:no-any
+    _write(chunk: any, encoding: string, callback: (err?: Error) => void): void {
+        callback();
+    }
+
+    _read(size: number): void {
+        // tslint:disable-next-line:no-null-keyword
+        this.push(null);
+    }
+}

--- a/packages/process/src/node/raw-process.spec.ts
+++ b/packages/process/src/node/raw-process.spec.ts
@@ -36,11 +36,16 @@ const FORK_TEST_FILE = path.join(__dirname, '../../src/node/test/process-fork-te
 
 describe('RawProcess', function () {
 
-    this.timeout(5000);
+    this.timeout(20_000);
+
     let rawProcessFactory: RawProcessFactory;
 
     beforeEach(() => {
         rawProcessFactory = createProcessTestContainer().get<RawProcessFactory>(RawProcessFactory);
+    });
+
+    after(() => {
+        track.cleanupSync();
     });
 
     it('test error on non-existent path', async function () {
@@ -48,6 +53,7 @@ describe('RawProcess', function () {
             const proc = rawProcessFactory({ command: '/non-existent' });
             proc.onStart(reject);
             proc.onError(resolve);
+            proc.onExit(reject);
         });
 
         expect(error.code).eq('ENOENT');
@@ -71,6 +77,7 @@ describe('RawProcess', function () {
             const proc = rawProcessFactory({ command: f.path });
             proc.onStart(reject);
             proc.onError(resolve);
+            proc.onExit(reject);
         });
 
         // On Windows, we get 'UNKNOWN'.
@@ -85,6 +92,7 @@ describe('RawProcess', function () {
             const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
             rawProcess.onStart(resolve);
             rawProcess.onError(reject);
+            rawProcess.onExit(reject);
         });
     });
 
@@ -116,7 +124,7 @@ describe('RawProcess', function () {
             const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
             rawProcess.onError(reject);
 
-            rawProcess.output.pipe(outStream);
+            rawProcess.outputStream.pipe(outStream);
 
             let buf = '';
             outStream.on('data', data => {
@@ -137,7 +145,7 @@ describe('RawProcess', function () {
             const rawProcess = rawProcessFactory({ command: process.execPath, 'args': args });
             rawProcess.onError(reject);
 
-            rawProcess.errorOutput.pipe(outStream);
+            rawProcess.errorStream.pipe(outStream);
 
             let buf = '';
             outStream.on('data', data => {
@@ -167,7 +175,7 @@ describe('RawProcess', function () {
             });
         });
 
-        rawProcess.output.pipe(outStream);
+        rawProcess.outputStream.pipe(outStream);
 
         expect(await p).to.be.equal('1.0.0');
     });
@@ -187,7 +195,7 @@ describe('RawProcess', function () {
             });
         });
 
-        rawProcess.errorOutput.pipe(outStream);
+        rawProcess.errorStream.pipe(outStream);
 
         expect(await p).to.have.string('Error');
     });

--- a/packages/process/src/node/terminal-process.ts
+++ b/packages/process/src/node/terminal-process.ts
@@ -17,13 +17,61 @@
 import { injectable, inject, named } from 'inversify';
 import { ILogger } from '@theia/core/lib/common';
 import { Process, ProcessType, ProcessOptions, ProcessErrorEvent } from './process';
+import { RawProcessOptions } from './raw-process';
 import { ProcessManager } from './process-manager';
 import { IPty, spawn } from '@theia/node-pty';
 import { MultiRingBuffer, MultiRingBufferReadableStream } from './multi-ring-buffer';
+import { DevNullStream } from './dev-null-stream';
 import { signame } from './utils';
+import { Writable } from 'stream';
+
+export type QuotingType = 'escaped' | 'strong' | 'weak';
+
+/**
+ * A `RuntimeQuotingType` represents the different ways to quote
+ * and escape a value in a given runtime (`sh`, `cmd`, etc...).
+ */
+export type RuntimeQuotingTypes = { [key in QuotingType]: string } & { shouldBeEscaped?: string[] };
+export const ShellQuoting = <RuntimeQuotingTypes>{
+    strong: "'",
+    weak: '"',
+    escaped: '\\',
+    shouldBeEscaped: ['$', ' ', '<', '>', '|', '{', '}', '(', ')', '\'', '"', '`'],
+};
+
+/**
+ * Map of `Runtime (string) -> ShellQuoting`, trying to cover the
+ * different ways in which each runtime manages quoting and escaping.
+ */
+// tslint:disable-next-line:no-any
+export const RuntimeQuotingMap: { [key in string]: RuntimeQuotingTypes | undefined } = {
+    'bash': ShellQuoting,
+    'sh': ShellQuoting,
+    'cmd.exe': {
+        strong: '"',
+        weak: '"',
+        escaped: '^',
+        shouldBeEscaped: ['%', '<', '>', '{', '}', '"'],
+    }
+};
+
+/**
+ * Struct describing how a string should be quoted.
+ * To be used when sanitizing arguments for a shell task.
+ */
+export interface QuotedString {
+    value: string;
+    quoting: QuotingType
+}
 
 export const TerminalProcessOptions = Symbol('TerminalProcessOptions');
-export interface TerminalProcessOptions extends ProcessOptions {
+export interface TerminalProcessOptions extends ProcessOptions<string | QuotedString> {
+    options?: {
+        shell?: {
+            executable: string
+            args: string[]
+        } | boolean;
+    }
 }
 
 export const TerminalProcessFactory = Symbol('TerminalProcessFactory');
@@ -34,7 +82,104 @@ export interface TerminalProcessFactory {
 @injectable()
 export class TerminalProcess extends Process {
 
-    protected readonly terminal: IPty;
+    /**
+     * Resolve the exec options based on type (shell/process).
+     *
+     * @param options
+     */
+    protected static resolveExecOptions(options: TerminalProcessOptions): RawProcessOptions {
+        return options.options && options.options.shell ?
+            this.createShellOptions(options) : this.normalizeProcessOptions(options);
+    }
+
+    /**
+     * Terminal options accept a special argument format when executing in a shell:
+     * Arguments can be of the form: { value: string, quoting: string }, specifying
+     * how the arg should be quoted/escaped in the shell command.
+     *
+     * @param options
+     */
+    protected static normalizeProcessOptions(options: TerminalProcessOptions): RawProcessOptions {
+        return {
+            ...options,
+            args: options.args && options.args.map(
+                arg => typeof arg === 'string' ? arg : arg.value),
+        };
+    }
+
+    /**
+     * Build the shell execution options (`runtime ...exec-argv "command ...argv"`).
+     *
+     * @param options
+     */
+    protected static createShellOptions(options: TerminalProcessOptions): RawProcessOptions {
+        const windows = process.platform === 'win32';
+        let runtime: string | undefined;
+        let execArgs: string[] | undefined;
+        let command = options.command;
+
+        // Extract user defined runtime, if any:
+        if (options.options && typeof options.options.shell === 'object') {
+            runtime = options.options.shell.executable;
+            execArgs = options.options.shell.args;
+        }
+
+        // Apply fallback values in case no specific runtime was specified:
+        runtime = runtime || windows ?
+            process.env['COMSPEC'] || 'cmd.exe' :
+            process.env['SHELL'] || 'sh';
+        execArgs = execArgs || windows ?
+            ['/c'] : ['-c'];
+
+        // Quote function, based on the selected runtime:
+        const quoteCharacters = RuntimeQuotingMap[runtime] || ShellQuoting;
+        function quote(string: string, quoting: QuotingType): string {
+
+            if (quoting === 'escaped') {
+                // Escaping most characters (https://stackoverflow.com/a/17606289/7983255)
+                for (const reservedSymbol of quoteCharacters.shouldBeEscaped || []) {
+                    string = string.split(reservedSymbol).join(quoteCharacters.escaped + reservedSymbol);
+                }
+
+            } else {
+                // Add quotes around the argument
+                const q = quoteCharacters[quoting];
+                string = q + string + q;
+            }
+
+            return string;
+        }
+
+        function quoteIfWhitespace(string: string): string {
+            return /\s/.test(string) ?
+                quote(string, 'strong') :
+                string;
+        }
+
+        // See VS Code behavior: https://code.visualstudio.com/docs/editor/tasks#_custom-tasks
+        // Basically, when `task.type === 'shell` && `task.args.length > 0`, `task.command`
+        // is only the executable to run in a shell, followed by the correctly escaped `args`.
+        // Else just run `task.command`.
+        if (options.args) {
+            command = quoteIfWhitespace(command);
+            for (const arg of options.args) {
+                command += ' ' + (typeof arg === 'string' ?
+                    quoteIfWhitespace(arg) : quote(arg.value, arg.quoting));
+            }
+        }
+
+        return <RawProcessOptions>{
+            ...options,
+            command: runtime,
+            args: [...execArgs, command],
+        };
+    }
+
+    protected readonly terminal: IPty | undefined;
+
+    readonly outputStream = this.createOutputStream();
+    readonly errorStream = new DevNullStream();
+    readonly inputStream: Writable;
 
     constructor(
         @inject(TerminalProcessOptions) options: TerminalProcessOptions,
@@ -42,15 +187,18 @@ export class TerminalProcess extends Process {
         @inject(MultiRingBuffer) protected readonly ringBuffer: MultiRingBuffer,
         @inject(ILogger) @named('process') logger: ILogger
     ) {
-        super(processManager, logger, ProcessType.Terminal, options);
+        super(processManager, logger, ProcessType.Terminal, TerminalProcess.resolveExecOptions(options));
 
+        if (this.isForkOptions(this.options)) {
+            throw new Error('terminal processes cannot be forked as of today');
+        }
         this.logger.debug('Starting terminal process', JSON.stringify(options, undefined, 2));
 
         try {
             this.terminal = spawn(
-                options.command,
-                options.args || [],
-                options.options || {});
+                this.options.command,
+                this.options.args || [],
+                this.options.options || {});
 
             this.terminal.on('exec', (reason: string | undefined) => {
                 if (reason === undefined) {
@@ -81,23 +229,30 @@ export class TerminalProcess extends Process {
             this.terminal.on('data', (data: string) => {
                 ringBuffer.enq(data);
             });
-        } catch (err) {
+
+            this.inputStream = new Writable({
+                write: (chunk: string) => {
+                    this.write(chunk);
+                },
+            });
+
+        } catch (error) {
+            this.inputStream = new DevNullStream();
+
+            // Normalize the error to make it as close as possible as what
+            // node's child_process.spawn would generate in the same
+            // situation.
+            const message: string = error.message;
+
+            if (message.startsWith('File not found: ')) {
+                error.errno = 'ENOENT';
+                error.code = 'ENOENT';
+                error.path = options.command;
+            }
+
             // node-pty throws exceptions on Windows.
             // Call the client error handler, but first give them a chance to register it.
-            process.nextTick(() => {
-                // Normalize the error to make it as close as possible as what
-                // node's child_process.spawn would generate in the same
-                // situation.
-                const message: string = err.message;
-
-                if (message.startsWith('File not found: ')) {
-                    err.errno = 'ENOENT';
-                    err.code = 'ENOENT';
-                    err.path = options.command;
-                }
-
-                this.errorEmitter.fire(err);
-            });
+            this.emitOnErrorAsync(error);
         }
     }
 
@@ -106,21 +261,30 @@ export class TerminalProcess extends Process {
     }
 
     get pid() {
-        return this.terminal.pid;
+        this.checkTerminal();
+        return this.terminal!.pid;
     }
 
     kill(signal?: string) {
-        if (this.killed === false) {
+        if (this.terminal && this.killed === false) {
             this.terminal.kill(signal);
         }
     }
 
     resize(cols: number, rows: number): void {
-        this.terminal.resize(cols, rows);
+        this.checkTerminal();
+        this.terminal!.resize(cols, rows);
     }
 
     write(data: string): void {
-        this.terminal.write(data);
+        this.checkTerminal();
+        this.terminal!.write(data);
+    }
+
+    protected checkTerminal(): void | never {
+        if (!this.terminal) {
+            throw new Error('pty process did not start correctly');
+        }
     }
 
 }

--- a/packages/process/src/node/utils.ts
+++ b/packages/process/src/node/utils.ts
@@ -62,5 +62,18 @@ export function signame(sig: number): string {
     }
 
     // Don't know this signal?  Return the number as a string.
-    return sig.toString();
+    return sig.toString(10);
+}
+
+/**
+ * Convert a code number to its short name
+ */
+export function codename(code: number): string {
+    for (const entry of objectEntries(os.constants.errno)) {
+        if (entry[1] === code) {
+            return entry[0];
+        }
+    }
+    // Return the number as string if we did not find a name for it.
+    return code.toString(10);
 }

--- a/packages/task/src/common/process/task-protocol.ts
+++ b/packages/task/src/common/process/task-protocol.ts
@@ -19,20 +19,20 @@ import { ApplicationError } from '@theia/core/lib/common/application-error';
 
 export type ProcessType = 'shell' | 'process';
 
-export interface CommandProperties {
+export interface CommandProperties<T = string> {
     readonly command: string;
-    readonly args?: string[];
+    readonly args?: T[];
     readonly options?: object;
 }
 
 /** Configuration of a Task that may be run as a process or a command inside a shell. */
-export interface ProcessTaskConfiguration extends TaskConfiguration, CommandProperties {
+export interface ProcessTaskConfiguration<T = string> extends TaskConfiguration, CommandProperties<T> {
     readonly type: ProcessType;
 
     /**
      * Windows version of CommandProperties. Used in preference on Windows, if defined.
      */
-    readonly windows?: CommandProperties;
+    readonly windows?: CommandProperties<T>;
 
     /**
      * The 'current working directory' the task will run in. Can be a uri-as-string

--- a/packages/task/test-resources/task.bat
+++ b/packages/task/test-resources/task.bat
@@ -3,7 +3,6 @@
 for /l %%x in (1,1,3) do (
    echo tasking... %*
    @REM sleep for ~1s
-   @REM  see: https://stackoverflow.com/questions/735285/how-to-wait-in-a-batch-script
-   ping 192.0.2.2 -n 1 -w 1000> nul
+   waitfor nothing /t 1 > nul
 )
 echo "done"


### PR DESCRIPTION
It seems like some confusion happened in Theia's implementation of
shell/process tasks, compared to VS Code, but as the goal is to be
compatible with the latter, some cleanup was required.

When executing tasks, we now always use node-pty.

The difference between a process or a shell task relies in the way the
command and its arguments are interpreted/executed:

- process: ask the system to spawn a specific executable, with args
- shell: defer the spawning to a shell that will evaluate a command line

When spawning a process, the expected paramaters are of the kind:

	spawn(executable, [arg1, arg2, arg3, ...])

While when spawning a shell task, we expect some command like

	$> executable arg1 "arg 2" ... && sleep 1 || echo fail

This commit makes Theia tasks and "terminal processes" (processes
spawned via node-pty) able to use both inputs.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
