### PR TITLE
[search-in-workspace] add missing icon tooltips

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -177,18 +177,21 @@ export class SearchInWorkspaceFrontendContribution extends AbstractViewContribut
         toolbarRegistry.registerItem({
             id: SearchInWorkspaceCommands.REFRESH_RESULTS.id,
             command: SearchInWorkspaceCommands.REFRESH_RESULTS.id,
+            tooltip: SearchInWorkspaceCommands.REFRESH_RESULTS.label,
             priority: 0,
             onDidChange
         });
         toolbarRegistry.registerItem({
             id: SearchInWorkspaceCommands.CLEAR_ALL.id,
             command: SearchInWorkspaceCommands.CLEAR_ALL.id,
+            tooltip: SearchInWorkspaceCommands.CLEAR_ALL.label,
             priority: 1,
             onDidChange
         });
         toolbarRegistry.registerItem({
             id: SearchInWorkspaceCommands.COLLAPSE_ALL.id,
             command: SearchInWorkspaceCommands.COLLAPSE_ALL.id,
+            tooltip: SearchInWorkspaceCommands.COLLAPSE_ALL.label,
             priority: 2,
             onDidChange
         });


### PR DESCRIPTION
Added missing `search-in-workspace` icon tooltips to align with vscode.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
