### PR TITLE
[vscode] Fix #4052 implementation of vscode.diff command

### DIFF
--- a/packages/core/src/browser/diff-uris.ts
+++ b/packages/core/src/browser/diff-uris.ts
@@ -75,12 +75,19 @@ export class DiffUriLabelProviderContribution implements LabelProviderContributi
         if (left.path.toString() === right.path.toString() && left.query && right.query) {
             return `${left.displayName}: ${left.query} ⟷ ${right.query}`;
         } else {
+            let title;
+            if (left.path.toString() !== right.path.toString() && left.displayName !== uri.displayName) {
+                title = `${uri.displayName}: `;
+            } else {
+                title = '';
+            }
+
             const leftLongName = this.labelProvider.getName(left);
             const rightLongName = this.labelProvider.getName(right);
             if (leftLongName === rightLongName) {
                 return leftLongName;
             }
-            return `${leftLongName} ⟷ ${rightLongName}`;
+            return `${title}${leftLongName} ⟷ ${rightLongName}`;
         }
     }
 

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -32,7 +32,7 @@ export namespace VscodeCommands {
     };
 
     export const DIFF: Command = {
-       id: 'vscode.diff'
+        id: 'vscode.diff'
     };
 
     export const SET_CONTEXT: Command = {
@@ -70,8 +70,19 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
         commands.registerCommand(VscodeCommands.DIFF, {
             isVisible: () => false,
             // tslint:disable-next-line: no-any
-            execute: async (left: URI, right: URI) => {
-                await this.diffService.openDiffEditor(new TheiaURI(left), new TheiaURI(right));
+            execute: async (left: URI, right: URI, label?: string) => {
+                if (!left || !right) {
+                    throw new Error(`${VscodeCommands.DIFF} command requires at least two URI arguments. Found left=${left}, right=${right} as arguments`);
+                }
+                if (!URI.isUri(left)) {
+                    throw new Error(`Invalid argument for ${VscodeCommands.DIFF.id} command with left argument. Expecting URI left type but found ${left}`);
+                }
+                if (!URI.isUri(right)) {
+                    throw new Error(`Invalid argument for ${VscodeCommands.DIFF.id} command with right argument. Expecting URI right type but found ${right}`);
+                }
+
+                const leftURI = new TheiaURI(left);
+                await this.diffService.openDiffEditor(leftURI, new TheiaURI(right), label);
             }
         });
 

--- a/packages/workspace/src/browser/diff-service.ts
+++ b/packages/workspace/src/browser/diff-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import {inject, injectable} from 'inversify';
+import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { FileSystem } from '@theia/filesystem/lib/common/filesystem';
@@ -28,36 +28,42 @@ export class DiffService {
     @inject(OpenerService) protected readonly openerService: OpenerService;
     @inject(MessageService) protected readonly messageService: MessageService;
 
-    public async openDiffEditor(left: URI, right: URI) {
-        const [leftExists, rightExists] = await Promise.all([
-            this.fileSystem.exists(left.toString()),
-            this.fileSystem.exists(right.toString())
-        ]);
-        if (leftExists && rightExists) {
-            const [leftStat, rightStat] = await Promise.all([
-                this.fileSystem.getFileStat(left.toString()),
-                this.fileSystem.getFileStat(right.toString()),
+    public async openDiffEditor(left: URI, right: URI, label?: string) {
+        if (left.scheme === 'file' && right.scheme === 'file') {
+            const [leftExists, rightExists] = await Promise.all([
+                this.fileSystem.exists(left.toString()),
+                this.fileSystem.exists(right.toString())
             ]);
-            if (leftStat && rightStat) {
-                if (!leftStat.isDirectory && !rightStat.isDirectory) {
-                    const uri = DiffUris.encode(left, right);
-                    const opener = await this.openerService.getOpener(uri);
-                    opener.open(uri);
-                } else {
-                    const details = (() => {
-                        if (leftStat.isDirectory && rightStat.isDirectory) {
-                            return 'Both resource were a directory.';
-                        } else {
-                            if (leftStat.isDirectory) {
-                                return `'${left.path.base}' was a directory.`;
+            if (leftExists && rightExists) {
+                const [leftStat, rightStat] = await Promise.all([
+                    this.fileSystem.getFileStat(left.toString()),
+                    this.fileSystem.getFileStat(right.toString()),
+                ]);
+                if (leftStat && rightStat) {
+                    if (!leftStat.isDirectory && !rightStat.isDirectory) {
+                        const uri = DiffUris.encode(left, right, label);
+                        const opener = await this.openerService.getOpener(uri);
+                        opener.open(uri);
+                    } else {
+                        const details = (() => {
+                            if (leftStat.isDirectory && rightStat.isDirectory) {
+                                return 'Both resource were a directory.';
                             } else {
-                                return `'${right.path.base}' was a directory.`;
+                                if (leftStat.isDirectory) {
+                                    return `'${left.path.base}' was a directory.`;
+                                } else {
+                                    return `'${right.path.base}' was a directory.`;
+                                }
                             }
-                        }
-                    });
-                    this.messageService.warn(`Directories cannot be compared. ${details()}`);
+                        });
+                        this.messageService.warn(`Directories cannot be compared. ${details()}`);
+                    }
                 }
             }
+        } else {
+            const uri = DiffUris.encode(left, right, label);
+            const opener = await this.openerService.getOpener(uri);
+            opener.open(uri);
         }
     }
 }


### PR DESCRIPTION
diff-service should only check URI on filesystem if it's file URI as it doesn't work for example if URIs are coming from workspace.registerTextDocumentContentProvider

Also fix propagation of DisplayName of the diff URI when used as 3rd argument of vscode.diff command

Can be tested with https://github.com/Microsoft/vscode/blob/master/extensions/vscode-api-tests/src/singlefolder-tests/commands.test.ts#L77-L105

Change-Id: I7e034f72e8b8f8582104be12d545bbae5d8f7921
Signed-off-by: Florent Benoit <fbenoit@redhat.com>


