### PR TITLE
add rust textmate based on a grammar from vscode

### DIFF
--- a/packages/textmate-grammars/data/rust.tmLanguage.json
+++ b/packages/textmate-grammars/data/rust.tmLanguage.json
@@ -1,0 +1,692 @@
+{
+  "information_for_contributors": [
+    "This file has been converted from https://github.com/zargony/atom-language-rust/blob/master/grammars/rust.cson",
+    "If you want to provide a fix or improvement, please create a pull request against the original repository.",
+    "Once accepted there, we are happy to receive an update request."
+  ],
+  "version": "https://github.com/zargony/atom-language-rust/commit/5238d9834953ed7c58d9b5b9bb0c084c3c11ecd6",
+  "name": "Rust",
+  "scopeName": "source.rust",
+  "patterns": [
+    {
+      "comment": "Implementation",
+      "begin": "\\b(impl)\\b",
+      "end": "\\{",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#sigils"
+        },
+        {
+          "include": "#mut"
+        },
+        {
+          "include": "#dyn"
+        },
+        {
+          "include": "#ref_lifetime"
+        },
+        {
+          "include": "#core_types"
+        },
+        {
+          "include": "#core_marker"
+        },
+        {
+          "include": "#core_traits"
+        },
+        {
+          "include": "#std_types"
+        },
+        {
+          "include": "#std_traits"
+        },
+        {
+          "include": "#type_params"
+        },
+        {
+          "include": "#where"
+        },
+        {
+          "name": "storage.type.rust",
+          "match": "\\bfor\\b"
+        },
+        {
+          "include": "#type"
+        }
+      ]
+    },
+    {
+      "include": "#block_doc_comment"
+    },
+    {
+      "include": "#block_comment"
+    },
+    {
+      "include": "#line_doc_comment"
+    },
+    {
+      "include": "#line_comment"
+    },
+    {
+      "comment": "Attribute",
+      "name": "meta.attribute.rust",
+      "begin": "#\\!?\\[",
+      "end": "\\]",
+      "patterns": [
+        {
+          "include": "#string_literal"
+        },
+        {
+          "include": "#block_doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_doc_comment"
+        },
+        {
+          "include": "#line_comment"
+        }
+      ]
+    },
+    {
+      "comment": "Single-quote string literal (character)",
+      "name": "string.quoted.single.rust",
+      "match": "b?'([^'\\\\]|\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'"
+    },
+    {
+      "include": "#string_literal"
+    },
+    {
+      "include": "#raw_string_literal"
+    },
+    {
+      "comment": "Floating point literal (fraction)",
+      "name": "constant.numeric.float.rust",
+      "match": "\\b[0-9][0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?(f32|f64)?\\b"
+    },
+    {
+      "comment": "Floating point literal (exponent)",
+      "name": "constant.numeric.float.rust",
+      "match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?[eE][+-]?[0-9_]+(f32|f64)?\\b"
+    },
+    {
+      "comment": "Floating point literal (typed)",
+      "name": "constant.numeric.float.rust",
+      "match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][+-]?[0-9_]+)?(f32|f64)\\b"
+    },
+    {
+      "comment": "Integer literal (decimal)",
+      "name": "constant.numeric.integer.decimal.rust",
+      "match": "\\b[0-9][0-9_]*([ui](8|16|32|64|128|s|size))?\\b"
+    },
+    {
+      "comment": "Integer literal (hexadecimal)",
+      "name": "constant.numeric.integer.hexadecimal.rust",
+      "match": "\\b0x[a-fA-F0-9_]+([ui](8|16|32|64|128|s|size))?\\b"
+    },
+    {
+      "comment": "Integer literal (octal)",
+      "name": "constant.numeric.integer.octal.rust",
+      "match": "\\b0o[0-7_]+([ui](8|16|32|64|128|s|size))?\\b"
+    },
+    {
+      "comment": "Integer literal (binary)",
+      "name": "constant.numeric.integer.binary.rust",
+      "match": "\\b0b[01_]+([ui](8|16|32|64|128|s|size))?\\b"
+    },
+    {
+      "comment": "Static storage modifier",
+      "name": "storage.modifier.static.rust",
+      "match": "\\bstatic\\b"
+    },
+    {
+      "comment": "Boolean constant",
+      "name": "constant.language.boolean.rust",
+      "match": "\\b(true|false)\\b"
+    },
+    {
+      "comment": "Control keyword",
+      "name": "keyword.control.rust",
+      "match": "\\b(break|continue|else|if|in|for|loop|match|return|while)\\b"
+    },
+    {
+      "comment": "Keyword",
+      "name": "keyword.other.rust",
+      "match": "\\b(crate|extern|mod|let|ref|use|super|move)\\b"
+    },
+    {
+      "comment": "Reserved keyword",
+      "name": "invalid.deprecated.rust",
+      "match": "\\b(abstract|alignof|become|do|final|macro|offsetof|override|priv|proc|pure|sizeof|typeof|virtual|yield)\\b"
+    },
+    {
+      "include": "#unsafe"
+    },
+    {
+      "include": "#sigils"
+    },
+    {
+      "include": "#self"
+    },
+    {
+      "include": "#mut"
+    },
+    {
+      "include": "#dyn"
+    },
+    {
+      "include": "#impl"
+    },
+    {
+      "include": "#box"
+    },
+    {
+      "include": "#lifetime"
+    },
+    {
+      "include": "#ref_lifetime"
+    },
+    {
+      "include": "#const"
+    },
+    {
+      "include": "#pub"
+    },
+    {
+      "comment": "Miscellaneous operator",
+      "name": "keyword.operator.misc.rust",
+      "match": "(=>|::|\\bas\\b)"
+    },
+    {
+      "comment": "Comparison operator",
+      "name": "keyword.operator.comparison.rust",
+      "match": "(&&|\\|\\||==|!=)"
+    },
+    {
+      "comment": "Assignment operator",
+      "name": "keyword.operator.assignment.rust",
+      "match": "(\\+=|-=|/=|\\*=|%=|\\^=|&=|\\|=|<<=|>>=|=)"
+    },
+    {
+      "comment": "Arithmetic operator",
+      "name": "keyword.operator.arithmetic.rust",
+      "match": "(!|\\+|-|/|\\*|%|\\^|&|\\||<<|>>)"
+    },
+    {
+      "comment": "Comparison operator (second group because of regex precedence)",
+      "name": "keyword.operator.comparison.rust",
+      "match": "(<=|>=|<|>)"
+    },
+    {
+      "include": "#core_types"
+    },
+    {
+      "include": "#core_vars"
+    },
+    {
+      "include": "#core_marker"
+    },
+    {
+      "include": "#core_traits"
+    },
+    {
+      "include": "#std_types"
+    },
+    {
+      "include": "#std_traits"
+    },
+    {
+      "comment": "Built-in macro",
+      "name": "support.function.builtin.rust",
+      "match": "\\b(macro_rules|compile_error|format_args|env|option_env|concat_idents|concat|line|column|file|stringify|include|include_str|include_bytes|module_path|cfg)!"
+    },
+    {
+      "comment": "Core macro",
+      "name": "support.function.core.rust",
+      "match": "\\b(panic|assert|assert_eq|assert_ne|debug_assert|debug_assert_eq|debug_assert_ne|try|write|writeln|unreachable|unimplemented)!"
+    },
+    {
+      "comment": "Standard library macro",
+      "name": "support.function.std.rust",
+      "match": "\\b(format|print|println|eprint|eprintln|select|vec)!"
+    },
+    {
+      "comment": "Logging macro",
+      "name": "support.function.log.rust",
+      "match": "\\b(log|error|warn|info|debug|trace|log_enabled)!"
+    },
+    {
+      "comment": "Invokation of a macro",
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*\\!)\\s*[({\\[]",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.macro.rust"
+        }
+      }
+    },
+    {
+      "comment": "Function call",
+      "match": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*\\(",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.rust"
+        }
+      }
+    },
+    {
+      "comment": "Function call with type parameters",
+      "begin": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*(::)(?=\\s*<.*>\\s*\\()",
+      "end": "\\(",
+      "captures": {
+        "1": {
+          "name": "entity.name.function.rust"
+        },
+        "2": {
+          "name": "keyword.operator.misc.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#type_params"
+        }
+      ]
+    },
+    {
+      "comment": "Function definition",
+      "begin": "\\b(fn)\\s+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)",
+      "end": "[\\{;]",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.fn.rust"
+        },
+        "2": {
+          "name": "entity.name.function.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#sigils"
+        },
+        {
+          "include": "#self"
+        },
+        {
+          "include": "#mut"
+        },
+        {
+          "include": "#dyn"
+        },
+        {
+          "include": "#impl"
+        },
+        {
+          "include": "#ref_lifetime"
+        },
+        {
+          "include": "#core_types"
+        },
+        {
+          "include": "#core_marker"
+        },
+        {
+          "include": "#core_traits"
+        },
+        {
+          "include": "#std_types"
+        },
+        {
+          "include": "#std_traits"
+        },
+        {
+          "include": "#type_params"
+        },
+        {
+          "include": "#const"
+        },
+        {
+          "include": "#where"
+        },
+        {
+          "include": "#unsafe"
+        },
+        {
+          "comment": "Function arguments",
+          "match": "\bfn\b",
+          "name": "keyword.other.fn.rust"
+        }
+      ]
+    },
+    {
+      "comment": "Type declaration",
+      "begin": "\\b(enum|struct|trait|union)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+      "end": "[\\{\\(;]",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.rust"
+        },
+        "2": {
+          "name": "entity.name.type.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#core_traits"
+        },
+        {
+          "include": "#std_traits"
+        },
+        {
+          "include": "#type_params"
+        },
+        {
+          "include": "#core_types"
+        },
+        {
+          "include": "#pub"
+        },
+        {
+          "include": "#where"
+        }
+      ]
+    },
+    {
+      "comment": "Type alias",
+      "begin": "\\b(type)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+      "end": ";",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.rust"
+        },
+        "2": {
+          "name": "entity.name.type.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#sigils"
+        },
+        {
+          "include": "#mut"
+        },
+        {
+          "include": "#dyn"
+        },
+        {
+          "include": "#impl"
+        },
+        {
+          "include": "#lifetime"
+        },
+        {
+          "include": "#ref_lifetime"
+        },
+        {
+          "include": "#core_types"
+        },
+        {
+          "include": "#core_marker"
+        },
+        {
+          "include": "#core_traits"
+        },
+        {
+          "include": "#std_types"
+        },
+        {
+          "include": "#std_traits"
+        },
+        {
+          "include": "#type_params"
+        }
+      ]
+    }
+  ],
+  "repository": {
+    "block_doc_comment": {
+      "comment": "Block documentation comment",
+      "name": "comment.block.documentation.rust",
+      "begin": "/\\*[\\*!](?![\\*/])",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "include": "#block_doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "block_comment": {
+      "comment": "Block comment",
+      "name": "comment.block.rust",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "patterns": [
+        {
+          "include": "#block_doc_comment"
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "line_doc_comment": {
+      "comment": "Single-line documentation comment",
+      "name": "comment.line.documentation.rust",
+      "begin": "//[!/](?=[^/])",
+      "end": "$"
+    },
+    "line_comment": {
+      "comment": "Single-line comment",
+      "name": "comment.line.double-slash.rust",
+      "begin": "//",
+      "end": "$"
+    },
+    "escaped_character": {
+      "name": "constant.character.escape.rust",
+      "match": "\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
+    },
+    "string_literal": {
+      "comment": "Double-quote string literal",
+      "name": "string.quoted.double.rust",
+      "begin": "b?\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "include": "#escaped_character"
+        }
+      ]
+    },
+    "raw_string_literal": {
+      "comment": "Raw double-quote string literal",
+      "name": "string.quoted.double.raw.rust",
+      "begin": "b?r(#*)\"",
+      "end": "\"\\1"
+    },
+    "sigils": {
+      "comment": "Sigil",
+      "name": "keyword.operator.sigil.rust",
+      "match": "[&*](?=[a-zA-Z0-9_\\(\\[\\|\\\"]+)"
+    },
+    "self": {
+      "comment": "Self variable",
+      "name": "variable.language.rust",
+      "match": "\\bself\\b"
+    },
+    "mut": {
+      "comment": "Mutable storage modifier",
+      "name": "storage.modifier.mut.rust",
+      "match": "\\bmut\\b"
+    },
+    "dyn": {
+      "comment": "Dynamic modifier",
+      "name": "storage.modifier.dyn.rust",
+      "match": "\\bdyn\\b"
+    },
+    "impl": {
+      "comment": "Existential type modifier",
+      "name": "storage.modifier.impl.rust",
+      "match": "\\bimpl\\b"
+    },
+    "box": {
+      "comment": "Box storage modifier",
+      "name": "storage.modifier.box.rust",
+      "match": "\\bbox\\b"
+    },
+    "const": {
+      "comment": "Const storage modifier",
+      "name": "storage.modifier.const.rust",
+      "match": "\\bconst\\b"
+    },
+    "pub": {
+      "comment": "Visibility modifier",
+      "name": "storage.modifier.visibility.rust",
+      "match": "\\bpub\\b"
+    },
+    "unsafe": {
+      "comment": "Unsafe code keyword",
+      "name": "keyword.other.unsafe.rust",
+      "match": "\\bunsafe\\b"
+    },
+    "where": {
+      "comment": "Generic where clause",
+      "name": "keyword.other.where.rust",
+      "match": "\\bwhere\\b"
+    },
+    "lifetime": {
+      "comment": "Named lifetime",
+      "name": "storage.modifier.lifetime.rust",
+      "match": "'([a-zA-Z_][a-zA-Z0-9_]*)\\b",
+      "captures": {
+        "1": {
+          "name": "entity.name.lifetime.rust"
+        }
+      }
+    },
+    "ref_lifetime": {
+      "comment": "Reference with named lifetime",
+      "match": "&('([a-zA-Z_][a-zA-Z0-9_]*))\\b",
+      "captures": {
+        "1": {
+          "name": "storage.modifier.lifetime.rust"
+        },
+        "2": {
+          "name": "entity.name.lifetime.rust"
+        }
+      }
+    },
+    "core_types": {
+      "comment": "Built-in/core type",
+      "name": "storage.type.core.rust",
+      "match": "\\b(bool|char|usize|isize|u8|u16|u32|u64|u128|i8|i16|i32|i64|i128|f32|f64|str|Self|Option|Result)\\b"
+    },
+    "core_vars": {
+      "comment": "Core type variant",
+      "name": "support.constant.core.rust",
+      "match": "\\b(Some|None|Ok|Err)\\b"
+    },
+    "core_marker": {
+      "comment": "Core trait (marker)",
+      "name": "support.type.marker.rust",
+      "match": "\\b(Copy|Send|Sized|Sync)\\b"
+    },
+    "core_traits": {
+      "comment": "Core trait",
+      "name": "support.type.core.rust",
+      "match": "\\b(Drop|Fn|FnMut|FnOnce|Clone|PartialEq|PartialOrd|Eq|Ord|AsRef|AsMut|Into|From|Default|Iterator|Extend|IntoIterator|DoubleEndedIterator|ExactSizeIterator)\\b"
+    },
+    "std_types": {
+      "comment": "Standard library type",
+      "name": "storage.class.std.rust",
+      "match": "\\b(Box|String|Vec|Path|PathBuf)\\b"
+    },
+    "std_traits": {
+      "comment": "Standard library trait",
+      "name": "support.type.std.rust",
+      "match": "\\b(ToOwned|ToString)\\b"
+    },
+    "type": {
+      "comment": "A type",
+      "name": "entity.name.type.rust",
+      "match": "\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b"
+    },
+    "type_params": {
+      "comment": "Type parameters",
+      "name": "meta.type_params.rust",
+      "begin": "<(?![=<])",
+      "end": "(?<![-])>",
+      "patterns": [
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
+        },
+        {
+          "include": "#sigils"
+        },
+        {
+          "include": "#mut"
+        },
+        {
+          "include": "#dyn"
+        },
+        {
+          "include": "#impl"
+        },
+        {
+          "include": "#lifetime"
+        },
+        {
+          "include": "#core_types"
+        },
+        {
+          "include": "#core_marker"
+        },
+        {
+          "include": "#core_traits"
+        },
+        {
+          "include": "#std_types"
+        },
+        {
+          "include": "#std_traits"
+        },
+        {
+          "include": "#type_params"
+        }
+      ]
+    }
+  }
+}

