### PR TITLE
[process/languages] Type backward compatibilty

### DIFF
--- a/packages/languages/src/node/language-server-contribution.ts
+++ b/packages/languages/src/node/language-server-contribution.ts
@@ -124,7 +124,7 @@ export abstract class BaseLanguageServerContribution implements LanguageServerCo
         });
     }
 
-    protected onDidFailSpawnProcess(error: ProcessErrorEvent): void {
+    protected onDidFailSpawnProcess(error: Error | ProcessErrorEvent): void {
         console.error(error);
     }
 

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -33,7 +33,7 @@ export interface IProcessStartEvent {
 /**
  * Data emitted when a process has failed to start.
  */
-export interface ProcessErrorEvent {
+export interface ProcessErrorEvent extends Error {
     /** An errno-like error string (e.g. ENOENT).  */
     code: string;
 }

--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -17,7 +17,7 @@
 import { injectable, inject, named } from 'inversify';
 import { ProcessManager } from './process-manager';
 import { ILogger } from '@theia/core/lib/common';
-import { Process, ProcessType, ProcessOptions, ForkOptions } from './process';
+import { Process, ProcessType, ProcessOptions, ForkOptions, ProcessErrorEvent } from './process';
 import { ChildProcess, spawn, fork } from 'child_process';
 import * as stream from 'stream';
 
@@ -106,9 +106,8 @@ export class RawProcess extends Process {
             }
 
             this.process.on('error', (error: NodeJS.ErrnoException) => {
-                this.emitOnError({
-                    code: error.code || 'Unknown error',
-                });
+                error.code = error.code || 'Unknown error';
+                this.emitOnError(error as ProcessErrorEvent);
             });
             this.process.on('exit', (exitCode: number, signal: string) => {
                 // node's child_process exit sets the unused parameter to null,

--- a/packages/process/src/node/terminal-process.ts
+++ b/packages/process/src/node/terminal-process.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, named } from 'inversify';
 import { ILogger } from '@theia/core/lib/common';
-import { Process, ProcessType, ProcessOptions } from './process';
+import { Process, ProcessType, ProcessOptions, ProcessErrorEvent } from './process';
 import { ProcessManager } from './process-manager';
 import { IPty, spawn } from '@theia/node-pty';
 import { MultiRingBuffer, MultiRingBufferReadableStream } from './multi-ring-buffer';
@@ -56,7 +56,9 @@ export class TerminalProcess extends Process {
                 if (reason === undefined) {
                     this.emitOnStarted();
                 } else {
-                    this.emitOnError({ code: reason });
+                    const error = new Error(reason) as ProcessErrorEvent;
+                    error.code = reason;
+                    this.emitOnError(error);
                 }
             });
 


### PR DESCRIPTION
Old clients expect to receive an `Error` when the new design emits
`ProcessErrorEvent` which is incompatible with the old typings.

This commit mitigates this by making a `ProcessErrorEvent` act as an
error, and patch `onDidFailSpawnProcess` to be backward compatible with
the old method signature.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

---

Fixes https://github.com/theia-ide/theia-rust-extension/issues/11
Fixes https://github.com/theia-ide/theia/issues/4930