### PR TITLE
[plugin-ext] Make sure that "Toggle Bottom Panel" is always at the most right of the status bar

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1095,7 +1095,7 @@ export class ApplicationShell extends Widget {
                 alignment: StatusBarAlignment.RIGHT,
                 tooltip: 'Toggle Bottom Panel',
                 command: 'core.toggle.bottom.panel',
-                priority: 0
+                priority: -1000
             };
             this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
         }


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/4685. ~~This ensures that plugins that sets a right status bar item, will not have a priority of 0 or less than 0, therefor, making the `toggle bottom panel` to always be the last item.~~

Update: Moved the core.toggle.bottom.panel to the last index during render. This way, it wont mess up any other plugins and the Toggle Bottom Panel will always be the last item(most right).

Before:
![statusbar-before](https://i.gyazo.com/7c0abd60fd1fba7095970b1076e37640.png)

After:
![statusbar-after](https://i.gyazo.com/f5414b871775ee2a7243c182404e57d8.png)

Signed-off-by: Uni Sayo <unibtc@gmail.com>
