### PR TITLE
[markers] enable navigating markers with single-click

### DIFF
--- a/packages/markers/src/browser/marker-tree-model.ts
+++ b/packages/markers/src/browser/marker-tree-model.ts
@@ -23,6 +23,12 @@ export class MarkerTreeModel extends TreeModelImpl {
 
     @inject(OpenerService) protected readonly openerService: OpenerService;
 
+    selectNode(node: TreeNode): void {
+        if (MarkerNode.is(node)) {
+            open(this.openerService, node.uri, this.getOpenerOptionsByMarker(node));
+        }
+    }
+
     protected doOpenNode(node: TreeNode): void {
         if (MarkerNode.is(node)) {
             open(this.openerService, node.uri, this.getOpenerOptionsByMarker(node));


### PR DESCRIPTION
Fixes #5003

---

**Description**

Enable navigating between markers in the `problems-widget`
with the use of a single-click rather than always a double-click.

Folder nodes behave the same way where a single-click collapses them,
while markers now simply require a single click (`select`) in order
to navigate to the corresponding marker in the editor.

**How to test**
1. Open a workspace, and ensure that multiple problems are present.
2. Open the `problems-widget`. (ex: `View` → `Problems`)
3. Notice the multiple errors present.
4. Single-click on a folder node (it should collapse/uncollapse).
5. Single-click on a problem marker (it should navigate to the problem in the editor).

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
