### PR TITLE
[filesystem] Fixes #4754 #4248 Parse content-disposition properly and fix firefox download

### DIFF
--- a/packages/filesystem/src/browser/download/file-download-service.ts
+++ b/packages/filesystem/src/browser/download/file-download-service.ts
@@ -168,7 +168,7 @@ export class FileDownloadService {
             const title = await this.title(response, uris);
             const { status, statusText } = response;
             if (status === 200) {
-                await this.forceDownload(response, title);
+                await this.forceDownload(response, decodeURIComponent(title));
             } else {
                 throw new Error(`Received unexpected status code: ${status}. [${statusText}]`);
             }
@@ -194,12 +194,17 @@ export class FileDownloadService {
             url = URL.createObjectURL(blob);
             if (this.anchor === undefined) {
                 this.anchor = document.createElement('a');
-                this.anchor.style.display = 'none';
             }
             this.anchor.href = url;
+            this.anchor.style.display = 'none';
             this.anchor.download = title;
+            document.body.appendChild(this.anchor);
             this.anchor.click();
         } finally {
+            // make sure anchor is removed from parent
+            if (this.anchor && this.anchor.parentNode) {
+                this.anchor.parentNode.removeChild(this.anchor);
+            }
             if (url) {
                 URL.revokeObjectURL(url);
             }

--- a/packages/filesystem/src/node/download/file-download-handler.ts
+++ b/packages/filesystem/src/node/download/file-download-handler.ts
@@ -53,7 +53,7 @@ export abstract class FileDownloadHandler {
         } else {
             this.logger.debug(`Cannot determine the content-type for file: ${filePath}. Skipping the 'Content-type' header from the HTTP response.`);
         }
-        response.setHeader('Content-Disposition', `attachment; filename=${name}`);
+        response.setHeader('Content-Disposition', `attachment; filename=${encodeURIComponent(name)}`);
         try {
             await fs.access(filePath, fs.constants.R_OK);
             fs.readFile(filePath, (error, data) => {


### PR DESCRIPTION
This is in continuation of PR #4755.

This commit Fixes #4754 and fixes #4248. It uses express' own attachment method and parses the content-disposition reliably and decodes the filename if possible. 

This also fixes the downloading on firefox by appending the anchor link to the body before triggering the click event and removes it after.

Signed-off-by: Uni Sayo <unibtc@gmail.com>