### PR TITLE
[ts] prefer workspace version over bundled

### DIFF
--- a/packages/typescript/src/browser/typescript-client-contribution.ts
+++ b/packages/typescript/src/browser/typescript-client-contribution.ts
@@ -151,7 +151,7 @@ export class TypeScriptClientContribution extends BaseLanguageClientContribution
         if (candidate && versions.some(version => TypescriptVersion.equals(candidate, version))) {
             return candidate;
         }
-        return versions[0];
+        return versions.find(version => version.qualifier === 'Workspace') || versions[0];
     }
     async getVersions(): Promise<TypescriptVersion[]> {
         await Promise.all([this.preferences.ready, this.workspace.ready]);


### PR DESCRIPTION
fix #4865

You cannot reproduce it in Theia repo, since bundled === workspace.

Fetch another repo, i.e. https://github.com/theia-ide/typescript-language-server,
install deps and then open it. Workspace version of TS should be used.

@kittaakos it is not reproducible with https://github.com/theia-ide/theia/pull/4896 as well, since in the real bundled app the latest typescript from npm will be installed.

