### PR TITLE
center and reorder icons in side bars

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -23,6 +23,7 @@
   --theia-private-sidebar-tab-height: 32px;
   --theia-private-sidebar-scrollbar-rail-width: 7px;
   --theia-private-sidebar-scrollbar-width: 5px;
+  --theia-private-sidebar-icon-size: 28px;
 }
 
 
@@ -56,10 +57,12 @@
 
 .p-TabBar.theia-app-left .p-TabBar-tab {
   border-left: var(--theia-panel-border-width) solid var(--theia-layout-color2);
+  margin-right: var(--theia-panel-border-width);
 }
 
 .p-TabBar.theia-app-right .p-TabBar-tab {
   border-right: var(--theia-panel-border-width) solid var(--theia-layout-color2);
+  margin-left: var(--theia-panel-border-width);
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tab.p-mod-current {
@@ -87,14 +90,14 @@
 }
 
 .p-TabBar.theia-app-sides .p-TabBar-tabIcon {
-  width: 30px;
-  height: 28px;
+  width: var(--theia-private-sidebar-icon-size);
+  height: var(--theia-private-sidebar-icon-size);
   background-color: var(--theia-tab-icon-color);
   opacity: 0.6;
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
-  mask-size: 28px;
-  -webkit-mask-size: 28px;
+  mask-size: var(--theia-private-sidebar-icon-size);
+  -webkit-mask-size: var(--theia-private-sidebar-icon-size);
 }
 
 .p-TabBar.theia-app-sides .file-icon.p-TabBar-tabIcon:hover,

--- a/packages/extension-manager/src/browser/extension-contribution.ts
+++ b/packages/extension-manager/src/browser/extension-contribution.ts
@@ -35,7 +35,7 @@ export class ExtensionContribution extends AbstractViewContribution<ExtensionWid
             widgetName: 'Extensions',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 300
+                rank: 500
             },
             toggleCommandId: 'extensionsView:toggle',
             toggleKeybinding: 'ctrlcmd+shift+x'

--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -56,7 +56,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
             widgetName: 'Git diff',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 400
+                rank: 500
             }
         });
     }

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -162,7 +162,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
             widgetName: 'Git',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 200
+                rank: 300
             },
             toggleCommandId: 'gitView:toggle',
             toggleKeybinding: 'ctrlcmd+shift+g'

--- a/packages/git/src/browser/history/git-history-contribution.ts
+++ b/packages/git/src/browser/history/git-history-contribution.ts
@@ -61,7 +61,7 @@ export class GitHistoryContribution extends AbstractViewContribution<GitHistoryW
             widgetName: GIT_HISTORY_LABEL,
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 400
+                rank: 500
             },
             toggleCommandId: GitHistoryCommands.OPEN_BRANCH_HISTORY.id,
             toggleKeybinding: GIT_HISTORY_TOGGLE_KEYBINDING

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-view-contribution.ts
@@ -29,7 +29,7 @@ export class PluginFrontendViewContribution extends AbstractViewContribution<Plu
             widgetName: 'Plugins',
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 300
+                rank: 400
             },
             toggleCommandId: 'pluginsView:toggle',
             toggleKeybinding: 'ctrlcmd+shift+l'

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -80,7 +80,7 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
             widgetName: SearchInWorkspaceWidget.LABEL,
             defaultWidgetOptions: {
                 area: 'left',
-                rank: 300
+                rank: 200
             },
             toggleCommandId: SearchInWorkspaceCommands.TOGGLE_SIW_WIDGET.id
         });


### PR DESCRIPTION
This PR:
- make sure that title icons are centered in side-bars
- reorder views in side bars to mimic VS Code order