### PR TITLE
Add ability to remove recent workspaces

### DIFF
--- a/packages/core/src/browser/quick-open/quick-open-action-provider.ts
+++ b/packages/core/src/browser/quick-open/quick-open-action-provider.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { Disposable } from '../../common/disposable';
-import { injectable } from 'inversify';
+import { injectable, unmanaged } from 'inversify';
 import { QuickOpenItem } from './quick-open-model';
 
 export interface QuickOpenActionProvider {
@@ -39,8 +39,9 @@ export interface QuickOpenAction extends QuickOpenActionOptions, Disposable {
 
 @injectable()
 export abstract class QuickOpenBaseAction implements QuickOpenAction {
-    constructor(protected options: QuickOpenActionOptions) {
-    }
+    constructor(
+        @unmanaged() protected options: QuickOpenActionOptions
+    ) { }
 
     get id(): string {
         return this.options.id;

--- a/packages/workspace/src/browser/index.ts
+++ b/packages/workspace/src/browser/index.ts
@@ -19,3 +19,4 @@ export * from './workspace-service';
 export * from './workspace-frontend-contribution';
 export * from './workspace-frontend-module';
 export * from './workspace-preferences';
+export * from './workspace-action-provider';

--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -15,13 +15,14 @@
  ********************************************************************************/
 
 import { injectable, inject } from 'inversify';
-import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenGroupItem, QuickOpenMode, LabelProvider } from '@theia/core/lib/browser';
+import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenGroupItem, QuickOpenMode, LabelProvider, QuickOpenActionProvider } from '@theia/core/lib/browser';
 import { WorkspaceService } from './workspace-service';
 import { getTemporaryWorkspaceFileUri } from '../common';
 import { WorkspacePreferences } from './workspace-preferences';
 import URI from '@theia/core/lib/common/uri';
 import { FileSystem, FileSystemUtils } from '@theia/filesystem/lib/common';
 import * as moment from 'moment';
+import { WorkspaceActionProvider } from './workspace-action-provider';
 
 @injectable()
 export class QuickOpenWorkspace implements QuickOpenModel {
@@ -29,11 +30,14 @@ export class QuickOpenWorkspace implements QuickOpenModel {
     protected items: QuickOpenGroupItem[];
     protected opened: boolean;
 
+    protected actionProvider: QuickOpenActionProvider | undefined;
+
     @inject(QuickOpenService) protected readonly quickOpenService: QuickOpenService;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
     @inject(FileSystem) protected readonly fileSystem: FileSystem;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(WorkspacePreferences) protected preferences: WorkspacePreferences;
+    @inject(WorkspaceActionProvider) protected workspaceActionProvider: WorkspaceActionProvider;
 
     async open(workspaces: string[]): Promise<void> {
         this.items = [];
@@ -65,6 +69,7 @@ export class QuickOpenWorkspace implements QuickOpenModel {
                 description: (home) ? FileSystemUtils.tildifyPath(uri.path.toString(), home) : uri.path.toString(),
                 groupLabel: `last modified ${moment(stat.lastModification).fromNow()}`,
                 iconClass: await this.labelProvider.getIcon(stat) + ' file-icon',
+                uri,
                 run: (mode: QuickOpenMode): boolean => {
                     if (mode !== QuickOpenMode.OPEN) {
                         return false;
@@ -77,6 +82,9 @@ export class QuickOpenWorkspace implements QuickOpenModel {
                     return true;
                 },
             }));
+            this.actionProvider = !!this.items[0].getUri()
+                ? this.workspaceActionProvider
+                : undefined;
         }
 
         this.quickOpenService.open(this, {
@@ -86,8 +94,8 @@ export class QuickOpenWorkspace implements QuickOpenModel {
         });
     }
 
-    onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
-        acceptor(this.items);
+    onType(lookFor: string, acceptor: (items: QuickOpenItem[], actionProvider?: QuickOpenActionProvider) => void): void {
+        acceptor(this.items, this.actionProvider);
     }
 
     select() {

--- a/packages/workspace/src/browser/workspace-action-provider.ts
+++ b/packages/workspace/src/browser/workspace-action-provider.ts
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { WorkspaceServer } from '../common';
+import { injectable, inject } from 'inversify';
+import { QuickOpenBaseAction, QuickOpenItem, QuickOpenActionProvider, QuickOpenAction } from '@theia/core/lib/browser';
+
+@injectable()
+export class RemoveWorkspaceAction extends QuickOpenBaseAction {
+
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+
+    constructor() {
+        super({ id: 'remove:workspace:action' });
+        this.class = 'fa fa-times';
+    }
+
+    async run(item?: QuickOpenItem): Promise<void> {
+        if (item && item.getUri()) {
+            return (
+                this.workspaceServer.removeRecentWorkspace &&
+                this.workspaceServer.removeRecentWorkspace(item.getUri()!.toString(true))
+            );
+        }
+        return;
+    }
+}
+
+@injectable()
+export class WorkspaceActionProvider implements QuickOpenActionProvider {
+
+    @inject(RemoveWorkspaceAction)
+    protected removeWorkspaceAction: RemoveWorkspaceAction;
+
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+
+    hasActions(): boolean {
+        return true;
+    }
+
+    async getActions(): Promise<QuickOpenAction[]> {
+        return this.workspaceServer.removeRecentWorkspace
+            ? [this.removeWorkspaceAction]
+            : [];
+    }
+}

--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -44,6 +44,7 @@ import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { WorkspaceUtils } from './workspace-utils';
 import { WorkspaceCompareHandler } from './workspace-compare-handler';
 import { DiffService } from './diff-service';
+import { WorkspaceActionProvider, RemoveWorkspaceAction } from './workspace-action-provider';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindWorkspacePreferences(bind);
@@ -87,4 +88,7 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     bind(QuickOpenWorkspace).toSelf().inSingletonScope();
 
     bind(WorkspaceUtils).toSelf().inSingletonScope();
+
+    bind(WorkspaceActionProvider).toSelf().inSingletonScope();
+    bind(RemoveWorkspaceAction).toSelf().inSingletonScope();
 });

--- a/packages/workspace/src/common/test/mock-workspace-server.ts
+++ b/packages/workspace/src/common/test/mock-workspace-server.ts
@@ -24,4 +24,6 @@ export class MockWorkspaceServer implements WorkspaceServer {
     getMostRecentlyUsedWorkspace(): Promise<string | undefined> { return Promise.resolve(''); }
 
     setMostRecentlyUsedWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
+
+    removeRecentWorkspace(uri: string): Promise<void> { return Promise.resolve(); }
 }

--- a/packages/workspace/src/common/workspace-protocol.ts
+++ b/packages/workspace/src/common/workspace-protocol.ts
@@ -34,7 +34,15 @@ export interface WorkspaceServer {
     setMostRecentlyUsedWorkspace(uri: string): Promise<void>;
 
     /**
+     * Removes a workspace from the list of recently opened workspaces.
+     *
+     * @param uri the workspace uri.
+     */
+    removeRecentWorkspace?(uri: string): Promise<void>;
+
+    /**
      * Returns list of recently opened workspaces as an array.
      */
     getRecentWorkspaces(): Promise<string[]>
+
 }

--- a/packages/workspace/src/node/default-workspace-server.ts
+++ b/packages/workspace/src/node/default-workspace-server.ts
@@ -105,6 +105,17 @@ export class DefaultWorkspaceServer implements WorkspaceServer {
         });
     }
 
+    async removeRecentWorkspace(uri: string): Promise<void> {
+        // Get the list of recent workspaces.
+        const recent = await this.getRecentWorkspaces();
+        // Filter out the given workspace by uri.
+        const updated: string[] = recent.filter(e => e !== uri && e.length > 0);
+        // Update persistent storage to reflect changes.
+        this.writeToUserHome({
+            recentRoots: updated
+        });
+    }
+
     async getRecentWorkspaces(): Promise<string[]> {
         const listUri: string[] = [];
         const data = await this.readRecentWorkspacePathsFromUserHome();


### PR DESCRIPTION
Fixes #4884

Added the ability to remove `Recent Workspaces` from the `Open Recent Workspace...` quick-open command palette. At the moment, the only way to be able to remove workspaces from the list was to completely delete the `recentworkspace.json` file found under the user's home under `.theia`. This meant that users would not be able to trim their list of outdated workspaces causing too much noise. Users can now directly remove items from the list.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
