### PR TITLE
Don't let sidepanel titles wrap.

### DIFF
--- a/packages/core/src/browser/shell/side-panel-toolbar.ts
+++ b/packages/core/src/browser/shell/side-panel-toolbar.ts
@@ -71,6 +71,7 @@ export class SidePanelToolbar extends Widget {
     protected init(): void {
         this.titleContainer = document.createElement('div');
         this.titleContainer.classList.add('theia-sidepanel-title');
+        this.titleContainer.classList.add('noWrapInfo');
         this.node.appendChild(this.titleContainer);
         this.node.classList.add('theia-sidepanel-toolbar');
         this.node.classList.add(`theia-${this.side}-side-panel`);


### PR DESCRIPTION
<img width="110" alt="Screen Shot 2019-03-21 at 15 16 11" src="https://user-images.githubusercontent.com/28291421/54758420-6b88c000-4bec-11e9-99f9-653670d83800.png">

Fixes theia-ide/theia#4644