### PR TITLE
[git] make the diff navigation header static

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -401,7 +401,7 @@ export class GitDiffListContainer extends React.Component<GitDiffListContainer.P
 
     render() {
         const { id, files } = this.props;
-        return <div ref={ref => this.listContainer = ref || undefined} className='listContainer' id={id} tabIndex={0}>{...files}</div>;
+        return <div ref={ref => this.listContainer = ref || undefined} className='listContainer filesChanged' id={id} tabIndex={0}>{...files}</div>;
     }
 
     componentDidMount() {

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -36,7 +36,7 @@
 
 .theia-git .header-row {
     display: flex;
-    flex-direction: row; 
+    flex-direction: row;
 }
 
 .theia-git .header-value {
@@ -63,4 +63,9 @@
     display: inline-block;
     margin-left: 10px;
     cursor: pointer;
+}
+
+.theia-git .listContainer.filesChanged {
+    flex: 1;
+    overflow: auto;
 }


### PR DESCRIPTION
Fixes #3456

Updated the `git diff` navigation header to be static (fixed).
Currently when there are a lot of changes present in the files changed
list, we lose the header when scrolling. This means that the navigation and
information present in the header is lost so users must always scroll
to the top to access them. This change addresses that issue by providing a
new css class and overflowing only the files changed list to be scrollable.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
