### PR TITLE
fix the order of tasks in "recently used"

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -60,12 +60,12 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
     /** Initialize this quick open model with the tasks. */
     async init(): Promise<void> {
-        const recentTasks = this.taskService.getRecentTasks();
+        const recentTasks = this.taskService.recentTasks;
         const configuredTasks = this.taskService.getConfiguredTasks();
         const providedTasks = await this.taskService.getProvidedTasks();
 
         const { filteredRecentTasks, filteredConfiguredTasks, filteredProvidedTasks } = this.getFilteredTasks(recentTasks, configuredTasks, providedTasks);
-        const stat = await this.workspaceService.workspace;
+        const stat = this.workspaceService.workspace;
         const isMulti = stat ? !stat.isDirectory : false;
         this.items = [];
         this.items.push(

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -114,11 +114,11 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         this.schemaUpdater.update();
 
         this.storageService.getData<{ recent: TaskConfiguration[] }>(TASKS_STORAGE_KEY, { recent: [] })
-            .then(tasks => this.taskService.addRecentTasks(tasks.recent));
+            .then(tasks => this.taskService.recentTasks = tasks.recent);
     }
 
     onStop(): void {
-        const recent = this.taskService.getRecentTasks();
+        const recent = this.taskService.recentTasks;
         this.storageService.setData<{ recent: TaskConfiguration[] }>(TASKS_STORAGE_KEY, { recent });
     }
 

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -44,7 +44,7 @@ export class TaskService implements TaskConfigurationClient {
      * The last executed task.
      */
     protected lastTask: { source: string, taskLabel: string } | undefined = undefined;
-    protected recentTasks: TaskConfiguration[] = [];
+    protected cachedRecentTasks: TaskConfiguration[] = [];
 
     @inject(FrontendApplication)
     protected readonly app: FrontendApplication;
@@ -157,23 +157,27 @@ export class TaskService implements TaskConfigurationClient {
         if (Array.isArray(tasks)) {
             tasks.forEach(task => this.addRecentTasks(task));
         } else {
-            const ind = this.recentTasks.findIndex(recent => TaskConfiguration.equals(recent, tasks));
+            const ind = this.cachedRecentTasks.findIndex(recent => TaskConfiguration.equals(recent, tasks));
             if (ind >= 0) {
-                this.recentTasks.splice(ind, 1);
+                this.cachedRecentTasks.splice(ind, 1);
             }
-            this.recentTasks.unshift(tasks);
+            this.cachedRecentTasks.unshift(tasks);
         }
     }
 
-    getRecentTasks(): TaskConfiguration[] {
-        return this.recentTasks;
+    get recentTasks(): TaskConfiguration[] {
+        return this.cachedRecentTasks;
+    }
+
+    set recentTasks(recent: TaskConfiguration[]) {
+        this.cachedRecentTasks = recent;
     }
 
     /**
      * Clears the list of recently used tasks.
      */
     clearRecentTasks(): void {
-        this.recentTasks = [];
+        this.cachedRecentTasks = [];
     }
 
     /**


### PR DESCRIPTION
- the order of recently used tasks is reversed every time Theia reloads. This change fixes the bug.

Signed-off-by: elaihau <liang.huang@ericsson.com>
