### PR TITLE
Bump Electron 3 version

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -35,7 +35,7 @@
     "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
-    "electron": "^3.0.10",
+    "electron": "^3.1.7",
     "electron-rebuild": "^1.5.11",
     "file-loader": "^1.1.11",
     "font-awesome-webpack": "0.0.5-beta.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "@types/yargs": "^11.1.0",
     "ajv": "^6.5.3",
     "body-parser": "^1.17.2",
-    "electron": "^3.0.10",
+    "electron": "^3.1.7",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
     "file-icons-js": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,10 +3439,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@^3.0.10:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.10.tgz#7d412856e8cf0d3041a612a32dd09e2af2d50f50"
-  integrity sha512-I39IeQP3NOlbjKzTDK8uK2JdiHDfhV5SruCS2Gttkn2MaKCY+yIzQ6Wr4DyBXLeTEkL1sbZxbqQVhCavAliv5w==
+electron@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.1.7.tgz#2041031db272e88f167b2e5fe2de9eecabcf4632"
+  integrity sha512-rvmucnAsB4hQVdD0fOd1ad7+5u/BX1ak6emcSyPsLUk6rTqvVfOMk5ryC19h7Yd/5X8NWvCGkgYzSyQbgAJngA==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"


### PR DESCRIPTION
Update Electron 3 version to latest ([3.1.7](https://github.com/electron/electron/releases/tag/v3.1.7)).