### PR TITLE
Fix hosted plugin instance not actually stopping

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-manager-client.ts
@@ -166,6 +166,7 @@ export class HostedPluginManagerClient {
         } catch (error) {
             this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(error));
             this.stateChanged.fire({ state: HostedInstanceState.FAILED, pluginLocation: this.pluginLocation });
+            this.stop();
         }
     }
 
@@ -227,6 +228,7 @@ export class HostedPluginManagerClient {
             }
             this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(lastError));
             this.stateChanged.fire({ state: HostedInstanceState.FAILED, pluginLocation: this.pluginLocation! });
+            this.stop();
         } else {
             this.messageService.warn('Hosted Plugin instance is not running.');
         }


### PR DESCRIPTION
When hosted plugin instance failed, the status is changed to stopped with red backgroud ![image](https://user-images.githubusercontent.com/24614792/57190862-ef420600-6f27-11e9-85d6-f72095e460ad.png) but the instance is not actually stopped.

So i see "Stopped" but if i try to re-run the instance: 
![image](https://user-images.githubusercontent.com/24614792/57190941-ed2c7700-6f28-11e9-8258-6d8d2b41ba41.png)
i get a message:
![image](https://user-images.githubusercontent.com/24614792/57190930-c79f6d80-6f28-11e9-99fe-b5ae7cce563f.png)
This is a confusing behavior.

So if i really want to re-run the instance again i need to stop it manually and run again. 

This PR simply stop the instance after it failed for some reason.


