### PR TITLE
use workspace file as key to store data in localstorage

### DIFF
--- a/packages/workspace/src/browser/workspace-storage-service.ts
+++ b/packages/workspace/src/browser/workspace-storage-service.ts
@@ -34,8 +34,8 @@ export class WorkspaceStorageService implements StorageService {
 
     @postConstruct()
     protected init() {
-        this.initialized = this.workspaceService.roots.then(roots => {
-            this.prefix = this.getPrefix(roots[0]);
+        this.initialized = this.workspaceService.roots.then(() => {
+            this.prefix = this.getPrefix(this.workspaceService.workspace);
         });
     }
 
@@ -57,7 +57,7 @@ export class WorkspaceStorageService implements StorageService {
         return `${this.prefix}:${originalKey}`;
     }
 
-    protected getPrefix(rootStat: FileStat | undefined): string {
-        return rootStat ? rootStat.uri : '_global_';
+    protected getPrefix(workspaceStat: FileStat | undefined): string {
+        return workspaceStat ? workspaceStat.uri : '_global_';
     }
 }


### PR DESCRIPTION
- In current theia, localstorage uses path of 1st root of a multi root workspace as the key to store layout data, which could result in issues reported in https://github.com/theia-ide/theia/issues/3257. With this change, the path of workspace file is used to as the key to save & retrieve data to / from local storage.
- fixes #3257

Signed-off-by: elaihau <liang.huang@ericsson.com>
