### PR TITLE
[readme.md] Use external absolute link for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br/>
 <div id="theia-logo" align="center">
     <br />
-    <img src="./logo/theia-logo.svg" alt="Theia Logo" width="300"/>
+    <img src="https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo.svg?sanitize=true" alt="Theia Logo" width="300"/>
     <h3>Cloud & Desktop IDE Platform</h3>
 </div>
 


### PR DESCRIPTION
It's useful when embedding README in other pages (usecase = typedoc rendering)
So the logo is displayed nicely.

Change-Id: Ic1063d972d13eb52bef1248ccf869e3ec0e01f23
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

