### PR TITLE
Fixes #4741 allow creation of sub-files and/or sub-folders if name has "/"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## v0.6.0
 
 - [filesystem] added the menu item `Upload Files...` to easily upload files into a workspace
+- [workspace] allow creation of files and folders using recursive paths
+
+Breaking changes:
+
+- [dialog] `validate` and `accept` methods are now Promisified [#4764](https://github.com/theia-ide/theia/pull/4764)
 
 ## v0.5.0
 

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -261,7 +261,7 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         }
     }
 
-    protected accept(): void {
+    protected async accept(): Promise<void> {
         if (this.props.canSelectFolders === false && !Array.isArray(this.value)) {
             this.widget.model.openNode(this.value);
             return;

--- a/packages/filesystem/src/browser/file-resource.ts
+++ b/packages/filesystem/src/browser/file-resource.ts
@@ -116,7 +116,7 @@ export class FileResource implements Resource {
     }
 
     protected async getFileStat(): Promise<FileStat | undefined> {
-        if (!this.fileSystem.exists(this.uriString)) {
+        if (!await this.fileSystem.exists(this.uriString)) {
             return undefined;
         }
         try {


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/4741. Creation of sub-files and/or sub-folders are already available,however, validation check does not allow `/` on the input box, making it impossible to create nested sub-folders and/or sub-files.

This PR allows recursive creation of folders or files via `/` .
- allow recursive creation for New File and New Folder only.
- do not allow creation of files and folders that starts with `/` 
- do not allow creation of files and folders that starts and ends with a whitepsace.
- do not allow recursive create on Rename.

Example:
- Creating a file using `test/scripts/index.js` will create test and `test/scripts` folder if it still does not exists and lastly it creates the file `test/scripts/index.js`

Signed-off-by: Uni Sayo <unibtc@gmail.com>