### PR TITLE
vscode/view icons and style improvements

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -33,6 +33,7 @@ export interface PreferenceChange {
     readonly preferenceName: string;
     readonly newValue?: any;
     readonly oldValue?: any;
+    readonly scope: PreferenceScope;
     affects(resourceUri?: string): boolean;
 }
 
@@ -49,6 +50,9 @@ export class PreferenceChangeImpl implements PreferenceChange {
     }
     get oldValue() {
         return this.change.oldValue;
+    }
+    get scope(): PreferenceScope {
+        return this.change.scope;
     }
 
     // TODO add tests

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -498,7 +498,12 @@ declare module monaco.services {
         getValue(section: string, overrides: any, workspace: any): any;
     }
 
+    export enum ConfigurationTarget {
+        DEFAULT
+    }
+
     export class ConfigurationChangeEvent {
+        _source?: ConfigurationTarget;
         change(keys: string[]): ConfigurationChangeEvent;
     }
 

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -432,6 +432,7 @@ export class TreeViewItem {
     collapsibleState?: TreeViewItemCollapsibleState;
 
     metadata?: any;
+    contextValue?: string;
 
 }
 

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -18,7 +18,7 @@
 
 import { createProxyIdentifier, ProxyIdentifier } from './rpc-protocol';
 import * as theia from '@theia/plugin';
-import { PluginLifecycle, PluginModel, PluginMetadata, PluginPackage } from '../common/plugin-protocol';
+import { PluginLifecycle, PluginModel, PluginMetadata, PluginPackage, IconUrl } from '../common/plugin-protocol';
 import { QueryParameters } from '../common/env';
 import { TextEditorCursorStyle } from '../common/editor-options';
 import { TextEditorLineNumbersStyle, EndOfLine, OverviewRulerLane, IndentAction, FileOperationOptions } from '../plugin/types-impl';
