### PR TITLE
[filesystem] handle copying when source and target destinations are the same

### DIFF
--- a/packages/filesystem/src/node/node-filesystem.spec.ts
+++ b/packages/filesystem/src/node/node-filesystem.spec.ts
@@ -446,6 +446,14 @@ describe('NodeFileSystem', function () {
             await expectThrowsAsync(fileSystem.copy(sourceUri.toString(), targetUri.toString()), Error);
         });
 
+        it('Copy a file to existing location with the same file name. Should be rejected with an error.', async () => {
+            const sourceUri = root.resolve('foo');
+            fs.mkdirSync(FileUri.fsPath(sourceUri));
+            expect(fs.statSync(FileUri.fsPath(sourceUri)).isDirectory()).to.be.true;
+
+            await expectThrowsAsync(fileSystem.copy(sourceUri.toString(), sourceUri.toString()), Error);
+        });
+
         it('Copy an empty directory to a non-existing location. Should return with the file stat representing the new file at the target location.', async () => {
             const sourceUri = root.resolve('foo');
             const targetUri = root.resolve('bar');

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -231,6 +231,9 @@ export class FileSystemNode implements FileSystem {
         if (targetStat && !overwrite) {
             throw FileSystemError.FileExists(targetUri, "Did you set the 'overwrite' flag to true?");
         }
+        if (targetStat && targetStat.uri === sourceStat.uri) {
+            throw FileSystemError.FileExists(targetUri, 'Cannot perform copy, source and destination are the same.');
+        }
         await fs.copy(FileUri.fsPath(_sourceUri), FileUri.fsPath(_targetUri), { overwrite, recursive });
         const newStat = await this.doGetStat(_targetUri, 1);
         if (newStat) {


### PR DESCRIPTION
Fixes #4812

- Fixes an issue when calling `copy` from the filesystem when
the `source` and `target` destinations are the same. Currently,
no check is performed to verify if the paths are different
which leads to `fs-extra` throwing an error.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
