### PR TITLE
Update file-icons in sidepanels to not have backgrounds

### DIFF
--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -100,6 +100,7 @@
   -webkit-mask-size: var(--theia-private-sidebar-icon-size);
 }
 
+.p-TabBar.theia-app-sides .file-icon.p-TabBar-tabIcon,
 .p-TabBar.theia-app-sides .file-icon.p-TabBar-tabIcon:hover,
 .p-TabBar.theia-app-sides .p-mod-current .file-icon.p-TabBar-tabIcon,
 .p-TabBar.theia-app-sides .fa.p-TabBar-tabIcon:hover,


### PR DESCRIPTION
Fixes #4704

- `file-icons` present in the sidebars (when an editor is docked on either side)
and are inactive, an odd background box is displayed. This background property
is used by other types of icons (mostly svg) so they have the proper color. In
the case of `file-icons` it is enough to simply not apply this background styling.

| Before | After |
|:---:|:---:|
| <img width="963" alt="Screen Shot 2019-03-25 at 7 12 33 PM" src="https://user-images.githubusercontent.com/40359487/54960181-f857b480-4f31-11e9-8720-19576fc74c41.png">|<img width="963" alt="Screen Shot 2019-03-25 at 7 11 21 PM" src="https://user-images.githubusercontent.com/40359487/54960188-fee62c00-4f31-11e9-813a-58e52179f767.png">|

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