--- a/packages/textmate-grammars/src/browser/rust.ts
+++ b/packages/textmate-grammars/src/browser/rust.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { injectable } from 'inversify';
+import { LanguageGrammarDefinitionContribution, TextmateRegistry } from '@theia/monaco/lib/browser/textmate';
+
+@injectable()
+export class RustContribution implements LanguageGrammarDefinitionContribution {
+    readonly id = 'rust';
+    // copid from https://github.com/Microsoft/vscode/blob/9e1975d98598ef268ca760b8381ee628f27fc121/extensions/rust/language-configuration.json
+    readonly config: monaco.languages.LanguageConfiguration = {
+        comments: {
+            lineComment: '//',
+            blockComment: ['/*', '*/']
+        },
+        brackets: [
+            ['{', '}'],
+            ['[', ']'],
+            ['(', ')']
+        ],
+        autoClosingPairs: [
+            { open: '{', close: '}' },
+            { open: '[', close: ']' },
+            { open: '(', close: ')' },
+            { open: '\"', close: '\"' }
+        ],
+        surroundingPairs: [
+            { open: '{', close: '}' },
+            { open: '[', close: ']' },
+            { open: '(', close: ')' },
+            { open: '\"', close: '\"' },
+            { open: "'", close: "'" }
+        ],
+        folding: {
+            markers: {
+                start: new RegExp('^\\s*//\\s*#?region\\b'),
+                end: new RegExp('^\\s*//\\s*#?endregion\\b')
+            }
+        }
+    };
+
+    registerTextmateLanguage(registry: TextmateRegistry) {
+        monaco.languages.register({
+            // copied from https://github.com/Microsoft/vscode/blob/9e1975d98598ef268ca760b8381ee628f27fc121/extensions/rust/package.json#L12-L17
+            id: this.id,
+            extensions: ['.rs'],
+            aliases: ['Rust', 'rust']
+        });
+
+        monaco.languages.setLanguageConfiguration(this.id, this.config);
+
+        // copied from https://github.com/Microsoft/vscode/blob/9e1975d98598ef268ca760b8381ee628f27fc121/extensions/rust/syntaxes/rust.tmLanguage.json
+        const platformGrammar = require('../../data/rust.tmLanguage.json');
+        registry.registerTextmateGrammarScope('source.rust', {
+            async getGrammarDefinition() {
+                return {
+                    format: 'json',
+                    content: platformGrammar
+                };
+            }
+        });
+        registry.mapLanguageIdToTextmateGrammar(this.id, 'source.rust');
+    }
+}

