### PR TITLE
Check whether selected item in dialog is non-leaf node

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -262,8 +262,11 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
     }
 
     protected async accept(): Promise<void> {
-        if (this.props.canSelectFolders === false && !Array.isArray(this.value)) {
-            this.widget.model.openNode(this.value);
+        const selection = this.value;
+        if (!this.props.canSelectFolders
+            && !Array.isArray(selection)
+            && selection.fileStat.isDirectory) {
+            this.widget.model.openNode(selection);
             return;
         }
         super.accept();

--- a/packages/plugin-ext/src/plugin/dialogs.ts
+++ b/packages/plugin-ext/src/plugin/dialogs.ts
@@ -29,8 +29,8 @@ export class DialogsExtImpl {
         const optionsMain = {
             openLabel: options.openLabel,
             defaultUri: options.defaultUri ? options.defaultUri.path : undefined,
-            canSelectFiles: options.canSelectFiles,
-            canSelectFolders: options.canSelectFolders,
+            canSelectFiles: options.canSelectFiles ? options.canSelectFiles : true,
+            canSelectFolders: options.canSelectFolders ? options.canSelectFolders : false,
             canSelectMany: options.canSelectMany,
             filters: options.filters
         } as OpenDialogOptionsMain;


### PR DESCRIPTION
This changes proposal adds additional check whether selected node is currently a non-leaf node to be able to reopen it in current dialog if dialog has an option `canSelectFolders` configured to false.

See more information in #4752 

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
