### PR TITLE
Don't redeploy already initialized plugins

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -50,6 +50,10 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         for (const plugin of frontendPlugins) {
             const metadata = await this.reader.getPluginMetadata(plugin.path());
             if (metadata) {
+                if (this.getDeployedFrontendMetadata().some(value => value.model.id === metadata.model.id)) {
+                    continue;
+                }
+
                 this.currentFrontendPluginsMetadata.push(metadata);
                 this.logger.info(`Deploying frontend plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint.frontend || plugin.path()}"`);
             }
@@ -60,6 +64,10 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
         for (const plugin of backendPlugins) {
             const metadata = await this.reader.getPluginMetadata(plugin.path());
             if (metadata) {
+                if (this.getDeployedBackendMetadata().some(value => value.model.id === metadata.model.id)) {
+                    continue;
+                }
+
                 this.currentBackendPluginsMetadata.push(metadata);
                 this.logger.info(`Deploying backend plugin "${metadata.model.name}@${metadata.model.version}" from "${metadata.model.entryPoint.backend || plugin.path()}"`);
             }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-deploy-command.ts
@@ -87,7 +87,7 @@ export class DeployQuickOpenItem extends QuickOpenItem {
         protected readonly pluginServer: PluginServer,
         protected readonly hostedPluginSupport: HostedPluginSupport,
         protected readonly pluginWidget: PluginWidget,
-        protected readonly description?: string,
+        protected readonly description?: string
     ) {
         super();
     }

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -37,7 +37,7 @@ export class PluginDeployerImpl implements PluginDeployer {
     protected readonly logger: ILogger;
 
     @inject(PluginDeployerHandler)
-    protected readonly hostedPluginServer: PluginDeployerHandler;
+    protected readonly pluginDeployerHandler: PluginDeployerHandler;
 
     @inject(PluginCliContribution)
     protected readonly cliContribution: PluginCliContribution;
@@ -112,9 +112,7 @@ export class PluginDeployerImpl implements PluginDeployer {
     }
 
     public async deploy(pluginEntry: string): Promise<void> {
-        const entries: string[] = [];
-        entries.push(pluginEntry);
-        await this.deployMultipleEntries(entries);
+        await this.deployMultipleEntries([pluginEntry]);
         return Promise.resolve();
     }
 
@@ -156,8 +154,8 @@ export class PluginDeployerImpl implements PluginDeployer {
 
         await Promise.all([
             // start the backend plugins
-            this.hostedPluginServer.deployBackendPlugins(acceptedBackendPlugins),
-            this.hostedPluginServer.deployFrontendPlugins(acceptedFrontendPlugins)
+            this.pluginDeployerHandler.deployBackendPlugins(acceptedBackendPlugins),
+            this.pluginDeployerHandler.deployFrontendPlugins(acceptedFrontendPlugins)
         ]);
     }
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### Reference issue
https://github.com/theia-ide/theia/issues/4181

Accordingly to the doc [1] activate method must be invoked only once. So, instead of redeploying all plugins this PR allows to deploy the only plugin that user selected.

[1] https://code.visualstudio.com/api/references/activation-events#Start-up