--- a/packages/textmate-grammars/src/browser/textmate-grammars-frontend-module.ts
+++ b/packages/textmate-grammars/src/browser/textmate-grammars-frontend-module.ts
@@ -53,6 +53,7 @@ import { JavascriptContribution } from './js';
 import { JsxTagsContribution } from './jsx-tags';
 import { PythonContribution } from './python';
 import { GoContribution } from './go';
+import { RustContribution } from './rust';
 
 export default new ContainerModule(bind => {
     bind(BatContribution).toSelf().inSingletonScope();
@@ -165,4 +166,7 @@ export default new ContainerModule(bind => {
 
     bind(GoContribution).toSelf().inSingletonScope();
     bind(LanguageGrammarDefinitionContribution).toService(GoContribution);
+
+    bind(RustContribution).toSelf().inSingletonScope();
+    bind(LanguageGrammarDefinitionContribution).toService(RustContribution);
 });


### PR DESCRIPTION
fix #4860

In order to verify open rust file and check that syntax highlighting is there.

TODO:
- [x] open a CQ - https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19524
- [x] open a PR to remove the grammar from https://github.com/theia-ide/theia-rust-extension - https://github.com/theia-ide/theia-rust-extension/pull/10

<img width="2032" alt="Screen Shot 2019-04-10 at 16 34 59" src="https://user-images.githubusercontent.com/3082655/55888008-e8d1a000-5bae-11e9-9697-19938e4ef776.png">