@@ -419,7 +419,13 @@ export class TreeViewItem {
 
     label: string;
 
+    /* font-awesome icon for compatibility */
     icon?: string;
+    iconUrl?: IconUrl;
+
+    themeIconId?: 'folder' | 'file';
+
+    resourceUri?: UriComponents;
 
     tooltip?: string;
 

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -51,13 +51,8 @@ export interface PluginPackage {
     packagePath: string;
 }
 export namespace PluginPackage {
-    /**
-     * @param relativePath should be normalized, i.e. should not contain `.` or `..`,
-     * otherwise they will be removed by a browser leading to a bogus path,
-     * see https://stackoverflow.com/questions/3856693/a-url-resource-that-is-a-dot-2e
-     */
     export function toPluginUrl(pck: PluginPackage, relativePath: string): string {
-        return `hostedPlugin/${getPluginId(pck)}/${relativePath}`;
+        return `hostedPlugin/${getPluginId(pck)}/${encodeURIComponent(relativePath)}`;
     }
 }
 

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -50,6 +50,16 @@ export interface PluginPackage {
     contributes?: PluginPackageContribution;
     packagePath: string;
 }
+export namespace PluginPackage {
+    /**
+     * @param relativePath should be normalized, i.e. should not contain `.` or `..`,
+     * otherwise they will be removed by a browser leading to a bogus path,
+     * see https://stackoverflow.com/questions/3856693/a-url-resource-that-is-a-dot-2e
+     */
+    export function toPluginUrl(pck: PluginPackage, relativePath: string): string {
+        return `hostedPlugin/${getPluginId(pck)}/${relativePath}`;
+    }
+}
 
 /**
  * This interface describes a package.json contribution section object.

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -53,11 +53,11 @@ export class HostedPluginReader implements BackendApplicationContribution {
     configure(app: express.Application): void {
         app.get('/hostedPlugin/:pluginId/:path(*)', (req, res) => {
             const pluginId = req.params.pluginId;
-            const filePath: string = req.params.path;
+            const filePath = decodeURIComponent(req.params.path);
 
-            const localPath: string | undefined = this.pluginsIdsFiles.get(pluginId);
+            const localPath = this.pluginsIdsFiles.get(pluginId);
             if (localPath) {
-                const fileToServe = localPath + filePath;
+                const fileToServe = path.join(localPath, filePath);
                 res.sendFile(fileToServe);
             } else {
                 res.status(404).send("The plugin with id '" + pluginId + "' does not exist.");

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -42,8 +42,7 @@ import {
     SnippetContribution,
     PluginPackageCommand,
     PluginCommand,
-    IconUrl,
-    getPluginId
+    IconUrl
 } from '../../../common/plugin-protocol';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -204,7 +203,7 @@ export class TheiaPluginScanner implements PluginScanner {
     }
 
     protected toPluginUrl(pck: PluginPackage, relativePath: string): string {
-        return path.join('hostedPlugin', getPluginId(pck), relativePath);
+        return PluginPackage.toPluginUrl(pck, relativePath);
     }
 
     protected readSnippets(pck: PluginPackage): SnippetContribution[] | undefined {

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.spec.ts
@@ -32,6 +32,7 @@ import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { QuickCommandService } from '@theia/core/lib/browser';
 import { PluginSharedStyle } from '../plugin-shared-style';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { TreeViewActions } from '../view/tree-view-actions';
 
 disableJSDOM();
 
@@ -64,6 +65,7 @@ before(() => {
         // tslint:disable-next-line:no-any mock PluginSharedStyle
         bind(PluginSharedStyle).toConstantValue({} as any);
         bind(SelectionService).toSelf().inSingletonScope();
+        bind(TreeViewActions).toSelf().inSingletonScope();
     });
 
     testContainer.load(module);

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -28,6 +28,7 @@ import { PluginContribution, Menu } from '../../../common';
 import { DebugStackFramesWidget } from '@theia/debug/lib/browser/view/debug-stack-frames-widget';
 import { DebugThreadsWidget } from '@theia/debug/lib/browser/view/debug-threads-widget';
 import { MetadataSelection } from '../metadata-selection';
+import { TreeViewActions } from '../view/tree-view-actions';
 
 @injectable()
 export class MenusContributionPointHandler {
@@ -50,6 +51,9 @@ export class MenusContributionPointHandler {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    @inject(TreeViewActions)
+    protected readonly treeViewActions: TreeViewActions;
+
     handle(contributions: PluginContribution): void {
         const allMenus = contributions.menus;
         if (!allMenus) {
@@ -65,6 +69,14 @@ export class MenusContributionPointHandler {
             } else if (location === 'editor/title') {
                 for (const action of allMenus[location]) {
                     this.registerEditorTitleAction(action);
+                }
+            } else if (location === 'view/item/context') {
+                for (const menu of allMenus[location]) {
+                    if (menu.group && /^inline/.test(menu.group)) {
+                        this.treeViewActions.registerInlineAction(menu);
+                    } else {
+                        this.registerMenuAction(VIEW_ITEM_CONTEXT_MENU, menu);
+                    }
                 }
             } else if (allMenus.hasOwnProperty(location)) {
                 const menuPaths = MenusContributionPointHandler.parseMenuPaths(location);
@@ -105,7 +117,6 @@ export class MenusContributionPointHandler {
         switch (value) {
             case 'editor/context': return [EDITOR_CONTEXT_MENU];
             case 'explorer/context': return [NAVIGATOR_CONTEXT_MENU];
-            case 'view/item/context': return [VIEW_ITEM_CONTEXT_MENU];
             case 'debug/callstack/context': return [DebugStackFramesWidget.CONTEXT_MENU, DebugThreadsWidget.CONTEXT_MENU];
         }
         return [];

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -26,7 +26,6 @@ import { KeybindingsContributionPointHandler } from './keybindings/keybindings-c
 import { MonacoSnippetSuggestProvider } from '@theia/monaco/lib/browser/monaco-snippet-suggest-provider';
 import { PluginSharedStyle } from './plugin-shared-style';
 import { CommandRegistry } from '@theia/core';
-import { BuiltinThemeProvider } from '@theia/core/lib/browser/theming';
 
 @injectable()
 export class PluginContributionHandler {
@@ -152,23 +151,12 @@ export class PluginContributionHandler {
         }
     }
 
-    protected pluginCommandIconId = 0;
     protected registerCommands(contribution: PluginContribution): void {
         if (!contribution.commands) {
             return;
         }
         for (const { iconUrl, command, category, title } of contribution.commands) {
-            let iconClass: string | undefined;
-            if (iconUrl) {
-                iconClass = 'plugin-command-icon-' + this.pluginCommandIconId++;
-                const darkIconUrl = typeof iconUrl === 'object' ? iconUrl.dark : iconUrl;
-                const lightIconUrl = typeof iconUrl === 'object' ? iconUrl.light : iconUrl;
-                this.style.insertRule('.' + iconClass, theme => `
-                    width: 16px;
-                    height: 16px;
-                    background: no-repeat url("${theme.id === BuiltinThemeProvider.lightTheme.id ? lightIconUrl : darkIconUrl}");
-                `);
-            }
+            const iconClass = iconUrl ? this.style.toIconClass(iconUrl) : undefined;
             this.commands.registerCommand({
                 id: command,
                 category,

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -60,6 +60,8 @@ import { PluginSharedStyle } from './plugin-shared-style';
 import { FSResourceResolver } from './file-system-main';
 import { SelectionProviderCommandContribution } from './selection-provider-command';
 import { ViewColumnService } from './view-column-service';
+import { TreeViewActions } from './view/tree-view-actions';
+import { TreeViewContextKeyService } from './view/tree-view-context-key-service';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindHostedPluginPreferences(bind);
@@ -116,6 +118,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         const provider = ctx.container.get(WebSocketConnectionProvider);
         return provider.createProxy<PluginServer>(pluginServerJsonRpcPath);
     }).inSingletonScope();
+
+    bind(TreeViewActions).toSelf().inSingletonScope();
+    bind(TreeViewContextKeyService).toSelf().inSingletonScope();
 
     bind(PluginSharedStyle).toSelf().inSingletonScope();
     bind(ViewRegistry).toSelf().inSingletonScope();

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -16,7 +16,8 @@
 
 import { injectable } from 'inversify';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-import { ThemeService, Theme } from '@theia/core/lib/browser/theming';
+import { ThemeService, Theme, BuiltinThemeProvider } from '@theia/core/lib/browser/theming';
+import { IconUrl } from '../../common/plugin-protocol';
 
 @injectable()
 export class PluginSharedStyle {
@@ -80,6 +81,25 @@ export class PluginSharedStyle {
                 sheet.deleteRule(i);
             }
         }
+    }
+
+    private iconSequence = 0;
+    private readonly icons = new Map<string, string>();
+    toIconClass(iconUrl: IconUrl, { size }: { size?: number } = { size: 16 }): string {
+        const darkIconUrl = typeof iconUrl === 'object' ? iconUrl.dark : iconUrl;
+        const lightIconUrl = typeof iconUrl === 'object' ? iconUrl.light : iconUrl;
+        const key = JSON.stringify({ lightIconUrl, darkIconUrl });
+        let iconClass = this.icons.get(key);
+        if (typeof iconClass !== 'string') {
+            iconClass = 'plugin-icon-' + this.iconSequence++;
+            this.insertRule('.' + iconClass, theme => `
+                    width: ${size}px;
+                    height: ${size}px;
+                    background: no-repeat url("${theme.id === BuiltinThemeProvider.lightTheme.id ? lightIconUrl : darkIconUrl}");
+                `);
+            this.icons.set(key, iconClass);
+        }
+        return iconClass;
     }
 
 }

--- a/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-shared-style.ts
@@ -96,6 +96,7 @@ export class PluginSharedStyle {
                     width: ${size}px;
                     height: ${size}px;
                     background: no-repeat url("${theme.id === BuiltinThemeProvider.lightTheme.id ? lightIconUrl : darkIconUrl}");
+                    background-size: ${size}px;
                 `);
             this.icons.set(key, iconClass);
         }

--- a/packages/plugin-ext/src/main/browser/style/view-registry.css
+++ b/packages/plugin-ext/src/main/browser/style/view-registry.css
@@ -64,7 +64,17 @@
 }
 
 .theia-views-container-section-content .tree-view-icon {
-    align-self: center;
     padding-right: var(--theia-ui-padding);
     -webkit-font-smoothing: antialiased;
 }
+
+.theia-tree-view-inline-action {
+    background-size: 22px !important;
+    width: 22px !important;
+    height: 22px !important;
+}
+
+.theia-views-container-section-content .theia-TreeNodeContent {
+    align-items: center;
+}
+

--- a/packages/plugin-ext/src/main/browser/style/view-registry.css
+++ b/packages/plugin-ext/src/main/browser/style/view-registry.css
@@ -15,10 +15,7 @@
  ********************************************************************************/
 
 .theia-views-container {
-    width: 100%;
-    height: 100%;
     overflow: hidden;
-    background: var(--theia-layout-color0);
 }
 
 .theia-views-container:focus {
@@ -31,51 +28,20 @@
 }
 
 .theia-views-container-section-title {
-    position: relative;
-    height: 22px;
-    background-color: var(--theia-layout-color2);
-    line-height: 22px;
+    display: flex;
+    padding-left: 4px;
     overflow: hidden;
+    line-height: 22px;
     color: var(--theia-ui-font-color1);
-    font-size: var(--theia-ui-font-size0);
+    font-size: 80%;
+    font-weight: 500;
+    background-color: var(--theia-layout-color4);
     text-transform:  uppercase;
     cursor: pointer;
     user-select: none;
 }
 
-.theia-views-container-section-title:hover {
-    background-color: var(--theia-layout-color1);
-}
-
-.theia-views-container-section-control {
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    width: 15px;
-    height: 22px;
-    padding: 0px 5px;
-    box-sizing: border-box;
-}
-
-.theia-views-container-section-control[opened='true']:before {
-    font-family: FontAwesome;
-    font-size: calc(var(--theia-content-font-size) * 0.8);
-    content: "\F0D7";
-}
-
-.theia-views-container-section-control[opened='false']:before {
-    font-family: FontAwesome;
-    font-size: calc(var(--theia-content-font-size) * 0.8);
-    content: "\F0DA";
-}
-
 .theia-views-container-section-label {
-    position: absolute;
-    left: 15px;
-    right: 0px;
-    top: 0px;
-    height: 22px;
-    line-height: 22px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -91,10 +57,6 @@
     height: 300px;
 }
 
-.theia-views-container-section-content[opened='false'] {
-    display: none;
-}
-
 .theia-views-container-section-content > div {
     position: absolute;
     width: 100%;
@@ -102,15 +64,7 @@
 }
 
 .theia-views-container-section-content .tree-view-icon {
-    max-height: calc(var(--theia-content-font-size) * 0.8);
-    line-height: 0.8em;
-
-}
-
-.theia-views-container-section-content .tree-view-icon:before {
-    font-size: calc(var(--theia-content-font-size) * 0.8);
-    text-align: center;
-    margin-right: 4px;
-    top: -1px;
-    position: relative;
+    align-self: center;
+    padding-right: var(--theia-ui-padding);
+    -webkit-font-smoothing: antialiased;
 }

--- a/packages/plugin-ext/src/main/browser/view/tree-view-actions.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-actions.ts
@@ -19,6 +19,8 @@ import { CommandRegistry, Command } from '@theia/core/lib/common/command';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { Menu } from '../../../common/plugin-protocol';
 
+// tslint:disable:no-any
+
 @injectable()
 export class TreeViewActions {
 
@@ -34,8 +36,7 @@ export class TreeViewActions {
         this.inlineActions.push(action);
     }
 
-    // tslint:disable-next-line:no-any
-    getInlineActions(...args: any[]): Command[] {
+    getInlineCommands(...args: any[]): Command[] {
         const commands: Command[] = [];
         for (const action of this.inlineActions) {
             const command = this.commands.getCommand(action.command);

--- a/packages/plugin-ext/src/main/browser/view/tree-view-actions.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-actions.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { CommandRegistry, Command } from '@theia/core/lib/common/command';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { Menu } from '../../../common/plugin-protocol';
+
+@injectable()
+export class TreeViewActions {
+
+    protected inlineActions: Menu[] = [];
+
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    registerInlineAction(action: Menu): void {
+        this.inlineActions.push(action);
+    }
+
+    // tslint:disable-next-line:no-any
+    getInlineActions(...args: any[]): Command[] {
+        const commands: Command[] = [];
+        for (const action of this.inlineActions) {
+            const command = this.commands.getCommand(action.command);
+            if (command &&
+                this.commands.isVisible(command.id, ...args)
+                && (!action.when || this.contextKeyService.match(action.when))) {
+                commands.push(command);
+            }
+        }
+        return commands;
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/view/tree-view-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-context-key-service.ts
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, postConstruct, inject } from 'inversify';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+
+@injectable()
+export class TreeViewContextKeyService {
+
+    protected _view: ContextKey<string>;
+    get view(): ContextKey<string> {
+        return this._view;
+    }
+
+    protected _viewItem: ContextKey<string>;
+    get viewItem(): ContextKey<string> {
+        return this._viewItem;
+    }
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    @postConstruct()
+    protected init(): void {
+        this._view = this.contextKeyService.createKey('view', '');
+        this._viewItem = this.contextKeyService.createKey('viewItem', '');
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/view/tree-views-main.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-views-main.tsx
@@ -362,7 +362,7 @@ export class TreeViewWidget extends TreeWidget {
         try {
             const arg = node.metadata;
             return <React.Fragment>
-                {this.actions.getInlineActions(arg).map(action => this.renderInlineAction(action, arg))}
+                {this.actions.getInlineCommands(arg).map(command => this.renderInlineCommand(command, arg))}
             </React.Fragment>;
         } finally {
             this.contextKeys.view.set(view);
@@ -371,13 +371,15 @@ export class TreeViewWidget extends TreeWidget {
     }
 
     // tslint:disable-next-line:no-any
-    protected renderInlineAction(action: Command, arg: any): React.ReactNode {
-        if (!action.iconClass) {
+    protected renderInlineCommand(command: Command, arg: any): React.ReactNode {
+        if (!command.iconClass) {
             return false;
         }
-        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, action.iconClass, 'theia-tree-view-inline-action'].join(' ');
-        return <div key={action.id} className={className} title={action.label || ''}
-            onClick={() => this.commands.executeCommand(action.id, arg)} />;
+        const className = [TREE_NODE_SEGMENT_CLASS, TREE_NODE_TAIL_CLASS, command.iconClass, 'theia-tree-view-inline-action'].join(' ');
+        return <div key={command.id} className={className} title={command.label || ''} onClick={e => {
+            e.stopPropagation();
+            this.commands.executeCommand(command.id, arg);
+        }} />;
     }
 
     protected hoverNodeId: string | undefined;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -326,10 +326,10 @@ export function createAPIFactory(
                 return editors.createTextEditorDecorationType(options);
             },
             registerTreeDataProvider<T>(viewId: string, treeDataProvider: theia.TreeDataProvider<T>): Disposable {
-                return treeViewsExt.registerTreeDataProvider(viewId, treeDataProvider);
+                return treeViewsExt.registerTreeDataProvider(plugin, viewId, treeDataProvider);
             },
             createTreeView<T>(viewId: string, options: { treeDataProvider: theia.TreeDataProvider<T> }): theia.TreeView<T> {
-                return treeViewsExt.createTreeView(viewId, options);
+                return treeViewsExt.createTreeView(plugin, viewId, options);
             },
             withProgress<R>(
                 options: ProgressOptions,


### PR DESCRIPTION
- fix #4606 - improve styling
- fix #3330 - complete support of `TreeItem.iconPath`
- addresses view gaps in #4912
- closes #4969 (superseded)
- fix #5041 - update monaco internal configurations on new default preferences from plugins
- fix #5043 - render png properly by setting a background size

<img width="2032" alt="Screen Shot 2019-05-02 at 11 55 01" src="https://user-images.githubusercontent.com/3082655/57068157-2e2a4e80-6cd1-11e9-8482-82569c058cd7.png">
