### PR TITLE
[workspace] Improved performance for the file rename action

### DIFF
--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -235,7 +235,7 @@ export class WorkspaceCommandContribution implements CommandContribution {
                         });
                         dialog.open().then(name => {
                             if (name) {
-                                this.fileSystem.move(uri.toString(), uri.parent.resolve(name).toString());
+                                this.fileSystem.move(uri.toString(), uri.parent.resolve(name).toString(), { overwrite: true });
                             }
                         });
                     }


### PR DESCRIPTION
When a file or a folder is renamed from the context menu, if the overwrite flag is set to false, the rename is performed (by the mv library) by copying the source to the target and then deleting the source. If the source file or folder is large, this process may take a long time during which the user is shown the two folders.

Since the renaming action already checks that no file or folder with the target name exists, it's safe to set the overwrite flag to true.