### PR TITLE
Added collapse all toolbar item to the explorer

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -30,6 +30,7 @@ import { NavigatorKeybindingContexts } from './navigator-keybinding-context';
 import { FileNavigatorFilter } from './navigator-filter';
 import { WorkspaceNode } from './navigator-tree';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export namespace FileNavigatorCommands {
     export const REVEAL_IN_NAVIGATOR: Command = {
@@ -41,7 +42,8 @@ export namespace FileNavigatorCommands {
         label: 'Toggle Hidden Files'
     };
     export const COLLAPSE_ALL: Command = {
-        id: 'navigator.collapse.all'
+        id: 'navigator.collapse.all',
+        iconClass: 'collapse-all'
     };
 }
 
@@ -77,7 +79,7 @@ export namespace NavigatorContextMenu {
 }
 
 @injectable()
-export class FileNavigatorContribution extends AbstractViewContribution<FileNavigatorWidget> implements FrontendApplicationContribution {
+export class FileNavigatorContribution extends AbstractViewContribution<FileNavigatorWidget> implements FrontendApplicationContribution, TabBarToolbarContribution {
 
     @inject(NavigatorContextKeyService)
     protected readonly contextKeyService: NavigatorContextKeyService;
@@ -251,6 +253,15 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             command: FileNavigatorCommands.TOGGLE_HIDDEN_FILES.id,
             keybinding: 'ctrlcmd+i',
             context: NavigatorKeybindingContexts.navigatorActive
+        });
+    }
+
+    async registerToolbarItems(toolbarRegistry: TabBarToolbarRegistry): Promise<void> {
+        toolbarRegistry.registerItem({
+            id: FileNavigatorCommands.COLLAPSE_ALL.id,
+            command: FileNavigatorCommands.COLLAPSE_ALL.id,
+            tooltip: 'Collapse All',
+            priority: 0,
         });
     }
 

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -26,6 +26,7 @@ import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { bindFileNavigatorPreferences } from './navigator-preferences';
 import { FileNavigatorFilter } from './navigator-filter';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -35,6 +36,7 @@ export default new ContainerModule(bind => {
 
     bindViewContribution(bind, FileNavigatorContribution);
     bind(FrontendApplicationContribution).toService(FileNavigatorContribution);
+    bind(TabBarToolbarContribution).toService(FileNavigatorContribution);
 
     bind(KeybindingContext).to(NavigatorActiveContext).inSingletonScope();
 


### PR DESCRIPTION
Added a `collapse all` toolbar item to the explorer used to collapse all nodes from the `navigator-tree`.

<img width="380" alt="Screen Shot 2019-03-21 at 7 55 38 PM" src="https://user-images.githubusercontent.com/40359487/54792268-c5e94700-4c13-11e9-9c98-bb17128b7f9c.png">

**Note:** I use the `collapse-all` toolbar item in vscode daily and thought it'd be something quite useful to have easily accessible in Theia. At the moment we are not using a band for the root node which has multiple toolbar actions in vscode, so the only logical place I could think of adding the toolbar item is for the widget itself, much like the `search-in-workspace`. 

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
