### PR TITLE
[navigator] don't apply collapse all item to all widgets

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -115,7 +115,6 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         };
         updateFocusContextKeys();
         this.shell.activeChanged.connect(updateFocusContextKeys);
-
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
@@ -137,10 +136,17 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             isVisible: () => true
         });
         registry.registerCommand(FileNavigatorCommands.COLLAPSE_ALL, {
-            execute: () => this.collapseFileNavigatorTree(),
-            isEnabled: () => this.workspaceService.opened,
-            isVisible: () => this.workspaceService.opened
+            execute: widget => this.withWidget(widget, () => this.collapseFileNavigatorTree()),
+            isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
+            isVisible: wodget => this.withWidget(wodget, () => this.workspaceService.opened)
         });
+    }
+
+    protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (navigator: FileNavigatorWidget) => T): T | false {
+        if (widget instanceof FileNavigatorWidget && widget.id === FILE_NAVIGATOR_ID) {
+            return cb(widget);
+        }
+        return false;
     }
 
     registerMenus(registry: MenuModelRegistry): void {


### PR DESCRIPTION
Toolbar item's command should check a given widget otherwise it is applied to all widgets by default.


State on master:
<img width="424" alt="Screen Shot 2019-03-22 at 09 26 40" src="https://user-images.githubusercontent.com/3082655/54809800-a0e0ec80-4c84-11e9-8cc0-3c9eef4ed55f.png">
