### PR TITLE
Hosted plugin flow - make request options extensible

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-uri-postprocessor.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-uri-postprocessor.ts
@@ -28,4 +28,5 @@ export const HostedPluginUriPostProcessorSymbolName = 'HostedPluginUriPostProces
 
 export interface HostedPluginUriPostProcessor {
     processUri(uri: URI): Promise<URI>;
+    processOptions(options: object): Promise<object>;
 }


### PR DESCRIPTION
Add extension point for providing custom options to hosted plugin ping request in order to support passing authorization header on cloud environment.
Fixes: #4363 

Signed-off-by: Doron Nahari doron.nahari@sap.com