### PR TITLE
[Proposal] Aligned the status bar styles with VS Code.

### DIFF
--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -82,6 +82,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         super();
         delete this.scrollOptions;
         this.id = 'theia-statusBar';
+        this.addClass('noselect');
     }
 
     protected get ready(): Promise<void> {

--- a/packages/core/src/browser/style/status-bar.css
+++ b/packages/core/src/browser/style/status-bar.css
@@ -61,3 +61,14 @@
 #theia-statusBar .area.right .element {
     margin-left: var(--theia-ui-padding);
 }
+
+#theia-statusBar .element {
+    /* https://css-tricks.com/os-specific-fonts-css/#article-header-id-0 */
+    /* https://github.com/Microsoft/vscode/blob/5dbdc8d19c8cf6dd10d558eabcc48bba962ea45f/src/vs/workbench/browser/media/style.css#L8-L24 */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif;
+    font-size: 12px;
+    text-rendering: auto;
+    text-decoration: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}

--- a/packages/git/src/browser/git-view-contribution.ts
+++ b/packages/git/src/browser/git-view-contribution.ts
@@ -502,7 +502,7 @@ export class GitViewContribution extends AbstractViewContribution<GitWidget>
         const { upstreamBranch, aheadBehind } = status;
         if (upstreamBranch) {
             return {
-                text: '$(refresh)' + (aheadBehind ? ` ${aheadBehind.behind} $(arrow-down) ${aheadBehind.ahead} $(arrow-up)` : ''),
+                text: '$(refresh)' + (aheadBehind && (aheadBehind.ahead + aheadBehind.behind) > 0 ? ` ${aheadBehind.behind}↓ ${aheadBehind.ahead}↑` : ''),
                 command: GIT_COMMANDS.SYNC.id,
                 tooltip: 'Synchronize Changes'
             };


### PR DESCRIPTION
I have aligned the status bar styles with VS Code. The story started with the up/down arrows for the [Git ahead/behind](https://github.com/theia-ide/theia/issues/4619).

The order from top to bottom (on macOS) is:
 - Safari,
 - FF,
 - Chrome, and
 -  VS Code.

<img width="448" alt="Screen Shot 2019-04-07 at 18 19 04" src="https://user-images.githubusercontent.com/1405703/55686460-bc751400-5961-11e9-9ac6-defa6bbb8e50.png">

<img width="439" alt="Screen Shot 2019-04-07 at 18 19 13" src="https://user-images.githubusercontent.com/1405703/55686462-c26af500-5961-11e9-8cc6-4b739a19a82b.png">


Thoughts? If the majority likes it, perhaps, we could use this style for all fonts, in general, in the application.

Closes: #4619