### PR TITLE
remove electron runtime dependency from CLI

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@theia/application-package": "^0.5.0",
-    "@theia/electron": "^0.5.0",
     "@types/fs-extra": "^4.0.2",
     "bunyan": "^1.8.10",
     "circular-dependency-plugin": "^5.0.0",

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -78,7 +78,8 @@ export class ApplicationPackageManager {
     }
 
     async startElectron(args: string[]): Promise<void> {
-        this.__process.spawnBin('electron', [this.pck.frontend('electron-main.js'), ...args],
+        const electronCli = require.resolve('electron/cli.js', { paths: [this.pck.projectPath] });
+        this.process.spawn(electronCli, [this.pck.frontend('electron-main.js'), ...args],
             { stdio: [0, 1, 2] });
     }
 

--- a/dev-packages/application-package/src/application-package.ts
+++ b/dev-packages/application-package/src/application-package.ts
@@ -51,9 +51,9 @@ export class ApplicationPackage {
         if (this.isElectron()) {
             const { version } = require('../package.json');
             try {
-                require('@theia/electron/package.json');
+                require.resolve('@theia/electron/package.json', { paths: [this.projectPath] });
             } catch {
-                console.warn(`please install @theia/electorn@${version} as a runtime dependency`);
+                console.warn(`please install @theia/electron@${version} as a runtime dependency`);
             }
         }
     }


### PR DESCRIPTION
fix #4871

that's a follow up of https://github.com/theia-ide/theia/pull/4873, turns out we have to remove it from CLI as well otherwise unnecessary deps pulled anyway: https://travis-ci.org/theia-ide/theia-apps/jobs/518657324#L538