### PR TITLE
Adjust open workspace explorer button alignment

### DIFF
--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -24,6 +24,9 @@
 .theia-navigator-container .open-workspace-button-container {
     margin: auto;
     margin-top: 5px;
+    display: flex;
+    justify-content: center;
+    align-self: center;
 }
 
 .theia-navigator-container .center {


### PR DESCRIPTION
Adjust the `Open Workspace` button present in the explorer when no workspace is currently opened. Previously, the alignment of the button was off (not centered) and after the change the button was updated to be centered in the widget.

|Before|After|
|:---:|:---:|
|<img width="474" alt="Screen Shot 2019-03-20 at 8 54 53 AM" src="https://user-images.githubusercontent.com/40359487/54686064-c936e280-4aee-11e9-8cc9-f9db5e9a3244.png">| <img width="510" alt="Screen Shot 2019-03-20 at 8 59 10 AM" src="https://user-images.githubusercontent.com/40359487/54686074-cf2cc380-4aee-11e9-9aae-e3cfc4c245c0.png">|



Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
