### PR TITLE
Add ability to close editor and retrieve document without opening the last one

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -732,6 +732,7 @@ export interface DocumentsMain {
     $tryCreateDocument(options?: { language?: string; content?: string; }): Promise<UriComponents>;
     $tryOpenDocument(uri: UriComponents, options?: TextDocumentShowOptions): Promise<void>;
     $trySaveDocument(uri: UriComponents): Promise<boolean>;
+    $tryCloseDocument(uri: UriComponents): Promise<boolean>;
 }
 
 export interface EnvMain {

--- a/packages/plugin-ext/src/main/browser/documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/documents-main.ts
@@ -188,4 +188,15 @@ export class DocumentsMainImpl implements DocumentsMain {
         return false;
     }
 
+    async $tryCloseDocument(uri: UriComponents): Promise<boolean> {
+        const widget = await this.editorManger.getByUri(new URI(CodeURI.revive(uri)));
+        if (widget) {
+            await Saveable.save(widget);
+            widget.close();
+            return true;
+        }
+
+        return false;
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/documents.ts
+++ b/packages/plugin-ext/src/plugin/documents.ts
@@ -197,6 +197,12 @@ export class DocumentsExtImpl implements DocumentsExt {
         return undefined;
     }
 
+    /**
+     * Retrieve document and open it in the editor if need.
+     *
+     * @param uri path to the resource
+     * @param options if options exists, resource will be opened in editor, otherwise only document object is returned
+     */
     async openDocument(uri: URI, options?: theia.TextDocumentShowOptions): Promise<DocumentDataExt | undefined> {
         const cached = this.editorsAndDocuments.getDocument(uri.toString());
         if (cached) {
@@ -248,6 +254,14 @@ export class DocumentsExtImpl implements DocumentsExt {
             };
         }
         await this.proxy.$tryOpenDocument(uri, documentOptions);
+
+        // below block of code needs to be removed after fix https://github.com/theia-ide/theia/issues/5079
+        if (!options) {
+            const document = this.editorsAndDocuments.getDocument(uri.toString());
+            await this.proxy.$tryCloseDocument(uri);
+            return document;
+        }
+
         return this.editorsAndDocuments.getDocument(uri.toString());
     }
 


### PR DESCRIPTION
This changes proposal adds small ability not to open editor if text document show options is undefined. This need to retrieve document object without opening the last one in persistence editor. This how vs code does in default behavior. This [method](https://github.com/theia-ide/theia/blob/master/packages/plugin-ext/src/api/plugin-api.ts#L733), according to default vs code behavior should not open editor, but return document object. Sample use case, is just getting document content and open it in web view. Without this fix we can get two opened editors. To avoid huge refactoring in plugin's documents and editors related code, there was decided to add simple checks if text document show options is undefined, then we don't keep opened editor.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>