### PR TITLE
GH-4814 Looking at Gulp/Jake/Grunt plugins extensions.

### DIFF
--- a/packages/plugin-ext/src/main/browser/tasks-main.ts
+++ b/packages/plugin-ext/src/main/browser/tasks-main.ts
@@ -75,7 +75,7 @@ export class TasksMainImpl implements TasksMain {
         const taskResolver = this.createTaskResolver(handle);
 
         const disposable = new DisposableCollection();
-        disposable.push(this.taskProviderRegistry.register(type, taskProvider));
+        disposable.push(this.taskProviderRegistry.register(type, taskProvider, handle));
         disposable.push(this.taskResolverRegistry.register(type, taskResolver));
         this.disposables.set(handle, disposable);
     }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1550,13 +1550,51 @@ export class Task {
     private taskSource: string;
     private taskGroup: TaskGroup | undefined;
     private taskPresentationOptions: theia.TaskPresentationOptions | undefined;
-
-    constructor(taskDefinition: theia.TaskDefinition,
+    constructor(
+        taskDefinition: theia.TaskDefinition,
         scope: theia.WorkspaceFolder | theia.TaskScope.Global | theia.TaskScope.Workspace,
         name: string,
         source: string,
         execution?: ProcessExecution | ShellExecution,
-        problemMatchers?: string | string[]) {
+        problemMatchers?: string | string[]
+    );
+
+    // Deprecated constructor used by Jake vscode built-in
+    constructor(
+        taskDefinition: theia.TaskDefinition,
+        name: string,
+        source: string,
+        execution?: ProcessExecution | ShellExecution,
+        problemMatchers?: string | string[],
+    );
+
+    // tslint:disable-next-line:no-any
+    constructor(...args: any[]) {
+        let taskDefinition: theia.TaskDefinition;
+        let scope: theia.WorkspaceFolder | theia.TaskScope.Global | theia.TaskScope.Workspace | undefined;
+        let name: string;
+        let source: string;
+        let execution: ProcessExecution | ShellExecution | undefined;
+        let problemMatchers: string | string[] | undefined;
+
+        if (typeof args[1] === 'string') {
+            [
+                taskDefinition,
+                name,
+                source,
+                execution,
+                problemMatchers,
+            ] = args;
+        } else {
+            [
+                taskDefinition,
+                scope,
+                name,
+                source,
+                execution,
+                problemMatchers,
+            ] = args;
+        }
 
         this.definition = taskDefinition;
         this.scope = scope;
@@ -1593,6 +1631,9 @@ export class Task {
     }
 
     set scope(value: theia.TaskScope.Global | theia.TaskScope.Workspace | theia.WorkspaceFolder | undefined) {
+        if (value === null) {
+            value = undefined;
+        }
         this.taskScope = value;
     }
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -157,7 +157,6 @@ declare module '@theia/plugin' {
         export let all: Plugin<any>[];
     }
 
-
     /**
  * A command is a unique identifier of a function
  * which can be executed by a user via a keyboard shortcut,
@@ -3672,7 +3671,7 @@ declare module '@theia/plugin' {
         size: number;
     }
 
-	/**
+    /**
 	 * A type that filesystem providers should use to signal errors.
 	 *
 	 * This class has factory methods for common error-cases, like `EntryNotFound` when
@@ -3680,45 +3679,45 @@ declare module '@theia/plugin' {
 	 */
     export class FileSystemError extends Error {
 
-		/**
+        /**
          * Create an error to signal that a file or folder wasn't found.
          * @param messageOrUri Message or uri.
          */
         static FileNotFound(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Create an error to signal that a file or folder already exists, e.g. when
          * creating but not overwriting a file.
          * @param messageOrUri Message or uri.
          */
         static FileExists(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Create an error to signal that a file is not a folder.
          * @param messageOrUri Message or uri.
          */
         static FileNotADirectory(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Create an error to signal that a file is a folder.
          * @param messageOrUri Message or uri.
          */
         static FileIsADirectory(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Create an error to signal that an operation lacks required permissions.
          * @param messageOrUri Message or uri.
          */
         static NoPermissions(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Create an error to signal that the file system is unavailable or too busy to
          * complete a request.
          * @param messageOrUri Message or uri.
          */
         static Unavailable(messageOrUri?: string | Uri): FileSystemError;
 
-		/**
+        /**
          * Creates a new filesystem error.
          *
          * @param messageOrUri Message or uri.
@@ -4120,7 +4119,6 @@ declare module '@theia/plugin' {
          * @return A thenable that resolves when the edit could be applied.
          */
         export function applyEdit(edit: WorkspaceEdit): PromiseLike<boolean>;
-
 
         /**
          * Register a filesystem provider for a given scheme, e.g. `ftp`.
@@ -5060,7 +5058,6 @@ declare module '@theia/plugin' {
         constructor(range: Range, newText: string);
     }
 
-
     /**
      * Completion item kinds.
      */
@@ -5773,9 +5770,9 @@ declare module '@theia/plugin' {
 
         /**
          * Check if this code action kind intersects `other`.
-         * The kind "refactor.extract" for example intersects refactor, "refactor.extract" and 
+         * The kind "refactor.extract" for example intersects refactor, "refactor.extract" and
          * `"refactor.extract.function", but not "unicorn.refactor.extract", or "refactor.extractAll".
-         * 
+         *
          * @param other Kind to check.
          */
         intersects(other: CodeActionKind): boolean;
@@ -6049,7 +6046,6 @@ declare module '@theia/plugin' {
          */
         resolveDocumentLink?(link: DocumentLink, token: CancellationToken | undefined): ProviderResult<DocumentLink>;
     }
-
 
     /**
     * The rename provider interface defines the contract between extensions and
@@ -7160,10 +7156,31 @@ declare module '@theia/plugin' {
          *  or '$eslint'. Problem matchers can be contributed by an extension using
          *  the `problemMatchers` extension point.
          */
-        constructor(taskDefinition: TaskDefinition,
+        constructor(
+            taskDefinition: TaskDefinition,
             scope: WorkspaceFolder | TaskScope.Global | TaskScope.Workspace,
             name: string,
             source?: string,
+            execution?: ProcessExecution | ShellExecution,
+            problemMatchers?: string | string[]);
+
+        /**
+         * ~~Creates a new task.~~
+         *
+         * @deprecated Use the new constructors that allow specifying a scope for the task.
+         *
+         * @param definition The task definition as defined in the taskDefinitions extension point.
+         * @param name The task's name. Is presented in the user interface.
+         * @param source The task's source (e.g. 'gulp', 'npm', ...). Is presented in the user interface.
+         * @param execution The process or shell execution.
+         * @param problemMatchers the names of problem matchers to use, like '$tsc'
+         *  or '$eslint'. Problem matchers can be contributed by an extension using
+         *  the `problemMatchers` extension point.
+         */
+        constructor(
+            taskDefinition: TaskDefinition,
+            name: string,
+            source: string,
             execution?: ProcessExecution | ShellExecution,
             problemMatchers?: string | string[]);
 

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -47,12 +47,8 @@ export class ProvidedTaskConfigurations {
         if (task) {
             return task;
         } else {
-            const provider = this.taskProviderRegistry.getProvider(source);
-            if (provider) {
-                const tasks = await provider.provideTasks();
-                this.cacheTasks(tasks);
-                return this.getCachedTask(source, taskLabel);
-            }
+            await this.getTasks();
+            return this.getCachedTask(source, taskLabel);
         }
     }
 

--- a/packages/task/src/browser/task-contribution.ts
+++ b/packages/task/src/browser/task-contribution.ts
@@ -70,10 +70,11 @@ export class TaskProviderRegistry {
     }
 
     /** Registers the given Task Provider to return Task Configurations of the specified type. */
-    register(type: string, provider: TaskProvider): Disposable {
-        this.providers.set(type, provider);
+    register(type: string, provider: TaskProvider, handle?: number): Disposable {
+        const key = handle === undefined ? type : `${type}::${handle}`;
+        this.providers.set(key, provider);
         return {
-            dispose: () => this.providers.delete(type)
+            dispose: () => this.providers.delete(key)
         };
     }
 


### PR DESCRIPTION
Fixes #4814 
It is possible to have tasks with the same type, so we need to
differentiate them.
Using the handle available with the task to create a unique provider.
This allow to have following plugins within the same workspace:
- grunt
- gulp
- jake

Jake is using the old API to computeTask(). Because of that, I need to implement the deprecated Task constructor to handle Jake. 
To support the vscode built-in plugin for JAKE , there is two ways:
1-   I need to implement the deprecated Task constructor to handle Jake. 
2-  Jake vscode built-in plugin needs to be adjusted to handle the creation of task using the newest API

In the current solution, I implemented solution 1, so we can support JAKE until vscode modify the Jake plugin

For solution 2, we need to modify:
File:  jake/src/main.ts
Method computeTasks() at ~line 145, need to modify the following line by adding the workspaceFolder as a parameter:

OLD:
let task = new vscode.Task(kind, taskName, 'jake', new vscode.ShellExecution(`${jakeCommand} ${taskName}`, options));

 NEW:
let task = new vscode.Task(kind, **this._workspaceFolder,** taskName, 'jake', new vscode.ShellExecution(`${jakeCommand} ${taskName}`, options));

For testing purpose, you need to add in the package.json the following packages. (Either in devDependencies or dependencies)
"dependencies": {
  "gulp": "latest",
     "gulp-util": "latest",
     "gulp-sass": "latest",
     "gulp-coffee": "latest",
     "gulp-uglify": "latest",
     "gulp-concat": "latest",
     "gulp-connect": "latest",
  "grunt": "~0.4.5",
     "grunt-cli": "^1.3.2",
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
  "jake": "^8.1.1"    
}
With those packages installed, you can test "Gulp", Grunt", "Jake" and "npm" if installed


Signed-off-by: Jacques Bouthillier <jacques.bouthillier@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
