### PR TITLE
Fix double confirmation in Electron when overwriting

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -304,7 +304,9 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
                 }
                 exist = await this.fileSystem.exists(selected.toString());
                 if (exist) {
-                    overwrite = await this.confirmOverwrite(selected); // TODO this should be handled differently in Electron.
+                    // Prompt users for confirmation before overwriting.
+                    // Electron handles this case itself, so do not prompt again.
+                    overwrite = this.isElectron() ? true : await this.confirmOverwrite(selected);
                 }
             }
         } while (selected && exist && !overwrite);


### PR DESCRIPTION
Fixes #4809

- Fixes issue present in Electron where two confirmations
are displayed when attempting to overwrite a file.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
