### PR TITLE
Set a minWidth and minHeight in frontend-generator for electron app.

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -164,6 +164,8 @@ if (isMaster) {
                 title: applicationName,
                 width: windowState.width,
                 height: windowState.height,
+                minWidth: 200,
+                minHeight: 120,
                 x: windowState.x,
                 y: windowState.y,
                 isMaximized: windowState.isMaximized


### PR DESCRIPTION
It was possible to resize the electron window to zero. Now there is set a minimum size of 500x300. 