### PR TITLE
[plug-in] RPC replacer/reviver objects: Encode as well in replyOK the URI objects

### DIFF
--- a/packages/plugin-ext/src/api/rpc-protocol.ts
+++ b/packages/plugin-ext/src/api/rpc-protocol.ts
@@ -323,7 +323,7 @@ class MessageFactory {
         if (typeof res === 'undefined') {
             return `{${prefix}"type":${MessageType.Reply},"id":"${req}"}`;
         }
-        return `{${prefix}"type":${MessageType.Reply},"id":"${req}","res":${JSON.stringify(res)}}`;
+        return `{${prefix}"type":${MessageType.Reply},"id":"${req}","res":${JSON.stringify(res, ObjectsTransferrer.replacer)}}`;
     }
 
     public static replyErr(req: string, err: any, messageToSendHostId?: string): string {


### PR DESCRIPTION
For now it was performed only on requests

It avoids to receive json object that are mangled as they're only json content, not object.
Fix #4715

For that case, the URI object was not an URI object so fsPath was not there and not built when requested.

![initializer](https://user-images.githubusercontent.com/436777/56290399-589dd880-6123-11e9-836b-b6ec236c2178.gif)

Change-Id: Id6cb4e016ce580a950e8055582ef6f6b73a9a4c5
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
