### PR TITLE
.gitignore plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ package-backup.json
 .history
 .Trash-*
 packages/plugin/typedoc
+plugins


### PR DESCRIPTION
The default location for the plugins folder is in the sources, but it is
currently not ignored.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

I know we can change the location of the folder, but if the default is in the sources, let's .gitignore it?