### PR TITLE
[git] Use workspace URI prefix for storage keys

### DIFF
--- a/packages/git/src/browser/git-repository-provider.spec.ts
+++ b/packages/git/src/browser/git-repository-provider.spec.ts
@@ -26,7 +26,7 @@ import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watc
 import { FileSystemNode } from '@theia/filesystem/lib/node/node-filesystem';
 import { FileChange } from '@theia/filesystem/lib/browser';
 import { Emitter } from '@theia/core';
-import { LocalStorageService } from '@theia/core/lib/browser';
+import { LocalStorageService, StorageService } from '@theia/core/lib/browser';
 import { GitRepositoryProvider } from './git-repository-provider';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
@@ -63,7 +63,7 @@ describe('GitRepositoryProvider', () => {
     let mockWorkspaceService: WorkspaceService;
     let mockFilesystem: FileSystem;
     let mockFileSystemWatcher: FileSystemWatcher;
-    let mockStorageService: LocalStorageService;
+    let mockStorageService: StorageService;
 
     let gitRepositoryProvider: GitRepositoryProvider;
     const mockRootChangeEmitter: Emitter<FileStat[]> = new Emitter();
@@ -89,7 +89,7 @@ describe('GitRepositoryProvider', () => {
         testContainer.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         testContainer.bind(FileSystem).toConstantValue(mockFilesystem);
         testContainer.bind(FileSystemWatcher).toConstantValue(mockFileSystemWatcher);
-        testContainer.bind(LocalStorageService).toConstantValue(mockStorageService);
+        testContainer.bind(StorageService).toConstantValue(mockStorageService);
 
         sinon.stub(mockWorkspaceService, 'onWorkspaceChanged').value(mockRootChangeEmitter.event);
         sinon.stub(mockFileSystemWatcher, 'onFilesChanged').value(mockFileChangeEmitter.event);

--- a/packages/git/src/browser/git-repository-provider.ts
+++ b/packages/git/src/browser/git-repository-provider.ts
@@ -19,7 +19,7 @@ import { injectable, inject } from 'inversify';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { FileSystem, FileStat } from '@theia/filesystem/lib/common';
 import { DisposableCollection, Event, Emitter } from '@theia/core';
-import { LocalStorageService } from '@theia/core/lib/browser';
+import { StorageService } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { FileSystemWatcher } from '@theia/filesystem/lib/browser/filesystem-watcher';
 
@@ -43,7 +43,7 @@ export class GitRepositoryProvider {
         @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
         @inject(FileSystemWatcher) protected readonly watcher: FileSystemWatcher,
         @inject(FileSystem) protected readonly fileSystem: FileSystem,
-        @inject(LocalStorageService) protected readonly storageService: LocalStorageService
+        @inject(StorageService) protected readonly storageService: StorageService
     ) {
         this.initialize();
     }


### PR DESCRIPTION
Fixes theia-ide/theia#4921

Storage keys should contain workspace URI:

<img width="1027" alt="Screen Shot 2019-04-16 at 10 37 46" src="https://user-images.githubusercontent.com/914497/56194652-b94de800-6033-11e9-9a9d-93a468e65519.png">
