### PR TITLE
[commands] add 'Clear Command History' command

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-contribution.ts
+++ b/packages/core/src/browser/quick-open/quick-command-contribution.ts
@@ -24,6 +24,11 @@ export const quickCommand: Command = {
     id: 'workbench.action.showCommands'
 };
 
+export const CLEAR_COMMAND_HISTORY: Command = {
+    id: 'clear.command.history',
+    label: 'Clear Command History'
+};
+
 @injectable()
 export class QuickCommandFrontendContribution implements CommandContribution, KeybindingContribution, MenuContribution {
 
@@ -35,6 +40,9 @@ export class QuickCommandFrontendContribution implements CommandContribution, Ke
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(quickCommand, {
             execute: () => this.quickOpenService.open('>')
+        });
+        commands.registerCommand(CLEAR_COMMAND_HISTORY, {
+            execute: () => commands.clearCommandHistory(),
         });
     }
 

--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -21,6 +21,7 @@ import { QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickOpenGroupItem, Quick
 import { QuickOpenOptions } from './quick-open-service';
 import { QuickOpenContribution, QuickOpenHandlerRegistry, QuickOpenHandler } from './prefix-quick-open-service';
 import { ContextKeyService } from '../context-key-service';
+import { CLEAR_COMMAND_HISTORY } from './quick-command-contribution';
 
 @injectable()
 export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
@@ -30,6 +31,11 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
     readonly prefix: string = '>';
 
     readonly description: string = 'Quick Command';
+
+    // The list of exempted commands not to be displayed in the recently used list.
+    readonly exemptedCommands: Command[] = [
+        CLEAR_COMMAND_HISTORY,
+    ];
 
     @inject(CommandRegistry)
     protected readonly commands: CommandRegistry;
@@ -106,9 +112,14 @@ export class QuickCommandService implements QuickOpenModel, QuickOpenHandler {
         // Build the list of recent commands.
         const rCommands: Command[] = [];
         recentCommands.forEach((r: Command) => {
-            const exists = allCommands.some((c: Command) => Command.equals(r, c));
+            // Determine if the command is exempted from display.
+            const exempted: boolean = this.exemptedCommands.some((c: Command) => Command.equals(r, c));
+            // Determine if the command currently exists in the list of all available commands.
+            const exists: boolean = allCommands.some((c: Command) => Command.equals(r, c));
             // Add the recently used item to the list.
-            if (exists) { rCommands.push(r); }
+            if (exists && !exempted) {
+                rCommands.push(r);
+            }
         });
 
         // Build the list of other commands.

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -376,4 +376,11 @@ export class CommandRegistry implements CommandService {
         }
     }
 
+    /**
+     * Clear the list of recently used commands.
+     */
+    clearCommandHistory(): void {
+        this.recent = [];
+    }
+
 }


### PR DESCRIPTION
Fixes #5048

Added the command `Clear Command History` used to clear the list
of recently used commands from the `quick-command` palette.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
