### PR TITLE
[markers] add 'Collapse All' toolbar item for the problems widget

### DIFF
--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -24,6 +24,7 @@ import { PROBLEM_KIND } from '../../common/problem-marker';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser/navigator-decorator-service';
 import { ProblemDecorator } from './problem-decorator';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 import '../../../src/browser/style/index.css';
 
@@ -40,6 +41,7 @@ export default new ContainerModule(bind => {
 
     bindViewContribution(bind, ProblemContribution);
     bind(FrontendApplicationContribution).toService(ProblemContribution);
+    bind(TabBarToolbarContribution).toService(ProblemContribution);
 
     bind(ProblemDecorator).toSelf().inSingletonScope();
     bind(NavigatorTreeDecorator).toService(ProblemDecorator);

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -23,6 +23,8 @@ import { TreeWidget, TreeProps, ContextMenuRenderer, TreeNode, NodeProps, TreeMo
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
 import * as React from 'react';
 
+export const PROBLEMS_WIDGET_ID = 'problems';
+
 @injectable()
 export class ProblemWidget extends TreeWidget {
 
@@ -34,7 +36,7 @@ export class ProblemWidget extends TreeWidget {
     ) {
         super(treeProps, model, contextMenuRenderer);
 
-        this.id = 'problems';
+        this.id = PROBLEMS_WIDGET_ID;
         this.title.label = 'Problems';
         this.title.caption = 'Problems';
         this.title.iconClass = 'fa problem-tab-icon';
@@ -61,8 +63,10 @@ export class ProblemWidget extends TreeWidget {
     protected handleCopy(event: ClipboardEvent) {
         const uris = this.model.selectedNodes.filter(MarkerNode.is).map(node => node.uri.toString());
         if (uris.length > 0) {
-            event.clipboardData.setData('text/plain', uris.join('\n'));
-            event.preventDefault();
+            if (event.clipboardData) {
+                event.clipboardData.setData('text/plain', uris.join('\n'));
+                event.preventDefault();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5069

Added a new toolbar item for the `problems-widget` in order to `Collapse All` nodes present in the problems widget. This aligns with the same toolbar item present in VSCode.

- Includes a minor fix to the `event.clipboardData` where it may be `undefined`.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
