### PR TITLE
[languages] adjust json and cpp auto-closing pairs

### DIFF
--- a/packages/cpp/src/browser/cpp-grammar-contribution.ts
+++ b/packages/cpp/src/browser/cpp-grammar-contribution.ts
@@ -37,6 +37,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
             { open: '(', close: ')' },
             { open: '\'', close: '\'', notIn: ['string', 'comment'] },
             { open: '"', close: '"', notIn: ['string'] },
+            { open: '/*', close: ' */', notIn: ['string'] }
         ],
         surroundingPairs: [
             { open: '{', close: '}' },

--- a/packages/json/src/browser/json-grammar-contribution.ts
+++ b/packages/json/src/browser/json-grammar-contribution.ts
@@ -34,10 +34,10 @@ export class JsonGrammarContribution implements LanguageGrammarDefinitionContrib
             { 'open': '{', 'close': '}', 'notIn': ['string'] },
             { 'open': '[', 'close': ']', 'notIn': ['string'] },
             { 'open': '(', 'close': ')', 'notIn': ['string'] },
-            { 'open': '\'', 'close': '\'', 'notIn': ['string'] },
             { 'open': '/*', 'close': '*/', 'notIn': ['string'] },
             { 'open': '\'', 'close': '\'', 'notIn': ['string', 'comment'] },
-            { 'open': '`', 'close': '`', 'notIn': ['string', 'comment'] }
+            { 'open': '`', 'close': '`', 'notIn': ['string', 'comment'] },
+            { 'open': '"', 'close': '"', 'notIn': ['string', 'comment'] },
         ]
     };
 


### PR DESCRIPTION
Fixes #4942
Fixes #4976

- adjust the `cpp` auto-closing pair for block comments, to automatically close the comment if available.
- adjust the `json` auto-closing pair for double quotes.
- remove unecessary duplicate `json` auto-closing pair for single-quotes.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
