### PR TITLE
[tasks] update the prefix quick-open service to use actionProviders

### DIFF
--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -20,6 +20,7 @@ import { QuickOpenService, QuickOpenOptions } from './quick-open-service';
 import { Disposable, DisposableCollection } from '../../common/disposable';
 import { ILogger } from '../../common/logger';
 import { MaybePromise } from '../../common/types';
+import { QuickOpenActionProvider } from './quick-open-action-provider';
 
 export const QuickOpenContribution = Symbol('QuickOpenContribution');
 /**
@@ -192,7 +193,7 @@ export class PrefixQuickOpenService {
         }, options);
     }
 
-    protected onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
+    protected onType(lookFor: string, acceptor: (items: QuickOpenItem[], actionProvider?: QuickOpenActionProvider | undefined) => void): void {
         const handler = this.handlers.getHandlerOrDefault(lookFor);
         if (handler === undefined) {
             const items: QuickOpenItem[] = [];
@@ -205,7 +206,7 @@ export class PrefixQuickOpenService {
         } else {
             const handlerModel = handler.getModel();
             const searchValue = this.handlers.isDefaultHandler(handler) ? lookFor : lookFor.substr(handler.prefix.length);
-            handlerModel.onType(searchValue, items => acceptor(items));
+            handlerModel.onType(searchValue, (items, actionProvider) => acceptor(items, actionProvider));
         }
     }
 


### PR DESCRIPTION
Fixes #4768

- updated the `prefix-quick-open-service` to pass the `actionProviders` if available.
- fixes an issue for the `tasks` prefix quick-open which did not have the configuration action available.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
