### PR TITLE
[workspaces] fix incorrect file-icon when displaying recent workspaces

### DIFF
--- a/packages/workspace/src/browser/quick-open-workspace.ts
+++ b/packages/workspace/src/browser/quick-open-workspace.ts
@@ -64,7 +64,7 @@ export class QuickOpenWorkspace implements QuickOpenModel {
                 label: uri.path.base,
                 description: (home) ? FileSystemUtils.tildifyPath(uri.path.toString(), home) : uri.path.toString(),
                 groupLabel: `last modified ${moment(stat.lastModification).fromNow()}`,
-                iconClass: await this.labelProvider.getIcon(uri) + ' file-icon',
+                iconClass: await this.labelProvider.getIcon(stat) + ' file-icon',
                 run: (mode: QuickOpenMode): boolean => {
                     if (mode !== QuickOpenMode.OPEN) {
                         return false;


### PR DESCRIPTION
Fixes #4949

Fixes minor issue where the file-icon displayed when displaying `recent workspaces` is incorrect. The issue occurs when a folder is opened with a `.` in the beginning (ex: .theia). In order to fix the issue, a `FileStat` is used instead of the `URI` since it holds more complete data on what the appropriate file-icon should be.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
