### PR TITLE
Allow to choose through CLI the VS Code API version that is provided by vscode.version

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
@@ -20,11 +20,18 @@ import { PluginVsCodeFileHandler } from './plugin-vscode-file-handler';
 import { PluginVsCodeDirectoryHandler } from './plugin-vscode-directory-handler';
 import { VsCodePluginScanner } from './scanner-vscode';
 import { VsCodePluginDeployerResolver } from './plugin-vscode-resolver';
+import { PluginVsCodeCliContribution } from './plugin-vscode-cli-contribution';
+import { CliContribution } from '@theia/core/lib/node';
+import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
 
 export default new ContainerModule(bind => {
     bind(PluginDeployerFileHandler).to(PluginVsCodeFileHandler).inSingletonScope();
     bind(PluginDeployerDirectoryHandler).to(PluginVsCodeDirectoryHandler).inSingletonScope();
     bind(PluginScanner).to(VsCodePluginScanner).inSingletonScope();
     bind(PluginDeployerResolver).to(VsCodePluginDeployerResolver).inSingletonScope();
+
+    bind(PluginVsCodeCliContribution).toSelf().inSingletonScope();
+    bind(CliContribution).toService(PluginVsCodeCliContribution);
+    bind(PluginHostEnvironmentVariable).toService(PluginVsCodeCliContribution);
 }
 );

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-cli-contribution.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { Argv, Arguments } from 'yargs';
+import { CliContribution } from '@theia/core/lib/node/cli';
+import { PluginHostEnvironmentVariable } from '@theia/plugin-ext/lib/common';
+import { VSCODE_DEFAULT_API_VERSION } from './plugin-vscode-init';
+/**
+ * CLI Contribution allowing to override the VS Code API version which is returned by `vscode.version` API call.
+ */
+@injectable()
+export class PluginVsCodeCliContribution implements CliContribution, PluginHostEnvironmentVariable {
+
+    static VSCODE_API_VERSION = 'vscode-api-version';
+
+    protected vsCodeApiVersion: string | undefined;
+
+    configure(conf: Argv): void {
+        conf.option(PluginVsCodeCliContribution.VSCODE_API_VERSION, {
+            // tslint:disable-next-line:max-line-length
+            description: `Overrides the version returned by VSCode API 'vscode.version'. Example: --${PluginVsCodeCliContribution.VSCODE_API_VERSION}=<Wanted Version>. Default [${VSCODE_DEFAULT_API_VERSION}]`,
+            type: 'string',
+            nargs: 1
+        });
+    }
+
+    setArguments(args: Arguments): void {
+        const arg = args[PluginVsCodeCliContribution.VSCODE_API_VERSION];
+        if (arg) {
+            this.vsCodeApiVersion = arg;
+        }
+    }
+
+    process(env: NodeJS.ProcessEnv): void {
+        if (this.vsCodeApiVersion) {
+            env['VSCODE_API_VERSION'] = this.vsCodeApiVersion;
+        }
+    }
+
+}

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,6 +19,8 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
+export const VSCODE_DEFAULT_API_VERSION = '1.32.3';
+
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });
 process.env['VSCODE_PID'] = process.env['THEIA_PARENT_PID'];
@@ -72,7 +74,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     };
 
     // override the version for vscode to be a VSCode version
-    (<any>vscode).version = '1.32.3';
+    (<any>vscode).version = process.env['VSCODE_API_VERSION'] || VSCODE_DEFAULT_API_VERSION;
 
     pluginsApiImpl.set(plugin.model.id, vscode);
     plugins.push(plugin);

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -628,3 +628,8 @@ export interface ServerPluginRunner {
      */
     getExtraPluginMetadata(): Promise<PluginMetadata[]>;
 }
+
+export const PluginHostEnvironmentVariable = Symbol('PluginHostEnvironmentVariable');
+export interface PluginHostEnvironmentVariable {
+    process(env: NodeJS.ProcessEnv): void;
+}

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -16,11 +16,11 @@
 
 import * as path from 'path';
 import * as cp from 'child_process';
-import { injectable, inject } from 'inversify';
-import { ILogger, ConnectionErrorHandler } from '@theia/core/lib/common';
+import { injectable, inject, named } from 'inversify';
+import { ILogger, ConnectionErrorHandler, ContributionProvider } from '@theia/core/lib/common';
 import { Emitter } from '@theia/core/lib/common/event';
 import { createIpcEnv } from '@theia/core/lib/node/messaging/ipc-protocol';
-import { HostedPluginClient, ServerPluginRunner, PluginMetadata } from '../../common/plugin-protocol';
+import { HostedPluginClient, ServerPluginRunner, PluginMetadata, PluginHostEnvironmentVariable } from '../../common/plugin-protocol';
 import { RPCProtocolImpl } from '../../api/rpc-protocol';
 import { MAIN_RPC_CONTEXT } from '../../api/plugin-api';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
@@ -40,6 +40,10 @@ export class HostedPluginProcess implements ServerPluginRunner {
 
     @inject(HostedPluginCliContribution)
     protected readonly cli: HostedPluginCliContribution;
+
+    @inject(ContributionProvider)
+    @named(PluginHostEnvironmentVariable)
+    protected readonly pluginHostEnvironmentVariables: ContributionProvider<PluginHostEnvironmentVariable>;
 
     private childProcess: cp.ChildProcess | undefined;
     private client: HostedPluginClient;
@@ -128,6 +132,8 @@ export class HostedPluginProcess implements ServerPluginRunner {
                 delete env[key];
             }
         }
+        // apply external env variables
+        this.pluginHostEnvironmentVariables.getContributions().forEach(envVar => envVar.process(env));
         if (this.cli.extensionTestsPath) {
             env.extensionTestsPath = this.cli.extensionTestsPath;
         }

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -27,7 +27,7 @@ import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginSupport } from './hosted-plugin';
 import { TheiaPluginScanner } from './scanners/scanner-theia';
 import { HostedPluginsManager, HostedPluginsManagerImpl } from './hosted-plugins-manager';
-import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath, PluginDeployerHandler } from '../../common/plugin-protocol';
+import { HostedPluginServer, PluginScanner, HostedPluginClient, hostedServicePath, PluginDeployerHandler, PluginHostEnvironmentVariable } from '../../common/plugin-protocol';
 import { GrammarsReader } from './scanners/grammars-reader';
 import { HostedPluginProcess } from './hosted-plugin-process';
 import { ExtPluginApiProvider } from '../../common/plugin-ext-api-contribution';
@@ -42,6 +42,8 @@ const commonHostedConnectionModule = ConnectionContainerModule.create(({ bind, b
     bind(HostedPluginsManager).toService(HostedPluginsManagerImpl);
 
     bindContributionProvider(bind, Symbol.for(ExtPluginApiProvider));
+    bindContributionProvider(bind, PluginHostEnvironmentVariable);
+
     bind(HostedPluginServerImpl).toSelf().inSingletonScope();
     bind(HostedPluginServer).toService(HostedPluginServerImpl);
     bindBackendService<HostedPluginServer, HostedPluginClient>(hostedServicePath, HostedPluginServer, (server, client) => {


### PR DESCRIPTION
$ yarn run start --vscode-api-version=1.40

(and you'll get 1.40 as API version)

this is a follow up of https://github.com/theia-ide/theia/issues/4124

Change-Id: I371e3b008f8d9a8bbd9e047dada4f75e1137e17a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

