### PR TITLE
Fix work extensions with no activation function

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -192,9 +192,7 @@ export class HostedPluginSupport {
         for (const plugin of pluginsMetadata) {
             if (plugin.model.entryPoint.frontend) {
                 result[0] = true;
-            }
-
-            if (plugin.model.entryPoint.backend) {
+            } else {
                 result[1] = true;
             }
 

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin.ts
@@ -67,7 +67,7 @@ export class HostedPluginSupport {
     }
 
     runPlugin(plugin: PluginModel): void {
-        if (plugin.entryPoint.backend) {
+        if (!plugin.entryPoint.frontend) {
             this.runPluginServer();
         }
     }

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -133,8 +133,16 @@ export class PluginHostRPC {
                 for (const plg of raw) {
                     const pluginModel = plg.model;
                     const pluginLifecycle = plg.lifecycle;
-                    if (pluginModel.entryPoint!.backend) {
 
+                    if (pluginModel.entryPoint!.frontend) {
+                        foreign.push({
+                            pluginPath: pluginModel.entryPoint.frontend!,
+                            pluginFolder: plg.source.packagePath,
+                            model: pluginModel,
+                            lifecycle: pluginLifecycle,
+                            rawModel: plg.source
+                        });
+                    } else {
                         let backendInitPath = pluginLifecycle.backendInitPath;
                         // if no init path, try to init as regular Theia plugin
                         if (!backendInitPath) {
@@ -152,14 +160,6 @@ export class PluginHostRPC {
                         self.initContext(backendInitPath, plugin);
 
                         result.push(plugin);
-                    } else {
-                        foreign.push({
-                            pluginPath: pluginModel.entryPoint.frontend!,
-                            pluginFolder: plg.source.packagePath,
-                            model: pluginModel,
-                            lifecycle: pluginLifecycle,
-                            rawModel: plg.source
-                        });
                     }
                 }
                 return [result, foreign];

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -123,6 +123,9 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
         // run plugins
         for (const plugin of plugins) {
+            if (!plugin.pluginPath) {
+                continue;
+            }
             const pluginMain = this.host.loadPlugin(plugin);
             // able to load the plug-in ?
             if (pluginMain !== undefined) {


### PR DESCRIPTION
### Referenced issue:
https://github.com/theia-ide/theia/issues/4850

### Description
We count's all vscode extensions like "backend theia plugins": https://github.com/theia-ide/theia/blob/master/packages/plugin-ext-vscode/src/node/scanner-vscode.ts#L42

So let's launch **all not frontend** plugins like backend plugins. And In case if extension has no activation function(and plugin path in this case was not initialized) allow to initialize this extension, but don't allow load extension script and don't allow start extension script(because no main script and activation methods).

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
