### PR TITLE
[search-in-workspace] pass the currently selected editor text when searching

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -183,6 +183,19 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
         this.update();
     }
 
+    /**
+     * Update the search term and input field.
+     * @param term the search term.
+     */
+    updateSearchTerm(term: string): void {
+        this.searchTerm = term;
+        const search = document.getElementById('search-input-field');
+        if (search) {
+            (search as HTMLInputElement).value = term;
+        }
+        this.refresh();
+    }
+
     hasResultList(): boolean {
         return this.hasResults;
     }


### PR DESCRIPTION
Fixes #4625

If available, when triggering the `search-in-workspace` widget, pass the currently selected text from the current editor to pre-populate the search input field.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
