### PR TITLE
Implement 'Save As'

### DIFF
--- a/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog-service.ts
@@ -76,11 +76,9 @@ export class DefaultFileDialogService {
         if (folder) {
             const rootUri = new URI(folder.uri).parent;
             const name = this.labelProvider.getName(rootUri);
-            const [rootStat, label] = await Promise.all([
-                this.fileSystem.getFileStat(rootUri.toString()),
-                this.labelProvider.getIcon(folder)
-            ]);
+            const rootStat = await this.fileSystem.getFileStat(rootUri.toString());
             if (rootStat) {
+                const label = await this.labelProvider.getIcon(rootStat);
                 return DirNode.createRoot(rootStat, name, label);
             }
         }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -104,6 +104,11 @@ export class SaveFileDialogProps extends FileDialogProps {
      */
     saveLabel?: string;
 
+    /**
+     * A human-readable value for the input.
+     */
+    inputValue?: string;
+
 }
 
 export abstract class FileDialog<T> extends AbstractDialog<T> {
@@ -343,6 +348,7 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
         this.fileNameField = document.createElement('input');
         this.fileNameField.type = 'text';
         this.fileNameField.classList.add(FILENAME_TEXTFIELD_CLASS);
+        this.fileNameField.value = this.props.inputValue || '';
         fileNamePanel.appendChild(this.fileNameField);
 
         this.fileNameField.onkeyup = () => this.validate();

--- a/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
+++ b/packages/filesystem/src/electron-browser/file-dialog/electron-file-dialog-service.ts
@@ -82,7 +82,7 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
     }
 
     protected async canReadWrite(uris: MaybeArray<URI>): Promise<boolean> {
-        for (const uri of uris) {
+        for (const uri of Array.isArray(uris) ? uris : [uris]) {
             if (!(await this.fileSystem.access(uri.toString(), FileAccess.Constants.R_OK | FileAccess.Constants.W_OK))) {
                 this.messageService.error(`Cannot access resource at ${uri.path}.`);
                 return false;
@@ -109,7 +109,8 @@ export class ElectronFileDialogService extends DefaultFileDialogService {
 
     protected toSaveDialogOptions(uri: URI, props: SaveFileDialogProps): SaveDialogOptions {
         const buttonLabel = props.saveLabel;
-        return { ...this.toDialogOptions(uri, props, 'Save'), buttonLabel };
+        const defaultPath = props.inputValue;
+        return { ...this.toDialogOptions(uri, props, 'Save'), buttonLabel, defaultPath };
     }
 
 }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -125,6 +125,11 @@ export namespace WorkspaceCommands {
         category: WORKSPACE_CATEGORY,
         label: 'Save Workspace As...'
     };
+    export const SAVE_AS: Command = {
+        id: 'file.saveAs',
+        category: 'File',
+        label: 'Save As...',
+    };
 }
 
 @injectable()


### PR DESCRIPTION
Fixes #799

This PR consists of:

1. Implemented the `Save As` functionality and command in order
to save a source URI to a target destination. The `URI` in question
can either be a single file URI or a folder URI (save all files under the
directory to a target).

2. Updated the `SaveDialogProps` to be able to pass an `inputValue` to
the html text input. This is useful when providing a programmatic name
to the input if available. In the instance of a `Save` dialog it is used
to show which `URI` currently has the context.

3. Fix bug when rendering the `SaveDialog` tree icons.
Incorrectly we were using the passed `URI` to determine the correct root icon
instead of using the root `FileStat` which provides the appropriate icon.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
