### PR TITLE
[tasks] add command to clear task history

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -60,6 +60,12 @@ export namespace TaskCommands {
         category: TASK_CATEGORY,
         label: 'Configure Tasks...'
     };
+
+    export const TASK_CLEAR_HISTORY: Command = {
+        id: 'task:clear-history',
+        category: TASK_CATEGORY,
+        label: 'Clear History'
+    };
 }
 
 const TASKS_STORAGE_KEY = 'tasks';
@@ -157,6 +163,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_CONFIGURE,
             {
                 execute: () => this.quickOpenTask.configure()
+            }
+        );
+
+        registry.registerCommand(
+            TaskCommands.TASK_CLEAR_HISTORY,
+            {
+                execute: () => this.taskService.clearRecentTasks()
             }
         );
     }

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -170,6 +170,13 @@ export class TaskService implements TaskConfigurationClient {
     }
 
     /**
+     * Clears the list of recently used tasks.
+     */
+    clearRecentTasks(): void {
+        this.recentTasks = [];
+    }
+
+    /**
      * Returns a task configuration provided by an extension by task source and label.
      * If there are no task configuration, returns undefined.
      */


### PR DESCRIPTION
Added a new command to clear the `recently used` tasks list.

Since Theia now supports displaying `recently used` tasks, there was no way to perform a cleanup and clear the history. This PR addresses that issue by providing a new helper command which clears the recently used list.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
