### PR TITLE
Set background of webview-icons to 'none'.

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/webview.css
+++ b/packages/plugin-ext/src/main/browser/style/webview.css
@@ -24,3 +24,7 @@
     flex-grow: 1;
     border: none; margin: 0; padding: 0;
 }
+
+.webview-icon {
+    background: none !important;
+}


### PR DESCRIPTION
Since the new styles of tabs using svg files as masks with a certain backgroundcolor set, font-icons need the background set to none in respective css. 
Done here for webview-icons.

Fixes theia-ide/theia#4664

