### PR TITLE
[process] Mark as killed when process errors out

### DIFF
--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -136,6 +136,10 @@ export abstract class Process {
         this.errorEmitter.fire(err);
     }
 
+    protected async emitOnErrorAsync(error: ProcessErrorEvent) {
+        process.nextTick(this.emitOnError.bind(this), error);
+    }
+
     protected handleOnError(error: ProcessErrorEvent) {
         this._killed = true;
         this.logger.error(error);

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.ts
@@ -133,10 +133,12 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             command: this.rgPath,
             args: [...args, what].concat(rootUris.map(root => FileUri.fsPath(root)))
         };
-        const process: RawProcess = this.rawProcessFactory(processOptions);
-        this.ongoingSearches.set(searchId, process);
 
-        process.onError(error => {
+        // TODO: Use child_process directly instead of rawProcessFactory?
+        const rgProcess: RawProcess = this.rawProcessFactory(processOptions);
+        this.ongoingSearches.set(searchId, rgProcess);
+
+        rgProcess.onError(error => {
             // tslint:disable-next-line:no-any
             let errorCode = (error as any).code;
 
@@ -157,7 +159,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
         // Buffer to accumulate incoming output.
         let databuf: string = '';
 
-        process.output.on('data', (chunk: string) => {
+        rgProcess.output.on('data', (chunk: string) => {
             // We might have already reached the max number of
             // results, sent a TERM signal to rg, but we still get
             // the data that was already output in the mean time.
@@ -215,7 +217,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
 
                         // Did we reach the maximum number of results?
                         if (opts && opts.maxResults && numResults >= opts.maxResults) {
-                            process.kill();
+                            rgProcess.kill();
                             this.wrapUpSearch(searchId);
                             break;
                         }
@@ -224,7 +226,7 @@ export class RipgrepSearchInWorkspaceServer implements SearchInWorkspaceServer {
             }
         });
 
-        process.output.on('end', () => {
+        rgProcess.output.on('end', () => {
             // If we reached maxResults, we should have already
             // wrapped up the search.  Returning early avoids
             // logging a warning message in wrapUpSearch.


### PR DESCRIPTION
Removes some unhandled errors from the tests because we used to not mark
processes that errored as `killed`.

Also renamed a potential name collision with the global `process` name.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Tried to investigate based on https://github.com/theia-ide/theia/pull/4556#issuecomment-472570013

I still think that the code shouldn't fail the way it is written, but maybe I am overlooking something.
Meanwhile, one of the culprits could be the name collision with `process`, on which `output` is indeed undefined...

This commit also fix the errors like: https://travis-ci.org/theia-ide/theia/jobs/508469621#L2568