### PR TITLE
files.enableTrash preference

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -6,7 +6,10 @@
   "theia": {
     "frontend": {
       "config": {
-        "applicationName": "Theia Browser Example"
+        "applicationName": "Theia Browser Example",
+        "preferences": {
+          "files.enableTrash": false
+        }
       }
     }
   },

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -14,12 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, interfaces } from 'inversify';
+import { injectable, interfaces, decorate, unmanaged } from 'inversify';
 import { createWebSocketConnection, Logger, ConsoleLogger } from 'vscode-ws-jsonrpc/lib';
 import { ConnectionHandler, JsonRpcProxyFactory, JsonRpcProxy, Emitter, Event } from '../../common';
 import { WebSocketChannel } from '../../common/messaging/web-socket-channel';
 import { Endpoint } from '../endpoint';
 const ReconnectingWebSocket = require('reconnecting-websocket');
+
+decorate(injectable(), JsonRpcProxyFactory);
+decorate(unmanaged(), JsonRpcProxyFactory, 0);
 
 export interface WebSocketOptions {
     /**
@@ -31,8 +34,21 @@ export interface WebSocketOptions {
 @injectable()
 export class WebSocketConnectionProvider {
 
-    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T> {
-        return container.get(WebSocketConnectionProvider).createProxy<T>(path, target);
+    /**
+     * Create a proxy object to remote interface of T type
+     * over a web socket connection for the given path and proxy factory.
+     */
+    static createProxy<T extends object>(container: interfaces.Container, path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    /**
+     * Create a proxy object to remote interface of T type
+     * over a web socket connection for the given path.
+     *
+     * An optional target can be provided to handle
+     * notifications and requests from a remote side.
+     */
+    static createProxy<T extends object>(container: interfaces.Container, path: string, target?: object): JsonRpcProxy<T>;
+    static createProxy<T extends object>(container: interfaces.Container, path: string, arg?: object): JsonRpcProxy<T> {
+        return container.get(WebSocketConnectionProvider).createProxy<T>(path, arg);
     }
 
     protected channelIdSeq = 0;
@@ -66,13 +82,19 @@ export class WebSocketConnectionProvider {
 
     /**
      * Create a proxy object to remote interface of T type
+     * over a web socket connection for the given path and proxy factory.
+     */
+    createProxy<T extends object>(path: string, factory: JsonRpcProxyFactory<T>): JsonRpcProxy<T>;
+    /**
+     * Create a proxy object to remote interface of T type
      * over a web socket connection for the given path.
      *
      * An optional target can be provided to handle
      * notifications and requests from a remote side.
      */
-    createProxy<T extends object>(path: string, target?: object): JsonRpcProxy<T> {
-        const factory = new JsonRpcProxyFactory<T>(target);
+    createProxy<T extends object>(path: string, target?: object): JsonRpcProxy<T>;
+    createProxy<T extends object>(path: string, arg?: object): JsonRpcProxy<T> {
+        const factory = arg instanceof JsonRpcProxyFactory ? arg : new JsonRpcProxyFactory<T>(arg);
         this.listen({
             path,
             onConnection: c => factory.listen(c)

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import '../../src/browser/style/index.css';
+
 import { ContainerModule } from 'inversify';
 import { ResourceResolver } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider, FrontendApplicationContribution, ConfirmDialog } from '@theia/core/lib/browser';
@@ -26,8 +28,7 @@ import { FileResourceResolver } from './file-resource';
 import { bindFileSystemPreferences } from './filesystem-preferences';
 import { FileSystemWatcher } from './filesystem-watcher';
 import { FileSystemFrontendContribution } from './filesystem-frontend-contribution';
-
-import '../../src/browser/style/index.css';
+import { FileSystemProxyFactory } from './filesystem-proxy-factory';
 
 export default new ContainerModule(bind => {
     bindFileSystemPreferences(bind);
@@ -47,9 +48,11 @@ export default new ContainerModule(bind => {
         return !!await dialog.open();
     });
 
-    bind(FileSystem).toDynamicValue(ctx =>
-        WebSocketConnectionProvider.createProxy<FileSystem>(ctx.container, fileSystemPath)
-    ).inSingletonScope();
+    bind(FileSystemProxyFactory).toSelf();
+    bind(FileSystem).toDynamicValue(ctx => {
+        const proxyFactory = ctx.container.get(FileSystemProxyFactory);
+        return WebSocketConnectionProvider.createProxy(ctx.container, fileSystemPath, proxyFactory);
+    }).inSingletonScope();
 
     bind(FileResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(FileResourceResolver);

--- a/packages/filesystem/src/browser/filesystem-preferences.ts
+++ b/packages/filesystem/src/browser/filesystem-preferences.ts
@@ -43,6 +43,11 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
             'default': { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
             'description': 'Configure glob patterns for excluding files and folders.',
             'scope': 'resource'
+        },
+        'files.enableTrash': {
+            'type': 'boolean',
+            'default': true,
+            'description': 'Moves files/folders to the OS trash (recycle bin on Windows) when deleting. Disabling this will delete files/folders permanently.'
         }
     }
 };
@@ -50,6 +55,7 @@ export const filesystemPreferenceSchema: PreferenceSchema = {
 export interface FileSystemConfiguration {
     'files.watcherExclude': { [globPattern: string]: boolean };
     'files.exclude': { [key: string]: boolean };
+    'files.enableTrash': boolean;
 }
 
 export const FileSystemPreferences = Symbol('FileSystemPreferences');

--- a/packages/filesystem/src/browser/filesystem-proxy-factory.ts
+++ b/packages/filesystem/src/browser/filesystem-proxy-factory.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable:no-any
+
+import { injectable, inject } from 'inversify';
+import { JsonRpcProxyFactory } from '@theia/core/lib/common/messaging/proxy-factory';
+import { FileSystem, FileDeleteOptions } from '../common/filesystem';
+import { FileSystemPreferences } from './filesystem-preferences';
+
+@injectable()
+export class FileSystemProxyFactory extends JsonRpcProxyFactory<FileSystem> {
+
+    @inject(FileSystemPreferences)
+    protected readonly preferences: FileSystemPreferences;
+
+    get(target: FileSystem, propertyKey: PropertyKey, receiver: any): any {
+        const property = super.get(target, propertyKey, receiver);
+        if (propertyKey !== 'delete') {
+            return property;
+        }
+        const deleteFn: FileSystem['delete'] = (uri, options) => {
+            const opt: FileDeleteOptions = { ...options };
+            if (opt.moveToTrash === undefined) {
+                opt.moveToTrash = this.preferences['files.enableTrash'];
+            }
+            return property(uri, opt);
+        };
+        return deleteFn;
+    }
+
+}

--- a/packages/navigator/src/browser/navigator-filter.ts
+++ b/packages/navigator/src/browser/navigator-filter.ts
@@ -22,8 +22,6 @@ import { PreferenceChangeEvent } from '@theia/core/lib/browser/preferences';
 import { FileSystemPreferences, FileSystemConfiguration } from '@theia/filesystem/lib/browser/filesystem-preferences';
 import { FileNavigatorPreferences, FileNavigatorConfiguration } from './navigator-preferences';
 
-const FILES_EXCLUDE_PREFERENCE: keyof FileSystemConfiguration = 'files.exclude';
-
 /**
  * Filter for omitting elements from the navigator. For more details on the exclusion patterns,
  * one should check either the manual with `man 5 gitignore` or just [here](https://git-scm.com/docs/gitignore).
@@ -44,7 +42,7 @@ export class FileNavigatorFilter {
 
     @postConstruct()
     protected async init(): Promise<void> {
-        this.filterPredicate = this.createFilterPredicate(this.filesPreferences[FILES_EXCLUDE_PREFERENCE]);
+        this.filterPredicate = this.createFilterPredicate(this.filesPreferences['files.exclude']);
         this.filesPreferences.onPreferenceChanged(event => this.onFilesPreferenceChanged(event));
         this.preferences.onPreferenceChanged(event => this.onPreferenceChanged(event));
     }
@@ -67,7 +65,7 @@ export class FileNavigatorFilter {
 
     protected onFilesPreferenceChanged(event: PreferenceChangeEvent<FileSystemConfiguration>): void {
         const { preferenceName, newValue } = event;
-        if (preferenceName === FILES_EXCLUDE_PREFERENCE) {
+        if (preferenceName === 'files.exclude') {
             this.filterPredicate = this.createFilterPredicate(newValue as FileNavigatorFilter.Exclusions | undefined || {});
             this.fireFilterChanged();
         }
@@ -82,7 +80,7 @@ export class FileNavigatorFilter {
 
     toggleHiddenFiles(): void {
         this.showHiddenFiles = !this.showHiddenFiles;
-        const filesExcludes = this.filesPreferences[FILES_EXCLUDE_PREFERENCE];
+        const filesExcludes = this.filesPreferences['files.exclude'];
 
         this.filterPredicate = this.createFilterPredicate(filesExcludes || {});
         this.fireFilterChanged();


### PR DESCRIPTION
fix #4524: add files.enableTrash preference
fix #4334: allow to override default preference values:
  - files.enableTrash is overridden to `false` as an example [for the browser app](https://github.com/theia-ide/theia/blob/cc702f5b22639d1aa2508348b5050558e12fcd5c/examples/browser/package.json#L10-L12)
  - one can override it programmatically: [PreferenceSchemaProvider.getDefaultValue](https://github.com/theia-ide/theia/blob/cc702f5b22639d1aa2508348b5050558e12fcd5c/packages/core/src/browser/preferences/preference-contribution.ts#L178)