### PR TITLE
fix ToolbarAwareTabBar detachment

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -337,9 +337,6 @@ export class ToolbarAwareTabBar extends ScrollableTabBar {
     }
 
     protected onBeforeDetach(msg: Message): void {
-        if (this.contentContainer) {
-            this.node.removeChild(this.contentContainer);
-        }
         if (this.toolbar && this.toolbar.isAttached) {
             Widget.detach(this.toolbar);
         }


### PR DESCRIPTION
fix #3674: detachment should rollback what attachment does, not remove nodes created in the constructor.