### PR TITLE
Fix minor typo in tree.spec.ts

### DIFF
--- a/packages/core/src/browser/tree/tree.spec.ts
+++ b/packages/core/src/browser/tree/tree.spec.ts
@@ -93,7 +93,7 @@ describe('Tree', () => {
 }`, node);
   });
 
-  it('removeChild - thrid', () => {
+  it('removeChild - third', () => {
     const node = getNode();
     CompositeTreeNode.removeChild(node, node.children[2]);
     assertTreeNode(`{


### PR DESCRIPTION
Fixed minor typo found in `tree.spec.ts`.

**Note:** this small PR was used to verify if the `Eclipse ECA Validation` tool worked correctly.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
