### PR TITLE
full screen mode for main and bottom areas

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -150,6 +150,11 @@ export namespace CommonCommands {
         category: VIEW_CATEGORY,
         label: 'Toggle Bottom Panel'
     };
+    export const TOGGLE_MAXIMIZED: Command = {
+        id: 'core.toggleMaximized',
+        category: VIEW_CATEGORY,
+        label: 'Toggle Maximized'
+    };
 
     export const SAVE: Command = {
         id: 'core.save',
@@ -331,6 +336,11 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             label: 'Collapse',
             order: '4'
         });
+        registry.registerMenuAction(SHELL_TABBAR_CONTEXT_MENU, {
+            commandId: CommonCommands.TOGGLE_MAXIMIZED.id,
+            label: 'Toggle Maximized',
+            order: '5'
+        });
         registry.registerMenuAction(CommonMenus.HELP, {
             commandId: CommonCommands.ABOUT_COMMAND.id,
             label: 'About',
@@ -459,6 +469,11 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
                 }
             }
         });
+        commandRegistry.registerCommand(CommonCommands.TOGGLE_MAXIMIZED, {
+            isEnabled: () => this.shell.canToggleMaximized(),
+            isVisible: () => this.shell.canToggleMaximized(),
+            execute: () => this.shell.toggleMaximized()
+        });
 
         commandRegistry.registerCommand(CommonCommands.SAVE, {
             execute: () => this.shell.save()
@@ -583,6 +598,10 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             {
                 command: CommonCommands.COLLAPSE_ALL_PANELS.id,
                 keybinding: 'alt+shift+c',
+            },
+            {
+                command: CommonCommands.TOGGLE_MAXIMIZED.id,
+                keybinding: 'ctrl+m',
             },
             // Saving
             {

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -26,7 +26,7 @@ import { IDragEvent } from '@phosphor/dragdrop';
 import { RecursivePartial, MaybePromise, Event as CommonEvent } from '../../common';
 import { Saveable } from '../saveable';
 import { StatusBarImpl, StatusBarEntry, StatusBarAlignment } from '../status-bar/status-bar';
-import { TheiaDockPanel } from './theia-dock-panel';
+import { TheiaDockPanel, BOTTOM_AREA_ID, MAIN_AREA_ID } from './theia-dock-panel';
 import { SidePanelHandler, SidePanel, SidePanelHandlerFactory } from './side-panel-handler';
 import { TabBarRendererFactory, TabBarRenderer, SHELL_TABBAR_CONTEXT_MENU, ScrollableTabBar, ToolbarAwareTabBar } from './tab-bars';
 import { SplitPositionHandler, SplitPositionOptions } from './split-panels';
@@ -407,7 +407,7 @@ export class ApplicationShell extends Widget {
             renderer,
             spacing: 0
         });
-        dockPanel.id = 'theia-main-content-panel';
+        dockPanel.id = MAIN_AREA_ID;
         return dockPanel;
     }
 
@@ -423,7 +423,7 @@ export class ApplicationShell extends Widget {
             renderer,
             spacing: 0
         });
-        dockPanel.id = 'theia-bottom-content-panel';
+        dockPanel.id = BOTTOM_AREA_ID;
         dockPanel.widgetAdded.connect((sender, widget) => {
             this.refreshBottomPanelToggleButton();
         });
@@ -1403,6 +1403,18 @@ export class ApplicationShell extends Widget {
      */
     get widgets(): ReadonlyArray<Widget> {
         return [...this.tracker.widgets];
+    }
+
+    canToggleMaximized(): boolean {
+        const area = this.currentWidget && this.getAreaFor(this.currentWidget);
+        return area === 'main' || area === 'bottom';
+    }
+
+    toggleMaximized(): void {
+        const area = this.currentWidget && this.getAreaPanelFor(this.currentWidget);
+        if (area instanceof TheiaDockPanel && (area === this.mainPanel || area === this.bottomPanel)) {
+            area.toggleMaximized();
+        }
     }
 
 }

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -29,6 +29,18 @@ body {
   background: var(--theia-layout-color0);
 }
 
+.theia-maximized {
+    position: fixed !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    width: auto !important;
+    height: auto !important;
+    z-index: 255 !important;
+    background: var(--theia-layout-color0);
+}
+
 .theia-ApplicationShell {
   position: absolute;
   top: 0;

--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -23,6 +23,7 @@ import { DebugVariablesWidget } from './debug-variables-widget';
 import { DebugToolBar } from './debug-toolbar-widget';
 import { DebugViewModel, DebugViewOptions } from './debug-view-model';
 import { ViewContainer } from '@theia/core/lib/browser/view-container';
+import { BOTTOM_AREA_ID, MAIN_AREA_ID } from '@theia/core/lib/browser/shell/theia-dock-panel';
 
 export const DebugSessionWidgetFactory = Symbol('DebugSessionWidgetFactory');
 export type DebugSessionWidgetFactory = (options: DebugViewOptions) => DebugSessionWidget;
@@ -117,7 +118,7 @@ export class DebugSessionWidget extends BaseWidget implements ApplicationShell.T
     onAfterAttach(msg: Message): void {
         const parentId = this.node.parentElement!.parentElement!.getAttribute('id');
         this.container.orientation =
-            parentId === 'theia-bottom-content-panel' || parentId === 'theia-main-content-panel'
+            parentId === BOTTOM_AREA_ID || parentId === MAIN_AREA_ID
                 ? 'horizontal'
                 : 'vertical';
         super.onAfterAttach(msg);


### PR DESCRIPTION
fix #4668

TODO:
- [x] ~exit on ESC~ - hard: it's colliding with monaco esc handlers
  - [x] use `CtrlCmd + M` as in Eclipse, see https://github.com/theia-ide/theia/pull/4744#issuecomment-477988100
- [x] `Toggle Maximized` command
- [x] `Toggle Maximized` context menu item