### PR TITLE
Involve selection service in tree view on plugin side

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -424,6 +424,8 @@ export class TreeViewItem {
 
     collapsibleState?: TreeViewItemCollapsibleState;
 
+    metadata?: any;
+
 }
 
 /**

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -27,6 +27,7 @@ import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-views-main';
 import { PluginContribution, Menu } from '../../../common';
 import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stack-frames-widget';
 import { DebugThreadsWidget } from '@theia/debug/lib/browser/view/debug-threads-widget';
+import { MetadataSelection } from '../metadata-selection';
 
 @injectable()
 export class MenusContributionPointHandler {
@@ -115,6 +116,12 @@ export class MenusContributionPointHandler {
         const command: Command = { id: commandId };
         const selectedResource = () => {
             const selection = this.selectionService.selection;
+
+            const metadata = MetadataSelection.getMetadata(selection);
+            if (metadata) {
+                return metadata;
+            }
+
             const uri = UriSelection.getUri(selection);
             return uri ? uri['codeUri'] : (typeof selection !== 'object' && typeof selection !== 'function') ? selection : undefined;
         };

--- a/packages/plugin-ext/src/main/browser/metadata-selection.ts
+++ b/packages/plugin-ext/src/main/browser/metadata-selection.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export interface MetadataSelection {
+    // tslint:disable-next-line:no-any
+    readonly metadata: any
+}
+
+export namespace MetadataSelection {
+
+    export function is(arg: Object | undefined): arg is MetadataSelection {
+        // tslint:disable-next-line:no-any
+        return typeof arg === 'object' && ('metadata' in arg);
+    }
+
+    // tslint:disable-next-line:no-any
+    export function getMetadata(selection: Object | undefined): any | undefined {
+        if (is(selection)) {
+            return selection.metadata;
+        }
+        if (Array.isArray(selection) && is(selection[0])) {
+            return selection[0].metadata;
+        }
+        return undefined;
+    }
+
+}

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -215,7 +215,8 @@ class TreeViewExtImpl<T> extends Disposable {
                     label: label,
                     icon,
                     tooltip: treeItem.tooltip,
-                    collapsibleState: treeItem.collapsibleState
+                    collapsibleState: treeItem.collapsibleState,
+                    metadata: value
                 } as TreeViewItem;
 
                 treeItems.push(treeViewItem);


### PR DESCRIPTION
This proposal changes provides an ability to use selection service in tree widget, which constructs on the plugin side. 

The problem appears in mechanism that delegates calls of the context menu items into calls of commands in command service. The problem was in that, in selection service the last selected file resource was stored and when we want to call a command from the context menu on tree, provided from plugin, we couldn't pass currently selected node as an argument into actual plugin.

Such problem was related with kubernetes plugin, where tree node should have a metadata information about object that displayed in the tree(cluster configuration, resources, attributes etc). Such metadata is used to controlling the kubernetes cluster.

Related issue: https://github.com/theia-ide/theia/issues/3882

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
