### PR TITLE
Fix plug-in path selection dialog for hosted instance

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -247,7 +247,10 @@ export class HostedPluginManagerClient {
 
         const dialog = this.openFileDialogFactory({
             title: HostedPluginCommands.SELECT_PATH.label!,
-            canSelectFiles: false
+            openLabel: 'Select',
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false
         });
         dialog.model.navigateTo(rootNode);
         const result = await dialog.open();


### PR DESCRIPTION
Fixes broken plug-in path selection dialog to be able to select a folder and run hosted Theia instance from UI.

Fixes https://github.com/theia-ide/theia/issues/4821