### PR TITLE
Fix incorrect notification-count styling

### DIFF
--- a/packages/core/src/browser/style/notification.css
+++ b/packages/core/src/browser/style/notification.css
@@ -14,6 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+:root {
+    --theia-notification-count-height: 15.5px;
+}
+
 .notification-count-container {
     align-self: center;
     background-color: var(--theia-ui-font-color3);
@@ -22,7 +26,7 @@
     display: flex;
     font-size: calc(var(--theia-ui-font-size0) * 0.8);
     font-weight: 500;
-    height: calc(var(--theia-private-horizontal-tab-height) * 0.7);
+    height: var(--theia-notification-count-height);
     justify-content: center;
     min-width: 6px;
     padding: 0 5px;

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -14,6 +14,10 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+:root {
+    --theia-private-mini-browser-height: 22px;
+}
+
 .theia-mini-browser {
     display: flex;
     flex-direction: column;
@@ -41,14 +45,14 @@
 
 .theia-mini-browser-toolbar input {
     width: 100%;
-    line-height: var(--theia-private-horizontal-tab-height);
+    line-height: var(--theia-private-mini-browser-height);
     margin-left: 4px;
     margin-right: 4px;
 }
 
 .theia-mini-browser-toolbar-read-only input {
     width: 100%;
-    line-height: var(--theia-private-horizontal-tab-height);
+    line-height: var(--theia-private-mini-browser-height);
     margin-left: 4px;
     margin-right: 4px;
     cursor: pointer;


### PR DESCRIPTION
Fixes #4678

- Added a new css variable in order to handle the `notification-count` height, and limit the risk of updating it as a side effect.

| Before | After |
|:---:|:---:|
|<img width="751" alt="Screen Shot 2019-03-23 at 11 54 21 AM" src="https://user-images.githubusercontent.com/40359487/54868474-3a7ecb80-4d63-11e9-891c-bb31886b82de.png">|<img width="749" alt="Screen Shot 2019-03-23 at 11 56 42 AM" src="https://user-images.githubusercontent.com/40359487/54868488-410d4300-4d63-11e9-980e-8a52c40225da.png">|



Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
