### PR TITLE
fix gotodefinition failure when editor in preview mode

### DIFF
--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { ApplicationShell, DockPanel } from '@theia/core/lib/browser';
-import { EditorManager,  EditorOpenerOptions, EditorWidget } from '@theia/editor/lib/browser';
+import { EditorManager, EditorOpenerOptions, EditorWidget } from '@theia/editor/lib/browser';
 import { EditorPreviewWidget } from './editor-preview-widget';
 import { EditorPreviewWidgetFactory, EditorPreviewWidgetOptions } from './editor-preview-factory';
 import { EditorPreviewPreferences } from './editor-preview-preferences';
@@ -35,7 +35,7 @@ export interface PreviewEditorOpenerOptions extends EditorOpenerOptions {
  * Class for managing an editor preview widget.
  */
 @injectable()
-export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|EditorWidget> {
+export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget | EditorWidget> {
 
     readonly id = EditorPreviewWidgetFactory.ID;
 
@@ -60,6 +60,14 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
                 return this.handlePreviewWidgetCreated(widget);
             }
         });
+
+        this.preferences.onPreferenceChanged(change => {
+            this.currentEditorPreview.then(editorPreview => {
+                if (!change.newValue && editorPreview) {
+                    editorPreview.pinEditorWidget();
+                }
+            });
+        });
     }
 
     protected async handlePreviewWidgetCreated(widget: EditorPreviewWidget): Promise<void> {
@@ -72,13 +80,13 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
         this.currentEditorPreview = Promise.resolve(widget);
         widget.disposed.connect(() => this.currentEditorPreview = Promise.resolve(undefined));
 
-        widget.onPinned(({preview, editorWidget}) => {
+        widget.onPinned(({ preview, editorWidget }) => {
             // TODO(caseyflynn): I don't believe there is ever a case where
             // this will not hold true.
             if (preview.parent && preview.parent instanceof DockPanel) {
-                preview.parent.addWidget(editorWidget, {ref: preview});
+                preview.parent.addWidget(editorWidget, { ref: preview });
             } else {
-                this.shell.addWidget(editorWidget, {area: 'main'});
+                this.shell.addWidget(editorWidget, { area: 'main' });
             }
             preview.dispose();
             this.shell.activateWidget(editorWidget.id);
@@ -100,7 +108,7 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget|
     }
 
     async open(uri: URI, options?: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | EditorWidget> {
-        options = {...options, mode: 'open'};
+        options = { ...options, mode: 'open' };
 
         const deferred = new Deferred<EditorPreviewWidget | undefined>();
         const previousPreview = await this.currentEditorPreview;

--- a/packages/editor/src/browser/editor-manager.ts
+++ b/packages/editor/src/browser/editor-manager.ts
@@ -25,6 +25,7 @@ import { TextEditor } from './editor';
 
 export interface EditorOpenerOptions extends WidgetOpenerOptions {
     selection?: RecursivePartial<Range>;
+    preview?: boolean;
 }
 
 @injectable()

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, decorate } from 'inversify';
 import { MonacoToProtocolConverter } from 'monaco-languageclient';
 import URI from '@theia/core/lib/common/uri';
-import { OpenerService, open, WidgetOpenMode, ApplicationShell } from '@theia/core/lib/browser';
+import { OpenerService, open, WidgetOpenMode, ApplicationShell, PreferenceService } from '@theia/core/lib/browser';
 import { EditorWidget, EditorOpenerOptions, EditorManager } from '@theia/editor/lib/browser';
 import { MonacoEditor } from './monaco-editor';
 
@@ -30,6 +30,8 @@ decorate(injectable(), monaco.services.CodeEditorServiceImpl);
 @injectable()
 export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
 
+    public static readonly ENABLE_PREVIEW_PREFERENCE: string = 'editor.enablePreview';
+
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
 
@@ -41,6 +43,9 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
 
     @inject(EditorManager)
     protected readonly editors: EditorManager;
+
+    @inject(PreferenceService)
+    protected readonly preferencesService: PreferenceService;
 
     constructor() {
         super(monaco.services.StaticServices.standaloneThemeService.get());
@@ -66,7 +71,8 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
         const mode = this.getEditorOpenMode(input);
         const selection = input.options && this.m2p.asRange(input.options.selection);
         const widgetOptions = this.getWidgetOptions(source, sideBySide);
-        return { mode, selection, widgetOptions };
+        const preview = !!this.preferencesService.get<boolean>(MonacoEditorService.ENABLE_PREVIEW_PREFERENCE, false);
+        return { mode, selection, widgetOptions, preview };
     }
     protected getEditorOpenMode(input: IResourceInput): WidgetOpenMode {
         const options = {


### PR DESCRIPTION
this path add preview option to EditorOpenerOptions according to 'editor.enablePreview' preference.
if editor.enablePreview changed to false will pin all prevew widget.

Signed-off-by: yewei <yeweiasia@gmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
