### PR TITLE
Retrieving launch configurations using Plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.0
 
 - [filesystem] added the menu item `Upload Files...` to easily upload files into a workspace
+- [preferences] changed signature for methods `getProvider`, `setProvider` and `createFolderPreferenceProvider` of `FoldersPreferenceProvider`.
 
 ## v0.5.0
 

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -19,6 +19,7 @@ import { inject, injectable, interfaces, named, postConstruct } from 'inversify'
 import { ContributionProvider, bindContributionProvider, escapeRegExpCharacters, Emitter, Event } from '../../common';
 import { PreferenceScope } from './preference-scope';
 import { PreferenceProvider, PreferenceProviderPriority, PreferenceProviderDataChange } from './preference-provider';
+import { IJSONSchema } from '../../common/json-schema';
 
 import {
     PreferenceSchema, PreferenceSchemaProperties, PreferenceDataSchema, PreferenceItem, PreferenceSchemaProperty, PreferenceDataProperty, JsonType
@@ -53,6 +54,7 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
 
     protected readonly preferences: { [name: string]: any } = {};
     protected readonly combinedSchema: PreferenceDataSchema = { properties: {}, patternProperties: {} };
+    private remoteSchemas: IJSONSchema[] = [];
 
     @inject(ContributionProvider) @named(PreferenceContribution)
     protected readonly preferenceContributions: ContributionProvider<PreferenceContribution>;
@@ -182,7 +184,7 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     }
 
     protected updateValidate(): void {
-        this.validateFunction = new Ajv().compile(this.combinedSchema);
+        this.validateFunction = new Ajv({ schemas: this.remoteSchemas }).compile(this.combinedSchema);
     }
 
     validate(name: string, value: any): boolean {
@@ -193,10 +195,28 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
         return this.combinedSchema;
     }
 
