### PR TITLE
Update scrollbar width to a larger value

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -158,18 +158,18 @@
 }
 
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x  > .ps__thumb-x {
-  height: var(--theia-private-horizontal-tab-scrollbar-height);
+  height: var(--theia-private-horizontal-tab-scrollbar-height) !important;
   bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
 }
 
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover,
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus {
-  height: var(--theia-private-horizontal-tab-scrollbar-rail-height);
+  height: var(--theia-private-horizontal-tab-scrollbar-rail-height) !important;
 }
 
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:hover > .ps__thumb-x,
 .p-TabBar[data-orientation='horizontal'] > .p-TabBar-content-container > .ps__rail-x:focus > .ps__thumb-x {
-  height: var(--theia-private-horizontal-tab-scrollbar-height);
+  height: calc(var(--theia-private-horizontal-tab-scrollbar-height) / 2) !important;
   bottom: calc((var(--theia-private-horizontal-tab-scrollbar-rail-height) - var(--theia-private-horizontal-tab-scrollbar-height)) / 2);
 }
 

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -187,7 +187,7 @@ is not optimized for dense, information rich UIs.
   --theia-icon-open-file: url(../icons/open-file-bright.svg);
 
   /* Scrollbars */
-  --theia-scrollbar-width: 6px;
+  --theia-scrollbar-width: 10px;
   --theia-scrollbar-rail-width: 10px;
   --theia-scrollbar-thumb-color: hsla(0,0%,61%,.4);
   --theia-scrollbar-rail-color: transparent;

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -187,7 +187,7 @@ is not optimized for dense, information rich UIs.
   --theia-icon-open-file: url(../icons/open-file-dark.svg);
 
   /* Scrollbars */
-  --theia-scrollbar-width: 6px;
+  --theia-scrollbar-width: 10px;
   --theia-scrollbar-rail-width: 10px;
   --theia-scrollbar-thumb-color: hsla(0,0%,39%,.4);
   --theia-scrollbar-rail-color: transparent;


### PR DESCRIPTION
Minor change to the perfect scrollbar width to update to a larger value. The change means that
the scrollbar is more accessible, visible and aligns more with the styling present in VSCode.

|Before|After|
|:---:|:---:|
|<img width="1267" alt="Screen Shot 2019-03-19 at 10 09 22 PM" src="https://user-images.githubusercontent.com/40359487/54654196-bfcc5c80-4a93-11e9-8dfc-2e40b06eae28.png">|<img width="1267" alt="Screen Shot 2019-03-19 at 10 12 12 PM" src="https://user-images.githubusercontent.com/40359487/54654289-1043ba00-4a94-11e9-9794-03ab1ddbb1e4.png">|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
