### PR TITLE
[plug-in] memory: fix memory leak on plug-ins reload

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -78,11 +78,11 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
 
     pluginsApiImpl.set(plugin.model.id, vscode);
     plugins.push(plugin);
+    pluginApiFactory = apiFactory;
 
     if (!isLoadOverride) {
         overrideInternalLoad();
         isLoadOverride = true;
-        pluginApiFactory = apiFactory;
     }
 };
 

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -80,7 +80,9 @@ export class PluginHostRPC {
      * note: stopPlugin can also be invoked through RPC proxy.
      */
     stopContext(): PromiseLike<void> {
-        return this.pluginManager.$stopPlugin('');
+        const promise = this.pluginManager.$stopPlugin('');
+        promise.then(() => delete this.apiFactory);
+        return promise;
     }
 
     // tslint:disable-next-line:no-any
@@ -92,11 +94,32 @@ export class PluginHostRPC {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 try {
                     // cleaning the cache for all files of that plug-in.
-                    Object.keys(require.cache).forEach(key => {
+                    Object.keys(require.cache).forEach(function (key) {
+                        const mod = require.cache[key];
+
+                        // remove children that are extensions
+                        let i = mod.children.length;
+                        while (i--) {
+                            const childMod: NodeJS.Module = mod.children[i];
+                            if (childMod && childMod.id.startsWith(plugin.pluginFolder)) {
+                                // cleanup exports
+                                childMod.exports = {};
+                                mod.children.splice(i, 1);
+                                for (let j = 0; j < childMod.children.length; j++) {
+                                    delete childMod.children[j];
+                                }
+                            }
+                        }
+
                         if (key.startsWith(plugin.pluginFolder)) {
                             // delete entry
                             delete require.cache[key];
+                            const ix = mod.parent.children.indexOf(mod);
+                            if (ix >= 0) {
+                                mod.parent.children.splice(ix, 1);
+                            }
                         }
+
                     });
                     return require(plugin.pluginPath);
                 } catch (e) {

--- a/packages/plugin-ext/src/hosted/node/scanners/backend-init-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/backend-init-theia.ts
@@ -30,11 +30,11 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
     pluginsApiImpl.set(plugin.model.id, apiImpl);
 
     plugins.push(plugin);
+    pluginApiFactory = apiFactory;
 
     if (!isLoadOverride) {
         overrideInternalLoad();
         isLoadOverride = true;
-        pluginApiFactory = apiFactory;
     }
 
 };

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -85,6 +85,12 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
                 dispose(pluginContext.subscriptions);
             }
         });
+
+        // clean map
+        this.activatedPlugins.clear();
+        this.pluginActivationPromises.clear();
+        this.pluginContextsMap.clear();
+
         return Promise.resolve();
     }
 


### PR DESCRIPTION
Fix for https://github.com/eclipse/che-theia/issues/120
about the require.cache cleanup, it was not enough to only remove entries from cache: https://github.com/nodejs/node/issues/8443


After like 20 reloads we only have one occurence of the scripts bundled in the vsix:
![image](https://user-images.githubusercontent.com/436777/56272386-e6190280-60fa-11e9-83b8-65ae3386b704.png)

Change-Id: I690e82db53a0d8478ebe3f8b7b5d6fc59fe8a12e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
