### PR TITLE
[core] disabled expand animation

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1444,19 +1444,19 @@ export namespace ApplicationShell {
         bottomPanel: Object.freeze(<BottomPanelOptions>{
             emptySize: 140,
             expandThreshold: 160,
-            expandDuration: 150,
+            expandDuration: 0,
             initialSizeRatio: 0.382
         }),
         leftPanel: Object.freeze(<SidePanel.Options>{
             emptySize: 140,
             expandThreshold: 140,
-            expandDuration: 150,
+            expandDuration: 0,
             initialSizeRatio: 0.191
         }),
         rightPanel: Object.freeze(<SidePanel.Options>{
             emptySize: 140,
             expandThreshold: 140,
-            expandDuration: 150,
+            expandDuration: 0,
             initialSizeRatio: 0.191
         })
     });


### PR DESCRIPTION
Set defaults to have panel expansion animation disabled (same as in VS Code and basically every other IDE). Also especially with opened terminals the slow animation on the right panel was causing strange resizing effects.