### PR TITLE
Add missing git diff caption

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -32,6 +32,8 @@ export const GIT_DIFF = 'git-diff';
 @injectable()
 export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> implements StatefulWidget {
 
+    protected readonly GIT_DIFF_TITLE = 'Diff';
+
     protected fileChangeNodes: GitFileChangeNode[] = [];
     protected options: Git.Options.Diff;
 
@@ -48,7 +50,9 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         super();
         this.id = GIT_DIFF;
         this.scrollContainer = 'git-diff-list-container';
-        this.title.label = 'Diff';
+        this.title.label = this.GIT_DIFF_TITLE;
+        this.title.caption = this.GIT_DIFF_TITLE;
+
         this.title.iconClass = 'theia-git-diff-icon';
 
         this.addClass('theia-git');


### PR DESCRIPTION
Fixes #4639

Currently, the `git-diff-widget` does not have a caption (tooltip).
This means that when the widget is docked, and it's icon is displayed,
no tooltip is shown when hovering while others widget do include it.
For the sake of completeness and consistency, the `git-diff-widget`
should include a caption.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
