### PR TITLE
create problem markers from task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## v0.9.0
+- [task] added support for VS Code task contribution points: `taskDefinitions`, `problemMatchers`, and `problemPatterns`
 
 - [plugin] added support of debug activation events [#5645](https://github.com/theia-ide/theia/pull/5645)
 

--- a/packages/cpp/src/browser/cpp-build-configurations.spec.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations.spec.ts
@@ -14,6 +14,9 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
 import { ContainerModule, Container } from 'inversify';
 import { expect } from 'chai';
 import { FileSystem } from '@theia/filesystem/lib/common';
@@ -25,6 +28,9 @@ import { FileSystemNode } from '@theia/filesystem/lib/node/node-filesystem';
 import { bindCppPreferences } from './cpp-preferences';
 import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
 import { MockPreferenceService } from '@theia/core/lib/browser/preferences/test/mock-preference-service';
+import { TaskDefinitionRegistry } from '@theia/task/lib/browser';
+
+disableJSDOM();
 
 let container: Container;
 
@@ -33,6 +39,7 @@ beforeEach(function () {
         bind(CppBuildConfigurationManager).to(CppBuildConfigurationManagerImpl).inSingletonScope();
         bind(StorageService).to(MockStorageService).inSingletonScope();
         bind(FileSystem).to(FileSystemNode).inSingletonScope();
+        bind(TaskDefinitionRegistry).toSelf().inSingletonScope();
         bindCppPreferences(bind);
         bind(PreferenceService).to(MockPreferenceService).inSingletonScope();
     });
@@ -77,6 +84,14 @@ async function initializeTest(buildConfigurations: CppBuildConfiguration[] | und
 }
 
 describe('build-configurations', function () {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
     it('should work with no preferences', async function () {
         const cppBuildConfigurations = await initializeTest(undefined, undefined);
 

--- a/packages/cpp/src/browser/cpp-task-provider.spec.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.spec.ts
@@ -22,6 +22,7 @@ import { Event } from '@theia/core';
 import { expect } from 'chai';
 import { TaskConfiguration } from '@theia/task/src/common';
 import { ProcessTaskConfiguration } from '@theia/task/lib/common/process/task-protocol';
+import { TaskDefinitionRegistry } from '@theia/task/lib/browser';
 
 // The object under test.
 let taskProvider: CppTaskProvider;
@@ -67,6 +68,7 @@ beforeEach(function () {
     const container: Container = new Container();
     container.bind(CppTaskProvider).toSelf().inSingletonScope();
     container.bind(TaskResolverRegistry).toSelf().inSingletonScope();
+    container.bind(TaskDefinitionRegistry).toSelf().inSingletonScope();
     container.bind(CppBuildConfigurationManager).to(MockCppBuildConfigurationManager);
     taskProvider = container.get(CppTaskProvider);
 

--- a/packages/cpp/src/browser/cpp-task-provider.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.ts
@@ -15,11 +15,12 @@
  ********************************************************************************/
 
 import parseArgv = require('string-argv');
-import { inject, injectable } from 'inversify';
+import { inject, injectable, postConstruct } from 'inversify';
 import { ProcessTaskConfiguration } from '@theia/task/lib/common/process/task-protocol';
+import { TaskDefinitionRegistry } from '@theia/task/lib/browser';
 import { TaskContribution, TaskProvider, TaskProviderRegistry, TaskResolver, TaskResolverRegistry } from '@theia/task/lib/browser/task-contribution';
 import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
-import { ContributedTaskConfiguration, TaskConfiguration } from '@theia/task/lib/common/task-protocol';
+import { ContributedTaskConfiguration, TaskConfiguration, } from '@theia/task/lib/common/task-protocol';
 
 /**
  * Data required to define a C/C++ build task the user could run.
@@ -35,7 +36,13 @@ const CPP_BUILD_TASK_SOURCE: string = 'cpp';
 export class CppTaskProvider implements TaskContribution, TaskProvider, TaskResolver {
 
     @inject(TaskResolverRegistry) protected readonly taskResolverRegistry: TaskResolverRegistry;
+    @inject(TaskDefinitionRegistry) protected readonly taskDefinitionRegistry: TaskDefinitionRegistry;
     @inject(CppBuildConfigurationManager) protected readonly cppBuildConfigurationManager: CppBuildConfigurationManager;
+
+    @postConstruct()
+    protected init(): void {
+        this.registerTaskDefinition();
+    }
 
     registerProviders(registry: TaskProviderRegistry) {
         registry.register(CPP_BUILD_TASK_SOURCE, this);
@@ -107,5 +114,15 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
         }
 
         return taskConfigs;
+    }
+
+    private registerTaskDefinition(): void {
+        this.taskDefinitionRegistry.register({
+            taskType: CPP_BUILD_TASK_TYPE_KEY,
+            properties: {
+                required: ['label'],
+                all: ['label']
+            }
+        });
     }
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -22,6 +22,7 @@ import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { IJSONSchema, IJSONSchemaSnippet } from '@theia/core/lib/common/json-schema';
 import { RecursivePartial } from '@theia/core/lib/common/types';
 import { PreferenceSchema, PreferenceSchemaProperties } from '@theia/core/lib/common/preferences/preference-schema';
+import { ProblemMatcherContribution, ProblemPatternContribution, TaskDefinition } from '@theia/task/lib/common';
 
 export const hostedServicePath = '/services/hostedPlugin';
 
@@ -72,6 +73,9 @@ export interface PluginPackageContribution {
     keybindings?: PluginPackageKeybinding[];
     debuggers?: PluginPackageDebuggersContribution[];
     snippets: PluginPackageSnippetsContribution[];
+    taskDefinitions?: PluginTaskDefinitionContribution[];
+    problemMatchers?: PluginProblemMatcherContribution[];
+    problemPatterns?: PluginProblemPatternContribution[];
 }
 
 export interface PluginPackageViewContainer {
@@ -173,6 +177,27 @@ export interface PluginPackageLanguageContributionConfiguration {
     wordPattern?: string;
     indentationRules?: IndentationRules;
     folding?: FoldingRules;
+}
+
+export interface PluginTaskDefinitionContribution {
+    type: string;
+    required: string[];
+    properties: {
+        [name: string]: {
+            type: string;
+            description?: string;
+            // tslint:disable-next-line:no-any
+            [additionalProperty: string]: any;
+        }
+    }
+}
+
+export interface PluginProblemMatcherContribution extends ProblemMatcherContribution {
+    name: string;
+}
+
+export interface PluginProblemPatternContribution extends ProblemPatternContribution {
+    name: string;
 }
 
 export const PluginScanner = Symbol('PluginScanner');
@@ -365,6 +390,9 @@ export interface PluginContribution {
     keybindings?: Keybinding[];
     debuggers?: DebuggerContribution[];
     snippets?: SnippetContribution[];
+    taskDefinitions?: TaskDefinition[];
+    problemMatchers?: ProblemMatcherContribution[];
+    problemPatterns?: ProblemPatternContribution[];
 }
 
 export interface SnippetContribution {

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -28,6 +28,7 @@ import { PluginSharedStyle } from './plugin-shared-style';
 import { CommandRegistry, Command, CommandHandler } from '@theia/core/lib/common/command';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { Emitter } from '@theia/core/lib/common/event';
+import { TaskDefinitionRegistry, ProblemMatcherRegistry, ProblemPatternRegistry } from '@theia/task/lib/browser';
 
 @injectable()
 export class PluginContributionHandler {
@@ -60,6 +61,15 @@ export class PluginContributionHandler {
 
     @inject(PluginSharedStyle)
     protected readonly style: PluginSharedStyle;
+
+    @inject(TaskDefinitionRegistry)
+    protected readonly taskDefinitionRegistry: TaskDefinitionRegistry;
+
+    @inject(ProblemMatcherRegistry)
+    protected readonly problemMatcherRegistry: ProblemMatcherRegistry;
+
+    @inject(ProblemPatternRegistry)
+    protected readonly problemPatternRegistry: ProblemPatternRegistry;
 
     protected readonly commandHandlers = new Map<string, CommandHandler['execute'] | undefined>();
 
@@ -155,6 +165,18 @@ export class PluginContributionHandler {
                     source: snippet.source
                 });
             }
+        }
+
+        if (contributions.taskDefinitions) {
+            contributions.taskDefinitions.forEach(def => this.taskDefinitionRegistry.register(def));
+        }
+
+        if (contributions.problemPatterns) {
+            contributions.problemPatterns.forEach(pattern => this.problemPatternRegistry.register(pattern));
+        }
+
+        if (contributions.problemMatchers) {
+            contributions.problemMatchers.forEach(matcher => this.problemMatcherRegistry.register(matcher));
         }
     }
 

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1733,12 +1733,14 @@ export class Task {
         if (this.taskExecution instanceof ProcessExecution) {
             Object.assign(this.taskDefinition, {
                 type: 'process',
-                id: this.taskExecution.computeId()
+                id: this.taskExecution.computeId(),
+                taskType: this.taskDefinition!.type
             });
         } else if (this.taskExecution instanceof ShellExecution) {
             Object.assign(this.taskDefinition, {
                 type: 'shell',
-                id: this.taskExecution.computeId()
+                id: this.taskExecution.computeId(),
+                taskType: this.taskDefinition!.type
             });
         }
     }

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -11,7 +11,8 @@
     "@theia/terminal": "^0.8.0",
     "@theia/variable-resolver": "^0.8.0",
     "@theia/workspace": "^0.8.0",
-    "jsonc-parser": "^2.0.2"
+    "jsonc-parser": "^2.0.2",
+    "vscode-uri": "^1.0.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -20,8 +20,9 @@ import {
     QuickOpenGroupItem, QuickOpenMode, QuickOpenHandler, QuickOpenOptions, QuickOpenActionProvider, QuickOpenGroupItemOptions
 } from '@theia/core/lib/browser/quick-open/';
 import { TaskService } from './task-service';
-import { ContributedTaskConfiguration, TaskInfo, TaskConfiguration } from '../common/task-protocol';
+import { TaskInfo, TaskConfiguration } from '../common/task-protocol';
 import { TaskConfigurations } from './task-configurations';
+import { TaskDefinitionRegistry } from './task-definition-registry';
 import URI from '@theia/core/lib/common/uri';
 import { TaskActionProvider } from './task-action-provider';
 import { LabelProvider } from '@theia/core/lib/browser';
@@ -59,6 +60,9 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
     @inject(TaskConfigurations)
     protected readonly taskConfigurations: TaskConfigurations;
 
+    @inject(TaskDefinitionRegistry)
+    protected readonly taskDefinitionRegistry: TaskDefinitionRegistry;
+
     /** Initialize this quick open model with the tasks. */
     async init(): Promise<void> {
         const recentTasks = this.taskService.recentTasks;
@@ -70,29 +74,38 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
         const isMulti = stat ? !stat.isDirectory : false;
         this.items = [];
         this.items.push(
-            ...filteredRecentTasks.map((task, index) =>
-                new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
+            ...filteredRecentTasks.map((task, index) => {
+                const item = new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
                     groupLabel: index === 0 ? 'recently used tasks' : undefined,
                     showBorder: false
-                })),
-            ...filteredConfiguredTasks.map((task, index) =>
-                new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
+                });
+                item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
+                return item;
+            }),
+            ...filteredConfiguredTasks.map((task, index) => {
+                const item = new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
                     groupLabel: index === 0 ? 'configured tasks' : undefined,
                     showBorder: (
                         filteredRecentTasks.length <= 0
                             ? false
                             : index === 0 ? true : false
                     )
-                })),
-            ...filteredProvidedTasks.map((task, index) =>
-                new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
+                });
+                item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
+                return item;
+            }),
+            ...filteredProvidedTasks.map((task, index) => {
+                const item = new TaskRunQuickOpenItem(task, this.taskService, isMulti, {
                     groupLabel: index === 0 ? 'detected tasks' : undefined,
                     showBorder: (
                         filteredRecentTasks.length <= 0 && filteredConfiguredTasks.length <= 0
                             ? false
                             : index === 0 ? true : false
                     )
-                }))
+                });
+                item['taskDefinitionRegistry'] = this.taskDefinitionRegistry;
+                return item;
+            })
         );
 
         this.actionProvider = this.items.length ? this.taskActionProvider : undefined;
