### PR TITLE
Remove Node 10 deprecated new Buffer()

### DIFF
--- a/packages/debug/src/node/debug-adapter-session.ts
+++ b/packages/debug/src/node/debug-adapter-session.ts
@@ -47,7 +47,7 @@ export class DebugAdapterSessionImpl implements DebugAdapterSession {
         protected readonly communicationProvider: CommunicationProvider
     ) {
         this.contentLength = -1;
-        this.buffer = new Buffer(0);
+        this.buffer = Buffer.alloc(0);
         this.toDispose.pushAll([
             this.communicationProvider,
             Disposable.create(() => this.write(JSON.stringify({ seq: -1, type: 'request', command: 'disconnect' }))),

--- a/packages/plugin-ext/src/plugin/file-system.ts
+++ b/packages/plugin-ext/src/plugin/file-system.ts
@@ -88,7 +88,7 @@ export class FileSystemExtImpl implements FileSystemExt {
 
         const uri = URI.revive(resource);
         const encoding = options === null ? undefined : options && options.encoding;
-        const buffer = new Buffer(content, encoding);
+        const buffer = Buffer.from(content, encoding);
         const opts = { create: true, overwrite: true };
         return Promise.resolve(this.fsProviders.get(handle)!.writeFile(uri, buffer, opts));
     }

--- a/packages/process/src/node/multi-ring-buffer.spec.ts
+++ b/packages/process/src/node/multi-ring-buffer.spec.ts
@@ -23,7 +23,7 @@ describe('MultiRingBuffer', function () {
 
     it('expect buffer to be empty initialized', function () {
         const size = 2;
-        const compareTo = new Buffer('0000', 'hex');
+        const compareTo = Buffer.from('0000', 'hex');
         const ringBuffer = new MultiRingBuffer({ size });
         // tslint:disable-next-line:no-unused-expression
         expect(ringBuffer['buffer'].equals(compareTo)).to.be.true;


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR fixes #4840 by removing the `new Buffer()` calls deprecated in Node 10
