### PR TITLE
[plug-in] [vscode] Propagate thisArg on registerCommand

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -36,12 +36,12 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
 
     // replace command API as it will send only the ID as a string parameter
     const registerCommand = vscode.commands.registerCommand;
-    vscode.commands.registerCommand = function (command: any, handler?: <T>(...args: any[]) => T | Thenable<T>): any {
+    vscode.commands.registerCommand = function (command: any, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): any {
         // use of the ID when registering commands
         if (typeof command === 'string' && handler) {
-            return vscode.commands.registerHandler(command, handler);
+            return vscode.commands.registerHandler(command, handler, thisArg);
         }
-        return registerCommand(command, handler);
+        return registerCommand(command, handler, thisArg);
     };
 
     // replace createWebviewPanel API for override html setter


### PR DESCRIPTION
thisArgs was introduced on registerCommand API by https://github.com/theia-ide/theia/pull/4264 but we were still missing it on the vscode part

It solves one problem with plantuml extension https://github.com/theia-ide/theia/issues/4899

Change-Id: I1c2d2354b409e650d6b63b444c36d2905d1e1218
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