@@ -222,6 +235,8 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
 export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
 
+    protected taskDefinitionRegistry: TaskDefinitionRegistry;
+
     constructor(
         protected readonly task: TaskConfiguration,
         protected taskService: TaskService,
@@ -236,7 +251,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
     }
 
     getLabel(): string {
-        if (ContributedTaskConfiguration.is(this.task)) {
+        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
             return `${this.task._source}: ${this.task.label}`;
         }
         return `${this.task.type}: ${this.task.label}`;
@@ -250,7 +265,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         if (!this.isMulti) {
             return '';
         }
-        if (ContributedTaskConfiguration.is(this.task)) {
+        if (this.taskDefinitionRegistry && !!this.taskDefinitionRegistry.getDefinition(this.task)) {
             if (this.task._scope) {
                 return new URI(this.task._scope).displayName;
             }
@@ -266,12 +281,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
             return false;
         }
 
-        if (ContributedTaskConfiguration.is(this.task)) {
-            this.taskService.run(this.task._source, this.task.label);
-        } else {
-            this.taskService.runConfiguredTask(this.task._source, this.task.label);
-        }
-
+        this.taskService.run(this.task._source, this.task.label);
         return true;
     }
 }

--- a/packages/task/src/browser/task-definition-registry.spec.ts
+++ b/packages/task/src/browser/task-definition-registry.spec.ts
@@ -1,0 +1,89 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+
+// tslint:disable:no-unused-expression
+describe('TaskDefinitionRegistry', () => {
+    let registry: TaskDefinitionRegistry;
+    const definitonContributionA = {
+        taskType: 'extA',
+        required: ['extensionType'],
+        properties: {
+            required: ['extensionType'],
+            all: ['extensionType', 'taskLabel']
+        }
+    };
+    const definitonContributionB = {
+        taskType: 'extA',
+        properties: {
+            required: ['extensionType', 'taskLabel', 'taskDetailedLabel'],
+            all: ['extensionType', 'taskLabel', 'taskDetailedLabel']
+        }
+    };
+
+    beforeEach(() => {
+        registry = new TaskDefinitionRegistry();
+    });
+
+    describe('register function', () => {
+        it('should transform the task definition contribution and store it in memory', () => {
+            registry.register(definitonContributionA);
+            expect(registry['definitions'].get(definitonContributionA.taskType)).to.be.ok;
+            expect(registry['definitions'].get(definitonContributionA.taskType)![0]).to.deep.equal(definitonContributionA);
+        });
+    });
+
+    describe('getDefinitions function', () => {
+        it('should return all definitions associated with the given type', () => {
+            registry.register(definitonContributionA);
+            const defs1 = registry.getDefinitions(definitonContributionA.taskType);
+            expect(defs1.length).to.eq(1);
+
+            registry.register(definitonContributionB);
+            const defs2 = registry.getDefinitions(definitonContributionA.taskType);
+            expect(defs2.length).to.eq(2);
+        });
+    });
+
+    describe('getDefinition function', () => {
+        it('should return undefined if the given task configuration does not match any registered definitions', () => {
+            registry.register(definitonContributionA);
+            registry.register(definitonContributionB);
+            const defs = registry.getDefinition({
+                type: definitonContributionA.taskType, label: 'grunt task', task: 'build'
+            });
+            expect(defs).to.be.not.ok;
+        });
+
+        it('should return the best match if there is one or more registered definitions match the given task configuration', () => {
+            registry.register(definitonContributionA);
+            registry.register(definitonContributionB);
+            const defs = registry.getDefinition({
+                type: definitonContributionA.taskType, label: 'extention task', extensionType: 'extensionType', taskLabel: 'taskLabel'
+            });
+            expect(defs).to.be.ok;
+            expect(defs!.taskType).to.be.eq(definitonContributionA.taskType);
+
+            const defs2 = registry.getDefinition({
+                type: definitonContributionA.taskType, label: 'extention task', extensionType: 'extensionType', taskLabel: 'taskLabel', taskDetailedLabel: 'taskDetailedLabel'
+            });
+            expect(defs2).to.be.ok;
+            expect(defs2!.taskType).to.be.eq(definitonContributionB.taskType);
+        });
+    });
+});

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { TaskDefinition, TaskConfiguration } from '../common';
+
+@injectable()
+export class TaskDefinitionRegistry {
+
+    // task type - array of task definitions
+    private definitions: Map<string, TaskDefinition[]> = new Map();
+
+    /**
+     * Finds the task definition(s) from the registry with the given `taskType`.
+     *
+     * @param taskType the type of the task
+     * @return an array of the task definitions. If no task definitions are found, an empty array is returned.
+     */
+    getDefinitions(taskType: string): TaskDefinition[] {
+        return this.definitions.get(taskType) || [];
+    }
+
+    /**
+     * Finds the task definition from the registry for the task configuration.
+     * The task configuration is considered as a "match" to the task definition if it has all the `required` properties.
+     * In case that more than one task definition is found, return the one that has the biggest number of matched properties.
+     *
+     * @param taskConfiguration the task configuration
+     * @return the task definition for the task configuration. If the task definition is not found, `undefined` is returned.
+     */
+    getDefinition(taskConfiguration: TaskConfiguration): TaskDefinition | undefined {
+        const definitions = this.getDefinitions(taskConfiguration.taskType || taskConfiguration.type);
+        let matchedDefinition: TaskDefinition | undefined;
+        let highest = -1;
+        for (const def of definitions) {
+            let score = 0;
+            if (!def.properties.required.every(requiredProp => taskConfiguration[requiredProp] !== undefined)) {
+                continue;
+            }
+            score += def.properties.required.length; // number of required properties
+            const requiredProps = new Set(def.properties.required);
+            // number of optional properties
+            score += def.properties.all.filter(p => !requiredProps.has(p) && taskConfiguration[p] !== undefined).length;
+            if (score > highest) {
+                highest = score;
+                matchedDefinition = def;
+            }
+        }
+        return matchedDefinition;
+    }
+
+    /**
+     * Add a task definition to the registry.
+     *
+     * @param definition the task definition to be added.
+     */
+    register(definition: TaskDefinition): void {
+        const taskType = definition.taskType;
+        this.definitions.set(taskType, [...this.getDefinitions(taskType), definition]);
+    }
+}

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -30,6 +30,9 @@ import { TaskWatcher } from '../common/task-watcher';
 import { bindProcessTaskModule } from './process/process-task-frontend-module';
 import { TaskSchemaUpdater } from './task-schema-updater';
 import { TaskActionProvider, ConfigureTaskAction } from './task-action-provider';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+import { ProblemMatcherRegistry } from './task-problem-matcher-registry';
+import { ProblemPatternRegistry } from './task-problem-pattern-registry';
 import '../../src/browser/style/index.css';
 import './tasks-monaco-contribution';
 
@@ -54,6 +57,10 @@ export default new ContainerModule(bind => {
         const taskWatcher = ctx.container.get(TaskWatcher);
         return connection.createProxy<TaskServer>(taskPath, taskWatcher.getTaskClient());
     }).inSingletonScope();
+
+    bind(TaskDefinitionRegistry).toSelf().inSingletonScope();
+    bind(ProblemMatcherRegistry).toSelf().inSingletonScope();
+    bind(ProblemPatternRegistry).toSelf().inSingletonScope();
 
     createCommonBindings(bind);
 