-    setSchema(schema: PreferenceSchema): void {
+    setSchema(schema: PreferenceSchema, remoteSchema?: IJSONSchema): void {
         const changes = this.doSetSchema(schema);
+        if (remoteSchema) {
+            this.doSetRemoteSchema(remoteSchema);
+        }
         this.fireDidPreferenceSchemaChanged();
         this.emitPreferencesChangedEvent(changes);
+    }
+
+    protected doSetRemoteSchema(schema: IJSONSchema): void {
+        // remove existing remote schema if any
+        const existingSchemaIndex = this.remoteSchemas.findIndex(s => !!s.$id && !!s.$id && s.$id !== s.$id);
+        if (existingSchemaIndex) {
+            this.remoteSchemas.splice(existingSchemaIndex, 1);
+        }
+
+        this.remoteSchemas.push(schema);
+    }
+
+    setRemoteSchema(schema: IJSONSchema): void {
+        this.doSetRemoteSchema(schema);
+        this.fireDidPreferenceSchemaChanged();
     }
 
     getPreferences(): { [name: string]: any } {

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -47,8 +47,8 @@ export abstract class PreferenceProvider implements Disposable {
     protected readonly onDidPreferencesChangedEmitter = new Emitter<PreferenceProviderDataChanges | undefined>();
     readonly onDidPreferencesChanged: Event<PreferenceProviderDataChanges | undefined> = this.onDidPreferencesChangedEmitter.event;
 
-    protected readonly onDidNotValidPreferencesReadEmitter = new Emitter<any>();
-    readonly onDidNotValidPreferencesRead: Event<any> = this.onDidNotValidPreferencesReadEmitter.event;
+    protected readonly onDidInvalidPreferencesReadEmitter = new Emitter<{ [key: string]: any }>();
+    readonly onDidInvalidPreferencesRead: Event<{ [key: string]: any }> = this.onDidInvalidPreferencesReadEmitter.event;
 
     protected readonly toDispose = new DisposableCollection();
 

--- a/packages/core/src/browser/preferences/preference-provider.ts
+++ b/packages/core/src/browser/preferences/preference-provider.ts
@@ -47,6 +47,9 @@ export abstract class PreferenceProvider implements Disposable {
     protected readonly onDidPreferencesChangedEmitter = new Emitter<PreferenceProviderDataChanges | undefined>();
     readonly onDidPreferencesChanged: Event<PreferenceProviderDataChanges | undefined> = this.onDidPreferencesChangedEmitter.event;
 
+    protected readonly onDidNotValidPreferencesReadEmitter = new Emitter<any>();
+    readonly onDidNotValidPreferencesRead: Event<any> = this.onDidNotValidPreferencesReadEmitter.event;
+
     protected readonly toDispose = new DisposableCollection();
 
     /**

--- a/packages/debug/src/browser/abstract-launch-preference-provider.ts
+++ b/packages/debug/src/browser/abstract-launch-preference-provider.ts
@@ -94,7 +94,7 @@ export abstract class AbstractLaunchPreferenceProvider implements LaunchPreferen
 
         this.toDispose.push(this.onDidLaunchChangedEmitter);
         this.toDispose.push(
-            this.preferenceProvider.onDidNotValidPreferencesRead(prefs => {
+            this.preferenceProvider.onDidInvalidPreferencesRead(prefs => {
                 if (!prefs || !GlobalLaunchConfig.is(prefs.launch)) {
                     return;
                 }

--- a/packages/debug/src/browser/abstract-launch-preference-provider.ts
+++ b/packages/debug/src/browser/abstract-launch-preference-provider.ts
@@ -1,0 +1,157 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, postConstruct } from 'inversify';
+import { PreferenceScope, PreferenceProvider } from '@theia/core/lib/browser';
+import { Emitter, Event } from '@theia/core';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { DisposableCollection } from '@theia/core';
+import { Disposable } from '@theia/core';
+
+export interface GlobalLaunchConfig {
+    version: string;
+    compounds?: LaunchCompound[];
+    configurations: LaunchConfig[];
+}
+
+export namespace GlobalLaunchConfig {
+    /* tslint:disable-next-line:no-any */
+    export function is(data: any): data is GlobalLaunchConfig {
+        return !data || (!!data.version && (!data.compounds || Array.isArray(data.compounds)) && Array.isArray(data.configurations));
+    }
+}
+
+export interface LaunchConfig {
+    type: string;
+    request: string;
+    name: string;
+
+    /* tslint:disable-next-line:no-any */
+    [field: string]: any;
+}
+
+export interface LaunchCompound {
+    name: string;
+    configurations: (string | { name: string, folder: string })[];
+}
+
+export const LaunchPreferenceProvider = Symbol('LaunchConfigurationProvider');
+export interface LaunchPreferenceProvider {
+
+    readonly onDidLaunchChanged: Event<void>;
+
+    ready: Promise<void>;
+
+    getConfigurationNames(withCompounds: boolean, resourceUri?: string): string[];
+
+}
+
+export const FolderLaunchProviderOptions = Symbol('FolderLaunchProviderOptions');
+export interface FolderLaunchProviderOptions {
+    folderUri: string;
+}
+
+export const LaunchProviderProvider = Symbol('LaunchProviderProvider');
+export type LaunchProviderProvider = (scope: PreferenceScope) => LaunchPreferenceProvider;
+
+@injectable()
+export abstract class AbstractLaunchPreferenceProvider implements LaunchPreferenceProvider, Disposable {
+
+    protected readonly onDidLaunchChangedEmitter = new Emitter<void>();
+    readonly onDidLaunchChanged: Event<void> = this.onDidLaunchChangedEmitter.event;
+
+    protected preferences: GlobalLaunchConfig | undefined;
+
+    protected _ready: Deferred<void> = new Deferred<void>();
+
+    protected readonly toDispose = new DisposableCollection();
+
+    protected readonly preferenceProvider: PreferenceProvider;
+
+    @postConstruct()
+    protected init(): void {
+        this.preferenceProvider.ready
+            .then(() => this._ready.resolve())
+            .catch(() => this._ready.resolve());
+
+        this.updatePreferences();
+        if (this.preferences !== undefined) {
+            this.emitLaunchChangedEvent();
+        }
+
+        this.toDispose.push(this.onDidLaunchChangedEmitter);
+        this.toDispose.push(
+            this.preferenceProvider.onDidNotValidPreferencesRead(prefs => {
+                if (!prefs || !GlobalLaunchConfig.is(prefs.launch)) {
+                    return;
+                }
+                if (!prefs.launch && !this.preferences) {
+                    return;
+                }
+                this.preferences = prefs.launch;
+                this.emitLaunchChangedEvent();
+            })
+        );
+        this.toDispose.push(
+            this.preferenceProvider.onDidPreferencesChanged(prefs => {
+                if (!prefs || !prefs.launch) {
+                    return;
+                }
+                this.updatePreferences();
+                this.emitLaunchChangedEvent();
+            })
+        );
+    }
+
+    protected updatePreferences(): void {
+        const prefs = this.preferenceProvider.getPreferences();
+        if (GlobalLaunchConfig.is(prefs.launch)) {
+            this.preferences = prefs.launch;
+        }
+    }
+
+    protected emitLaunchChangedEvent(): void {
+        this.onDidLaunchChangedEmitter.fire(undefined);
+    }
+
+    get ready(): Promise<void> {
+        return this._ready.promise;
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    getConfigurationNames(withCompounds = true, resourceUri?: string): string[] {
+        const config = this.preferences;
+        if (!config) {
+            return [];
+        }
+
+        const names = config.configurations
+            .filter(launchConfig => launchConfig && typeof launchConfig.name === 'string')
+            .map(launchConfig => launchConfig.name);
+        if (withCompounds && config.compounds) {
+            const compoundNames = config.compounds
+                .filter(compoundConfig => typeof compoundConfig.name === 'string' && compoundConfig.configurations && compoundConfig.configurations.length)
+                .map(compoundConfig => compoundConfig.name);
+            names.push(...compoundNames);
+        }
+
+        return names;
+    }
+
+}

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -20,7 +20,7 @@ import { ContainerModule, interfaces } from 'inversify';
 import { DebugConfigurationManager } from './debug-configuration-manager';
 import { DebugWidget } from './view/debug-widget';
 import { DebugPath, DebugService } from '../common/debug-service';
-import { WidgetFactory, WebSocketConnectionProvider, FrontendApplicationContribution, bindViewContribution, KeybindingContext } from '@theia/core/lib/browser';
+import { WidgetFactory, WebSocketConnectionProvider, FrontendApplicationContribution, bindViewContribution, KeybindingContext, PreferenceScope } from '@theia/core/lib/browser';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugResourceResolver } from './debug-resource';
 import {
@@ -44,6 +44,10 @@ import './debug-monaco-contribution';
 import { bindDebugPreferences } from './debug-preferences';
 import { DebugSchemaUpdater } from './debug-schema-updater';
 import { DebugCallStackItemTypeKey } from './debug-call-stack-item-type-key';
+import { LaunchProviderProvider, LaunchPreferenceProvider } from './abstract-launch-preference-provider';
+import { WorkspaceLaunchProvider } from './workspace-launch-provider';
+import { UserLaunchProvider } from './user-launch-provider';
+import { FoldersLaunchProvider } from './folders-launch-provider';
 
 export default new ContainerModule((bind: interfaces.Bind) => {
     bind(DebugCallStackItemTypeKey).toDynamicValue(({ container }) =>
@@ -84,6 +88,12 @@ export default new ContainerModule((bind: interfaces.Bind) => {
 
     bind(DebugSessionContributionRegistryImpl).toSelf().inSingletonScope();
     bind(DebugSessionContributionRegistry).toService(DebugSessionContributionRegistryImpl);
+
+    bind(LaunchPreferenceProvider).to(UserLaunchProvider).inSingletonScope().whenTargetNamed(PreferenceScope.User);
+    bind(LaunchPreferenceProvider).to(WorkspaceLaunchProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);
+    bind(LaunchPreferenceProvider).to(FoldersLaunchProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Folder);
+    bind(LaunchProviderProvider).toFactory(ctx => (scope: PreferenceScope) =>
+        ctx.container.getNamed(LaunchPreferenceProvider, scope));
 
     bindDebugPreferences(bind);
 });

--- a/packages/debug/src/browser/debug-preferences.ts
+++ b/packages/debug/src/browser/debug-preferences.ts
@@ -53,14 +53,14 @@ export class DebugConfiguration {
 export const DebugPreferences = Symbol('DebugPreferences');
 export type DebugPreferences = PreferenceProxy<DebugConfiguration>;
 
-export function createDebugreferences(preferences: PreferenceService): DebugPreferences {
+export function createDebugPreferences(preferences: PreferenceService): DebugPreferences {
     return createPreferenceProxy(preferences, debugPreferencesSchema);
 }
 
 export function bindDebugPreferences(bind: interfaces.Bind): void {
     bind(DebugPreferences).toDynamicValue(ctx => {
         const preferences = ctx.container.get<PreferenceService>(PreferenceService);
-        return createDebugreferences(preferences);
+        return createDebugPreferences(preferences);
     }).inSingletonScope();
 
     bind(PreferenceContribution).toConstantValue({ schema: debugPreferencesSchema });

--- a/packages/debug/src/browser/debug-schema-updater.ts
+++ b/packages/debug/src/browser/debug-schema-updater.ts
@@ -14,13 +14,16 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { JsonSchemaStore } from '@theia/core/lib/browser/json-schema-store';
 import { InMemoryResources, deepClone } from '@theia/core/lib/common';
 import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { DebugService } from '../common/debug-service';
 import { debugPreferencesSchema } from './debug-preferences';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { LaunchPreferenceProvider, LaunchProviderProvider } from './abstract-launch-preference-provider';
+import { PreferenceSchema, PreferenceSchemaProvider, PreferenceScope } from '@theia/core/lib/browser';
 
 @injectable()
 export class DebugSchemaUpdater {
@@ -28,10 +31,67 @@ export class DebugSchemaUpdater {
     @inject(JsonSchemaStore) protected readonly jsonSchemaStore: JsonSchemaStore;
     @inject(InMemoryResources) protected readonly inmemoryResources: InMemoryResources;
     @inject(DebugService) protected readonly debug: DebugService;
+    @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(PreferenceSchemaProvider) protected readonly preferenceSchemaProvider: PreferenceSchemaProvider;
+    @inject(LaunchProviderProvider) protected readonly launchProviderProvider: LaunchProviderProvider;
 
-    async update(): Promise<void> {
+    private launchProviders: LaunchPreferenceProvider[] = [];
+
+    private debugLaunchSchemaId = 'vscode://debug/launch.json';
+
+    private schemaIsSet = false;
+
+    @postConstruct()
+    protected init(): void {
+        this.initializeLaunchProviders();
+    }
+
+    protected initializeLaunchProviders(): void {
+        PreferenceScope.getScopes().forEach(scope => {
+            if (scope === PreferenceScope.Default) {
+                return;
+            }
+            const provider = this.launchProviderProvider(scope);
+            this.launchProviders.push(provider);
+        });
+        this.launchProviders.map(p =>
+            p.onDidLaunchChanged(() => {
+                this.updateDebugLaunchSchema();
+            })
+        );
+    }
+
+    protected async updateDebugLaunchSchema(): Promise<void> {
+        const schema = await this.update();
+        this.setDebugLaunchSchema(schema);
+    }
+
+    protected setDebugLaunchSchema(remoteSchema: IJSONSchema) {
+        if (this.schemaIsSet) {
+            this.preferenceSchemaProvider.setRemoteSchema(remoteSchema);
+            return;
+        }
+
+        this.schemaIsSet = true;
+
+        const debugLaunchPreferencesSchema: PreferenceSchema = {
+            type: 'object',
+            scope: 'resource',
+            properties: {
+                'launch': {
+                    type: 'object',
+                    description: "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces",
+                    default: { configurations: [], compounds: [] },
+                    $ref: launchSchemaId
+                }
+            }
+        };
+        this.preferenceSchemaProvider.setSchema(debugLaunchPreferencesSchema, remoteSchema);
+    }
+
+    async update(): Promise<IJSONSchema> {
         const types = await this.debug.debugTypes();
-        const launchSchemaUrl = new URI('vscode://debug/launch.json');
+        const launchSchemaUrl = new URI(this.debugLaunchSchemaId);
         const schema = { ...deepClone(launchSchema) };
         const items = (<IJSONSchema>schema!.properties!['configurations'].items);
 
@@ -48,6 +108,26 @@ export class DebugSchemaUpdater {
         }
         items.defaultSnippets!.push(...await this.debug.getConfigurationSnippets());
 
+        await Promise.all(this.launchProviders.map(l => l.ready));
+
+        const compoundConfigurationSchema = (schema.properties!.compounds.items as IJSONSchema).properties!.configurations;
+        const launchNames = this.launchProviders
+            .map(launch => launch.getConfigurationNames(false))
+            .reduce((allNames: string[], names: string[]) => {
+                names.forEach(name => {
+                    if (allNames.indexOf(name) === -1) {
+                        allNames.push(name);
+                    }
+                });
+                return allNames;
+            }, []);
+        (compoundConfigurationSchema.items as IJSONSchema).oneOf![0].enum = launchNames;
+        (compoundConfigurationSchema.items as IJSONSchema).oneOf![1].properties!.name.enum = launchNames;
+
+        const roots = await this.workspaceService.roots;
+        const folderNames = roots.map(root => root.uri);
+        (compoundConfigurationSchema.items as IJSONSchema).oneOf![1].properties!.folder.enum = folderNames;
+
         const contents = JSON.stringify(schema);
         try {
             await this.inmemoryResources.update(launchSchemaUrl, contents);
@@ -58,15 +138,17 @@ export class DebugSchemaUpdater {
                 url: launchSchemaUrl.toString()
             });
         }
+
+        return schema;
     }
 }
 
 // debug general schema
-const defaultCompound = { name: 'Compound', configurations: [] };
+export const defaultCompound = { name: 'Compound', configurations: [] };
 
-const launchSchemaId = 'vscode://schemas/launch';
-const launchSchema: IJSONSchema = {
-    id: launchSchemaId,
+export const launchSchemaId = 'vscode://schemas/launch';
+export const launchSchema: IJSONSchema = {
+    $id: launchSchemaId,
     type: 'object',
     title: 'Launch',
     required: [],

--- a/packages/debug/src/browser/folders-launch-provider.ts
+++ b/packages/debug/src/browser/folders-launch-provider.ts
@@ -1,0 +1,128 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, postConstruct, named } from 'inversify';
+import { Disposable, DisposableCollection } from '@theia/core';
+import { Emitter, Event } from '@theia/core';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { LaunchPreferenceProvider, GlobalLaunchConfig } from './abstract-launch-preference-provider';
+import { PreferenceScope, PreferenceProvider } from '@theia/core/lib/browser';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+
+@injectable()
+export class FoldersLaunchProvider implements LaunchPreferenceProvider, Disposable {
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+    @inject(PreferenceProvider) @named(PreferenceScope.Folder)
+    protected readonly preferenceProvider: PreferenceProvider;
+
+    protected readonly onDidLaunchChangedEmitter = new Emitter<void>();
+    readonly onDidLaunchChanged: Event<void> = this.onDidLaunchChangedEmitter.event;
+
+    protected preferencesNotValid: GlobalLaunchConfig | undefined;
+    protected preferencesByFolder: Map<string, GlobalLaunchConfig | undefined> = new Map();
+
+    protected _ready: Deferred<void> = new Deferred<void>();
+
+    protected readonly toDispose = new DisposableCollection();
+
+    @postConstruct()
+    protected init(): void {
+        this.preferenceProvider.ready
+            .then(() => this._ready.resolve())
+            .catch(() => this._ready.resolve());
+
+        this.updatePreferences();
+        if (this.preferencesByFolder.size !== 0) {
+            this.emitLaunchChangedEvent();
+        }
+
+        this.toDispose.push(this.onDidLaunchChangedEmitter);
+        this.toDispose.push(
+            this.preferenceProvider.onDidNotValidPreferencesRead(prefs => {
+                if (!prefs || !GlobalLaunchConfig.is(prefs.launch)) {
+                    return;
+                }
+                if (!prefs.launch && !this.preferencesNotValid) {
+                    return;
+                }
+                this.preferencesNotValid = prefs.launch;
+                this.emitLaunchChangedEvent();
+            })
+        );
+        this.toDispose.push(
+            this.preferenceProvider.onDidPreferencesChanged(prefs => {
+                if (!prefs || !prefs.launch) {
+                    return;
+                }
+                this.updatePreferences();
+                this.emitLaunchChangedEvent();
+            })
+        );
+    }
+
+    protected updatePreferences(): void {
+        this.preferencesByFolder.clear();
+        this.preferencesNotValid = undefined;
+        for (const root of this.workspaceService.tryGetRoots()) {
+            const preferences = this.preferenceProvider.getPreferences(root.uri);
+            if (GlobalLaunchConfig.is(preferences.launch)) {
+                this.preferencesByFolder.set(root.uri, preferences.launch);
+            }
+        }
+    }
+
+    protected emitLaunchChangedEvent(): void {
+        this.onDidLaunchChangedEmitter.fire(undefined);
+    }
+
+    get ready(): Promise<void> {
+        return this._ready.promise;
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    getConfigurationNames(withCompounds: boolean, resourceUri: string): string[] {
+        let names: string[] = [];
+
+        const launchConfigurations = Array.from(this.preferencesByFolder.values());
+        launchConfigurations.push(this.preferencesNotValid);
+
+        for (const config of launchConfigurations) {
+            if (!config) {
+                continue;
+            }
+
+            const configNames = config.configurations
+                .filter(launchConfig => launchConfig && typeof launchConfig.name === 'string')
+                .map(launchConfig => launchConfig.name);
+            if (withCompounds && config.compounds) {
+                const compoundNames = config.compounds
+                    .filter(compoundConfig => typeof compoundConfig.name === 'string' && compoundConfig.configurations && compoundConfig.configurations.length)
+                    .map(compoundConfig => compoundConfig.name);
+                configNames.push(...compoundNames);
+            }
+
+            names = names.concat(configNames);
+        }
+
+        return names;
+    }
+
+}

--- a/packages/debug/src/browser/folders-launch-provider.ts
+++ b/packages/debug/src/browser/folders-launch-provider.ts
@@ -53,7 +53,7 @@ export class FoldersLaunchProvider implements LaunchPreferenceProvider, Disposab
 
         this.toDispose.push(this.onDidLaunchChangedEmitter);
         this.toDispose.push(
-            this.preferenceProvider.onDidNotValidPreferencesRead(prefs => {
+            this.preferenceProvider.onDidInvalidPreferencesRead(prefs => {
                 if (!prefs || !GlobalLaunchConfig.is(prefs.launch)) {
                     return;
                 }

--- a/packages/debug/src/browser/user-launch-provider.ts
+++ b/packages/debug/src/browser/user-launch-provider.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, named } from 'inversify';
+import { PreferenceProvider, PreferenceScope } from '@theia/core/lib/browser';
+import { AbstractLaunchPreferenceProvider } from './abstract-launch-preference-provider';
+
+@injectable()
+export class UserLaunchProvider extends AbstractLaunchPreferenceProvider {
+
+    @inject(PreferenceProvider) @named(PreferenceScope.User)
+    protected readonly preferenceProvider: PreferenceProvider;
+
+}

--- a/packages/debug/src/browser/workspace-launch-provider.ts
+++ b/packages/debug/src/browser/workspace-launch-provider.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject, named } from 'inversify';
+import { PreferenceProvider, PreferenceScope } from '@theia/core/lib/browser';
+import { AbstractLaunchPreferenceProvider } from './abstract-launch-preference-provider';
+
+@injectable()
+export class WorkspaceLaunchProvider extends AbstractLaunchPreferenceProvider {
+
+    @inject(PreferenceProvider) @named(PreferenceScope.Workspace)
+    protected readonly preferenceProvider: PreferenceProvider;
+
+}

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -730,12 +730,12 @@ export interface PreferenceRegistryMain {
         target: boolean | ConfigurationTarget | undefined,
         key: string,
         value: any,
-        resource: any | undefined
+        resource?: string
     ): PromiseLike<void>;
     $removeConfigurationOption(
         target: boolean | ConfigurationTarget | undefined,
         key: string,
-        resource: any | undefined
+        resource?: string
     ): PromiseLike<void>;
 }
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -34,6 +34,7 @@ import { StoragePathService } from '../../main/browser/storage-path-service';
 import { getPreferences } from '../../main/browser/preference-registry-main';
 import { PluginServer } from '../../common/plugin-protocol';
 import { KeysToKeysToAnyValue } from '../../common/types';
+import { FileStat } from '@theia/filesystem/lib/common/filesystem';
 
 @injectable()
 export class HostedPluginSupport {
@@ -97,6 +98,7 @@ export class HostedPluginSupport {
             this.server.getExtPluginAPI(),
             this.pluginServer.keyValueStorageGetAll(true),
             this.pluginServer.keyValueStorageGetAll(false),
+            this.workspaceService.roots,
         ]).then(metadata => {
             const pluginsInitData: PluginsInitializationData = {
                 plugins: metadata['0'],
@@ -105,7 +107,8 @@ export class HostedPluginSupport {
                 storagePath: metadata['3'],
                 pluginAPIs: metadata['4'],
                 globalStates: metadata['5'],
-                workspaceStates: metadata['6']
+                workspaceStates: metadata['6'],
+                roots: metadata['7']
             };
             this.loadPlugins(pluginsInitData, this.container);
         }).catch(e => console.error(e));
@@ -130,7 +133,7 @@ export class HostedPluginSupport {
                 const hostedExtManager = worker.rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
                 hostedExtManager.$init({
                     plugins: initData.plugins,
-                    preferences: getPreferences(this.preferenceProviderProvider),
+                    preferences: getPreferences(this.preferenceProviderProvider, initData.roots),
                     globalState: initData.globalStates,
                     workspaceState: initData.workspaceStates,
                     env: { queryParams: getQueryParameters() },
@@ -171,7 +174,7 @@ export class HostedPluginSupport {
                     const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
                     hostedExtManager.$init({
                         plugins: plugins,
-                        preferences: getPreferences(this.preferenceProviderProvider),
+                        preferences: getPreferences(this.preferenceProviderProvider, initData.roots),
                         globalState: initData.globalStates,
                         workspaceState: initData.workspaceStates,
                         env: { queryParams: getQueryParameters() },
@@ -236,5 +239,6 @@ interface PluginsInitializationData {
     storagePath: string | undefined,
     pluginAPIs: ExtPluginApi[],
     globalStates: KeysToKeysToAnyValue,
-    workspaceStates: KeysToKeysToAnyValue
+    workspaceStates: KeysToKeysToAnyValue,
+    roots: FileStat[],
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
- // tslint:disable:no-any
+// tslint:disable:no-any
 
 import * as path from 'path';
 import * as fs from 'fs-extra';

--- a/packages/plugin-ext/src/plugin/preferences/configuration.spec.ts
+++ b/packages/plugin-ext/src/plugin/preferences/configuration.spec.ts
@@ -1,0 +1,250 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import * as chai from 'chai';
+import { Configuration, ConfigurationModel } from './configuration';
+import { PreferenceData } from '../../common';
+import { PreferenceScope } from '@theia/preferences/lib/browser';
+import { WorkspaceExtImpl } from '../workspace';
+import URI from 'vscode-uri';
+
+const expect = chai.expect;
+
+interface Inspect<C> {
+    default: C;
+    user: C;
+    workspace?: C;
+    workspaceFolder?: C;
+    value: C;
+}
+let inspect: Inspect<number>;
+
+const projects = ['/projects/workspace/project1', '/projects/workspace/project2'];
+
+const propertyName = 'tabSize';
+const preferences: PreferenceData = {
+    [PreferenceScope.Default]: {
+        [propertyName]: 6,
+    },
+    [PreferenceScope.User]: {
+        [propertyName]: 5
+    },
+    [PreferenceScope.Workspace]: {
+        [propertyName]: 4
+    },
+    [PreferenceScope.Folder]: {
+        [projects[0]]: {
+            [propertyName]: 3
+        },
+        [projects[1]]: {
+            [propertyName]: 2
+        }
+    }
+};
+
+const workspace: WorkspaceExtImpl = {} as WorkspaceExtImpl;
+let configuration: Configuration;
+let defaultConfiguration: ConfigurationModel;
+let userConfiguration: ConfigurationModel;
+let workspaceConfiguration: ConfigurationModel;
+let folderConfigurations: { [key: string]: ConfigurationModel };
+before(() => {
+    workspace.getWorkspaceFolder = (uri => {
+        const name = uri.toString().replace(/[^\/]+$/, '$1');
+        const index = projects.indexOf(uri.toString());
+        return { uri, name, index };
+    });
+
+    defaultConfiguration = new ConfigurationModel(
+        preferences[PreferenceScope.Default],
+        Object.keys(preferences[PreferenceScope.Default])
+    );
+    userConfiguration = new ConfigurationModel(
+        preferences[PreferenceScope.User],
+        Object.keys(preferences[PreferenceScope.User])
+    );
+    workspaceConfiguration = new ConfigurationModel(
+        preferences[PreferenceScope.Workspace],
+        Object.keys(preferences[PreferenceScope.Workspace])
+    );
+    folderConfigurations = projects.reduce((configurations: { [key: string]: ConfigurationModel }, project: string) => {
+        const folderPrefs = preferences[PreferenceScope.Folder][project];
+        configurations[project] = new ConfigurationModel(folderPrefs, Object.keys(folderPrefs));
+        return configurations;
+    }, {});
+});
+
+describe('Configuration:', () => {
+
+    describe('Default scope preferences:', () => {
+
+        beforeEach(() => {
+            configuration = new Configuration(
+                defaultConfiguration, new ConfigurationModel({}, []), undefined, undefined
+            );
+            inspect = configuration.inspect(propertyName, workspace, undefined);
+        });
+
+        it('should have correct value of \'default\' property', () => {
+            expect(inspect).to.have.property(
+                'default',
+                preferences[PreferenceScope.Default][propertyName]
+            );
+            expect(inspect.default).to.equal(preferences[PreferenceScope.Default][propertyName]);
+        });
+
+        it('should have correct value of \'value\' property', () => {
+            expect(inspect).to.have.property(
+                'value',
+                preferences[PreferenceScope.Default][propertyName]
+            );
+            expect(inspect.value).to.equal(preferences[PreferenceScope.Default][propertyName]);
+        });
+
+    });
+
+    describe('User scope preferences:', () => {
+
+        beforeEach(() => {
+            configuration = new Configuration(
+                defaultConfiguration, userConfiguration, undefined, undefined
+            );
+            inspect = configuration.inspect(propertyName, workspace, undefined);
+        });
+
+        it('should have correct value of \'default\' property', () => {
+            expect(inspect).to.have.property(
+                'default',
+                preferences[PreferenceScope.Default][propertyName]
+            );
+            expect(inspect.default).to.equal(preferences[PreferenceScope.Default][propertyName]);
+        });
+
+        it('should have correct value of \'user\' property', () => {
+            expect(inspect).to.have.property(
+                'user',
+                preferences[PreferenceScope.User][propertyName]
+            );
+            expect(inspect.user).to.equal(preferences[PreferenceScope.User][propertyName]);
+        });
+
+        it('should have correct value of \'value\' property', () => {
+            expect(inspect).to.have.property(
+                'value',
+                preferences[PreferenceScope.User][propertyName]
+            );
+            expect(inspect.value).to.equal(preferences[PreferenceScope.User][propertyName]);
+        });
+
+    });
+
+    describe('Workspace scope preferences:', () => {
+
+        beforeEach(() => {
+            configuration = new Configuration(
+                defaultConfiguration, userConfiguration, workspaceConfiguration, undefined
+            );
+            inspect = configuration.inspect(propertyName, workspace, undefined);
+        });
+
+        it('should have correct value of \'default\' property', () => {
+            expect(inspect).to.have.property(
+                'default',
+                preferences[PreferenceScope.Default][propertyName]
+            );
+            expect(inspect.default).to.equal(preferences[PreferenceScope.Default][propertyName]);
+        });
+
+        it('should have correct value of \'user\' property', () => {
+            expect(inspect).to.have.property(
+                'user',
+                preferences[PreferenceScope.User][propertyName]
+            );
+            expect(inspect.user).to.equal(preferences[PreferenceScope.User][propertyName]);
+        });
+
+        it('should have correct value of \'workspace\' property', () => {
+            expect(inspect).to.have.property(
+                'workspace',
+                preferences[PreferenceScope.Workspace][propertyName]
+            );
+            expect(inspect.workspace).to.equal(preferences[PreferenceScope.Workspace][propertyName]);
+        });
+
+        it('should have correct value of \'value\' property', () => {
+            expect(inspect).to.have.property(
+                'value',
+                preferences[PreferenceScope.Workspace][propertyName]
+            );
+            expect(inspect.value).to.equal(preferences[PreferenceScope.Workspace][propertyName]);
+        });
+
+    });
+
+    describe('Folder scope preferences:', () => {
+        const project = projects[0];
+
+        beforeEach(() => {
+            configuration = new Configuration(
+                defaultConfiguration, userConfiguration, workspaceConfiguration, folderConfigurations
+            );
+            const resource = URI.revive({ path: project });
+            inspect = configuration.inspect(propertyName, workspace, resource);
+        });
+
+        it('should have correct value of \'default\' property', () => {
+            expect(inspect).to.have.property(
+                'default',
+                preferences[PreferenceScope.Default][propertyName]
+            );
+            expect(inspect.default).to.equal(preferences[PreferenceScope.Default][propertyName]);
+        });
+
+        it('should have correct value of \'user\' property', () => {
+            expect(inspect).to.have.property(
+                'user',
+                preferences[PreferenceScope.User][propertyName]
+            );
+            expect(inspect.user).to.equal(preferences[PreferenceScope.User][propertyName]);
+        });
+
+        it('should have correct value of \'workspace\' property', () => {
+            expect(inspect).to.have.property(
+                'workspace',
+                preferences[PreferenceScope.Workspace][propertyName]
+            );
+            expect(inspect.workspace).to.equal(preferences[PreferenceScope.Workspace][propertyName]);
+        });
+
+        it('should have correct value of \'workspaceFolder\' property', () => {
+            expect(inspect).to.have.property(
+                'workspaceFolder',
+                preferences[PreferenceScope.Folder][project][propertyName]
+            );
+            expect(inspect.workspaceFolder).to.equal(preferences[PreferenceScope.Folder][project][propertyName]);
+        });
+
+        it('should have correct value of \'value\' property', () => {
+            expect(inspect).to.have.property(
+                'value',
+                preferences[PreferenceScope.Folder][project][propertyName]
+            );
+            expect(inspect.value).to.equal(preferences[PreferenceScope.Folder][project][propertyName]);
+        });
+
+    });
+
+});

--- a/packages/preferences/src/browser/folder-launch-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-launch-preference-provider.ts
@@ -32,7 +32,7 @@ export class FolderLaunchPreferenceProvider extends FolderPreferenceProvider {
     // tslint:disable-next-line:no-any
     protected parse(content: string): any {
         const parsedData = super.parse(content);
-        if (Object.keys(parsedData).length > 0) {
+        if (!!parsedData && Object.keys(parsedData).length > 0) {
             return { launch: parsedData };
         }
         return parsedData;

--- a/packages/preferences/src/browser/folder-launch-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-launch-preference-provider.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { FolderPreferenceProvider } from './folder-preference-provider';
+
+@injectable()
+export class FolderLaunchPreferenceProvider extends FolderPreferenceProvider {
+
+    async getUri(): Promise<URI | undefined> {
+        this.folderUri = new URI(this.options.folder.uri);
+        if (await this.fileSystem.exists(this.folderUri.toString())) {
+            const uri = this.folderUri.resolve('.theia').resolve('launch.json');
+            return uri;
+        }
+    }
+
+    // tslint:disable-next-line:no-any
+    protected parse(content: string): any {
+        const parsedData = super.parse(content);
+        if (Object.keys(parsedData).length > 0) {
+            return { launch: parsedData };
+        }
+        return parsedData;
+    }
+}

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -28,12 +28,13 @@ export interface FolderPreferenceProviderFactory {
 export const FolderPreferenceProviderOptions = Symbol('FolderPreferenceProviderOptions');
 export interface FolderPreferenceProviderOptions {
     folder: FileStat;
+    fileName: string;
 }
 
 @injectable()
 export class FolderPreferenceProvider extends AbstractResourcePreferenceProvider {
 
-    private folderUri: URI | undefined;
+    protected folderUri: URI | undefined;
 
     constructor(
         @inject(FolderPreferenceProviderOptions) protected readonly options: FolderPreferenceProviderOptions,

--- a/packages/preferences/src/browser/folder-preference-provider.ts
+++ b/packages/preferences/src/browser/folder-preference-provider.ts
@@ -19,6 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { PreferenceScope, PreferenceProvider, PreferenceProviderPriority } from '@theia/core/lib/browser';
 import { AbstractResourcePreferenceProvider } from './abstract-resource-preference-provider';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
+import { ResourceKind } from './folders-preferences-provider';
 
 export const FolderPreferenceProviderFactory = Symbol('FolderPreferenceProviderFactory');
 export interface FolderPreferenceProviderFactory {
@@ -28,7 +29,7 @@ export interface FolderPreferenceProviderFactory {
 export const FolderPreferenceProviderOptions = Symbol('FolderPreferenceProviderOptions');
 export interface FolderPreferenceProviderOptions {
     folder: FileStat;
-    fileName: string;
+    kind: ResourceKind;
 }
 
 @injectable()

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -24,7 +24,7 @@ import { createPreferencesTreeWidget } from './preference-tree-container';
 import { PreferencesMenuFactory } from './preferences-menu-factory';
 import { PreferencesFrontendApplicationContribution } from './preferences-frontend-application-contribution';
 import { PreferencesContainer, PreferencesTreeWidget, PreferencesEditorsContainer } from './preferences-tree-widget';
-import { FoldersPreferencesProvider, SETTINGS_FILE_NAME } from './folders-preferences-provider';
+import { FoldersPreferencesProvider } from './folders-preferences-provider';
 import { FolderPreferenceProvider, FolderPreferenceProviderFactory, FolderPreferenceProviderOptions } from './folder-preference-provider';
 import { FolderLaunchPreferenceProvider } from './folder-launch-preference-provider';
 
@@ -43,7 +43,7 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
             const child = new Container({ defaultScope: 'Transient' });
             child.parent = ctx.container;
             child.bind(FolderPreferenceProviderOptions).toConstantValue(options);
-            if (options.fileName === SETTINGS_FILE_NAME) {
+            if (options.kind === 'settings') {
                 return child.get(FolderPreferenceProvider);
             } else {
                 return child.get(FolderLaunchPreferenceProvider);

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -24,8 +24,9 @@ import { createPreferencesTreeWidget } from './preference-tree-container';
 import { PreferencesMenuFactory } from './preferences-menu-factory';
 import { PreferencesFrontendApplicationContribution } from './preferences-frontend-application-contribution';
 import { PreferencesContainer, PreferencesTreeWidget, PreferencesEditorsContainer } from './preferences-tree-widget';
-import { FoldersPreferencesProvider } from './folders-preferences-provider';
+import { FoldersPreferencesProvider, SETTINGS_FILE_NAME } from './folders-preferences-provider';
 import { FolderPreferenceProvider, FolderPreferenceProviderFactory, FolderPreferenceProviderOptions } from './folder-preference-provider';
+import { FolderLaunchPreferenceProvider } from './folder-launch-preference-provider';
 
 import './preferences-monaco-contribution';
 
@@ -36,12 +37,17 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
     bind(PreferenceProvider).to(WorkspacePreferenceProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Workspace);
     bind(PreferenceProvider).to(FoldersPreferencesProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Folder);
     bind(FolderPreferenceProvider).toSelf().inTransientScope();
+    bind(FolderLaunchPreferenceProvider).toSelf().inTransientScope();
     bind(FolderPreferenceProviderFactory).toFactory(ctx =>
         (options: FolderPreferenceProviderOptions) => {
             const child = new Container({ defaultScope: 'Transient' });
             child.parent = ctx.container;
             child.bind(FolderPreferenceProviderOptions).toConstantValue(options);
-            return child.get(FolderPreferenceProvider);
+            if (options.fileName === SETTINGS_FILE_NAME) {
+                return child.get(FolderPreferenceProvider);
+            } else {
+                return child.get(FolderLaunchPreferenceProvider);
+            }
         }
     );
 

--- a/packages/preferences/src/browser/preference-service.spec.ts
+++ b/packages/preferences/src/browser/preference-service.spec.ts
@@ -743,7 +743,7 @@ describe('Preference Service', () => {
 
             it('should fire "onDidLaunchChanged" event with correct argument', async () => {
                 const spy = sinon.spy();
-                userProvider.onDidNotValidPreferencesRead(spy);
+                userProvider.onDidInvalidPreferencesRead(spy);
 
                 fs.writeFileSync(tempPath, userConfigStr);
                 await (<any>userProvider).readPreferences();
@@ -778,7 +778,7 @@ describe('Preference Service', () => {
 
             it('should not fire "onDidLaunchChanged"', async () => {
                 const spy = sinon.spy();
-                userProvider.onDidNotValidPreferencesRead(spy);
+                userProvider.onDidInvalidPreferencesRead(spy);
 
                 fs.writeFileSync(tempPath, userConfigStr);
                 await (<any>userProvider).readPreferences();


### PR DESCRIPTION
This PR aims to fix https://github.com/theia-ide/theia/issues/4188. In order to fix the issue following improvements are introduced:

- [plugin-ext] getting and inspecting configuration for a resource
- [preferences] handling preference properties that are not valid at the time of reading and re-validating them later on new preference schema has been set.
- [preferences] handling `launch.json` to retrieve launch configurations
- [debug] handling changes of launch configuration in order to build new preference schema

This PR also fixes https://github.com/theia-ide/theia/issues/2290