### PR TITLE
Added debug console icon

### DIFF
--- a/packages/debug/src/browser/console/debug-console-contribution.ts
+++ b/packages/debug/src/browser/console/debug-console-contribution.ts
@@ -41,7 +41,8 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
     static options: ConsoleOptions = {
         id: 'debug-console',
         title: {
-            label: 'Debug Console'
+            label: 'Debug Console',
+            iconClass: 'theia-debug-console-icon'
         },
         input: {
             uri: DebugConsoleSession.uri,

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -157,6 +157,11 @@
     mask: url('debug-dark.svg') 50%;
 }
 
+.theia-debug-console-icon {
+    -webkit-mask: url('repl.svg');
+    mask: url('repl.svg');
+}
+
 /** Console */
 
 .theia-debug-console-unavailable {


### PR DESCRIPTION
Fixes #4638

Added debug console icon. The icon selected is the same
as found from the debug widget to open the debug console.

<div align='center'>

![Screenshot from 2019-03-21 10-51-25](https://user-images.githubusercontent.com/40359487/54760873-58afc480-4bc7-11e9-89d6-0eb1c54a9f08.png)
![Screenshot from 2019-03-21 10-51-48](https://user-images.githubusercontent.com/40359487/54760876-58afc480-4bc7-11e9-8bd5-2c0e2a499430.png)

</div>



Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
