### PR TITLE
GH-4940: Changed the way we require the server.

### DIFF
--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -29,8 +29,7 @@ export class BackendGenerator extends AbstractGenerator {
 require('reflect-metadata');
 const path = require('path');
 const express = require('express');
-const { Container, injectable } = require('inversify');
-
+const { Container } = require('inversify');
 const { BackendApplication, CliManager } = require('@theia/core/lib/node');
 const { backendApplicationModule } = require('@theia/core/lib/node/backend-application-module');
 const { messagingBackendModule } = require('@theia/core/lib/node/messaging/messaging-backend-module');
@@ -75,10 +74,11 @@ module.exports = (port, host, argv) => Promise.resolve()${this.compileBackendMod
     protected compileMain(backendModules: Map<string, string>): string {
         return `// @ts-check
 const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');
+const main = require('@theia/core/lib/node/main');
 BackendApplicationConfigProvider.set(${this.prettyStringify(this.pck.props.backend.config)});
 
-const serverPath = require('path').resolve(__dirname, 'server');
-const address = require('@theia/core/lib/node/main').default(serverPath);
+const serverModule = require('./server');
+const address = main.start(serverModule());
 address.then(function (address) {
     if (process && process.send) {
         process.send(address.port.toString());

--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -54,9 +54,8 @@ function start(port, host, argv) {
     const cliManager = container.get(CliManager);
     return cliManager.initializeCli(argv).then(function () {
         const application = container.get(BackendApplication);
-        application.use(express.static(path.join(__dirname, '../../lib'), {
-            index: 'index.html'
-        }));
+        application.use(express.static(path.join(__dirname, '../../lib')));
+        application.use(express.static(path.join(__dirname, '../../lib/index.html')));
         return application.start(port, host);
     });
 }

--- a/packages/core/src/node/main.ts
+++ b/packages/core/src/node/main.ts
@@ -14,7 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import * as http from 'http';
+import * as https from 'https';
+import { AddressInfo } from 'net';
 import { checkParentAlive } from './messaging/ipc-protocol';
+import { MaybePromise } from '../common/types';
 
 checkParentAlive();
 
@@ -23,12 +27,12 @@ process.on('unhandledRejection', (reason, promise) => {
 });
 
 export interface Address {
-    port: number;
-    address: string;
+    readonly port: number;
+    readonly address: string;
 }
 
-export async function start(serverPath: string): Promise<Address> {
-    const server = await require(serverPath)();
-    return server.address();
+export async function start(serverModule: MaybePromise<http.Server | https.Server>): Promise<Address> {
+    const server = await serverModule;
+    return server.address() as AddressInfo;
 }
 export default start;


### PR DESCRIPTION
Instead of resolving the path of the server module and requiring it in
the Theia's `main`, we require the server module directly.

This change does not intend to change the actual behavior but supposed
to help the packaging process when bundling Theia into a single
executable.

Bundlers usually parse `requires` from the source code and they cannot
do much out-of-the-box with requires called with a non-literal
argument.

Closes: #4940.
Closes: #4944.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
