### PR TITLE
[tasks] align tasks quick-open with vscode

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -23,6 +23,10 @@
     color: var(--theia-ui-font-color1) !important;
 }
 
+.quick-open-entry-keybinding {
+    padding-right: 15px;
+}
+
 /*
  * set z-index to 0, so tabs are not above overlay widgets
  */
@@ -45,10 +49,6 @@
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
     background-image: none;
     margin-right: 0px;
-}
-
-.monaco-tree-row  {
-    padding-right: 11px;
 }
 
 .quick-open-entry .quick-open-row .monaco-icon-label .monaco-icon-label-description-container .monaco-highlighted-label .highlight {


### PR DESCRIPTION
Fixes #4770

- aligned the `tasks` quick-open to display borders between categories
(recently opened, configured, and provided tasks).
- aligned the `tasks` quick-open to only display a description (uri) when running in multi-root.
- fixed issue regarding right spacing in the quick-open which did not display the border correctly nor the action providers.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
