### PR TITLE
Add QuickPickItem alwaysShow property

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -250,6 +250,7 @@ export interface PickOpenItem {
     description?: string;
     detail?: string;
     picked?: boolean;
+    alwaysShow?: boolean;
 }
 
 export enum MainMessageType {

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -71,17 +71,19 @@ export class QuickOpenExtImpl implements QuickOpenExt {
                     let description: string | undefined;
                     let detail: string | undefined;
                     let picked: boolean | undefined;
+                    let alwaysShow: boolean | undefined;
                     if (typeof item === 'string') {
                         label = item;
                     } else {
-                        ({ label, description, detail, picked } = item);
+                        ({ label, description, detail, picked, alwaysShow } = item);
                     }
                     pickItems.push({
                         label,
                         description,
                         handle,
                         detail,
-                        picked
+                        picked,
+                        alwaysShow
                     });
                 }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -1878,6 +1878,11 @@ declare module '@theia/plugin' {
          * not implemented yet
          */
         picked?: boolean;
+
+        /**
+         * Always show this item.
+         */
+        alwaysShow?: boolean;
     }
 
     /**


### PR DESCRIPTION
Added missing `alwaysShow` property to the `QuickPickItem` API interface.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
