### PR TITLE
align window.setStatusBarMessage with vscode

### DIFF
--- a/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
+++ b/packages/plugin-ext/src/plugin/status-bar-message-registry.ts
@@ -21,39 +21,82 @@ import {
 import { RPCProtocol } from '../api/rpc-protocol';
 import { StatusBarItemImpl } from './status-bar/status-bar-item';
 
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 export class StatusBarMessageRegistryExt {
 
     proxy: StatusBarMessageRegistryMain;
 
+    protected readonly statusMessage: StatusBarMessage;
+
     constructor(rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.STATUS_BAR_MESSAGE_REGISTRY_MAIN);
+        this.statusMessage = new StatusBarMessage(this);
     }
 
+    // copied from https://github.com/Microsoft/vscode/blob/6c8f02b41db9ae5c4d15df767d47755e5c73b9d5/src/vs/workbench/api/node/extHostStatusBar.ts#L174
     // tslint:disable-next-line:no-any
-    setStatusBarMessage(text: string, arg?: number | PromiseLike<any>): Disposable {
-        const id = StatusBarItemImpl.nextId();
-        this.proxy.$setMessage(id, text, 0, 1, undefined, undefined, undefined);
-        let handle: NodeJS.Timer | undefined;
+    setStatusBarMessage(text: string, timeoutOrThenable?: number | PromiseLike<any>): Disposable {
+        const d = this.statusMessage.setMessage(text);
+        // tslint:disable-next-line:no-any
+        let handle: any;
 
-        if (typeof arg === 'number') {
-            handle = setTimeout(() => this.dispose(id), arg);
-        } else if (typeof arg !== 'undefined') {
-            arg.then(() => this.dispose(id), () => this.dispose(id));
+        if (typeof timeoutOrThenable === 'number') {
+            handle = setTimeout(() => d.dispose(), timeoutOrThenable);
+        } else if (typeof timeoutOrThenable !== 'undefined') {
+            timeoutOrThenable.then(() => d.dispose(), () => d.dispose());
         }
 
-        return Disposable.create(() => {
-            this.dispose(id);
-            if (handle) {
-                clearTimeout(handle);
-            }
+        return new Disposable(() => {
+            d.dispose();
+            clearTimeout(handle);
         });
-    }
 
-    private dispose(id: string): void {
-        this.proxy.$dispose(id);
     }
 
     createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem {
         return new StatusBarItemImpl(this.proxy, alignment, priority);
+    }
+}
+
+// copied from https://github.com/Microsoft/vscode/blob/6c8f02b41db9ae5c4d15df767d47755e5c73b9d5/src/vs/workbench/api/node/extHostStatusBar.ts#L122
+class StatusBarMessage {
+
+    private _item: StatusBarItem;
+    private _messages: { message: string }[] = [];
+
+    constructor(statusBar: StatusBarMessageRegistryExt) {
+        this._item = statusBar.createStatusBarItem(StatusBarAlignment.Left, Number.MIN_VALUE);
+    }
+
+    dispose() {
+        this._messages.length = 0;
+        this._item.dispose();
+    }
+
+    setMessage(message: string): Disposable {
+        const data: { message: string } = { message }; // use object to not confuse equal strings
+        this._messages.unshift(data);
+        this._update();
+
+        return new Disposable(() => {
+            const idx = this._messages.indexOf(data);
+            if (idx >= 0) {
+                this._messages.splice(idx, 1);
+                this._update();
+            }
+        });
+    }
+
+    private _update() {
+        if (this._messages.length > 0) {
+            this._item.text = this._messages[0].message;
+            this._item.show();
+        } else {
+            this._item.hide();
+        }
     }
 }


### PR DESCRIPTION
fix #4759, basically copies impl from VS Code

In order to verify:
- install rust extension
- check that only status message from RLS appears, not like in #4759

I'm using this repo https://github.com/geropl/ps-rs.git

TODO:
- [x] open a CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19523