### PR TITLE
Set the minimum perfect scrollbar length

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -133,7 +133,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     ) {
         super();
         this.scrollOptions = {
-            suppressScrollX: true
+            suppressScrollX: true,
+            minScrollbarLength: 35
         };
         this.addClass(TREE_CLASS);
         this.node.tabIndex = 0;

--- a/packages/core/src/browser/widgets/react-widget.tsx
+++ b/packages/core/src/browser/widgets/react-widget.tsx
@@ -28,7 +28,8 @@ export abstract class ReactWidget extends BaseWidget {
     constructor() {
         super();
         this.scrollOptions = {
-            suppressScrollX: true
+            suppressScrollX: true,
+            minScrollbarLength: 35,
         };
         this.toDispose.push(Disposable.create(() => {
             ReactDOM.unmountComponentAtNode(this.node);


### PR DESCRIPTION
Fixes #2788

Set the minimum perfect scrollbar length with the `minScrollbarLength`
scrollbar option. Currently in Theia, when there is a lot of vertical
height the scrollbar becomes quite small and hard to use. With this
change we define a minimum length for the scrollbar so it always
remains easily visible for users.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