--- a/packages/task/src/browser/task-problem-matcher-registry.ts
+++ b/packages/task/src/browser/task-problem-matcher-registry.ts
@@ -1,0 +1,235 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { inject, injectable, postConstruct } from 'inversify';
+import {
+    ApplyToKind, FileLocationKind, NamedProblemMatcher, Severity,
+    ProblemPattern, ProblemMatcher, ProblemMatcherContribution, WatchingMatcher
+} from '../common';
+import { ProblemPatternRegistry } from './task-problem-pattern-registry';
+
+@injectable()
+export class ProblemMatcherRegistry {
+
+    private matchers: { [name: string]: NamedProblemMatcher };
+    private readyPromise: Promise<void>;
+
+    @inject(ProblemPatternRegistry)
+    protected readonly problemPatternRegistry: ProblemPatternRegistry;
+
+    @postConstruct()
+    protected init() {
+        // tslint:disable-next-line:no-null-keyword
+        this.matchers = Object.create(null);
+        this.problemPatternRegistry.onReady().then(() => {
+            this.fillDefaults();
+            this.readyPromise = new Promise<void>((res, rej) => res(undefined));
+        });
+    }
+
+    onReady(): Promise<void> {
+        return this.readyPromise;
+    }
+
+    /**
+     * Add a problem matcher to the registry.
+     *
+     * @param definition the problem matcher to be added.
+     */
+    async register(matcher: ProblemMatcherContribution): Promise<void> {
+        if (!matcher.name) {
+            console.error('Only named Problem Matchers can be registered.');
+            return;
+        }
+        const problemMatcher = await this.getProblemMatcherFromContribution(matcher);
+        this.add(problemMatcher as NamedProblemMatcher);
+    }
+
+    /**
+     * Finds the problem matcher from the registry by its name.
+     *
+     * @param name the name of the problem matcher
+     * @return the problem matcher. If the task definition is not found, `undefined` is returned.
+     */
+    get(name: string): NamedProblemMatcher | undefined {
+        if (name.startsWith('$')) {
+            return this.matchers[name.slice(1)];
+        }
+        return this.matchers[name];
+    }
+
+    /**
+     * Transforms the `ProblemMatcherContribution` to a `ProblemMatcher`
+     *
+     * @return the problem matcher
+     */
+    async getProblemMatcherFromContribution(matcher: ProblemMatcherContribution): Promise<ProblemMatcher> {
+        const { fileLocation, filePrefix } = this.getFileLocationKindAndPrefix(matcher);
+        const patterns: ProblemPattern[] = [];
+        if (matcher.pattern) {
+            if (typeof matcher.pattern === 'string') {
+                await this.problemPatternRegistry.onReady();
+                const registeredPattern = this.problemPatternRegistry.get(matcher.pattern);
+                if (Array.isArray(registeredPattern)) {
+                    patterns.push(...registeredPattern);
+                } else if (!!registeredPattern) {
+                    patterns.push(registeredPattern);
+                }
+            } else if (Array.isArray(matcher.pattern)) {
+                patterns.push(...matcher.pattern.map(p => ProblemPattern.fromProblemPatternContribution(p)));
+            } else {
+                patterns.push(ProblemPattern.fromProblemPatternContribution(matcher.pattern));
+            }
+        }
+        const problemMatcher = {
+            name: matcher.name,
+            label: matcher.label,
+            deprecated: matcher.deprecated,
+            owner: matcher.owner,
+            source: matcher.source,
+            applyTo: ApplyToKind.fromString(matcher.applyTo) || ApplyToKind.allDocuments,
+            fileLocation,
+            filePrefix,
+            pattern: patterns,
+            severity: Severity.fromValue(matcher.severity),
+            watching: WatchingMatcher.fromWatchingMatcherContribution(matcher.background || matcher.watching)
+        };
+        return problemMatcher;
+    }
+
+    private add(matcher: NamedProblemMatcher): void {
+        this.matchers[matcher.name] = matcher;
+    }
+
+    private getFileLocationKindAndPrefix(matcher: ProblemMatcherContribution): { fileLocation: FileLocationKind, filePrefix: string } {
+        let fileLocation = FileLocationKind.Relative;
+        let filePrefix = '${workspaceFolder}';
+        if (matcher.fileLocation !== undefined) {
+            if (Array.isArray(matcher.fileLocation)) {
+                if (matcher.fileLocation.length > 0) {
+                    const locationKind = FileLocationKind.fromString(matcher.fileLocation[0]);
+                    if (matcher.fileLocation.length === 1 && locationKind === FileLocationKind.Absolute) {
+                        fileLocation = locationKind;
+                    } else if (matcher.fileLocation.length === 2 && locationKind === FileLocationKind.Relative && matcher.fileLocation[1]) {
+                        fileLocation = locationKind;
+                        filePrefix = matcher.fileLocation[1];
+                    }
+                }
+            } else {
+                const locationKind = FileLocationKind.fromString(matcher.fileLocation);
+                if (locationKind) {
+                    fileLocation = locationKind;
+                    if (locationKind === FileLocationKind.Relative) {
+                        filePrefix = '${workspaceFolder}';
+                    }
+                }
+            }
+        }
+        return { fileLocation, filePrefix };
+    }
+
+    // copied from https://github.com/Microsoft/vscode/blob/1.33.1/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+    private fillDefaults(): void {
+        this.add({
+            name: 'msCompile',
+            label: 'Microsoft compiler problems',
+            owner: 'msCompile',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            pattern: (this.problemPatternRegistry.get('msCompile'))!
+        });
+
+        this.add({
+            name: 'lessCompile',
+            label: 'Less problems',
+            deprecated: true,
+            owner: 'lessCompile',
+            source: 'less',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            pattern: (this.problemPatternRegistry.get('lessCompile'))!,
+            severity: Severity.Error
+        });
+
+        this.add({
+            name: 'gulp-tsc',
+            label: 'Gulp TSC Problems',
+            owner: 'typescript',
+            source: 'ts',
+            applyTo: ApplyToKind.closedDocuments,
+            fileLocation: FileLocationKind.Relative,
+            filePrefix: '${workspaceFolder}',
+            pattern: (this.problemPatternRegistry.get('gulp-tsc'))!
+        });
+
+        this.add({
+            name: 'jshint',
+            label: 'JSHint problems',
+            owner: 'jshint',
+            source: 'jshint',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            pattern: (this.problemPatternRegistry.get('jshint'))!
+        });
+
+        this.add({
+            name: 'jshint-stylish',
+            label: 'JSHint stylish problems',
+            owner: 'jshint',
+            source: 'jshint',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            pattern: (this.problemPatternRegistry.get('jshint-stylish'))!
+        });
+
+        this.add({
+            name: 'eslint-compact',
+            label: 'ESLint compact problems',
+            owner: 'eslint',
+            source: 'eslint',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            filePrefix: '${workspaceFolder}',
+            pattern: (this.problemPatternRegistry.get('eslint-compact'))!
+        });
+
+        this.add({
+            name: 'eslint-stylish',
+            label: 'ESLint stylish problems',
+            owner: 'eslint',
+            source: 'eslint',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Absolute,
+            pattern: (this.problemPatternRegistry.get('eslint-stylish'))!
+        });
+
+        this.add({
+            name: 'go',
+            label: 'Go problems',
+            owner: 'go',
+            source: 'go',
+            applyTo: ApplyToKind.allDocuments,
+            fileLocation: FileLocationKind.Relative,
+            filePrefix: '${workspaceFolder}',
+            pattern: (this.problemPatternRegistry.get('go'))!
+        });
+    }
+}

