### PR TITLE
Fix 'getTask' method

### DIFF
--- a/packages/task/src/browser/provided-task-configurations.spec.ts
+++ b/packages/task/src/browser/provided-task-configurations.spec.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { assert } from 'chai';
+import { Container } from 'inversify';
+import { ProvidedTaskConfigurations } from './provided-task-configurations';
+import { TaskProviderRegistry } from './task-contribution';
+import { TaskConfiguration } from '../common';
+
+describe('provided-task-configurations', () => {
+    let container: Container;
+    beforeEach(() => {
+        container = new Container();
+        container.bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();
+        container.bind(TaskProviderRegistry).toSelf().inSingletonScope();
+    });
+
+    it('provided-task-search', async () => {
+        const providerRegistry = container.get(TaskProviderRegistry);
+        providerRegistry.register('test', {
+            provideTasks(): Promise<TaskConfiguration[]> {
+                return Promise.resolve([{ type: 'test', label: 'task from test', _source: 'test', _scope: 'test' } as TaskConfiguration]);
+            }
+        });
+
+        const task = await container.get(ProvidedTaskConfigurations).getTask('test', 'task from test');
+        assert.isOk(task);
+        assert.equal(task!.type, 'test');
+        assert.equal(task!.label, 'task from test');
+    });
+});

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -42,7 +42,21 @@ export class ProvidedTaskConfigurations {
     }
 
     /** returns the task configuration for a given source and label or undefined if none */
-    getTask(source: string, taskLabel: string): TaskConfiguration | undefined {
+    async getTask(source: string, taskLabel: string): Promise<TaskConfiguration | undefined> {
+        const task = this.getCachedTask(source, taskLabel);
+        if (task) {
+            return task;
+        } else {
+            const provider = this.taskProviderRegistry.getProvider(source);
+            if (provider) {
+                const tasks = await provider.provideTasks();
+                this.cacheTasks(tasks);
+                return this.getCachedTask(source, taskLabel);
+            }
+        }
+    }
+
+    protected getCachedTask(source: string, taskLabel: string): TaskConfiguration | undefined {
         const labelConfigMap = this.tasksMap.get(source);
         if (labelConfigMap) {
             return labelConfigMap.get(taskLabel);

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -157,7 +157,7 @@ export class TaskService implements TaskConfigurationClient {
      * Returns a task configuration provided by an extension by task source and label.
      * If there are no task configuration, returns undefined.
      */
-    getProvidedTask(source: string, label: string): TaskConfiguration | undefined {
+    async getProvidedTask(source: string, label: string): Promise<TaskConfiguration | undefined> {
         return this.providedTaskConfigurations.getTask(source, label);
     }
 
@@ -209,7 +209,7 @@ export class TaskService implements TaskConfigurationClient {
      * It looks for configured and provided tasks.
      */
     async run(source: string, taskLabel: string): Promise<void> {
-        let task = this.getProvidedTask(source, taskLabel);
+        let task = await this.getProvidedTask(source, taskLabel);
         if (!task) {
             task = this.taskConfigurations.getTask(source, taskLabel);
             if (!task) {


### PR DESCRIPTION
If some one call `getTask` before `getTasks` it always return `undefined`, this pull try to fix that behavior 

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
