### PR TITLE
[terminal] Fixes #4767 Set terminal preference's minimum value for lineHeight and fontSize

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -39,6 +39,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
         'terminal.integrated.fontSize': {
             type: 'number',
             description: 'Controls the font size in pixels of the terminal.',
+            minimum: 6,
             default: EDITOR_FONT_DEFAULTS.fontSize
         },
         'terminal.integrated.fontWeight': {
@@ -61,6 +62,7 @@ export const TerminalConfigSchema: PreferenceSchema = {
         'terminal.integrated.lineHeight': {
             description: 'Controls the line height of the terminal, this number is multiplied by the terminal font size to get the actual line-height in pixels.',
             type: 'number',
+            minimum: 1,
             default: 1
         },
     }


### PR DESCRIPTION
Fixes https://github.com/theia-ide/theia/issues/4767 by setting the minimum value of lineHeight to 1. Also set the fontSize minimum to 9 (equivalent to xx-small) and letterSpacing minimum to 0. 
Also fixed misspelled `FontWeigth`

Signed-off-by: Uni Sayo <unibtc@gmail.com>