### PR TITLE
[commands] add support for recently used commands

### DIFF
--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -19,28 +19,83 @@ import { ContributionProvider } from './contribution-provider';
 import * as chai from 'chai';
 
 const expect = chai.expect;
+let commandRegistry: CommandRegistry;
 
 describe('Commands', () => {
-    it('should properly pass arguments when any', async () => {
-        const commandRegistry = new CommandRegistry(
-            new EmptyContributionProvider()
-        );
 
-        // Registering a concat command to test
-        commandRegistry.registerCommand(
-            <Command>{ id: 'concat' },
-            new ConcatCommandHandler()
-        );
+    beforeEach(() => {
+        commandRegistry = new CommandRegistry(new EmptyContributionProvider());
+    });
 
-        expect(
-            'commandarg1_commandarg2_commandarg3'
-        ).equals(
-            await commandRegistry.executeCommand(
-                'concat',
-                'commandarg1',
-                '_commandarg2',
-                '_commandarg3')
-        );
+    it('should register and execute a given command', async () => {
+        const concatId = 'concat';
+        const command: Command = { id: concatId };
+        commandRegistry.registerCommand(command, new ConcatCommandHandler());
+        const result = await commandRegistry.executeCommand(concatId, 'a', 'b', 'c');
+        expect('abc').equals(result);
+    });
+
+    it('should execute a given command, and add it to recently used', async () => {
+        const commandId = 'stub';
+        const command: Command = { id: commandId };
+        commandRegistry.registerCommand(command, new StubCommandHandler());
+        await commandRegistry.executeCommand(commandId);
+        expect(commandRegistry.recent.length).equal(1);
+    });
+
+    it('should execute multiple commands, and add them to recently used in the order they were used', async () => {
+        const commandIds = ['a', 'b', 'c'];
+        const commands: Command[] = [
+            { id: commandIds[0] },
+            { id: commandIds[1] },
+            { id: commandIds[2] },
+        ];
+
+        // Register each command.
+        commands.forEach((c: Command) => {
+            commandRegistry.registerCommand(c, new StubCommandHandler());
+        });
+
+        // Execute order c, b, a.
+        await commandRegistry.executeCommand(commandIds[2]);
+        await commandRegistry.executeCommand(commandIds[1]);
+        await commandRegistry.executeCommand(commandIds[0]);
+
+        // Expect recently used to be a, b, c.
+        const result: Command[] = commandRegistry.recent;
+
+        expect(result.length).equal(3);
+        expect(result[0].id).equal(commandIds[0]);
+        expect(result[1].id).equal(commandIds[1]);
+        expect(result[2].id).equal(commandIds[2]);
+    });
+
+    it('should execute a command that\'s already been executed, and add it to the top of the most recently used', async () => {
+        const commandIds = ['a', 'b', 'c'];
+        const commands: Command[] = [
+            { id: commandIds[0] },
+            { id: commandIds[1] },
+            { id: commandIds[2] },
+        ];
+
+        // Register each command.
+        commands.forEach((c: Command) => {
+            commandRegistry.registerCommand(c, new StubCommandHandler());
+        });
+
+        // Execute order a, b, c, a.
+        await commandRegistry.executeCommand(commandIds[0]);
+        await commandRegistry.executeCommand(commandIds[1]);
+        await commandRegistry.executeCommand(commandIds[2]);
+        await commandRegistry.executeCommand(commandIds[0]);
+
+        // Expect recently used to be a, b, c.
+        const result: Command[] = commandRegistry.recent;
+
+        expect(result.length).equal(3);
+        expect(result[0].id).equal(commandIds[0]);
+        expect(result[1].id).equal(commandIds[2]);
+        expect(result[2].id).equal(commandIds[1]);
     });
 });
 
@@ -58,4 +113,8 @@ class ConcatCommandHandler implements CommandHandler {
         });
         return concat;
     }
+}
+
+class StubCommandHandler implements CommandHandler {
+    execute(...args: string[]) { return undefined; }
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -374,6 +374,11 @@ export class QuickOpenEntryGroup extends monaco.quickOpen.QuickOpenEntryGroup {
         return this.item.showBorder();
     }
 
+    getKeybinding(): monaco.keybindings.ResolvedKeybinding | undefined {
+        const entry = this.getEntry();
+        return entry ? entry.getKeybinding() : super.getKeybinding();
+    }
+
 }
 
 export class MonacoQuickOpenAction implements monaco.quickOpen.IAction {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -23,10 +23,6 @@
     color: var(--theia-ui-font-color1) !important;
 }
 
-.quick-open-entry-keybinding {
-    padding-right: 15px;
-}
-
 /*
  * set z-index to 0, so tabs are not above overlay widgets
  */


### PR DESCRIPTION
Fixes #2518

Added support for recently used commands.
Commands which have been recently executed will now be placed above others when triggering `quick-commands` making it easier for users to see their favorite or last recently used commands.

<div align='center'>

<img width="748" alt="Screen Shot 2019-04-18 at 8 43 39 PM" src="https://user-images.githubusercontent.com/40359487/56399213-af3a0e00-621a-11e9-834e-9a013eb0c925.png">

</div>

---

**Features Remaining**
- [x] _Enable the display `groupLabel` and `keybinding` together in the quick-open._
- [x] _Store recently used commands in local storage._ 

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
