### PR TITLE
[plugin] add `CodeActionKind` intersects plugin api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.0
 
 - [filesystem] added the menu item `Upload Files...` to easily upload files into a workspace
+- [plugin] added `CodeActionKind` `intersects` Plug-in API
 - [task] added support to configure tasks
 - [workspace] allow creation of files and folders using recursive paths
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -950,6 +950,10 @@ export class CodeActionKind {
     public contains(other: CodeActionKind): boolean {
         return this.value === other.value || startsWithIgnoreCase(other.value, this.value + CodeActionKind.sep);
     }
+
+    public intersects(other: CodeActionKind): boolean {
+        return this.contains(other) || other.contains(this);
+    }
 }
 
 export enum TextDocumentSaveReason {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -5759,6 +5759,15 @@ declare module '@theia/plugin' {
          * @param other Kind to check.
          */
         contains(other: CodeActionKind): boolean;
+
+        /**
+         * Check if this code action kind intersects `other`.
+         * The kind "refactor.extract" for example intersects refactor, "refactor.extract" and 
+         * `"refactor.extract.function", but not "unicorn.refactor.extract", or "refactor.extractAll".
+         * 
+         * @param other Kind to check.
+         */
+        intersects(other: CodeActionKind): boolean;
     }
 
     /**


### PR DESCRIPTION
Added the Plugin API for `CodeActionKind` `intersects(other: CodeActionKind)` method.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
