### PR TITLE
Fix tree node capitalization outside of nav

### DIFF
--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -53,7 +53,7 @@
     mask: url('files.svg');
 }
 
-.theia-FileTree > div > div > div > div:first-child {
+#files > div > div > div > div:first-child {
     background-color: var(--theia-layout-color4);
     text-transform: uppercase;
     font-size: 80%;


### PR DESCRIPTION
Fixes #4692

The PR #4670 introduced changes which meant that the navigator's file tree's
first node was capitalized among other styling updates. Since other components
use the same `class` `theia-FileTree`, those components were also updated as a
consequence. This PR addresses that issue by making sure only the navigator
gets the new styling by using its `id` instead of the generic class.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
