### PR TITLE
prevent opening editor when a single click with shift or ctrl key pre…

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -213,7 +213,8 @@ export class FileNavigatorWidget extends FileTreeWidget {
     }
 
     protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
-        if (node && this.corePreferences['list.openMode'] === 'singleClick') {
+        const modifierKeyCombined: boolean = isOSX ? (event.shiftKey || event.metaKey) : (event.shiftKey || event.ctrlKey);
+        if (!modifierKeyCombined && node && this.corePreferences['list.openMode'] === 'singleClick') {
             this.model.previewNode(node);
         }
         super.handleClickEvent(node, event);


### PR DESCRIPTION
this patch will prevent opening the editor when click the file tree node with
shift or ctrl key pressed. the file will just be selected.

Signed-off-by: yewei <yeweiasia@gmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
this will solve the issue https://github.com/theia-ide/theia/issues/3712
