### PR TITLE
Respect type of click in tree on plugin side to correct set up selection

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -409,7 +409,7 @@ export interface TreeViewsMain {
 export interface TreeViewsExt {
     $getChildren(treeViewId: string, treeItemId: string | undefined): Promise<TreeViewItem[] | undefined>;
     $setExpanded(treeViewId: string, treeItemId: string, expanded: boolean): Promise<any>;
-    $setSelection(treeViewId: string, treeItemId: string): Promise<any>;
+    $setSelection(treeViewId: string, treeItemId: string, contextSelection: boolean): Promise<any>;
 }
 
 export class TreeViewItem {

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.tsx
@@ -131,7 +131,7 @@ export class TreeViewsMainImpl implements TreeViewsMain {
                 const treeItemId = event[0].id;
                 const [, contextValue = ''] = treeItemId.split('/');
 
-                this.proxy.$setSelection(treeViewId, treeItemId);
+                this.proxy.$setSelection(treeViewId, treeItemId, treeViewWidget.contextSelection);
                 this.viewItemCtxKey.set(contextValue);
             } else {
                 this.viewItemCtxKey.set('');
@@ -140,6 +140,11 @@ export class TreeViewsMainImpl implements TreeViewsMain {
         });
     }
 
+}
+
+export interface SelectionEventHandler {
+    readonly node: SelectableTreeNode;
+    readonly contextSelection: boolean;
 }
 
 export interface DescriptiveMetadata {
@@ -223,6 +228,8 @@ export class TreeViewDataProviderMain {
 @injectable()
 export class TreeViewWidget extends TreeWidget {
 
+    protected _contextSelection = false;
+
     constructor(
         @inject(TreeProps) readonly treeProps: TreeProps,
         @inject(TreeModel) readonly model: TreeModel,
@@ -249,6 +256,19 @@ export class TreeViewWidget extends TreeWidget {
 
             this.model.root = node;
         });
+    }
+
+    get contextSelection(): boolean {
+        return this._contextSelection;
+    }
+
+    protected handleContextMenuEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        try {
+            this._contextSelection = true;
+            super.handleContextMenuEvent(node, event);
+        } finally {
+            this._contextSelection = false;
+        }
     }
 
     public updateWidget() {

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -95,13 +95,13 @@ export class TreeViewsExtImpl implements TreeViewsExt {
         }
     }
 
-    async $setSelection(treeViewId: string, treeItemId: string): Promise<any> {
+    async $setSelection(treeViewId: string, treeItemId: string, contextSelection: boolean): Promise<any> {
         const treeView = this.treeViews.get(treeViewId);
         if (!treeView) {
             throw new Error('No tree view with id' + treeViewId);
         }
 
-        treeView.onSelectionChanged(treeItemId);
+        treeView.onSelectionChanged(treeItemId, contextSelection);
     }
 
 }
@@ -253,7 +253,7 @@ class TreeViewExtImpl<T> extends Disposable {
         }
     }
 
-    async onSelectionChanged(treeItemId: string): Promise<any> {
+    async onSelectionChanged(treeItemId: string, contextSelection: boolean): Promise<any> {
         // get element from a cache
         const cachedElement: T | undefined = this.cache.get(treeItemId);
 
@@ -263,7 +263,7 @@ class TreeViewExtImpl<T> extends Disposable {
             // Ask data provider for a tree item for the value
             const treeItem = await this.treeDataProvider.getTreeItem(cachedElement);
 
-            if (treeItem.command) {
+            if (!contextSelection && treeItem.command) {
                 this.commandRegistry.executeCommand((treeItem.command.command || treeItem.command.id)!, ...(treeItem.command.arguments || []));
             }
         }


### PR DESCRIPTION
This changes proposal adds fix that respects the right click on tree view, that provides from plugin side to display the content of tree. The problem was in tree selection. Mechanism that communicates with plugins just set up single selection handler and on any selection changes event it sent rpc call to open document, no matter whether it was mouse click or context menu click.

This fix is needed for working flow in Kubernetes plugin. In case, when user wants to upload own config file in specific config map.

Related issue: #4805 

![kubectl-create-delete-config](https://user-images.githubusercontent.com/1968177/55779790-16372480-5aaf-11e9-81e2-2d5be0ee59c1.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