--- a/packages/task/src/browser/task-problem-pattern-registry.ts
+++ b/packages/task/src/browser/task-problem-pattern-registry.ts
@@ -1,0 +1,194 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { injectable, postConstruct } from 'inversify';
+import { NamedProblemPattern, ProblemLocationKind, ProblemPattern, ProblemPatternContribution } from '../common';
+
+@injectable()
+export class ProblemPatternRegistry {
+    private patterns: { [name: string]: NamedProblemPattern | NamedProblemPattern[] };
+    private readyPromise: Promise<void>;
+
+    @postConstruct()
+    protected init() {
+        // tslint:disable-next-line:no-null-keyword
+        this.patterns = Object.create(null);
+        this.fillDefaults();
+        this.readyPromise = new Promise<void>((res, rej) => res(undefined));
+    }
+
+    onReady(): Promise<void> {
+        return this.readyPromise;
+    }
+
+    /**
+     * Add a problem pattern to the registry.
+     *
+     * @param definition the problem pattern to be added.
+     */
+    register(value: ProblemPatternContribution | ProblemPatternContribution[]): void {
+        if (Array.isArray(value)) {
+            value.forEach(problemPatternContribution => this.register(problemPatternContribution));
+        } else {
+            if (!value.name) {
+                console.error('Only named Problem Patterns can be registered.');
+                return;
+            }
+            const problemPattern = ProblemPattern.fromProblemPatternContribution(value);
+            this.add(problemPattern.name!, problemPattern);
+        }
+    }
+
+    /**
+     * Finds the problem pattern(s) from the registry with the given name.
+     *
+     * @param key the name of the problem patterns
+     * @return a problem pattern or an array of the problem patterns associated with the name. If no problem patterns are found, `undefined` is returned.
+     */
+    get(key: string): undefined | NamedProblemPattern | NamedProblemPattern[] {
+        return this.patterns[key];
+    }
+
+    private add(key: string, value: ProblemPattern | ProblemPattern[]): void {
+        let toAdd: NamedProblemPattern | NamedProblemPattern[];
+        if (Array.isArray(value)) {
+            toAdd = value.map(v => Object.assign(v, { name: key }));
+        } else {
+            toAdd = Object.assign(value, { name: key });
+        }
+        this.patterns[key] = toAdd;
+    }
+
+    // copied from https://github.com/Microsoft/vscode/blob/1.33.1/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+    private fillDefaults(): void {
+        this.add('msCompile', {
+            regexp: /^(?:\s+\d+\>)?([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\)\s*:\s+(error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            location: 2,
+            severity: 3,
+            code: 4,
+            message: 5
+        });
+        this.add('gulp-tsc', {
+            regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(\d+)\s+(.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            location: 2,
+            code: 3,
+            message: 4
+        });
+        this.add('cpp', {
+            regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(C\d+)\s*:\s*(.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            location: 2,
+            severity: 3,
+            code: 4,
+            message: 5
+        });
+        this.add('csc', {
+            regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(CS\d+)\s*:\s*(.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            location: 2,
+            severity: 3,
+            code: 4,
+            message: 5
+        });
+        this.add('vb', {
+            regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(BC\d+)\s*:\s*(.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            location: 2,
+            severity: 3,
+            code: 4,
+            message: 5
+        });
+        this.add('lessCompile', {
+            regexp: /^\s*(.*) in file (.*) line no. (\d+)$/.source,
+            kind: ProblemLocationKind.Location,
+            message: 1,
+            file: 2,
+            line: 3
+        });
+        this.add('jshint', {
+            regexp: /^(.*):\s+line\s+(\d+),\s+col\s+(\d+),\s(.+?)(?:\s+\((\w)(\d+)\))?$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1,
+            line: 2,
+            character: 3,
+            message: 4,
+            severity: 5,
+            code: 6
+        });
+        this.add('jshint-stylish', [
+            {
+                regexp: /^(.+)$/.source,
+                kind: ProblemLocationKind.Location,
+                file: 1
+            },
+            {
+                regexp: /^\s+line\s+(\d+)\s+col\s+(\d+)\s+(.+?)(?:\s+\((\w)(\d+)\))?$/.source,
+                line: 1,
+                character: 2,
+                message: 3,
+                severity: 4,
+                code: 5,
+                loop: true
+            }
+        ]);
+        this.add('eslint-compact', {
+            regexp: /^(.+):\sline\s(\d+),\scol\s(\d+),\s(Error|Warning|Info)\s-\s(.+)\s\((.+)\)$/.source,
+            file: 1,
+            kind: ProblemLocationKind.Location,
+            line: 2,
+            character: 3,
+            severity: 4,
+            message: 5,
+            code: 6
+        });
+        this.add('eslint-stylish', [
+            {
+                regexp: /^([^\s].*)$/.source,
+                kind: ProblemLocationKind.Location,
+                file: 1
+            },
+            {
+                regexp: /^\s+(\d+):(\d+)\s+(error|warning|info)\s+(.+?)(?:\s\s+(.*))?$/.source,
+                line: 1,
+                character: 2,
+                severity: 3,
+                message: 4,
+                code: 5,
+                loop: true
+            }
+        ]);
+        this.add('go', {
+            regexp: /^([^:]*: )?((.:)?[^:]*):(\d+)(:(\d+))?: (.*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 2,
+            line: 4,
+            character: 6,
+            message: 7
+        });
+    }
+}

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -112,7 +112,7 @@ const taskConfigurationSchema: IJSONSchema = {
             allOf: [
                 {
                     type: 'object',
-                    required: ['type', 'label'],
+                    required: ['type'],
                     properties: {
                         label: {
                             type: 'string',
@@ -153,6 +153,21 @@ const taskConfigurationSchema: IJSONSchema = {
                                 args: commandArgSchema,
                                 options: commandOptionsSchema
                             }
+                        },
+                        problemMatcher: {
+                            oneOf: [
+                                {
+                                    type: 'object',
+                                    description: 'User defined problem matcher(s) to parse the output of the task',
+                                },
+                                {
+                                    type: 'array',
+                                    description: 'Name(s) of the problem matcher(s) to parse the output of the task',
+                                    items: {
+                                        type: 'string'
+                                    }
+                                }
+                            ]
                         }
                     }
                 }

--- a/packages/task/src/common/index.ts
+++ b/packages/task/src/common/index.ts
@@ -16,3 +16,4 @@
 
 export * from './task-protocol';
 export * from './task-watcher';
+export * from './problem-matcher-protocol';

--- a/packages/task/src/common/problem-matcher-protocol.ts
+++ b/packages/task/src/common/problem-matcher-protocol.ts
@@ -1,0 +1,241 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// This file is inspired by VSCode https://github.com/Microsoft/vscode/blob/1.33.1/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+// 'problemMatcher.ts' copyright:
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver-types';
+import vscodeURI from 'vscode-uri/lib/umd';
+import { ProblemPatternContribution, WatchingMatcherContribution } from './task-protocol';
+
+export enum ApplyToKind {
+    allDocuments,
+    openDocuments,
+    closedDocuments
+}
+
+export namespace ApplyToKind {
+    export function fromString(value: string | undefined): ApplyToKind | undefined {
+        if (value) {
+            value = value.toLowerCase();
+            if (value === 'alldocuments') {
+                return ApplyToKind.allDocuments;
+            } else if (value === 'opendocuments') {
+                return ApplyToKind.openDocuments;
+            } else if (value === 'closeddocuments') {
+                return ApplyToKind.closedDocuments;
+            }
+        }
+        return undefined;
+    }
+}
+
+export enum FileLocationKind {
+    Auto,
+    Relative,
+    Absolute
+}
+
+export namespace FileLocationKind {
+    export function fromString(value: string): FileLocationKind | undefined {
+        value = value.toLowerCase();
+        if (value === 'absolute') {
+            return FileLocationKind.Absolute;
+        } else if (value === 'relative') {
+            return FileLocationKind.Relative;
+        } else {
+            return undefined;
+        }
+    }
+}
+
+export enum Severity {
+    Ignore = 0,
+    Info = 1,
+    Warning = 2,
+    Error = 3
+}
+
+export namespace Severity {
+
+    const _error = 'error';
+    const _warning = 'warning';
+    const _warn = 'warn';
+    const _info = 'info';
+
+    // Parses 'error', 'warning', 'warn', 'info' in call casings and falls back to ignore.
+    export function fromValue(value: string | undefined): Severity {
+        if (!value) {
+            return Severity.Ignore;
+        }
+
+        if (value.toLowerCase() === _error) {
+            return Severity.Error;
+        }
+
+        if (value.toLowerCase() === _warning || value.toLowerCase() === _warn) {
+            return Severity.Warning;
+        }
+
+        if (value.toLowerCase() === _info) {
+            return Severity.Info;
+        }
+        return Severity.Ignore;
+    }
+
+    export function toDiagnosticSeverity(value: Severity): DiagnosticSeverity {
+        switch (value) {
+            case Severity.Ignore:
+                return DiagnosticSeverity.Hint;
+            case Severity.Info:
+                return DiagnosticSeverity.Information;
+            case Severity.Warning:
+                return DiagnosticSeverity.Warning;
+            case Severity.Error:
+                return DiagnosticSeverity.Error;
+            default:
+                return DiagnosticSeverity.Error;
+        }
+    }
+}
+
+export interface WatchingPattern {
+    regexp: string;
+    file?: number;
+}
+
+export interface WatchingMatcher {
+    // If set to true the background monitor is in active mode when the task starts.
+    // This is equals of issuing a line that matches the beginPattern
+    activeOnStart: boolean;
+    beginsPattern: WatchingPattern;
+    endsPattern: WatchingPattern;
+}
+export namespace WatchingMatcher {
+    export function fromWatchingMatcherContribution(value: WatchingMatcherContribution | undefined): WatchingMatcher | undefined {
+        if (!value) {
+            return undefined;
+        }
+        return {
+            activeOnStart: !!value.activeOnStart,
+            beginsPattern: typeof value.beginsPattern === 'string' ? { regexp: value.beginsPattern } : value.beginsPattern,
+            endsPattern: typeof value.endsPattern === 'string' ? { regexp: value.endsPattern } : value.endsPattern
+        };
+    }
+}
+
+export enum ProblemLocationKind {
+    File,
+    Location
+}
+
+export namespace ProblemLocationKind {
+    export function fromString(value: string): ProblemLocationKind | undefined {
+        value = value.toLowerCase();
+        if (value === 'file') {
+            return ProblemLocationKind.File;
+        } else if (value === 'location') {
+            return ProblemLocationKind.Location;
+        } else {
+            return undefined;
+        }
+    }
+}
+
+export interface ProblemMatcher {
+    deprecated?: boolean;
+
+    owner: string;
+    source?: string;
+    applyTo: ApplyToKind;
+    fileLocation: FileLocationKind;
+    filePrefix?: string;
+    pattern: ProblemPattern | ProblemPattern[];
+    severity?: Severity;
+    watching?: WatchingMatcher;
+    uriProvider?: (path: string) => vscodeURI;
+}
+
+export interface NamedProblemMatcher extends ProblemMatcher {
+    name: string;
+    label: string;
+}
+
+export namespace ProblemMatcher {
+    export function isWatchModeWatcher(matcher: ProblemMatcher): boolean {
+        return !!matcher.watching;
+    }
+}
+
+export interface ProblemPattern {
+    name?: string;
+
+    regexp: string;
+
+    kind?: ProblemLocationKind;
+    file?: number;
+    message?: number;
+    location?: number;
+    line?: number;
+    character?: number;
+    endLine?: number;
+    endCharacter?: number;
+    code?: number;
+    severity?: number;
+    loop?: boolean;
+}
+
+export interface NamedProblemPattern extends ProblemPattern {
+    name: string;
+}
+
+export namespace ProblemPattern {
+    export function fromProblemPatternContribution(value: ProblemPatternContribution): ProblemPattern {
+        return {
+            name: value.name,
+            regexp: value.regexp,
+            kind: value.kind ? ProblemLocationKind.fromString(value.kind) : undefined,
+            file: value.file,
+            message: value.message,
+            location: value.location,
+            line: value.line,
+            character: value.character,
+            endLine: value.endLine,
+            endCharacter: value.endCharacter,
+            code: value.code,
+            severity: value.severity,
+            loop: value.loop
+        };
+    }
+}
+
+export interface ProblemMatch {
+    resource?: vscodeURI;
+    description: ProblemMatcher;
+}
+
+export interface ProblemMatchData extends ProblemMatch {
+    marker: Diagnostic;
+}
+export namespace ProblemMatchData {
+    export function is(data: ProblemMatch): data is ProblemMatchData {
+        return 'marker' in data;
+    }
+}

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -15,19 +15,23 @@
  ********************************************************************************/
 
 import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { ProblemMatcher, ProblemMatch, WatchingPattern } from './problem-matcher-protocol';
 
 export const taskPath = '/services/task';
 
 export const TaskServer = Symbol('TaskServer');
 export const TaskClient = Symbol('TaskClient');
 
-export interface TaskConfiguration {
+export interface TaskCustomization {
+    type: string;
+    problemMatcher?: string | ProblemMatcherContribution | (string | ProblemMatcherContribution)[];
+    // tslint:disable-next-line:no-any
+    [name: string]: any;
+}
+
+export interface TaskConfiguration extends TaskCustomization {
     /** A label that uniquely identifies a task configuration per source */
     readonly label: string;
-    readonly type: string;
-    /** Additional task type specific properties. */
-    // tslint:disable-next-line:no-any
-    readonly [key: string]: any;
 }
 export namespace TaskConfiguration {
     export function equals(one: TaskConfiguration, other: TaskConfiguration): boolean {
@@ -48,11 +52,6 @@ export interface ContributedTaskConfiguration extends TaskConfiguration {
      */
     readonly _scope: string | undefined;
 }
-export namespace ContributedTaskConfiguration {
-    export function is(config: TaskConfiguration | undefined): config is ContributedTaskConfiguration {
-        return !!config && '_source' in config && '_scope' in config;
-    }
-}
 
 /** Runtime information about Task. */
 export interface TaskInfo {
@@ -71,7 +70,7 @@ export interface TaskInfo {
 
 export interface TaskServer extends JsonRpcServer<TaskClient> {
     /** Run a task. Optionally pass a context.  */
-    run(task: TaskConfiguration, ctx?: string): Promise<TaskInfo>;
+    run(task: TaskConfiguration, ctx?: string, option?: RunTaskOption): Promise<TaskInfo>;
     /** Kill a task, by id. */
     kill(taskId: number): Promise<void>;
     /**
@@ -89,6 +88,17 @@ export interface TaskServer extends JsonRpcServer<TaskClient> {
 
 }
 
+export interface TaskCustomizationData {
+    type: string;
+    problemMatcher?: ProblemMatcher[];
+    // tslint:disable-next-line:no-any
+    [name: string]: any;
+}
+
+export interface RunTaskOption {
+    customization?: TaskCustomizationData;
+}
+
 /** Event sent when a task has concluded its execution */
 export interface TaskExitedEvent {
     readonly taskId: number;
@@ -101,9 +111,70 @@ export interface TaskExitedEvent {
     readonly config?: TaskConfiguration;
 }
 
+export interface TaskOutputEvent {
+    readonly taskId: number;
+    readonly ctx?: string;
+    readonly line: string;
+}
+
+export interface TaskOutputProcessedEvent {
+    readonly taskId: number;
+    readonly ctx?: string;
+    readonly problems?: ProblemMatch[];
+}
+
 export interface TaskClient {
     onTaskExit(event: TaskExitedEvent): void;
     onTaskCreated(event: TaskInfo): void;
     onDidStartTaskProcess(event: TaskInfo): void;
     onDidEndTaskProcess(event: TaskExitedEvent): void;
+    onDidProcessTaskOutput(event: TaskOutputProcessedEvent): void;
+}
+
+export interface TaskDefinition {
+    taskType: string;
+    properties: {
+        required: string[];
+        all: string[];
+    }
+}
+
+export interface WatchingMatcherContribution {
+    // If set to true the background monitor is in active mode when the task starts.
+    // This is equals of issuing a line that matches the beginPattern
+    activeOnStart?: boolean;
+    beginsPattern: string | WatchingPattern;
+    endsPattern: string | WatchingPattern;
+}
+
+export interface ProblemMatcherContribution {
+    name?: string;
+    label: string;
+    deprecated?: boolean;
+
+    owner: string;
+    source?: string;
+    applyTo?: string;
+    fileLocation?: 'absolute' | 'relative' | string[];
+    pattern: string | ProblemPatternContribution | ProblemPatternContribution[];
+    severity?: string;
+    watching?: WatchingMatcherContribution; // deprecated. Use `background`.
+    background?: WatchingMatcherContribution;
+}
+
+export interface ProblemPatternContribution {
+    name?: string;
+    regexp: string;
+
+    kind?: string;
+    file?: number;
+    message?: number;
+    location?: number;
+    line?: number;
+    character?: number;
+    endLine?: number;
+    endCharacter?: number;
+    code?: number;
+    severity?: number;
+    loop?: boolean;
 }

--- a/packages/task/src/common/task-watcher.ts
+++ b/packages/task/src/common/task-watcher.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from 'inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
-import { TaskClient, TaskExitedEvent, TaskInfo } from './task-protocol';
+import { TaskClient, TaskExitedEvent, TaskInfo, TaskOutputProcessedEvent } from './task-protocol';
 
 @injectable()
 export class TaskWatcher {
@@ -26,6 +26,7 @@ export class TaskWatcher {
         const exitEmitter = this.onTaskExitEmitter;
         const taskProcessStartedEmitter = this.onDidStartTaskProcessEmitter;
         const taskProcessEndedEmitter = this.onDidEndTaskProcessEmitter;
+        const outputProcessedEmitter = this.onOutputProcessedEmitter;
         return {
             onTaskCreated(event: TaskInfo) {
                 newTaskEmitter.fire(event);
@@ -38,6 +39,9 @@ export class TaskWatcher {
             },
             onDidEndTaskProcess(event: TaskExitedEvent) {
                 taskProcessEndedEmitter.fire(event);
+            },
+            onDidProcessTaskOutput(event: TaskOutputProcessedEvent) {
+                outputProcessedEmitter.fire(event);
             }
         };
     }
@@ -46,6 +50,7 @@ export class TaskWatcher {
     protected onTaskExitEmitter = new Emitter<TaskExitedEvent>();
     protected onDidStartTaskProcessEmitter = new Emitter<TaskInfo>();
     protected onDidEndTaskProcessEmitter = new Emitter<TaskExitedEvent>();
+    protected onOutputProcessedEmitter = new Emitter<TaskOutputProcessedEvent>();
 
     get onTaskCreated(): Event<TaskInfo> {
         return this.onTaskCreatedEmitter.event;
@@ -58,5 +63,8 @@ export class TaskWatcher {
     }
     get onDidEndTaskProcess(): Event<TaskExitedEvent> {
         return this.onDidEndTaskProcessEmitter.event;
+    }
+    get onOutputProcessed(): Event<TaskOutputProcessedEvent> {
+        return this.onOutputProcessedEmitter.event;
     }
 }

--- a/packages/task/src/node/process/process-task.spec.ts
+++ b/packages/task/src/node/process/process-task.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 Ericsson and others.
+ * Copyright (C) 2019 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-export * from './task-service';
-export * from './task-contribution';
-export * from './task-definition-registry';
-export * from './task-problem-matcher-registry';
-export * from './task-problem-pattern-registry';
+import { expect } from 'chai';
+import { removeAnsiEscapeCodes } from './process-task';
+
+describe('removeAnsiEscapeCodes function', () => {
+    it('should remove all end line and color codes', () => {
+        const str1 = '  [2m14:21[22m  [33mwarning[39m  Missing semicolon  [2msemi[22m\r';
+        let res = removeAnsiEscapeCodes(str1);
+        expect(res).to.eq('  14:21  warning  Missing semicolon  semi');
+
+        const str2 = '[37;40mnpm[0m [0m[31;40mERR![0m [0m[35mcode[0m ELIFECYCLE\r';
+        res = removeAnsiEscapeCodes(str2);
+        expect(res).to.eq('npm ERR! code ELIFECYCLE');
+    });
+});

--- a/packages/task/src/node/task-abstract-line-matcher.ts
+++ b/packages/task/src/node/task-abstract-line-matcher.ts
@@ -1,0 +1,315 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isWindows } from '@theia/core/lib/common/os';
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver-types';
+import {
+    FileLocationKind, ProblemMatcher, ProblemPattern,
+    ProblemMatch, ProblemMatchData, ProblemLocationKind, Severity
+} from '../common/problem-matcher-protocol';
+import URI from '@theia/core/lib/common/uri';
+import vscodeURI from 'vscode-uri/lib/umd';
+
+const endOfLine: string = isWindows ? '\r\n' : '\n';
+
+export interface ProblemData {
+    kind?: ProblemLocationKind;
+    file?: string;
+    location?: string;
+    line?: string;
+    character?: string;
+    endLine?: string;
+    endCharacter?: string;
+    message?: string;
+    severity?: string;
+    code?: string;
+}
+
+export abstract class AbstractLineMatcher {
+
+    protected patterns: ProblemPattern[] = [];
+    protected activePatternIndex: number = 0;
+    protected activePattern: ProblemPattern | undefined;
+    protected cachedProblemData: ProblemData;
+
+    constructor(
+        protected matcher: ProblemMatcher
+    ) {
+        if (Array.isArray(matcher.pattern)) {
+            this.patterns = matcher.pattern;
+        } else {
+            this.patterns = [matcher.pattern];
+        }
+        this.cachedProblemData = this.getEmptyProblemData();
+
+        if (this.patterns.slice(0, this.patternCount - 1).some(p => !!p.loop)) {
+            console.error('Problem Matcher: Only the last pattern can loop');
+        }
+    }
+
+    /**
+     * Finds the problem identified by this line matcher.
+     *
+     * @param line the line of text to find the problem from
+     * @return the identified problem. If the problem is not found, `undefined` is returned.
+     */
+    abstract match(line: string): ProblemMatch | undefined;
+
+    /**
+     * Number of problem patterns that the line matcher uses.
+     */
+    get patternCount() {
+        return this.patterns.length;
+    }
+
+    protected getEmptyProblemData(): ProblemData {
+        // tslint:disable-next-line:no-null-keyword
+        return Object.create(null) as ProblemData;
+    }
+
+    protected fillProblemData(data: ProblemData | null, pattern: ProblemPattern, matches: RegExpExecArray): data is ProblemData {
+        if (data) {
+            this.fillProperty(data, 'file', pattern, matches, true);
+            this.appendProperty(data, 'message', pattern, matches, true);
+            this.fillProperty(data, 'code', pattern, matches, true);
+            this.fillProperty(data, 'severity', pattern, matches, true);
+            this.fillProperty(data, 'location', pattern, matches, true);
+            this.fillProperty(data, 'line', pattern, matches);
+            this.fillProperty(data, 'character', pattern, matches);
+            this.fillProperty(data, 'endLine', pattern, matches);
+            this.fillProperty(data, 'endCharacter', pattern, matches);
+            return true;
+        }
+        return false;
+    }
+
+    private appendProperty(data: ProblemData, property: keyof ProblemData, pattern: ProblemPattern, matches: RegExpExecArray, trim: boolean = false): void {
+        const patternProperty = pattern[property];
+        if (data[property] === undefined) {
+            this.fillProperty(data, property, pattern, matches, trim);
+        } else if (patternProperty !== undefined && patternProperty < matches.length) {
+            let value = matches[patternProperty];
+            if (trim) {
+                value = value.trim();
+            }
+            data[property] += endOfLine + value;
+        }
+    }
+
+    private fillProperty(data: ProblemData, property: keyof ProblemData, pattern: ProblemPattern, matches: RegExpExecArray, trim: boolean = false): void {
+        const patternAtProperty = pattern[property];
+        if (data[property] === undefined && patternAtProperty !== undefined && patternAtProperty < matches.length) {
+            let value = matches[patternAtProperty];
+            if (value !== undefined) {
+                if (trim) {
+                    value = value.trim();
+                }
+                data[property] = value;
+            }
+        }
+    }
+
+    protected getMarkerMatch(data: ProblemData): ProblemMatch | undefined {
+        try {
+            const location = this.getLocation(data);
+            if (data.file && location && data.message) {
+                const marker: Diagnostic = {
+                    severity: this.getSeverity(data),
+                    range: location,
+                    message: data.message
+                };
+                if (data.code !== undefined) {
+                    marker.code = data.code;
+                }
+                if (this.matcher.source !== undefined) {
+                    marker.source = this.matcher.source;
+                }
+                return {
+                    description: this.matcher,
+                    resource: this.getResource(data.file, this.matcher),
+                    marker
+                } as ProblemMatchData;
+            }
+            return {
+                description: this.matcher
+            };
+        } catch (err) {
+            console.error(`Failed to convert problem data into match: ${JSON.stringify(data)}`);
+        }
+        return undefined;
+    }
+
+    private getLocation(data: ProblemData): Range | null {
+        if (data.kind === ProblemLocationKind.File) {
+            return this.createRange(0, 0, 0, 0);
+        }
+        if (data.location) {
+            return this.parseLocationInfo(data.location);
+        }
+        if (!data.line) {
+            // tslint:disable-next-line:no-null-keyword
+            return null;
+        }
+        const startLine = parseInt(data.line);
+        const startColumn = data.character ? parseInt(data.character) : undefined;
+        const endLine = data.endLine ? parseInt(data.endLine) : undefined;
+        const endColumn = data.endCharacter ? parseInt(data.endCharacter) : undefined;
+        return this.createRange(startLine, startColumn, endLine, endColumn);
+    }
+
+    private parseLocationInfo(value: string): Range | null {
+        if (!value || !value.match(/(\d+|\d+,\d+|\d+,\d+,\d+,\d+)/)) {
+            // tslint:disable-next-line:no-null-keyword
+            return null;
+        }
+        const parts = value.split(',');
+        const startLine = parseInt(parts[0]);
+        const startColumn = parts.length > 1 ? parseInt(parts[1]) : undefined;
+        if (parts.length > 3) {
+            return this.createRange(startLine, startColumn, parseInt(parts[2]), parseInt(parts[3]));
+        } else {
+            return this.createRange(startLine, startColumn, undefined, undefined);
+        }
+    }
+
+    private createRange(startLine: number, startColumn: number | undefined, endLine: number | undefined, endColumn: number | undefined): Range {
+        let range: Range;
+        if (startColumn !== undefined) {
+            if (endColumn !== undefined) {
+                range = Range.create(startLine, startColumn, endLine || startLine, endColumn);
+            } else {
+                range = Range.create(startLine, startColumn, startLine, startColumn);
+            }
+        } else {
+            range = Range.create(startLine, 1, startLine, Number.MAX_VALUE);
+        }
+
+        // range indexes should be zero-based
+        return Range.create(
+            this.getZeroBasedRangeIndex(range.start.line),
+            this.getZeroBasedRangeIndex(range.start.character),
+            this.getZeroBasedRangeIndex(range.end.line),
+            this.getZeroBasedRangeIndex(range.end.character)
+        );
+    }
+
+    private getZeroBasedRangeIndex(ind: number): number {
+        return ind === 0 ? ind : ind - 1;
+    }
+
+    private getSeverity(data: ProblemData): DiagnosticSeverity {
+        // tslint:disable-next-line:no-null-keyword
+        let result: Severity | null = null;
+        if (data.severity) {
+            const value = data.severity;
+            if (value) {
+                result = Severity.fromValue(value);
+                if (result === Severity.Ignore) {
+                    if (value === 'E') {
+                        result = Severity.Error;
+                    } else if (value === 'W') {
+                        result = Severity.Warning;
+                    } else if (value === 'I') {
+                        result = Severity.Info;
+                    } else if (value.toLowerCase() === 'hint') {
+                        result = Severity.Info;
+                    } else if (value.toLowerCase() === 'note') {
+                        result = Severity.Info;
+                    }
+                }
+            }
+        }
+        if (result === null || result === Severity.Ignore) {
+            result = this.matcher.severity || Severity.Error;
+        }
+        return Severity.toDiagnosticSeverity(result);
+    }
+
+    private getResource(filename: string, matcher: ProblemMatcher): vscodeURI {
+        const kind = matcher.fileLocation;
+        let fullPath: string | undefined;
+        if (kind === FileLocationKind.Absolute) {
+            fullPath = filename;
+        } else if ((kind === FileLocationKind.Relative) && matcher.filePrefix) {
+            let relativeFileName = filename.replace(/\\/g, '/');
+            if (relativeFileName.startsWith('./')) {
+                relativeFileName = relativeFileName.slice(2);
+            }
+            fullPath = new URI(matcher.filePrefix).resolve(relativeFileName).path.toString();
+        }
+        if (fullPath === undefined) {
+            throw new Error('FileLocationKind is not actionable. Does the matcher have a filePrefix? This should never happen.');
+        }
+        fullPath = fullPath.replace(/\\/g, '/');
+        if (fullPath[0] !== '/') {
+            fullPath = '/' + fullPath;
+        }
+        if (matcher.uriProvider !== undefined) {
+            return matcher.uriProvider(fullPath);
+        } else {
+            return vscodeURI.file(fullPath);
+        }
+    }
+
+    protected resetActivePatternIndex(defaultIndex?: number): void {
+        if (defaultIndex === undefined) {
+            defaultIndex = 0;
+        }
+        this.activePatternIndex = defaultIndex;
+        this.activePattern = this.patterns[defaultIndex];
+    }
+
+    protected nextProblemPattern(): void {
+        this.activePatternIndex++;
+        if (this.activePatternIndex > this.patternCount - 1) {
+            this.resetActivePatternIndex();
+        } else {
+            this.activePattern = this.patterns[this.activePatternIndex];
+        }
+    }
+
+    protected doOneLineMatch(line: string): boolean {
+        if (this.activePattern) {
+            const regexp = new RegExp(this.activePattern.regexp);
+            const regexMatches = regexp.exec(line);
+            if (regexMatches) {
+                if (this.activePattern.kind !== undefined && this.cachedProblemData.kind !== undefined) {
+                    this.cachedProblemData.kind = this.activePattern.kind;
+                }
+                return this.fillProblemData(this.cachedProblemData, this.activePattern, regexMatches);
+            }
+        }
+        return false;
+    }
+
+    // check if active pattern is the last pattern
+    protected isUsingTheLastPattern(): boolean {
+        return this.patternCount > 0 && this.activePatternIndex === this.patternCount - 1;
+    }
+
+    protected isLastPatternLoop(): boolean {
+        return this.patternCount > 0 && !!this.patterns[this.patternCount - 1].loop;
+    }
+
+    protected resetCachedProblemData(): void {
+        this.cachedProblemData = this.getEmptyProblemData();
+    }
+}

--- a/packages/task/src/node/task-backend-module.ts
+++ b/packages/task/src/node/task-backend-module.ts
@@ -24,12 +24,13 @@ import { TaskManager } from './task-manager';
 import { TaskRunnerContribution, TaskRunnerRegistry } from './task-runner';
 import { TaskServerImpl } from './task-server';
 import { createCommonBindings } from '../common/task-common-module';
-import { TaskClient, TaskServer, taskPath } from '../common/task-protocol';
+import { TaskClient, TaskServer, taskPath } from '../common';
 
 export default new ContainerModule(bind => {
 
     bind(TaskManager).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(TaskManager);
+
     bind(TaskServer).to(TaskServerImpl).inSingletonScope();
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new JsonRpcConnectionHandler<TaskClient>(taskPath, client => {

--- a/packages/task/src/node/task-line-matchers.ts
+++ b/packages/task/src/node/task-line-matchers.ts
@@ -1,0 +1,131 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { AbstractLineMatcher } from './task-abstract-line-matcher';
+import { ProblemMatcher, ProblemMatch, WatchingPattern } from '../common/problem-matcher-protocol';
+
+export class StartStopLineMatcher extends AbstractLineMatcher {
+
+    constructor(
+        protected matcher: ProblemMatcher
+    ) {
+        super(matcher);
+    }
+
+    /**
+     * Finds the problem identified by this line matcher.
+     *
+     * @param line the line of text to find the problem from
+     * @return the identified problem. If the problem is not found, `undefined` is returned.
+     */
+    match(line: string): ProblemMatch | undefined {
+        if (!this.activePattern) {
+            this.resetActivePatternIndex();
+        }
+        if (this.activePattern) {
+            const originalProblemData = Object.assign(this.getEmptyProblemData(), this.cachedProblemData);
+            const foundMatch = this.doOneLineMatch(line);
+            if (foundMatch) {
+                if (this.isUsingTheLastPattern()) {
+                    const matchResult = this.getMarkerMatch(this.cachedProblemData);
+                    if (this.isLastPatternLoop()) {
+                        this.cachedProblemData = originalProblemData;
+                    } else {
+                        this.resetCachedProblemData();
+                        this.resetActivePatternIndex();
+                    }
+                    return matchResult;
+                } else {
+                    this.nextProblemPattern();
+                }
+            } else {
+                this.resetCachedProblemData();
+                if (this.activePatternIndex !== 0) { // if no match, use the first pattern to parse the same line
+                    this.resetActivePatternIndex();
+                    return this.match(line);
+                }
+            }
+        }
+        return undefined;
+    }
+}
+
+export class WatchModeLineMatcher extends StartStopLineMatcher {
+
+    private beginsPattern: WatchingPattern;
+    private endsPattern: WatchingPattern;
+    private activeOnStart: boolean = false;
+
+    constructor(
+        protected matcher: ProblemMatcher
+    ) {
+        super(matcher);
+        this.beginsPattern = matcher.watching!.beginsPattern;
+        this.endsPattern = matcher.watching!.endsPattern;
+        this.activeOnStart = matcher.watching!.activeOnStart === true;
+        this.resetActivePatternIndex(this.activeOnStart ? 0 : -1);
+    }
+
+    /**
+     * Finds the problem identified by this line matcher.
+     *
+     * @param line the line of text to find the problem from
+     * @return the identified problem. If the problem is not found, `undefined` is returned.
+     */
+    match(line: string): ProblemMatch | undefined {
+        if (this.activeOnStart) {
+            this.activeOnStart = false;
+            this.resetActivePatternIndex(0);
+            this.resetCachedProblemData();
+            return super.match(line);
+        }
+
+        if (this.matchBegin(line)) {
+            const beginsPatternMatch = this.getMarkerMatch(this.cachedProblemData);
+            this.resetCachedProblemData();
+            return beginsPatternMatch;
+        }
+        if (this.matchEnd(line)) {
+            this.resetCachedProblemData();
+            return undefined;
+        }
+        if (this.activePattern) {
+            return super.match(line);
+        }
+        return undefined;
+    }
+
+    private matchBegin(line: string): boolean {
+        const beginRegexp = new RegExp(this.beginsPattern.regexp);
+        const regexMatches = beginRegexp.exec(line);
+        if (regexMatches) {
+            this.fillProblemData(this.cachedProblemData, this.beginsPattern, regexMatches);
+            this.resetActivePatternIndex(0);
+            return true;
+        }
+        return false;
+    }
+
+    private matchEnd(line: string): boolean {
+        const endRegexp = new RegExp(this.endsPattern.regexp);
+        const match = endRegexp.exec(line);
+        if (match) {
+            this.resetActivePatternIndex(-1);
+            return true;
+        }
+        return false;
+    }
+}

--- a/packages/task/src/node/task-problem-collector.spec.ts
+++ b/packages/task/src/node/task-problem-collector.spec.ts
@@ -1,0 +1,259 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { expect } from 'chai';
+import { DiagnosticSeverity } from 'vscode-languageserver-types';
+import { ProblemCollector } from './task-problem-collector';
+import { ApplyToKind, FileLocationKind, ProblemLocationKind, ProblemMatch, ProblemMatchData, ProblemMatcher, Severity } from '../common/problem-matcher-protocol';
+
+const startStopMatcher1: ProblemMatcher = {
+    owner: 'test1',
+    source: 'test1',
+    applyTo: ApplyToKind.allDocuments,
+    fileLocation: FileLocationKind.Absolute,
+    pattern: {
+        regexp: /^([^:]*: )?((.:)?[^:]*):(\d+)(:(\d+))?: (.*)$/.source,
+        kind: ProblemLocationKind.Location,
+        file: 2,
+        line: 4,
+        character: 6,
+        message: 7
+    },
+    severity: Severity.Error
+};
+
+const startStopMatcher2: ProblemMatcher = {
+    owner: 'test2',
+    source: 'test2',
+    applyTo: ApplyToKind.allDocuments,
+    fileLocation: FileLocationKind.Absolute,
+    pattern: [
+        {
+            regexp: /^([^\s].*)$/.source,
+            kind: ProblemLocationKind.Location,
+            file: 1
+        },
+        {
+            regexp: /^\s+(\d+):(\d+)\s+(error|warning|info)\s+(.+?)(?:\s\s+(.*))?$/.source,
+            line: 1,
+            character: 2,
+            severity: 3,
+            message: 4,
+            code: 5,
+            loop: true
+        }
+    ],
+    severity: Severity.Error
+};
+
+const watchMatcher: ProblemMatcher = {
+    owner: 'test3',
+    applyTo: ApplyToKind.closedDocuments,
+    fileLocation: FileLocationKind.Absolute,
+    pattern: {
+        regexp: /Error: ([^(]+)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\): (.*)$/.source,
+        file: 1,
+        location: 2,
+        message: 3
+    },
+    watching: {
+        activeOnStart: false,
+        beginsPattern: { regexp: /Starting compilation/.source },
+        endsPattern: { regexp: /Finished compilation/.source }
+    }
+};
+
+describe('ProblemCollector', () => {
+    let collector: ProblemCollector;
+    const allMatches: ProblemMatch[] = [];
+
+    const collectMatches = (lines: string[]) => {
+        lines.forEach(line => {
+            const matches = collector.processLine(line);
+            if (matches.length > 0) {
+                allMatches.push(...matches);
+            }
+        });
+    };
+
+    beforeEach(() => {
+        allMatches.length = 0;
+    });
+
+    it('should find problems from start-stop task when problem matcher is associated with one problem pattern', () => {
+        collector = new ProblemCollector([startStopMatcher1]);
+        collectMatches([
+            'npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1557403301319-0.5645247996849125/node but npm is using /usr/local/bin/node itself.',
+            'Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.',
+            '',
+            '# command-line-arguments',
+            '/home/test/hello.go:9:2: undefined: fmt.Pntln',
+            '/home/test/hello.go:10:6: undefined: numb',
+            '/home/test/hello.go:15:9: undefined: stri'
+        ]);
+
+        expect(allMatches.length).to.eq(3);
+
+        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 8, character: 1 }, end: { line: 8, character: 1 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test1',
+            message: 'undefined: fmt.Pntln'
+        });
+
+        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 9, character: 5 }, end: { line: 9, character: 5 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test1',
+            message: 'undefined: numb'
+        });
+
+        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/hello.go');
+        expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 14, character: 8 }, end: { line: 14, character: 8 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test1',
+            message: 'undefined: stri'
+        });
+    });
+
+    it('should find problems from start-stop task when problem matcher is associated with more than one problem pattern', () => {
+        collector = new ProblemCollector([startStopMatcher2]);
+        collectMatches([
+            '> test@0.1.0 lint /home/test',
+            '> eslint .',
+            '',
+            '',
+            '/home/test/test-dir.js',
+            '  14:21  warning  Missing semicolon  semi',
+            '  15:23  warning  Missing semicolon  semi',
+            '  103:9  error  Parsing error: Unexpected token inte',
+            '',
+            '/home/test/more-test.js',
+            '  13:9  error  Parsing error: Unexpected token 1000',
+            '',
+            '✖ 3 problems (1 error, 2 warnings)',
+            '  0 errors and 2 warnings potentially fixable with the `--fix` option.'
+        ]);
+
+        expect(allMatches.length).to.eq(4);
+
+        expect((allMatches[0] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[0] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 13, character: 20 }, end: { line: 13, character: 20 } },
+            severity: DiagnosticSeverity.Warning,
+            source: 'test2',
+            message: 'Missing semicolon',
+            code: 'semi'
+        });
+
+        expect((allMatches[1] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[1] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 14, character: 22 }, end: { line: 14, character: 22 } },
+            severity: DiagnosticSeverity.Warning,
+            source: 'test2',
+            message: 'Missing semicolon',
+            code: 'semi'
+        });
+
+        expect((allMatches[2] as ProblemMatchData).resource!.path).eq('/home/test/test-dir.js');
+        expect((allMatches[2] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 102, character: 8 }, end: { line: 102, character: 8 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test2',
+            message: 'Parsing error: Unexpected token inte'
+        });
+
+        expect((allMatches[3] as ProblemMatchData).resource!.path).eq('/home/test/more-test.js');
+        expect((allMatches[3] as ProblemMatchData).marker).deep.equal({
+            range: { start: { line: 12, character: 8 }, end: { line: 12, character: 8 } },
+            severity: DiagnosticSeverity.Error,
+            source: 'test2',
+            message: 'Parsing error: Unexpected token 1000'
+        });
+    });
+
+    it('should search and find defined problems from watch task\'s output', () => {
+        collector = new ProblemCollector([watchMatcher]);
+
+        collectMatches([
+            '> code-oss-dev@1.33.1 watch /home/test/vscode',
+            '> gulp watch --max_old_space_size=4095',
+            '',
+            '[09:15:37] Node flags detected: --max_old_space_size=4095',
+            '[09:15:37] Respawned to PID: 14560',
+            '[09:15:40] Using gulpfile ~/dev/vscode/gulpfile.js',
+            "[09:15:40] Starting 'watch'...",
+            '[09:15:40] Starting clean-out ...',
+            '[09:15:41] Starting clean-extension-configuration-editing ...',
+            '[09:15:41] Starting clean-extension-css-language-features-client ...',
+            '[09:15:41] Starting clean-extension-css-language-features-server ...',
+            '[09:15:41] Starting clean-extension-debug-auto-launch ...',
+            '[09:15:41] Starting watch-extension:markdown-language-features-preview-src ...',
+            '[09:15:41] Starting compilation...', // begin pattern 1
+            '[09:15:41] Finished clean-extension-typescript-basics-test-colorize-fixtures after 49 ms',
+            '[09:15:41] Starting watch-extension:typescript-basics-test-colorize-fixtures ...',
+            '[09:15:41] Finished compilation with 0 errors after 30 ms',
+            '[09:15:41] Finished clean-extension-css-language-features-client after 119 ms',
+            '[09:15:41] Starting watch-extension:css-language-features-client ...',
+            '[09:15:41] Starting compilation...', // begin pattern 2
+            '[09:15:41] Finished clean-extension-configuration-editing after 128 ms',
+            '[09:15:41] Starting watch-extension:configuration-editing ...',
+            '[09:15:41] Finished clean-extension-debug-auto-launch after 133 ms',
+            '[09:15:41] Starting watch-extension:debug-auto-launch ...',
+            '[09:15:41] Finished clean-extension-debug-server-ready after 138 ms',
+            '[09:15:52] Starting watch-extension:html-language-features-server ...',
+            '[09:15:58] Finished clean-out after 17196 ms',
+            '[09:15:58] Starting watch-client ...',
+            '[09:17:25] Finished compilation with 0 errors after 104209 ms',
+            '[09:19:22] Starting compilation...', // begin pattern 3
+            "[09:19:23] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,19): ')' expected.", // problem 1
+            "[09:19:23] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,57): ';' expected.", // problem 2
+            '[09:19:23] Finished compilation with 2 errors after 1051 ms',
+            '[09:20:21] Starting compilation...', // begin pattern 4
+            "[09:20:24] Error: /home/test/src/vs/workbench/contrib/tasks/common/problemCollectors.ts(15,30): Cannot find module 'n/uuid'.", // problem 3
+            "[09:20:24] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,19): ')' expected.", // problem 4
+            "[09:20:24] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,57): ';' expected.", // problem 5
+            '[09:20:24] Finished compilation with 3 errors after 2586 ms',
+            '[09:20:24] Starting compilation...', // begin pattern 5
+            '[09:20:25] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskTemplates.ts(12,14): Type expected.', // problem 6
+            "[09:20:25] Error: /home/test/src/vs/workbench/contrib/tasks/common/problemCollectors.ts(15,30): Cannot find module 'n/uuid'.", // problem 7
+            "[09:20:25] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,19): ')' expected.", // problem 8
+            "[09:20:25] Error: /home/test/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts(517,57): ';' expected.", // problem 9
+            '[09:20:25] Finished compilation with 4 errors after 441 ms'
+        ]);
+
+        expect(allMatches.length).to.eq(14); // 9 events for problems + 5 events for beginner pattern
+    });
+
+    it('should return an empty array if no problems are found', () => {
+        collector = new ProblemCollector([startStopMatcher2]);
+
+        collectMatches([]);
+        expect(allMatches.length).to.eq(0);
+
+        collectMatches([
+            '> test@0.1.0 lint /home/test',
+            '> eslint .',
+            '',
+            '',
+            '0 problems (0 error, 0 warnings)',
+        ]);
+        expect(allMatches.length).to.eq(0);
+    });
+});

--- a/packages/task/src/node/task-problem-collector.ts
+++ b/packages/task/src/node/task-problem-collector.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { AbstractLineMatcher } from './task-abstract-line-matcher';
+import { ProblemMatcher, ProblemMatch } from '../common/problem-matcher-protocol';
+import { StartStopLineMatcher, WatchModeLineMatcher } from './task-line-matchers';
+
+export class ProblemCollector {
+
+    private lineMatchers: AbstractLineMatcher[] = [];
+
+    constructor(
+        protected problemMatchers: ProblemMatcher[]
+    ) {
+        for (const matcher of problemMatchers) {
+            if (ProblemMatcher.isWatchModeWatcher(matcher)) {
+                this.lineMatchers.push(new WatchModeLineMatcher(matcher));
+            } else {
+                this.lineMatchers.push(new StartStopLineMatcher(matcher));
+            }
+        }
+    }
+
+    processLine(line: string): ProblemMatch[] {
+        const markers: ProblemMatch[] = [];
+        this.lineMatchers.forEach(lineMatcher => {
+            const match = lineMatcher.match(line);
+            if (match) {
+                markers.push(match);
+            }
+        });
+        return markers;
+    }
+}

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { inject, injectable, named } from 'inversify';
-import { ILogger } from '@theia/core/lib/common/';
+import { Disposable, DisposableCollection, ILogger } from '@theia/core/lib/common/';
 import {
     TaskClient,
     TaskExitedEvent,
@@ -32,10 +32,12 @@ import { ProcessTask } from './process/process-task';
 import { ProblemCollector } from './task-problem-collector';
 
 @injectable()
-export class TaskServerImpl implements TaskServer {
+export class TaskServerImpl implements TaskServer, Disposable {
 
     /** Task clients, to send notifications-to. */
     protected clients: TaskClient[] = [];
+    /** Map of task id and task disposable */
+    protected readonly toDispose = new Map<number, DisposableCollection>();
 
     @inject(ILogger) @named('task')
     protected readonly logger: ILogger;
@@ -50,12 +52,21 @@ export class TaskServerImpl implements TaskServer {
     private problemCollectors: Map<string, Map<number, ProblemCollector>> = new Map();
 
     dispose() {
-        // do nothing
+        for (const toDispose of this.toDispose.values()) {
+            toDispose.dispose();
+        }
+        this.toDispose.clear();
+    }
+
+    protected disposeByTaskId(taskId: number): void {
+        if (this.toDispose.has(taskId)) {
+            this.toDispose.get(taskId)!.dispose();
+            this.toDispose.delete(taskId);
+        }
     }
 
     async getTasks(context?: string): Promise<TaskInfo[]> {
         const taskInfo: TaskInfo[] = [];
-
         const tasks = this.taskManager.getTasks(context);
         if (tasks !== undefined) {
             for (const task of tasks) {
@@ -71,31 +82,40 @@ export class TaskServerImpl implements TaskServer {
         const runner = this.runnerRegistry.getRunner(taskConfiguration.type);
         const task = await runner.run(taskConfiguration, ctx);
 
-        task.onExit(event => {
-            this.taskManager.delete(task);
-            this.fireTaskExitedEvent(event);
-            this.removedCachedProblemCollector(event.ctx || '', event.taskId);
-        });
+        if (!this.toDispose.has(task.id)) {
+            this.toDispose.set(task.id, new DisposableCollection());
+        }
+        this.toDispose.get(task.id)!.push(
+            task.onExit(event => {
+                this.taskManager.delete(task);
+                this.fireTaskExitedEvent(event);
+                this.removedCachedProblemCollector(event.ctx || '', event.taskId);
+                this.disposeByTaskId(event.taskId);
+            })
+        );
 
         const resolvedMatchers = option && option.customization ? option.customization.problemMatcher || [] : [];
         if (resolvedMatchers.length > 0) {
-            task.onOutput(event => {
-                let collector: ProblemCollector | undefined = this.getCachedProblemCollector(event.ctx || '', event.taskId);
-                if (!collector) {
-                    collector = new ProblemCollector(resolvedMatchers);
-                    this.cacheProblemCollector(event.ctx || '', event.taskId, collector);
-                }
+            this.toDispose.get(task.id)!.push(
+                task.onOutput(event => {
+                    let collector: ProblemCollector | undefined = this.getCachedProblemCollector(event.ctx || '', event.taskId);
+                    if (!collector) {
+                        collector = new ProblemCollector(resolvedMatchers);
+                        this.cacheProblemCollector(event.ctx || '', event.taskId, collector);
+                    }
 
-                const problems = collector.processLine(event.line);
-                if (problems.length > 0) {
-                    this.fireTaskOutputProcessedEvent({
-                        taskId: event.taskId,
-                        ctx: event.ctx,
-                        problems
-                    });
-                }
-            });
+                    const problems = collector.processLine(event.line);
+                    if (problems.length > 0) {
+                        this.fireTaskOutputProcessedEvent({
+                            taskId: event.taskId,
+                            ctx: event.ctx,
+                            problems
+                        });
+                    }
+                })
+            );
         }
+        this.toDispose.get(task.id)!.push(task);
 
         const taskInfo = await task.getRuntimeInfo();
         this.fireTaskCreatedEvent(taskInfo);

--- a/packages/task/src/node/task.ts
+++ b/packages/task/src/node/task.ts
@@ -17,12 +17,12 @@
 import { injectable } from 'inversify';
 import { ILogger, Emitter, Event, MaybePromise } from '@theia/core/lib/common/';
 import { TaskManager } from './task-manager';
-import { TaskInfo, TaskExitedEvent, TaskConfiguration } from '../common/task-protocol';
+import { TaskInfo, TaskExitedEvent, TaskConfiguration, TaskOutputEvent } from '../common/task-protocol';
 
 export interface TaskOptions {
-    label: string,
-    config: TaskConfiguration
-    context?: string
+    label: string;
+    config: TaskConfiguration;
+    context?: string;
 }
 
 @injectable()
@@ -30,6 +30,7 @@ export abstract class Task {
 
     protected taskId: number;
     readonly exitEmitter: Emitter<TaskExitedEvent>;
+    readonly outputEmitter: Emitter<TaskOutputEvent>;
 
     constructor(
         protected readonly taskManager: TaskManager,
@@ -38,6 +39,7 @@ export abstract class Task {
     ) {
         this.taskId = this.taskManager.register(this, this.options.context);
         this.exitEmitter = new Emitter<TaskExitedEvent>();
+        this.outputEmitter = new Emitter<TaskOutputEvent>();
     }
 
     /** Terminates the task. */
@@ -47,9 +49,17 @@ export abstract class Task {
         return this.exitEmitter.event;
     }
 
+    get onOutput(): Event<TaskOutputEvent> {
+        return this.outputEmitter.event;
+    }
+
     /** Has to be called when a task has concluded its execution. */
     protected fireTaskExited(event: TaskExitedEvent): void {
         this.exitEmitter.fire(event);
+    }
+
+    protected fireOutputLine(event: TaskOutputEvent): void {
+        this.outputEmitter.fire(event);
     }
 
     /** Returns runtime information about task. */

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -82,6 +82,14 @@ export class WorkspaceVariableContribution implements VariableContribution {
             }
         });
         variables.registerVariable({
+            name: 'cwd',
+            description: 'The path of the current working directory',
+            resolve: (context?: URI) => {
+                const uri = this.getWorkspaceRootUri(context);
+                return (uri && uri.path.toString()) || '';
+            }
+        });
+        variables.registerVariable({
             name: 'file',
             description: 'The path of the currently opened file',
             resolve: () => {


### PR DESCRIPTION
What's included in this PR:
- support taskDefinition, problemMatcher, & problemPattern contributed by Theia plugins.
- support customizing tasks by adding named & anonymous problem matchers and patterns in .theia/tasks.json.
- support parsing output from both "start - finish" tasks and "watch" tasks.
- support both single line and multi line patterns.
- create problem markers on parsing task output with the plugin-defined or user-defined problem matchers and patterns.

What's not included:
- prompt users to provide problem matcher and / or patterns before starting tasks
- remove problem markers automatically when problems are fixed

CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19787. Approved on June 4 2019.
CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20139. Approved on June 11 2019.

Resolves #4211

Signed-off-by: elaihau <liang.huang@ericsson.com>


