### PR TITLE
Added NOTICE.md file

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,281 @@
+# Notices for Eclipse Theia
+
+This content is produced and maintained by the Eclipse Theia project.
+
+* Project home: https://projects.eclipse.org/projects/ecd.theia
+
+## Trademarks
+
+Eclipse Theia is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License v. 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+available under the following Secondary Licenses when the conditions for such
+availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath Exception which is
+available at https://www.gnu.org/software/classpath/license.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse/theia-generator-plugin
+* https://github.com/eclipse/theia-yeoman-plugin
+* https://github.com/eclipse/theia-plugin-packager
+* https://github.com/eclipse/theia-cpp-extension
+* https://github.com/eclipse/theia-python-extension
+* https://github.com/eclipse/theia-java-extension
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+chalk (2.4.1)
+
+* License: MIT
+* Project: https://github.com/chalk/chalk
+* Source: https://github.com/chalk/chalk
+
+code copied from project cortex-debug (0.1.21)
+
+* License: MIT
+
+Code copied from project Microsoft/vscode (1.31.0)
+
+* License: MIT
+
+Code copied from project Microsoft/vscode (1.32.3)
+
+* License: MIT
+* Project: https://code.visualstudio.com/
+* Source: https://github.com/Microsoft/vscode
+
+dugite (1.52.0)
+
+* License: MIT
+
+electron@2.0.14 (2.0.14)
+
+* License: MIT AND BSD-2-Clause AND Apache-2.0 AND (AFL-2.1 OR BSD-3-Clause)
+   AND BSD-3-Clause AND ISC AND X11 AND Public-Domain AND (GPL-2.0 OR MIT) AND
+   Unlicense AND IJG AND ICU AND UNICODE-TOU AND NTP AND (MIT OR BSD-3-Clause)
+   AND Libpng AND MPL-2.0 AND LGPL-2.1+
+* Project: https://github.com/electron/electron
+* Source: https://github.com/electron/electron/releases/tag/v2.0.14
+
+GH-3397: Implemented the HTTP-based authentication for Git in Electron. (n/a)
+
+* License: MIT
+
+glob promise (3.4.0)
+
+* License: ISC
+* Project: https://github.com/ahmadnassri/glob-promise
+* Source: https://github.com/ahmadnassri/glob-promise
+
+long.js (3.2.0)
+
+* License: Apache-2.0
+
+micromatch (3.1.10)
+
+* License: MIT
+* Project: https://github.com/micromatch/micromatch
+* Source: https://github.com/micromatch/micromatch
+
+monaco-typescript (2.3.0)
+
+* License: MIT
+* Project: https://github.com/Microsoft/monaco-typescript
+* Source: https://github.com/Microsoft/monaco-typescript.git
+
+native-keymap (1.2.5)
+
+* License: Pending
+* Project: https://github.com/Microsoft/node-native-keymap
+* Source: https://github.com/Microsoft/node-native-keymap
+
+node-oniguruma (n/a)
+
+* License: BSD-2-Clause AND GPL-2.0 WITH Autoconf-exception-2.0 AND
+   GPL-2.0-or-later WITH libtool-exception AND X11 AND MIT AND Public-Domain
+
+node.js dependencies for Theia (n/a)
+
+* License: MIT AND BSD-3-Clause AND ISC AND Apache-2.0 AND BSD-2-Clause AND
+   Zlib AND X11 AND (BSD-3-Clause OR AFL-2.1) AND CC-By-4.0 AND CC-by-2.5-SA AND
+   CC0-1.0 AND (BSD-3-Clause OR MPL-2.0) AND Unlicense AND (MIT OR GPL-3.0) AND
+   (MIT OR GPL-2.0) AND (Apache-2.0 OR
+
+ps-list (5.0.1)
+
+* License: MIT
+* Project: https://github.com/sindresorhus/ps-list
+* Source: https://github.com/sindresorhus/ps-list
+
+read-pkg (4.0.1)
+
+* License: MIT
+* Project: https://github.com/sindresorhus/read-pkg
+* Source: https://github.com/sindresorhus/read-pkg
+
+requestretry (3.1.0)
+
+* License: MIT
+* Project: https://github.com/FGRibreau/node-request-retry
+* Source: https://github.com/FGRibreau/node-request-retry
+
+rimraf (2.6.2)
+
+* License: ISC
+
+textmate/tcl.tmbundle (n/a)
+
+* License: LicenseRef-Php_Tmbundle
+
+theia npm node (n/a)
+
+* License: BSD-2-Clause OR (MIT OR Apache-2.0) AND (AFL-2.1 OR BSD-3-Clause)
+   AND Apache-2.0 AND Artistic-2.0 AND BSD-3-Clause AND (BSD-3-Clause OR MIT)
+   AND MPL-2.0 AND CC0-1.0 AND CC-BY-3.0 AND CC-BY-4.0 AND CC-BY-SA-2.5 AND
+   GPL-2.0 WITH Autoconf-ex
+
+theia-cpp-extension npm node (n/a)
+
+* License: BSD-2-Clause OR (MIT OR Apache-2.0) AND MIT AND BSD-3-Clause AND
+   Zlib AND (MIT OR GPL-3.0) AND OFL-1.1 AND Apache-2.0 AND CC0-1.0 AND
+   CC-BY-3.0 AND ISC AND MPL-2.0 AND License-Ref-Public-Domain AND BSL-1.0 AND
+   (AFL-2.1 OR BSD-3.0) AND Unlicense AND Artist
+
+tslint (5.10.0)
+
+* License: Apache-2.0 AND MIT
+* Project: http://palantir.github.io/tslint/
+* Source: https://github.com/palantir/tslint
+
+typefox/monaco-language-client (0.5.0)
+
+* License: MIT
+
+typescript-formatter (7.2.2)
+
+* License: MIT
+* Project: https://github.com/vvakame/typescript-formatter
+* Source: https://github.com/vvakame/typescript-formatter
+
+VS Code (1.33.0)
+
+* License: MIT
+
+vscode (1.26.0)
+
+* License: MIT
+
+vscode (1.31.0)
+
+* License: MIT
+
+vscode-debugadapter-node (n/a)
+
+* License: MIT
+
+vscode-java (0.36.0)
+
+* License: EPL-1.0
+
+vscode-java-debug (0.15.0)
+
+* License: MIT
+
+webdriverio (n/a)
+
+* License: MIT
+* Project: http://webdriver.io/
+* Source: https://github.com/webdriverio/webdriverio.git
+
+when (3.7.8)
+
+* License: MIT
+* Project: https://github.com/cujojs/when
+* Source: https://github.com/cujojs/when
+
+wjordan/browser-path SHA6719d19077b1454bff8b802f9be79cb1b69ebe7e (n/a)
+
+* License: MIT
+
+xterm.js (3.9.1)
+
+* License: MIT
+
+yargs (12.0.1)
+
+* License: MIT
+* Project: http://yargs.js.org/
+* Source: https://github.com/yargs/yargs
+
+yeoman environment (2.3.0)
+
+* License: BSD-2-Clause AND BSD-3-Clause
+* Project: https://github.com/yeoman/environment
+* Source: https://github.com/yeoman/environment
+
+yeoman generator (3.0.0)
+
+* License: BSD-2-Clause AND BSD-3-Clause
+* Project: http://yeoman.io
+* Source: https://github.com/yeoman/generator
+
+yeoman-generator (2.0)
+
+* License: BSD-2-Clause
+* Project: http://yeoman.io/
+* Source: https://github.com/yeoman/generator
+
+yosay (2.0.2)
+
+* License: BSD-2-Clause
+* Project: https://github.com/yeoman/yosay
+* Source: https://github.com/yeoman/yosay
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.
+
+
+## Electron
+
+NOTICE:
+
+Please note Electron combines Chromium and Node.js into a single runtime. 
+While Electron, Chromium and Node.js are generally licensed under very
+permissive MIT and BSD-3-Clause licenses, both Electron and Chromium distribute
+FFmpeg.  While FFmpeg is under the LGPL-2.1-or-later license it incorporates
+several optional parts and optimizations that are covered by the
+GPL-2.0-or-later.  We understand both Electron and Chromium do not distribute
+versions of FFmpeg with GPL content enabled; however, FFmpeg may be configured
+enabled to work with proprietary codecs.  It is our understanding these
+proprietary codecs may be patented; and as a result, may be subject to
+licensing fees.
+
+We strongly recommend downstream consumers verify the type of FFmpeg support
+configured and modify as required.  More information on instructions to verify
+can be found here
+https://electronjs.org/docs/development/upgrading-chromium#verify-ffmpeg-support
+
+


### PR DESCRIPTION
This file is mandated by the Foundation. For the most part it's auto-
generated. Exception: the "Electron" section towards the end has been
manually added, as requested in CQ #19253, comment #17.

To eventually update this file, See the Eclipse Theia project page,
navigate to the "Legal Documentation Generator" and look for "NOTICE
FILE".

Today the direct URL is:
https://www.eclipse.org/projects/tools/documentation.php?id=ecd.theia

Make sure to preserve the manually added "Electron" section
at the end.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
