### PR TITLE
[explorer] update the explorer to handle multiple-root workspaces

### DIFF
--- a/packages/navigator/src/browser/navigator-model.spec.ts
+++ b/packages/navigator/src/browser/navigator-model.spec.ts
@@ -129,6 +129,7 @@ describe('FileNavigatorModel', () => {
     let mockPreferences: CorePreferences;
 
     const mockWorkspaceServiceEmitter: Emitter<FileStat[]> = new Emitter();
+    const mockWorkspaceOnLocationChangeEmitter: Emitter<FileStat | undefined> = new Emitter();
     const mockFileChangeEmitter: Emitter<FileChange[]> = new Emitter();
     const mockFileMoveEmitter: Emitter<FileMoveEvent> = new Emitter();
     const mockTreeChangeEmitter: Emitter<void> = new Emitter();
@@ -175,6 +176,7 @@ describe('FileNavigatorModel', () => {
         testContainer.bind(CorePreferences).toConstantValue(mockPreferences);
 
         sinon.stub(mockWorkspaceService, 'onWorkspaceChanged').value(mockWorkspaceServiceEmitter.event);
+        sinon.stub(mockWorkspaceService, 'onWorkspaceLocationChanged').value(mockWorkspaceOnLocationChangeEmitter.event);
         sinon.stub(mockFileSystemWatcher, 'onFilesChanged').value(mockFileChangeEmitter.event);
         sinon.stub(mockFileSystemWatcher, 'onDidMove').value(mockFileMoveEmitter.event);
         sinon.stub(mockFileNavigatorTree, 'onChanged').value(mockTreeChangeEmitter.event);

--- a/packages/navigator/src/browser/navigator-model.ts
+++ b/packages/navigator/src/browser/navigator-model.ts
@@ -35,6 +35,11 @@ export class FileNavigatorModel extends FileTreeModel {
                 this.updateRoot();
             })
         );
+        this.toDispose.push(
+            this.workspaceService.onWorkspaceLocationChanged(() => {
+                this.updateRoot();
+            })
+        );
         super.init();
     }
 
@@ -71,7 +76,11 @@ export class FileNavigatorModel extends FileTreeModel {
 
     protected async createRoot(): Promise<TreeNode | undefined> {
         if (this.workspaceService.opened) {
-            const workspaceNode = WorkspaceNode.createRoot();
+            const stat = this.workspaceService.workspace;
+            const isMulti = (stat) ? !stat.isDirectory : false;
+            const workspaceNode = isMulti
+                ? this.createMultipleRootNode()
+                : WorkspaceNode.createRoot();
             const roots = await this.workspaceService.roots;
             for (const root of roots) {
                 workspaceNode.children.push(
@@ -80,6 +89,20 @@ export class FileNavigatorModel extends FileTreeModel {
             }
             return workspaceNode;
         }
+    }
+
+    /**
+     * Create multiple root node used to display
+     * the multiple root workspace name.
+     *
+     * @returns `WorkspaceNode`
+     */
+    protected createMultipleRootNode(): WorkspaceNode {
+        const workspace = this.workspaceService.workspace;
+        const name = (workspace)
+            ? new URI(workspace.uri).path.name
+            : 'untitled';
+        return WorkspaceNode.createRoot(name);
     }
 
     /**

--- a/packages/navigator/src/browser/navigator-tree.ts
+++ b/packages/navigator/src/browser/navigator-tree.ts
@@ -63,16 +63,16 @@ export namespace WorkspaceNode {
     export const name = 'WorkspaceNode';
 
     export function is(node: TreeNode | undefined): node is WorkspaceNode {
-        return CompositeTreeNode.is(node) && node.name === WorkspaceNode.name;
+        return CompositeTreeNode.is(node) && node.id === WorkspaceNode.id;
     }
 
-    export function createRoot(): WorkspaceNode {
+    export function createRoot(multiRootName?: string): WorkspaceNode {
         return {
             id: WorkspaceNode.id,
-            name: WorkspaceNode.name,
+            name: multiRootName || WorkspaceNode.name,
             parent: undefined,
             children: [],
-            visible: false,
+            visible: !!multiRootName,
             selected: false
         };
     }


### PR DESCRIPTION
Currently the explorer applies styling for the first child node (workspace root) but this does not work
in the context of a multiple-root workspace. When in a multiple root workspace add a root node which simply describes the workspace name and aligns with vscode.

<div align='center'>

<img width="495" alt="Screen Shot 2019-03-26 at 10 00 14 PM" src="https://user-images.githubusercontent.com/40359487/55045060-ebf75880-5012-11e9-83c3-75930124fcb2.png">


</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
