### PR TITLE
keep properties in definitions of contributed tasks

### DIFF
--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1679,17 +1679,16 @@ export class Task {
     }
 
     private updateDefinitionBasedOnExecution(): void {
-        this.taskDefinition = undefined;
         if (this.taskExecution instanceof ProcessExecution) {
-            this.taskDefinition = {
+            Object.assign(this.taskDefinition, {
                 type: 'process',
                 id: this.taskExecution.computeId()
-            };
+            });
         } else if (this.taskExecution instanceof ShellExecution) {
-            this.taskDefinition = {
+            Object.assign(this.taskDefinition, {
                 type: 'shell',
                 id: this.taskExecution.computeId()
-            };
+            });
         }
     }
 }


### PR DESCRIPTION
Task constructor assigns type and id to contributed tasks and removes all the other properties from the task definitions at the same time. This causes Theia not having enough information to proceed when applying customization from tasks.json to the contributed tasks. With this change no properties would be removed from definitions of contributed tasks.

Signed-off-by: elaihau <liang.huang@ericsson.com>
