### PR TITLE
[tree] Support icons in tail decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [task] added support to configure tasks
 - [workspace] allow creation of files and folders using recursive paths
 - [electron] upgraded version of electron used to version 3.
+- [tree] support icons in node tail decorators
 
 Breaking changes:
 

--- a/packages/core/src/browser/tree/tree-decorator.ts
+++ b/packages/core/src/browser/tree/tree-decorator.ts
@@ -233,16 +233,53 @@ export namespace TreeDecoration {
 
     }
 
-    /**
-     * Unlike caption suffixes, tail decorations appears right-aligned after the caption and the caption suffixes (is any).
-     */
-    export interface TailDecoration extends CaptionAffix {
+    export interface BaseTailDecoration {
 
         /**
          * Optional tooltip for the tail decoration.
          */
         readonly tooltip?: string;
+    }
 
+    /**
+     * Unlike caption suffixes, tail decorations appears right-aligned after the caption and the caption suffixes (is any).
+     */
+    export interface TailDecoration extends BaseTailDecoration {
+        /**
+         * The text content of the tail decoration.
+         */
+        readonly data: string;
+
+        /**
+         * Font data for customizing the content.
+         */
+        readonly fontData?: FontData;
+    }
+
+    export interface TailDecorationIcon extends BaseTailDecoration {
+        /**
+         * This should be the name of the Font Awesome icon with out the `fa fa-` prefix, just the name, for instance `paw`.
+         * For the existing icons, see here: https://fontawesome.com/v4.7.0/icons/.
+         */
+        readonly icon: string;
+
+        /**
+         * The color of the icon.
+         */
+        readonly color?: Color;
+    }
+
+    export interface TailDecorationIconClass extends BaseTailDecoration {
+        /**
+         * This should be the entire Font Awesome class array, for instance ['fa', 'fa-paw']
+         * For the existing icons, see here: https://fontawesome.com/v4.7.0/icons/.
+         */
+        readonly iconClass: string[];
+
+        /**
+         * The color of the icon.
+         */
+        readonly color?: Color;
     }
 
     /**
@@ -307,18 +344,12 @@ export namespace TreeDecoration {
     /**
      * Has not effect if the tree node being decorated has no associated icon.
      */
-    export interface IconOverlay {
+    export interface BaseOverlay {
 
         /**
          * The position where the decoration will be placed on the top of the original icon.
          */
         readonly position: IconOverlayPosition;
-
-        /**
-         * This should be the name of the Font Awesome icon with out the `fa fa-` prefix, just the name, for instance `paw`.
-         * For the existing icons, see here: https://fontawesome.com/v4.7.0/icons/.
-         */
-        readonly icon: string;
 
         /**
          * The color of the overlaying icon. If not specified, then the default icon color will be used.
@@ -330,6 +361,22 @@ export namespace TreeDecoration {
          */
         readonly background?: IconOverlayBackground;
 
+    }
+
+    export interface IconOverlay extends BaseOverlay {
+        /**
+         * This should be the name of the Font Awesome icon with out the `fa fa-` prefix, just the name, for instance `paw`.
+         * For the existing icons, see here: https://fontawesome.com/v4.7.0/icons/.
+         */
+        readonly icon: string;
+    }
+
+    export interface IconClassOverlay extends BaseOverlay {
+        /**
+         * This should be the entire Font Awesome class array, for instance ['fa', 'fa-paw']
+         * For the existing icons, see here: https://fontawesome.com/v4.7.0/icons/.
+         */
+        readonly iconClass: string[];
     }
 
     /**
@@ -468,7 +515,7 @@ export namespace TreeDecoration {
         /**
          * Optional right-aligned decorations that appear after the node caption and after the caption suffixes (is any).
          */
-        readonly tailDecorations?: TailDecoration[];
+        readonly tailDecorations?: Array<TailDecoration | TailDecorationIcon | TailDecorationIconClass>;
 
         /**
          * Custom tooltip for the decorated item. Tooltip will be appended to the original tooltip, if any.
@@ -483,7 +530,7 @@ export namespace TreeDecoration {
         /**
          * Has not effect if given, but the tree node does not have an associated image.
          */
-        readonly iconOverlay?: IconOverlay;
+        readonly iconOverlay?: IconOverlay | IconClassOverlay;
 
         /**
          * An array of ranges to highlight the caption.

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -546,15 +546,16 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
         const overlayIcons: React.ReactNode[] = [];
         new Map(this.getDecorationData(node, 'iconOverlay').reverse().filter(notEmpty)
-            .map(overlay => [overlay.position, overlay] as [TreeDecoration.IconOverlayPosition, TreeDecoration.IconOverlay]))
+            .map(overlay => [overlay.position, overlay] as [TreeDecoration.IconOverlayPosition, TreeDecoration.IconOverlay | TreeDecoration.IconClassOverlay]))
             .forEach((overlay, position) => {
-                const overlayClass = (iconName: string) =>
-                    ['a', 'fa', `fa-${iconName}`, TreeDecoration.Styles.DECORATOR_SIZE_CLASS, TreeDecoration.IconOverlayPosition.getStyle(position)].join(' ');
+                const iconClasses = [TreeDecoration.Styles.DECORATOR_SIZE_CLASS, TreeDecoration.IconOverlayPosition.getStyle(position)];
                 const style = (color?: string) => color === undefined ? {} : { color };
                 if (overlay.background) {
-                    overlayIcons.push(<span key={node.id + 'bg'} className={overlayClass(overlay.background.shape)} style={style(overlay.background.color)}></span>);
+                    overlayIcons.push(<span key={node.id + 'bg'} className={this.getIconClass(overlay.background.shape, iconClasses)} style={style(overlay.background.color)}>
+                    </span>);
                 }
-                overlayIcons.push(<span key={node.id} className={overlayClass(overlay.icon)} style={style(overlay.color)}></span>);
+                const overlayIcon = (overlay as TreeDecoration.IconOverlay).icon || (overlay as TreeDecoration.IconClassOverlay).iconClass;
+                overlayIcons.push(<span key={node.id} className={this.getIconClass(overlayIcon, iconClasses)} style={style(overlay.color)}></span>);
             });
 
         if (overlayIcons.length > 0) {
@@ -565,16 +566,27 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     protected renderTailDecorations(node: TreeNode, props: NodeProps): React.ReactNode {
-        const style = (fontData: TreeDecoration.FontData | undefined) => this.applyFontStyles({}, fontData);
         return <React.Fragment>
             {this.getDecorationData(node, 'tailDecorations').filter(notEmpty).reduce((acc, current) => acc.concat(current), []).map((decoration, index) => {
-                const { fontData, data, tooltip } = decoration;
+                const { tooltip } = decoration;
+                const { data, fontData } = decoration as TreeDecoration.TailDecoration;
+                const color = (decoration as TreeDecoration.TailDecorationIcon).color;
+                const icon = (decoration as TreeDecoration.TailDecorationIcon).icon || (decoration as TreeDecoration.TailDecorationIconClass).iconClass;
                 const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS].join(' ');
-                return <div key={node.id + className + index} className={className} style={style(fontData)} title={tooltip}>
-                    {data}
+                const style = fontData ? this.applyFontStyles({}, fontData) : color ? { color } : undefined;
+                const content = data ? data : icon ? <span key={node.id + 'icon' + index} className={this.getIconClass(icon)}></span> : '';
+                return <div key={node.id + className + index} className={className} style={style} title={tooltip}>
+                    {content}
                 </div>;
             })}
         </React.Fragment>;
+    }
+
+    // Determine the classes to use for an icon
+    // Assumes a Font Awesome name when passed a single string, otherwise uses the passed string array
+    private getIconClass(iconName: string | string[], additionalClasses: string[] = []): string {
+        const iconClass = (typeof iconName === 'string') ? ['a', 'fa', `fa-${iconName}`] : ['a'].concat(iconName);
+        return iconClass.concat(additionalClasses).join(' ');
     }
 
     protected renderNode(node: TreeNode, props: NodeProps): React.ReactNode {


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR introduces support for icons in tail decorators. It makes the `data` property optional and introduces an `icon` property. Rendering differs based on the existence of these properties:

![Screen Shot 2019-04-04 at 20 35 57](https://user-images.githubusercontent.com/61341/55584115-69118480-571b-11e9-9380-ac9d551a004d.png)

There is also a change to the `icon` type to allow strings or string arrays. In this way the user can either specify an icon to use (existing method with string) or specify an array of classes. This unlocks the ability to use the pro Font Awesome icons (assuming the user has a license) which use different prefixes. e.g. `far fa-alarm-clock`.

Implementation looks like:
```typescript
...
            tailDecorations: [
                {
                    icon: 'anchor',
                    color: 'green',
                    tooltip
                },
                {
                    icon: ['fa', 'fa-bug'],
                    color: 'red',
                    tooltip
                },
                {
                    data: 'U',
                    fontData: {
                        color: 'green'
                    },
                    tooltip
                }
            ]
...
```