### PR TITLE
Add line numbers to search-in-workspace results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0
 - [plugin] `workspace.openTextDocument` API now respects the contributed `FileSystemProviders`
+- [search-in-workspace] added a new preference `search.lineNumbers` to control whether to show line numbers for search results.
 
 Breaking changes:
 - [editor] computation of resource context keys moved to core [#4531](https://github.com/theia-ide/theia/pull/4531)

--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-module.ts
@@ -27,6 +27,7 @@ import { SearchInWorkspaceFrontendContribution } from './search-in-workspace-fro
 import { InMemoryTextResourceResolver } from './in-memory-text-resource';
 import { SearchInWorkspaceContextKeyService } from './search-in-workspace-context-key-service';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { bindSearchInWorkspacePreferences } from './search-in-workspace-preferences';
 
 export default new ContainerModule(bind => {
     bind(SearchInWorkspaceContextKeyService).toSelf().inSingletonScope();
@@ -55,6 +56,8 @@ export default new ContainerModule(bind => {
 
     bind(InMemoryTextResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(InMemoryTextResourceResolver);
+
+    bindSearchInWorkspacePreferences(bind);
 });
 
 export function createSearchTreeWidget(parent: interfaces.Container): SearchInWorkspaceResultTreeWidget {

--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { PreferenceSchema, PreferenceProxy, PreferenceService, createPreferenceProxy, PreferenceContribution } from '@theia/core/lib/browser/preferences';
+import { interfaces } from 'inversify';
+
+export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
+    type: 'object',
+    properties: {
+        'search.lineNumbers': {
+            description: 'Controls whether to show line numbers for search results.',
+            default: false,
+            type: 'boolean',
+        }
+    }
+};
+
+export class SearchInWorkspaceConfiguration {
+    'search.lineNumbers': boolean;
+}
+
+export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');
+export type SearchInWorkspacePreferences = PreferenceProxy<SearchInWorkspaceConfiguration>;
+
+export function createSearchInWorkspacePreferences(preferences: PreferenceService): SearchInWorkspacePreferences {
+    return createPreferenceProxy(preferences, searchInWorkspacePreferencesSchema);
+}
+
+export function bindSearchInWorkspacePreferences(bind: interfaces.Bind): void {
+    bind(SearchInWorkspacePreferences).toDynamicValue(ctx => {
+        const preferences = ctx.container.get<PreferenceService>(PreferenceService);
+        return createSearchInWorkspacePreferences(preferences);
+    }).inSingletonScope();
+    bind(PreferenceContribution).toConstantValue({ schema: searchInWorkspacePreferencesSchema });
+}

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -42,6 +42,7 @@ import { SearchInWorkspaceService } from './search-in-workspace-service';
 import { MEMORY_TEXT } from './in-memory-text-resource';
 import URI from '@theia/core/lib/common/uri';
 import * as React from 'react';
+import { SearchInWorkspacePreferences } from './search-in-workspace-preferences';
 
 const ROOT_ID = 'ResultTree';
 
@@ -115,6 +116,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(TreeExpansionService) protected readonly expansionService: TreeExpansionService;
+    @inject(SearchInWorkspacePreferences) protected readonly searchInWorkspacePreferences: SearchInWorkspacePreferences;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -152,6 +154,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
         this.toDispose.push(this.editorManager.onActiveEditorChanged(() => {
             this.updateCurrentEditorDecorations();
+        }));
+
+        this.toDispose.push(this.searchInWorkspacePreferences.onPreferenceChanged(() => {
+            this.update();
         }));
     }
 
@@ -588,6 +594,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
     protected renderResultLineNode(node: SearchInWorkspaceResultLineNode): React.ReactNode {
         const prefix = node.character > 26 ? '... ' : '';
         return <div className={`resultLine noWrapInfo ${node.selected ? 'selected' : ''}`}>
+            {this.searchInWorkspacePreferences['search.lineNumbers'] && <span className='theia-siw-lineNumber'>{node.line}</span>}
             <span>
                 {prefix + node.lineText.substr(0, node.character - 1).substr(-25)}
             </span>

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -397,3 +397,8 @@
     color: var(--theia-ui-font-color2);
     margin-left: 17px;
 }
+
+.theia-siw-lineNumber {
+    color:  var(--theia-ui-font-color2);
+    padding-right: 4px;
+}


### PR DESCRIPTION
Added line numbers to the `search-in-workspace` results, which
are added through a preference. This enables users to easily
view which line the results are found with the already included
file name and short excerpt of line.

<div align='center'>

<img width="1156" alt="Screen Shot 2019-03-22 at 4 39 42 PM" src="https://user-images.githubusercontent.com/40359487/54851713-2edac880-4cc1-11e9-8da6-5764a10e77c4.png">


</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
