### PR TITLE
Remove no longer used interfaces from java-protocol.ts

### DIFF
--- a/packages/java/src/browser/java-protocol.ts
+++ b/packages/java/src/browser/java-protocol.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { RequestType, NotificationType } from 'vscode-jsonrpc';
-import { VersionedTextDocumentIdentifier, TextDocumentIdentifier, Command, MessageType, ExecuteCommandParams } from '@theia/languages/lib/browser';
+import { TextDocumentIdentifier, Command, MessageType, ExecuteCommandParams } from '@theia/languages/lib/browser';
 
 export interface StatusReport {
     message: string;
@@ -34,26 +34,12 @@ export interface ActionableMessage {
     commands?: Command[];
 }
 
-export interface SemanticHighlightingParams {
-    readonly textDocument: VersionedTextDocumentIdentifier;
-    readonly lines: SemanticHighlightingInformation[];
-}
-
-export interface SemanticHighlightingInformation {
-    readonly line: number;
-    readonly tokens: string | undefined;
-}
-
 export namespace ClassFileContentsRequest {
     export const type = new RequestType<TextDocumentIdentifier, string | undefined, void, void>('java/classFileContents');
 }
 
 export namespace ActionableNotification {
     export const type = new NotificationType<ActionableMessage, void>('language/actionableNotification');
-}
-
-export namespace SemanticHighlight {
-    export const type = new NotificationType<SemanticHighlightingParams, void>('textDocument/semanticHighlighting');
 }
 
 export enum CompileWorkspaceStatus {


### PR DESCRIPTION
This is a follow-up ot #2574 which moved semantic highlighting interfaces
to a language-agnostic place but left these interfaces behind.

Closes #4689.

Signed-off-by: Nathan Ridge <zeratul976@hotmail.com>