### PR TITLE
Add missing licenses

### DIFF
--- a/dev-packages/ext-scripts/package.json
+++ b/dev-packages/ext-scripts/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "@theia/ext-scripts",
   "version": "0.4.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "description": "NPM scripts for Theia packages.",
   "files": [
     "theiaext"

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "@theia/example-browser",
   "version": "0.4.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
     "frontend": {
       "config": {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "name": "@theia/example-electron",
   "version": "0.4.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
     "target": "electron",
     "frontend": {


### PR DESCRIPTION
Fixes #4718

In order to help with the IP scan performed by the Eclipse Foundation, it
would help to add license info in each `package.json`. This PR addresses
the `package.json` which do not currently have licenses.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
