### PR TITLE
[commands] add preference to control the number of recently used items to display

### DIFF
--- a/packages/core/src/browser/core-preferences.ts
+++ b/packages/core/src/browser/core-preferences.ts
@@ -38,6 +38,12 @@ export const corePreferenceSchema: PreferenceSchema = {
             ],
             default: 'ifRequired',
             description: 'When to confirm before closing the application window.',
+        },
+        'workbench.commandPalette.history': {
+            type: 'number',
+            default: 50,
+            minimum: 0,
+            description: 'Controls the number of recently used commands to keep in history for the command palette. Set to 0 to disable command history.'
         }
     }
 };
@@ -45,6 +51,7 @@ export const corePreferenceSchema: PreferenceSchema = {
 export interface CoreConfiguration {
     'application.confirmExit': 'never' | 'ifRequired' | 'always';
     'list.openMode': 'singleClick' | 'doubleClick';
+    'workbench.commandPalette.history': number;
 }
 
 export const CorePreferences = Symbol('CorePreferences');


### PR DESCRIPTION
Fixes #5049

Added a new preference in order to control the number of recently used items to display in the 
`quick-command` palette.

- [x] Register [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19632)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
