### PR TITLE
set git diff title icon

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -93,6 +93,8 @@
   opacity: 0.6;
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
+  mask-size: 28px;
+  -webkit-mask-size: 28px;
 }
 
 .p-TabBar.theia-app-sides .file-icon.p-TabBar-tabIcon:hover,

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -49,6 +49,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         this.id = GIT_DIFF;
         this.scrollContainer = 'git-diff-list-container';
         this.title.label = 'Diff';
+        this.title.iconClass = 'theia-git-diff-icon';
 
         this.addClass('theia-git');
     }

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -18,6 +18,11 @@
     color: var(--theia-ui-font-color1);
 }
 
+.theia-git-diff-icon {
+    -webkit-mask: url('git-diff.svg');
+    mask: url('git-diff.svg');
+}
+
 .theia-git .git-diff-container {
     display: flex;
     flex-direction: column;

--- a/packages/git/src/browser/style/git-diff.svg
+++ b/packages/git/src/browser/style/git-diff.svg
@@ -1,0 +1,6 @@
+<!--Copyright (c) Microsoft Corporation. All rights reserved.-->
+<!--Copyright (C) 2019 TypeFox and others.-->
+<!--Licensed under the MIT License. See License.txt in the project root for license information.-->
+<svg fill="#F6F6F6" height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+    <path clip-rule="evenodd" d="m6 12h-1c-.27-.02-.48-.11-.69-.31s-.3-.42-.31-.69v-6.28c.59-.34 1-.98 1-1.72 0-1.11-.89-2-2-2s-2 .89-2 2c0 .73.41 1.38 1 1.72v6.28c.03.78.34 1.47.94 2.06s1.28.91 2.06.94c0 0 1.02 0 1 0v2l3-3-3-3zm-3-10.2c.66 0 1.2.55 1.2 1.2s-.55 1.2-1.2 1.2-1.2-.55-1.2-1.2.55-1.2 1.2-1.2zm11 9.48c0-1.73 0-6.28 0-6.28-.03-.78-.34-1.47-.94-2.06s-1.28-.91-2.06-.94h-1v-2l-3 3 3 3v-2h1c.27.02.48.11.69.31s.3.42.31.69v6.28c-.59.34-1 .98-1 1.72 0 1.11.89 2 2 2s2-.89 2-2c0-.73-.41-1.38-1-1.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2s.55-1.2 1.2-1.2 1.2.55 1.2 1.2-.55 1.2-1.2 1.2z" fill="#F6F6F6" fill-rule="evenodd" />
+</svg>


### PR DESCRIPTION
fix #4633

the existing icon was modified, no new icons were copied

<img width="482" alt="Screen Shot 2019-03-21 at 10 50 05" src="https://user-images.githubusercontent.com/3082655/54744381-27cf8f80-4bc7-11e9-89d8-1a55ac3bdf7f.png">
<img width="418" alt="Screen Shot 2019-03-21 at 10 49 56" src="https://user-images.githubusercontent.com/3082655/54744382-28682600-4bc7-11e9-883e-035b6de300eb.png">