### PR TITLE
[plug-in] Range object is lost across serialization

### DIFF
--- a/packages/plugin-ext/src/api/rpc-protocol.ts
+++ b/packages/plugin-ext/src/api/rpc-protocol.ts
@@ -26,7 +26,7 @@ import { Event } from '@theia/core/lib/common/event';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import VSCodeURI from 'vscode-uri';
 import URI from '@theia/core/lib/common/uri';
-import { CancellationToken, CancellationTokenSource } from 'vscode-languageserver-protocol';
+import { CancellationToken, CancellationTokenSource, Range, Position } from 'vscode-languageserver-protocol';
 
 export interface MessageConnection {
     send(msg: {}): void;
@@ -357,6 +357,22 @@ namespace ObjectsTransferrer {
                 $type: SerializedObjectType.THEIA_URI,
                 data: value.toString()
             } as SerializedObject;
+        } else if (Range.is(value)) {
+            const range = value as Range;
+            const serializedValue = {
+                start: {
+                    line: range.start.line,
+                    character: range.start.character
+                },
+                end: {
+                    line: range.end.line,
+                    character: range.end.character
+                }
+            };
+            return {
+                $type: SerializedObjectType.THEIA_RANGE,
+                data: JSON.stringify(serializedValue)
+            } as SerializedObject;
         } else if (value && value['$mid'] === 1) {
             // Given value is VSCode URI
             // We cannot use instanceof here because VSCode URI has toJSON method which is invoked before this replacer.
@@ -378,6 +394,11 @@ namespace ObjectsTransferrer {
                     return new URI(value.data);
                 case SerializedObjectType.VSCODE_URI:
                     return VSCodeURI.parse(value.data);
+                case SerializedObjectType.THEIA_RANGE:
+                    // tslint:disable-next-line:no-any
+                    const obj: any = JSON.parse(value.data);
+                    // May require to use types-impl there instead of vscode lang server Range for the revival
+                    return Range.create(Position.create(obj.start.line, obj.start.character), Position.create(obj.end.line, obj.end.character));
             }
         }
 
@@ -393,7 +414,8 @@ interface SerializedObject {
 
 enum SerializedObjectType {
     THEIA_URI,
-    VSCODE_URI
+    VSCODE_URI,
+    THEIA_RANGE
 }
 
 function isSerializedObject(obj: any): obj is SerializedObject {


### PR DESCRIPTION
it contains at the end only _start and _end attributes while extension expects to have a valid Range object (and then call start on it, etc)

One problem of  #4781 is being solved 

To test, try the httpie extension as described in #4781

the VS Code extension is doing
```javascript
let activeLine = !range ? editor.selection.active.line : range.start.line;
```

but range object containing only _start and _end it fails.


I also suspect that some types should be moved elsewhere but it may be part of other work

Change-Id: I69a316219009a13aebeb804ee142e0320571ecd6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
