### PR TITLE
[electron] Bind plugin components on the backend

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -11,10 +11,6 @@
       }
     }
   },
-  "//": [
-    "`@theia/plugin-ext` and `@theia/plugin-ext-vscode` are missing due to https://github.com/theia-ide/theia/issues/3723",
-    "`@theia/debug`, `@theia/debug-nodejs` and `@theia/java-debug` are removed due to https://github.com/theia-ide/theia/issues/3716"
-  ],
   "dependencies": {
     "@theia/callhierarchy": "^0.5.0",
     "@theia/console": "^0.5.0",
@@ -44,6 +40,8 @@
     "@theia/navigator": "^0.5.0",
     "@theia/outline-view": "^0.5.0",
     "@theia/output": "^0.5.0",
+    "@theia/plugin": "^0.5.0",
+    "@theia/plugin-ext-vscode": "^0.5.0",
     "@theia/preferences": "^0.5.0",
     "@theia/preview": "^0.5.0",
     "@theia/process": "^0.5.0",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -62,7 +62,7 @@
     "clean": "theia clean",
     "build": "theiaext compile && theia build --mode development",
     "watch": "concurrently -n compile,bundle \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
-    "start": "theia start",
+    "start": "theia start --plugins=local-dir:../../plugins",
     "start:debug": "yarn start --log-level=debug",
     "test": "electron-mocha --timeout 60000 \"./lib/test/**/*.espec.js\"",
     "test:ui": "wdio wdio.conf.js"

--- a/packages/plugin-ext/src/plugin-ext-backend-electron-module.ts
+++ b/packages/plugin-ext/src/plugin-ext-backend-electron-module.ts
@@ -16,7 +16,9 @@
 
 import { ContainerModule } from 'inversify';
 import { bindElectronBackend } from './hosted/node-electron/plugin-ext-hosted-electron-backend-module';
+import { bindMainBackend } from './main/node/plugin-ext-backend-module';
 
 export default new ContainerModule(bind => {
+    bindMainBackend(bind);
     bindElectronBackend(bind);
 });


### PR DESCRIPTION
The electron inversify container is missing a couple of bindings
required by the whole plugin system to work correctly.

This commit binds what is missing for plugins to function on electron.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Fixes https://github.com/theia-ide/theia/issues/4802
Fixes https://github.com/theia-ide/theia/issues/3651
Fixes https://github.com/theia-ide/theia/issues/2210