### PR TITLE
[command] add clear recently used commands test

### DIFF
--- a/packages/core/src/common/command.spec.ts
+++ b/packages/core/src/common/command.spec.ts
@@ -97,6 +97,29 @@ describe('Commands', () => {
         expect(result[1].id).equal(commandIds[2]);
         expect(result[2].id).equal(commandIds[1]);
     });
+
+    it('should clear the recently used command history', async () => {
+        const commandIds = ['a', 'b', 'c'];
+        const commands: Command[] = [
+            { id: commandIds[0] },
+            { id: commandIds[1] },
+            { id: commandIds[2] },
+        ];
+
+        // Register each command.
+        commands.forEach((c: Command) => {
+            commandRegistry.registerCommand(c, new StubCommandHandler());
+        });
+
+        // Execute each command.
+        await commandRegistry.executeCommand(commandIds[0]);
+        await commandRegistry.executeCommand(commandIds[1]);
+        await commandRegistry.executeCommand(commandIds[2]);
+
+        // Clear the list of recently used commands.
+        commandRegistry.clearCommandHistory();
+        expect(commandRegistry.recent.length).equal(0);
+    });
 });
 
 class EmptyContributionProvider implements ContributionProvider<CommandContribution> {


### PR DESCRIPTION
Added an additional test to `command.spec.ts` in order to test the functionality of clearing the recently used command history.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
