### PR TITLE
[UX] Make sidebar widgets closable

### DIFF
--- a/packages/extension-manager/src/browser/extension-widget.tsx
+++ b/packages/extension-manager/src/browser/extension-widget.tsx
@@ -42,6 +42,7 @@ export class ExtensionWidget extends ReactWidget {
         this.title.label = 'Extensions';
         this.title.caption = 'Extensions';
         this.title.iconClass = 'extensions-tab-icon';
+        this.title.closable = true;
         this.addClass('theia-extensions');
 
         this.update();

--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -52,7 +52,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
         this.scrollContainer = 'git-diff-list-container';
         this.title.label = this.GIT_DIFF_TITLE;
         this.title.caption = this.GIT_DIFF_TITLE;
-
+        this.title.closable = true;
         this.title.iconClass = 'theia-git-diff-icon';
 
         this.addClass('theia-git');

--- a/packages/git/src/browser/git-widget.tsx
+++ b/packages/git/src/browser/git-widget.tsx
@@ -81,6 +81,7 @@ export class GitWidget extends GitDiffWidget implements StatefulWidget {
         this.title.label = 'Git';
         this.title.caption = 'Git';
         this.title.iconClass = 'git-tab-icon';
+        this.title.closable = true;
         this.scrollContainer = GitWidget.Styles.CHANGES_CONTAINER;
         this.addClass('theia-git');
         this.node.tabIndex = 0;

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -76,6 +76,7 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
         this.title.label = GIT_HISTORY_LABEL;
         this.title.caption = GIT_HISTORY_LABEL;
         this.title.iconClass = 'fa git-history-tab-icon';
+        this.title.closable = true;
         this.addClass('theia-git');
         this.resetState();
         this.cancelIndicator = new CancellationTokenSource();

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -60,6 +60,7 @@ export class FileNavigatorWidget extends FileTreeWidget {
         this.id = FILE_NAVIGATOR_ID;
         this.title.label = LABEL;
         this.title.caption = LABEL;
+        this.title.closable = true;
         this.title.iconClass = 'navigator-tab-icon';
         this.addClass(CLASS);
         this.initialize();

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -58,6 +58,7 @@ export class OutlineViewWidget extends TreeWidget {
         this.id = 'outline-view';
         this.title.label = 'Outline';
         this.title.caption = 'Outline';
+        this.title.closable = true;
         this.title.iconClass = 'fa outline-view-tab-icon';
         this.addClass('theia-outline-view');
     }

--- a/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-widget.tsx
@@ -40,6 +40,7 @@ export class PluginWidget extends ReactWidget {
         this.title.label = 'Plugins';
         this.title.caption = 'Plugins';
         this.title.iconClass = 'fa plugins-tab-icon';
+        this.title.closable = true;
         this.addClass('theia-plugins');
 
         this.update();

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -87,7 +87,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.title.label = SearchInWorkspaceWidget.LABEL;
         this.title.caption = SearchInWorkspaceWidget.LABEL;
         this.title.iconClass = 'search-in-workspace-tab-icon';
-
+        this.title.closable = true;
         this.contentNode = document.createElement('div');
         this.contentNode.classList.add('t-siw-search-container');
         this.searchFormContainer = document.createElement('div');


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/4691#issuecomment-476149448, this adds the close icon when sidebar widgets are moved to `main-panel`

Before: 
![before](https://i.gyazo.com/5fa3291cdb97f964501909ac9ba612ee.png)

After:
![after](https://i.gyazo.com/8ff426c5dd94d340089c8b0d0c07a75b.png)

Signed-off-by: Uni Sayo <unibtc@gmail.com>