### PR TITLE
[Plugin-API Make possiblee to disable cancellation token in the rpc-protocol

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -863,52 +863,52 @@ export interface ProcessTaskDto extends TaskDto, CommandProperties {
 
 export interface LanguagesExt {
     $provideCompletionItems(handle: number, resource: UriComponents, position: Position,
-        context: CompletionContext, token?: CancellationToken): Promise<CompletionResultDto | undefined>;
-    $resolveCompletionItem(handle: number, resource: UriComponents, position: Position, completion: Completion, token?: CancellationToken): Promise<Completion>;
+        context: CompletionContext, token: CancellationToken): Promise<CompletionResultDto | undefined>;
+    $resolveCompletionItem(handle: number, resource: UriComponents, position: Position, completion: Completion, token: CancellationToken): Promise<Completion>;
     $releaseCompletionItems(handle: number, id: number): void;
-    $provideImplementation(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
-    $provideTypeDefinition(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
-    $provideDefinition(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
-    $provideReferences(handle: number, resource: UriComponents, position: Position, context: ReferenceContext, token?: CancellationToken): Promise<Location[] | undefined>;
-    $provideSignatureHelp(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<SignatureHelp | undefined>;
-    $provideHover(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<Hover | undefined>;
-    $provideDocumentHighlights(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): Promise<DocumentHighlight[] | undefined>;
+    $provideImplementation(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
+    $provideTypeDefinition(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
+    $provideDefinition(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
+    $provideReferences(handle: number, resource: UriComponents, position: Position, context: ReferenceContext, token: CancellationToken): Promise<Location[] | undefined>;
+    $provideSignatureHelp(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<SignatureHelp | undefined>;
+    $provideHover(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Hover | undefined>;
+    $provideDocumentHighlights(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<DocumentHighlight[] | undefined>;
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents,
-        options: FormattingOptions, token?: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
+        options: FormattingOptions, token: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range,
-        options: FormattingOptions, token?: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
+        options: FormattingOptions, token: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
     $provideOnTypeFormattingEdits(
         handle: number,
         resource: UriComponents,
         position: Position,
         ch: string,
         options: FormattingOptions,
-        token?: CancellationToken
+        token: CancellationToken
     ): Promise<ModelSingleEditOperation[] | undefined>;
-    $provideDocumentLinks(handle: number, resource: UriComponents, token?: CancellationToken): Promise<DocumentLink[] | undefined>;
-    $resolveDocumentLink(handle: number, link: DocumentLink, token?: CancellationToken): Promise<DocumentLink | undefined>;
-    $provideCodeLenses(handle: number, resource: UriComponents, token?: CancellationToken): Promise<CodeLensSymbol[] | undefined>;
-    $resolveCodeLens(handle: number, resource: UriComponents, symbol: CodeLensSymbol, token?: CancellationToken): Promise<CodeLensSymbol | undefined>;
+    $provideDocumentLinks(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentLink[] | undefined>;
+    $resolveDocumentLink(handle: number, link: DocumentLink, token: CancellationToken): Promise<DocumentLink | undefined>;
+    $provideCodeLenses(handle: number, resource: UriComponents, token: CancellationToken): Promise<CodeLensSymbol[] | undefined>;
+    $resolveCodeLens(handle: number, resource: UriComponents, symbol: CodeLensSymbol, token: CancellationToken): Promise<CodeLensSymbol | undefined>;
     $provideCodeActions(
         handle: number,
         resource: UriComponents,
         rangeOrSelection: Range | Selection,
         context: monaco.languages.CodeActionContext,
-        token?: CancellationToken
+        token: CancellationToken
     ): Promise<monaco.languages.CodeAction[]>;
-    $provideDocumentSymbols(handle: number, resource: UriComponents, token?: CancellationToken): Promise<DocumentSymbol[] | undefined>;
-    $provideWorkspaceSymbols(handle: number, query: string, token?: CancellationToken): PromiseLike<SymbolInformation[]>;
-    $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token?: CancellationToken): PromiseLike<SymbolInformation>;
+    $provideDocumentSymbols(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentSymbol[] | undefined>;
+    $provideWorkspaceSymbols(handle: number, query: string, token: CancellationToken): PromiseLike<SymbolInformation[]>;
+    $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: CancellationToken): PromiseLike<SymbolInformation>;
     $provideFoldingRange(
         handle: number,
         resource: UriComponents,
         context: monaco.languages.FoldingContext,
-        token?: CancellationToken
+        token: CancellationToken
     ): PromiseLike<monaco.languages.FoldingRange[] | undefined>;
-    $provideDocumentColors(handle: number, resource: UriComponents, token?: CancellationToken): PromiseLike<RawColorInfo[]>;
-    $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo, token?: CancellationToken): PromiseLike<ColorPresentation[]>;
-    $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string, token?: CancellationToken): PromiseLike<WorkspaceEditDto | undefined>;
-    $resolveRenameLocation(handle: number, resource: UriComponents, position: Position, token?: CancellationToken): PromiseLike<RenameLocation | undefined>;
+    $provideDocumentColors(handle: number, resource: UriComponents, token: CancellationToken): PromiseLike<RawColorInfo[]>;
+    $provideColorPresentations(handle: number, resource: UriComponents, colorInfo: RawColorInfo, token: CancellationToken): PromiseLike<ColorPresentation[]>;
+    $provideRenameEdits(handle: number, resource: UriComponents, position: Position, newName: string, token: CancellationToken): PromiseLike<WorkspaceEditDto | undefined>;
+    $resolveRenameLocation(handle: number, resource: UriComponents, position: Position, token: CancellationToken): PromiseLike<RenameLocation | undefined>;
 }
 
 export interface LanguagesMain {

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -25,7 +25,7 @@ export class TaskProviderAdapter {
 
     constructor(private readonly provider: theia.TaskProvider) { }
 
-    provideTasks(token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    provideTasks(token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         return Promise.resolve(this.provider.provideTasks(token)).then(tasks => {
             if (!Array.isArray(tasks)) {
                 return undefined;
@@ -46,7 +46,7 @@ export class TaskProviderAdapter {
         });
     }
 
-    resolveTask(task: TaskDto, token: theia.CancellationToken): Promise<TaskDto | undefined> {
+    resolveTask(task: TaskDto, token?: theia.CancellationToken): Promise<TaskDto | undefined> {
         if (typeof this.provider.resolveTask !== 'function') {
             return Promise.resolve(undefined);
         }

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -80,7 +80,7 @@ export class TasksExtImpl implements TasksExt {
         return this.createDisposable(callId);
     }
 
-    $provideTasks(handle: number, token: theia.CancellationToken): Promise<TaskDto[] | undefined> {
+    $provideTasks(handle: number, token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.provideTasks(token);
@@ -89,7 +89,7 @@ export class TasksExtImpl implements TasksExt {
         }
     }
 
-    $resolveTask(handle: number, task: TaskDto, token: theia.CancellationToken): Promise<TaskDto | undefined> {
+    $resolveTask(handle: number, task: TaskDto, token?: theia.CancellationToken): Promise<TaskDto | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {
             return adapter.resolveTask(task, token);


### PR DESCRIPTION
Check for an `'disable.cancellation.token'` to to disable creation of cancelation token in the rpc-protocol.
fixes #4957
is needed for https://github.com/theia-ide/theia/pull/4279
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
