### PR TITLE
[vscode] bump VS Code API version to the latest version available

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,7 +19,7 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.32.3';
+export const VSCODE_DEFAULT_API_VERSION = '1.33.1';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });


### PR DESCRIPTION
latest is 1.33.1 https://github.com/Microsoft/vscode/releases

Change-Id: Ibe547b8ff9bd21bb9ab8a3d9f6a9b5f0ab6e1b84
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
