### PR TITLE
typehierarchy shortcut is now ctrlcmd+shift+h #4558

### DIFF
--- a/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
+++ b/packages/typehierarchy/src/browser/typehierarchy-contribution.ts
@@ -44,7 +44,7 @@ export class TypeHierarchyContribution extends AbstractViewContribution<TypeHier
                 area: 'bottom'
             },
             toggleCommandId: TypeHierarchyCommands.TOGGLE_VIEW.id,
-            toggleKeybinding: 'ctrlcmd+alt+a'
+            toggleKeybinding: 'ctrlcmd+shift+h'
         });
     }
 


### PR DESCRIPTION
The shortcut for toggling the typehierarchy view is now ctrlcmd+shift+h
Proposal for #4558 
