### PR TITLE
Don't rewrite debug capabilities

### DIFF
--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -258,7 +258,7 @@ export class DebugSession implements CompositeTreeElement {
             supportsVariablePaging: false,
             supportsRunInTerminalRequest: true
         });
-        this._capabilities = response.body || {};
+        this.updateCapabilities(response.body || {});
     }
     protected async launchOrAttach(): Promise<void> {
         try {


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
Sometimes debug's capabilities come before we get the response from `initialize` request, it may happened on [capabilities](https://github.com/theia-ide/theia/blob/master/packages/debug/src/browser/debug-session.tsx#L105) event. In that case we don't need to rewrite capabilities' value.

Related issue: https://github.com/eclipse/che/issues/12790