### PR TITLE
[keybindings] make keybinding widget search static

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -61,7 +61,7 @@ export class KeybindingWidget extends ReactWidget {
     protected query: string = '';
 
     protected readonly regexp = /<match>(.*?)<\/match>/g;
-    protected readonly keybindingSeperator = /<match>\+<\/match>/g;
+    protected readonly keybindingSeparator = /<match>\+<\/match>/g;
 
     protected readonly fuzzyOptions = {
         pre: '<match>',
@@ -131,7 +131,7 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected render(): React.ReactNode {
-        return <div>
+        return <div id='kb-main-container'>
             {this.renderSearch()}
             {(this.items.length > 0) ? this.renderTable() : this.renderMessage()}
         </div>;
@@ -158,7 +158,7 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected renderTable(): React.ReactNode {
-        return <div>
+        return <div id='kb-table-container'>
             <div className='kb'>
                 <table>
                     <thead>
@@ -214,7 +214,7 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected renderKeybinding(keybinding: string): React.ReactNode {
-        const regex = new RegExp(this.keybindingSeperator);
+        const regex = new RegExp(this.keybindingSeparator);
         keybinding = keybinding.replace(regex, '+');
         const keys = keybinding.split('+');
 
@@ -227,7 +227,7 @@ export class KeybindingWidget extends ReactWidget {
                         </span>;
                     } else {
                         return <React.Fragment key={index}>
-                            <span className='monco-keybinding-seperator'>+</span>
+                            <span className='monaco-keybinding-separator'>+</span>
                             <span className='monaco-keybinding-key'>{this.renderKeybinding(key)}</span>
                         </React.Fragment>;
                     }

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -14,6 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+#kb-main-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#kb-table-container {
+    flex: 1;
+    overflow: auto;
+}
+
 .fuzzy-match {
     font-weight: 600;
     color: var(--theia-brand-color1);
@@ -104,6 +115,9 @@
     padding-top: 5px;
     text-align: left;
     vertical-align: middle;
+    position: sticky;
+    top: 0;
+    background-color: var(--theia-layout-color2);
 }
 
 .kb table .th-action {


### PR DESCRIPTION
Fixes #3037

Updated the keybindings widget search bar to be static (fixed in place)
This makes it a lot easier for users to search the table, without the
need to constantly scroll up to re-search.

- Fixed minor typos found in variable names.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
