### PR TITLE
update localstorage prefix on workspace file change

### DIFF
--- a/packages/workspace/src/browser/workspace-storage-service.ts
+++ b/packages/workspace/src/browser/workspace-storage-service.ts
@@ -35,7 +35,8 @@ export class WorkspaceStorageService implements StorageService {
     @postConstruct()
     protected init() {
         this.initialized = this.workspaceService.roots.then(() => {
-            this.prefix = this.getPrefix(this.workspaceService.workspace);
+            this.updatePrefix();
+            this.workspaceService.onWorkspaceLocationChanged(() => this.updatePrefix());
         });
     }
 
@@ -59,5 +60,9 @@ export class WorkspaceStorageService implements StorageService {
 
     protected getPrefix(workspaceStat: FileStat | undefined): string {
         return workspaceStat ? workspaceStat.uri : '_global_';
+    }
+
+    private updatePrefix(): void {
+        this.prefix = this.getPrefix(this.workspaceService.workspace);
     }
 }


### PR DESCRIPTION
In current theia, the path of workspace folder or workspace file is used to prefix the key to save information in local storage. This works in most cases, except for the ones where the prefix needs update:
- a single-folder workspace becomes a multi-root workspace, and
- a workspace is "saved as" a different workspace

This change fixes the problem mentioned above.

Signed-off-by: elaihau <liang.huang@ericsson.com>
