### PR TITLE
[plug-in] Bump VS Code API version

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc.
+ * Copyright (C) 2018-2019 Red Hat, Inc.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,7 +72,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     };
 
     // override the version for vscode to be a VSCode version
-    (<any>vscode).version = '1.27.2';
+    (<any>vscode).version = '1.32.3';
 
     pluginsApiImpl.set(plugin.model.id, vscode);
     plugins.push(plugin);


### PR DESCRIPTION
Bump VS Code API version to the latest
Fixes #4124 

I will provide a way to override it through ENV Var later

I'm still wondering looking at https://github.com/Microsoft/vscode/issues/71059 if we should not bump it to 1.33.0 instead or move release lifecycle at the beginning of the month instead of the last thursday of the month to better match release lifecycle of VS Code. (else for one month we're behind of one version...)

Change-Id: Ifb5f82e0f914a47ba2b0cbc7529452a9a0c68287
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

