### PR TITLE
Fix incorrect method name for registerReferenceProvider

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -913,7 +913,7 @@ export interface LanguagesMain {
     $registerImplementationProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerTypeDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registeReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void;
+    $registerReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerSignatureHelpProvider(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[]): void;
     $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerDocumentHighlightProvider(handle: number, selector: SerializedDocumentFilter[]): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -112,7 +112,7 @@ export class LanguagesMainImpl implements LanguagesMain {
         this.disposables.set(handle, disposable);
     }
 
-    $registeReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void {
+    $registerReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void {
         const languageSelector = fromLanguageSelector(selector);
         const referenceProvider = this.createReferenceProvider(handle, languageSelector);
         const disposable = new DisposableCollection();

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -429,7 +429,7 @@ export class LanguagesExtImpl implements LanguagesExt {
 
     registerReferenceProvider(selector: theia.DocumentSelector, provider: theia.ReferenceProvider): theia.Disposable {
         const callId = this.addNewAdapter(new ReferenceAdapter(provider, this.documents));
-        this.proxy.$registeReferenceProvider(callId, this.transformDocumentSelector(selector));
+        this.proxy.$registerReferenceProvider(callId, this.transformDocumentSelector(selector));
         return this.createDisposable(callId);
     }
     // ### Code Reference Provider end


### PR DESCRIPTION
Fix typo in `registerReferenceProvider` Plug-in API.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
