### PR TITLE
non-blocking file upload API (formdata based)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Breaking changes:
 
 - [preferences] refactored to integrate launch configurations as preferences
+- [filesystem] extracted `FileUploadService` and refactored `FileTreeWidget` to use it [#5086](https://github.com/theia-ide/theia/pull/5086)
+  - moved `FileDownloadCommands.UPLOAD` to `FileSystemCommands.UPLOAD`
 
 ## v0.6.0
 

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -4,7 +4,6 @@
   "description": "Theia - FileSystem Extension",
   "dependencies": {
     "@theia/core": "^0.6.0",
-    "@types/base64-js": "^1.2.5",
     "@types/body-parser": "^1.17.0",
     "@types/formidable": "^1.0.31",
     "@types/fs-extra": "^4.0.2",
@@ -13,7 +12,6 @@
     "@types/tar-fs": "^1.16.1",
     "@types/touch": "0.0.1",
     "@types/uuid": "^3.4.3",
-    "base64-js": "^1.2.1",
     "body-parser": "^1.18.3",
     "drivelist": "^6.4.3",
     "formidable": "^1.2.1",

--- a/packages/filesystem/src/browser/download/file-download-command-contribution.ts
+++ b/packages/filesystem/src/browser/download/file-download-command-contribution.ts
@@ -16,14 +16,11 @@
 
 import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
+import { environment } from '@theia/application-package/lib/environment';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
 import { UriAwareCommandHandler, UriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
-import { ExpandableTreeNode } from '@theia/core/lib/browser/tree';
 import { FileDownloadService } from './file-download-service';
-import { FileSelection } from '../file-selection';
-import { TreeWidgetSelection } from '@theia/core/lib/browser/tree/tree-widget-selection';
-import { isCancelled } from '@theia/core/lib/common/cancellation';
 
 @injectable()
 export class FileDownloadCommandContribution implements CommandContribution {
@@ -37,30 +34,6 @@ export class FileDownloadCommandContribution implements CommandContribution {
     registerCommands(registry: CommandRegistry): void {
         const handler = new UriAwareCommandHandler<URI[]>(this.selectionService, this.downloadHandler(), { multi: true });
         registry.registerCommand(FileDownloadCommands.DOWNLOAD, handler);
-        registry.registerCommand(FileDownloadCommands.UPLOAD, new FileSelection.CommandHandler(this.selectionService, {
-            multi: false,
-            isEnabled: selection => this.canUpload(selection),
-            isVisible: selection => this.canUpload(selection),
-            execute: selection => this.upload(selection)
-        }));
-    }
-
-    protected canUpload({ fileStat }: FileSelection): boolean {
-        return fileStat.isDirectory;
-    }
-
-    protected async upload(selection: FileSelection): Promise<void> {
-        try {
-            const source = TreeWidgetSelection.getSource(this.selectionService.selection);
-            await this.downloadService.upload(selection.fileStat.uri);
-            if (ExpandableTreeNode.is(selection) && source) {
-                await source.model.expandNode(selection);
-            }
-        } catch (e) {
-            if (!isCancelled(e)) {
-                console.error(e);
-            }
-        }
     }
 
     protected downloadHandler(): UriCommandHandler<URI[]> {
@@ -76,7 +49,7 @@ export class FileDownloadCommandContribution implements CommandContribution {
     }
 
     protected isDownloadEnabled(uris: URI[]): boolean {
-        return uris.length > 0 && uris.every(u => u.scheme === 'file');
+        return !environment.electron.is() && uris.length > 0 && uris.every(u => u.scheme === 'file');
     }
 
     protected isDownloadVisible(uris: URI[]): boolean {
@@ -91,12 +64,6 @@ export namespace FileDownloadCommands {
         id: 'file.download',
         category: 'File',
         label: 'Download'
-    };
-
-    export const UPLOAD: Command = {
-        id: 'file.upload',
-        category: 'File',
-        label: 'Upload Files...'
     };
 
 }

--- a/packages/filesystem/src/browser/download/file-download-service.ts
+++ b/packages/filesystem/src/browser/download/file-download-service.ts
@@ -14,16 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { inject, injectable, postConstruct } from 'inversify';
+import { inject, injectable } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { cancelled } from '@theia/core/lib/common/cancellation';
 import { ILogger } from '@theia/core/lib/common/logger';
-import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar';
 import { FileSystem } from '../../common/filesystem';
 import { FileDownloadData } from '../../common/download/file-download-data';
-import { Deferred } from '@theia/core/lib/common/promise-util';
 import { MessageService } from '@theia/core/lib/common/message-service';
+import { FilesEndpoint } from '../files-endpoint';
 
 @injectable()
 export class FileDownloadService {
@@ -46,106 +44,8 @@ export class FileDownloadService {
     @inject(MessageService)
     protected readonly messageService: MessageService;
 
-    protected uploadForm: {
-        target: HTMLInputElement
-        file: HTMLInputElement
-    };
-
-    @postConstruct()
-    protected init(): void {
-        this.uploadForm = this.createUploadForm();
-    }
-
-    protected createUploadForm(): {
-        target: HTMLInputElement
-        file: HTMLInputElement
-    } {
-        const target = document.createElement('input');
-        target.type = 'text';
-        target.name = 'target';
-
-        const file = document.createElement('input');
-        file.type = 'file';
-        file.name = 'upload';
-        file.multiple = true;
-
-        const form = document.createElement('form');
-        form.style.display = 'none';
-        form.enctype = 'multipart/form-data';
-        form.append(target);
-        form.append(file);
-
-        document.body.appendChild(form);
-
-        file.addEventListener('change', async () => {
-            if (file.value) {
-                const body = new FormData(form);
-                // clean up to allow upload to the same folder twice
-                file.value = '';
-                const filesUrl = this.filesUrl();
-                const deferredUpload = this.deferredUpload;
-                try {
-                    const request = new XMLHttpRequest();
-
-                    const cb = () => {
-                        if (request.status === 200) {
-                            deferredUpload.resolve();
-                        } else {
-                            let statusText = request.statusText;
-                            if (!statusText) {
-                                if (request.status === 413) {
-                                    statusText = 'Payload Too Large';
-                                } else if (request.status) {
-                                    statusText = String(request.status);
-                                } else {
-                                    statusText = 'Network Failure';
-                                }
-                            }
-                            const message = 'Upload Failed: ' + statusText;
-                            deferredUpload.reject(new Error(message));
-                            this.messageService.error(message);
-                        }
-                    };
-                    request.addEventListener('load', cb);
-                    request.addEventListener('error', cb);
-                    request.addEventListener('abort', () => deferredUpload.reject(cancelled()));
-
-                    const progress = await this.messageService.showProgress({
-                        text: 'Uploading Files...', options: { cancelable: true }
-                    }, () => {
-                        request.upload.removeEventListener('progress', progressListener);
-                        request.abort();
-                    });
-                    deferredUpload.promise.then(() => progress.cancel(), () => progress.cancel());
-                    const progressListener = (event: ProgressEvent) => {
-                        if (event.lengthComputable) {
-                            progress.report({
-                                work: {
-                                    done: event.loaded,
-                                    total: event.total
-                                }
-                            });
-                        }
-                    };
-                    request.upload.addEventListener('progress', progressListener);
-
-                    request.open('POST', filesUrl);
-                    request.send(body);
-                } catch (e) {
-                    deferredUpload.reject(e);
-                }
-            }
-        });
-        return { target, file };
-    }
-
-    protected deferredUpload = new Deferred<void>();
-    upload(targetUri: string | URI): Promise<void> {
-        this.deferredUpload = new Deferred<void>();
-        this.uploadForm.target.value = String(targetUri);
-        this.uploadForm.file.click();
-        return this.deferredUpload.promise;
-    }
+    @inject(FilesEndpoint)
+    protected readonly filesEndpoint: FilesEndpoint;
 
     async download(uris: URI[]): Promise<void> {
         if (uris.length === 0) {
@@ -272,7 +172,7 @@ export class FileDownloadService {
     }
 
     protected filesUrl(): string {
-        return new Endpoint({ path: 'files' }).getRestUrl().toString();
+        return this.filesEndpoint.url.toString();
     }
 
 }

--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -1,0 +1,414 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable:no-any
+
+import { injectable, inject, postConstruct } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { cancelled, CancellationTokenSource, CancellationToken, checkCancelled } from '@theia/core/lib/common/cancellation';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { Progress } from '@theia/core/src/common/message-service-protocol';
+import { MaybePromise } from '@theia/core/src/common/types';
+import { DisposableCollection, Disposable } from '@theia/core/lib/common/disposable';
+import { FilesEndpoint } from './files-endpoint';
+
+// limit upload size to avoid out of memory in main process
+const maxUploadSize = 64 * 1024 * 1024;
+// timeout a request if it hangs on a flaky connection
+const uploadRequestTimeout = 5 * 1000;
+// retry to upload on a flaky connection
+const maxAttempts = 5;
+const initialRetryTimeout = 1000;
+
+export interface FileUploadParams {
+    source?: DataTransfer
+    progress?: FileUploadProgressParams
+}
+export interface FileUploadProgressParams {
+    text: string
+}
+
+export interface FileUploadResult {
+    uploaded: URI[]
+}
+
+@injectable()
+export class FileUploadService {
+
+    static TARGET = 'target';
+    static UPLOAD = 'upload';
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(FilesEndpoint)
+    protected readonly endpoint: FilesEndpoint;
+
+    protected uploadForm: FileUploadService.Form;
+
+    @postConstruct()
+    protected init(): void {
+        this.uploadForm = this.createUploadForm();
+    }
+
+    protected createUploadForm(): FileUploadService.Form {
+        const targetInput = document.createElement('input');
+        targetInput.type = 'text';
+        targetInput.name = FileUploadService.TARGET;
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.name = FileUploadService.UPLOAD;
+        fileInput.multiple = true;
+
+        const form = document.createElement('form');
+        form.style.display = 'none';
+        form.enctype = 'multipart/form-data';
+        form.append(targetInput);
+        form.append(fileInput);
+
+        document.body.appendChild(form);
+
+        fileInput.addEventListener('change', () => {
+            if (this.deferredUpload && fileInput.value) {
+                const body = new FormData(form);
+                // clean up to allow upload to the same folder twice
+                fileInput.value = '';
+                const target = new URI(<string>body.get(FileUploadService.TARGET));
+                const uploaded = body.getAll(FileUploadService.UPLOAD).map((file: File) => target.resolve(file.name));
+                const { resolve, reject } = this.deferredUpload;
+                this.deferredUpload = undefined;
+                this.withProgress((progress, token) => this.submitForm({
+                    body, token,
+                    onDidProgress: event => {
+                        if (event.lengthComputable) {
+                            progress.report({
+                                work: {
+                                    done: event.loaded,
+                                    total: event.total
+                                }
+                            });
+                        }
+                    }
+                }), this.uploadForm.progress).then(() => resolve({ uploaded }), reject);
+            }
+        });
+        return { targetInput, fileInput };
+    }
+
+    protected deferredUpload: Deferred<FileUploadResult> | undefined;
+    async upload(targetUri: string | URI, params: FileUploadParams = {}): Promise<FileUploadResult> {
+        const { source } = params;
+        if (source) {
+            return this.withProgress(async (progress, token) => {
+                const context: FileUploadService.Context = { entries: [], progress, token };
+                await this.indexDataTransfer(new URI(String(targetUri)), source, context);
+                return this.doUpload(context);
+            }, params.progress);
+        }
+        this.deferredUpload = new Deferred<FileUploadResult>();
+        this.uploadForm.targetInput.value = String(targetUri);
+        this.uploadForm.fileInput.click();
+        this.uploadForm.progress = params.progress;
+        return this.deferredUpload.promise;
+    }
+
+    protected async doUpload({ entries, progress, token }: FileUploadService.Context): Promise<FileUploadResult> {
+        const result: FileUploadResult = { uploaded: [] };
+        if (!entries.length) {
+            return result;
+        }
+        let done = 0;
+        const total = entries.length;
+        let chunkSize = 0;
+        let chunkLength = 0;
+        let body = new FormData();
+        const uploadChunk = async () => {
+            progress.report({ work: { done, total } });
+            await this.submitForm({
+                body, token,
+                onDidProgress: event => {
+                    if (event.lengthComputable) {
+                        const chunkDone = chunkLength * event.loaded / event.total;
+                        progress.report({
+                            work: {
+                                done: done + chunkDone,
+                                total
+                            }
+                        });
+                    }
+                }
+            });
+            checkCancelled(token);
+            for (const file of body.getAll(FileUploadService.UPLOAD)) {
+                result.uploaded.push(new URI((file as File).name));
+            }
+            done += chunkLength;
+            progress.report({ work: { done, total } });
+            chunkLength = 0;
+            chunkSize = 0;
+            body = new FormData();
+        };
+        for (const entry of entries) {
+            const file = await entry.file();
+            checkCancelled(token);
+            if (chunkLength && chunkSize + file.size > maxUploadSize) {
+                await uploadChunk();
+            }
+            chunkLength++;
+            chunkSize += file.size;
+            body.append(FileUploadService.UPLOAD, file, entry.uri.toString());
+        }
+        if (chunkLength) {
+            await uploadChunk();
+        }
+        progress.report({ work: { done: total, total } });
+        return result;
+    }
+
+    protected async withProgress<T>(
+        cb: (progress: Progress, token: CancellationToken) => Promise<T>,
+        { text }: FileUploadProgressParams = { text: 'Uploading Files...' }
+    ): Promise<T> {
+        const cancellationSource = new CancellationTokenSource();
+        const { token } = cancellationSource;
+        const progress = await this.messageService.showProgress({ text, options: { cancelable: true } }, () => cancellationSource.cancel());
+        try {
+            return await cb(progress, token);
+        } finally {
+            progress.cancel();
+        }
+    }
+
+    protected async indexDataTransfer(targetUri: URI, dataTransfer: DataTransfer, context: FileUploadService.Context): Promise<void> {
+        checkCancelled(context.token);
+        if (dataTransfer.items) {
+            await this.indexDataTransferItemList(targetUri, dataTransfer.items, context);
+        } else {
+            this.indexFileList(targetUri, dataTransfer.files, context);
+        }
+    }
+
+    protected indexFileList(targetUri: URI, files: FileList, context: FileUploadService.Context): void {
+        for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            if (file) {
+                this.indexFile(targetUri, file, context);
+            }
+        }
+    }
+
+    protected indexFile(targetUri: URI, file: File, context: FileUploadService.Context): void {
+        context.entries.push({
+            uri: targetUri.resolve(file.name),
+            file: () => file
+        });
+    }
+
+    protected async indexDataTransferItemList(targetUri: URI, items: DataTransferItemList, context: FileUploadService.Context): Promise<void> {
+        checkCancelled(context.token);
+        const promises: Promise<void>[] = [];
+        for (let i = 0; i < items.length; i++) {
+            const entry = items[i].webkitGetAsEntry() as WebKitEntry;
+            promises.push(this.indexEntry(targetUri, entry, context));
+        }
+        await Promise.all(promises);
+    }
+
+    protected async indexEntry(targetUri: URI, entry: WebKitEntry | null, context: FileUploadService.Context): Promise<void> {
+        checkCancelled(context.token);
+        if (!entry) {
+            return;
+        }
+        if (entry.isDirectory) {
+            await this.indexDirectoryEntry(targetUri, entry as WebKitDirectoryEntry, context);
+        } else {
+            this.indexFileEntry(targetUri, entry as WebKitFileEntry, context);
+        }
+    }
+
+    protected async indexDirectoryEntry(targetUri: URI, entry: WebKitDirectoryEntry, context: FileUploadService.Context): Promise<void> {
+        checkCancelled(context.token);
+        const newTargetUri = targetUri.resolve(entry.name);
+        const promises: Promise<void>[] = [];
+        await this.readEntries(entry, items => promises.push(this.indexEntries(newTargetUri, items, context)), context);
+        await Promise.all(promises);
+    }
+
+    /**
+     *  Read all entries within a folder by block of 100 files or folders until the
+     *  whole folder has been read.
+     */
+    protected async readEntries(entry: WebKitDirectoryEntry, cb: (items: any) => void, context: FileUploadService.Context): Promise<void> {
+        return new Promise<void>(async (resolve, reject) => {
+            const reader = entry.createReader();
+            const getEntries = () => reader.readEntries(results => {
+                if (!context.token.isCancellationRequested && results && results.length) {
+                    cb(results);
+                    getEntries(); // loop to read all entries
+                } else {
+                    resolve();
+                }
+            }, reject);
+            getEntries();
+        });
+    }
+
+    protected async indexEntries(targetUri: URI, entries: WebKitEntry[], context: FileUploadService.Context): Promise<void> {
+        checkCancelled(context.token);
+        const promises: Promise<void>[] = [];
+        for (let i = 0; i < entries.length; i++) {
+            promises.push(this.indexEntry(targetUri, entries[i], context));
+        }
+        await Promise.all(promises);
+    }
+
+    protected indexFileEntry(targetUri: URI, entry: WebKitFileEntry, context: FileUploadService.Context): void {
+        context.entries.push({
+            uri: targetUri.resolve(entry.name),
+            file: () => new Promise((resolve, reject) => entry.file(resolve, reject))
+        });
+    }
+
+    protected async submitForm(options: FileUploadService.SubmitOptions): Promise<void> {
+        let attempts = 0;
+        let retryTimeout = initialRetryTimeout;
+        let error: FileUploadService.SubmitError | undefined;
+        while (attempts < maxAttempts) {
+            try {
+                error = undefined;
+                await this.doSubmitForm(options);
+                return;
+            } catch (e) {
+                if (!FileUploadService.isSubmitError(e)) {
+                    throw e;
+                }
+                error = e;
+                if (e.status === 0) {
+                    this.messageService.warn(`Upload Failed: ${e.message}, trying again in ${retryTimeout / 1000} sec${retryTimeout !== 1000 ? 's' : ''}`, {
+                        timeout: retryTimeout
+                    });
+                    await new Promise(resolve => setTimeout(resolve, retryTimeout));
+                    retryTimeout = retryTimeout * 2;
+                    attempts++;
+                } else {
+                    attempts = maxAttempts;
+                }
+            }
+        }
+        if (error) {
+            this.messageService.error('Upload Failed: ' + error.message, { timeout: 0 });
+            throw error;
+        }
+    }
+
+    protected async doSubmitForm({ body, token, onDidProgress }: FileUploadService.SubmitOptions): Promise<void> {
+        const deferredUpload = new Deferred<void>();
+        try {
+            const request = new XMLHttpRequest();
+
+            const toDispose = new DisposableCollection();
+            deferredUpload.promise.then(() => toDispose.dispose(), () => toDispose.dispose());
+            // IMPORTANT: we should release all listeners in order to release associated FormData and Files!
+            const addRequestListener = <K extends keyof XMLHttpRequestEventMap>(type: K, listener: (this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any) => {
+                request.addEventListener(type, listener);
+                toDispose.push(Disposable.create(() => request.removeEventListener<K>(type, listener)));
+            };
+            const addProgressListener = (listener: (event: ProgressEvent) => void) => {
+                request.upload.addEventListener('progress', listener);
+                toDispose.push(Disposable.create(() => request.upload.removeEventListener('progress', listener)));
+            };
+
+            const rejectRequest = (statusText: string, status = 0) => {
+                const error: FileUploadService.SubmitError = Object.assign(new Error(statusText), { status });
+                deferredUpload.reject(error);
+            };
+
+            const cb = () => {
+                if (request.status === 200) {
+                    deferredUpload.resolve();
+                } else {
+                    let statusText = request.statusText;
+                    if (!statusText) {
+                        if (request.status === 413) {
+                            statusText = 'Payload Too Large';
+                        } else if (request.status) {
+                            statusText = String(request.status);
+                        } else {
+                            statusText = 'Network Failure';
+                        }
+                    }
+                    rejectRequest(statusText, request.status);
+                }
+            };
+            addRequestListener('load', cb);
+            addRequestListener('error', cb);
+            addRequestListener('abort', () => deferredUpload.reject(cancelled()));
+
+            toDispose.push(token.onCancellationRequested(() => request.abort()));
+            addProgressListener(onDidProgress);
+
+            const toDisposeOnResetTimeout = new DisposableCollection();
+            const resetTimeout = () => {
+                toDisposeOnResetTimeout.dispose();
+                toDispose.push(toDisposeOnResetTimeout);
+                const handle = setTimeout(() => {
+                    rejectRequest('the request has timed out');
+                    request.abort();
+                }, uploadRequestTimeout);
+                toDisposeOnResetTimeout.push(Disposable.create(() => clearTimeout(handle)));
+            };
+            resetTimeout();
+            addProgressListener(resetTimeout);
+
+            request.open('POST', this.endpoint.url.toString());
+            request.send(body);
+        } catch (e) {
+            deferredUpload.reject(e);
+        }
+        return deferredUpload.promise;
+    }
+
+}
+
+export namespace FileUploadService {
+    export interface UploadEntry {
+        file: () => MaybePromise<File>
+        uri: URI
+    }
+    export interface Context {
+        progress: Progress
+        token: CancellationToken
+        entries: UploadEntry[]
+    }
+    export interface Form {
+        targetInput: HTMLInputElement
+        fileInput: HTMLInputElement
+        progress?: FileUploadProgressParams
+    }
+    export interface SubmitOptions {
+        body: FormData
+        token: CancellationToken
+        onDidProgress: (event: ProgressEvent) => void
+    }
+    export interface SubmitError extends Error {
+        status: number;
+    }
+    export function isSubmitError(e: any): e is SubmitError {
+        return !!e && 'status' in e;
+    }
+}

--- a/packages/filesystem/src/browser/files-endpoint.ts
+++ b/packages/filesystem/src/browser/files-endpoint.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { Endpoint } from '@theia/core/lib/browser/endpoint';
+
+@injectable()
+export class FilesEndpoint {
+
+    private readonly endpoint = new Endpoint({ path: 'files' });
+
+    get url(): URI {
+        return this.endpoint.getRestUrl();
+    }
+
+}

--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -17,7 +17,7 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule, interfaces } from 'inversify';
-import { ResourceResolver } from '@theia/core/lib/common';
+import { ResourceResolver, CommandContribution } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider, FrontendApplicationContribution, ConfirmDialog } from '@theia/core/lib/browser';
 import { FileSystem, fileSystemPath, FileShouldOverwrite, FileStat } from '../common';
 import {
@@ -29,6 +29,8 @@ import { bindFileSystemPreferences } from './filesystem-preferences';
 import { FileSystemWatcher } from './filesystem-watcher';
 import { FileSystemFrontendContribution } from './filesystem-frontend-contribution';
 import { FileSystemProxyFactory } from './filesystem-proxy-factory';
+import { FilesEndpoint } from './files-endpoint';
+import { FileUploadService } from './file-upload-service';
 
 export default new ContainerModule(bind => {
     bindFileSystemPreferences(bind);
@@ -56,7 +58,12 @@ export default new ContainerModule(bind => {
 
     bindFileResource(bind);
 
-    bind(FrontendApplicationContribution).to(FileSystemFrontendContribution).inSingletonScope();
+    bind(FilesEndpoint).toSelf().inSingletonScope();
+    bind(FileUploadService).toSelf().inSingletonScope();
+
+    bind(FileSystemFrontendContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(FileSystemFrontendContribution);
+    bind(FrontendApplicationContribution).toService(FileSystemFrontendContribution);
 });
 
 export function bindFileResource(bind: interfaces.Bind): void {

--- a/packages/messages/src/browser/notifications.ts
+++ b/packages/messages/src/browser/notifications.ts
@@ -160,7 +160,7 @@ class ProgressNotificationImpl implements ProgressNotification {
         container = document.getElementById('notification-container-' + this.properties.id);
         if (container) {
             const progressContainer = container.appendChild(document.createElement('div'));
-            progressContainer.className = 'progress';
+            progressContainer.className = 'theia-notification-progress';
             const progress = progressContainer.appendChild(document.createElement('p'));
             progress.id = 'notification-progress-' + this.properties.id;
         }

--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -77,10 +77,12 @@
     color: var(--theia-warn-color0);
 }
 
-.theia-Notification .progress {
+.theia-notification-progress {
     order: 2;
     width: 35px;
+    display: flex;
     align-items: center;
+    justify-items: left;
     -webkit-user-select: text;
     -moz-user-select: text;
     -ms-user-select: text;
@@ -89,7 +91,7 @@
     height: 100%;
 }
 
-.theia-Notification .progress > p {
+.theia-notification-progress > p {
     margin: 0px;
     font-size: var(--theia-ui-font-size1);
     vertical-align: middle;

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -31,6 +31,7 @@ import { FileNavigatorFilter } from './navigator-filter';
 import { WorkspaceNode } from './navigator-tree';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 
 export namespace FileNavigatorCommands {
     export const REVEAL_IN_NAVIGATOR: Command = {
@@ -195,7 +196,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
         const downloadUploadMenu = [...NAVIGATOR_CONTEXT_MENU, '6_downloadupload'];
         registry.registerMenuAction(downloadUploadMenu, {
-            commandId: FileDownloadCommands.UPLOAD.id,
+            commandId: FileSystemCommands.UPLOAD.id,
             order: 'a'
         });
         registry.registerMenuAction(downloadUploadMenu, {

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -33,6 +33,7 @@ import { WorkspaceDuplicateHandler } from './workspace-duplicate-handler';
 import { FileSystemUtils } from '@theia/filesystem/lib/common';
 import { WorkspaceCompareHandler } from './workspace-compare-handler';
 import { FileDownloadCommands } from '@theia/filesystem/lib/browser/download/file-download-command-contribution';
+import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 
 const validFilename: (arg: string) => boolean = require('valid-filename');
 
@@ -144,7 +145,7 @@ export class FileMenuContribution implements MenuContribution {
         });
         const downloadUploadMenu = [...CommonMenus.FILE, '4_downloadupload'];
         registry.registerMenuAction(downloadUploadMenu, {
-            commandId: FileDownloadCommands.UPLOAD.id,
+            commandId: FileSystemCommands.UPLOAD.id,
             order: 'a'
         });
         registry.registerMenuAction(downloadUploadMenu, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,10 +133,6 @@
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
 
-"@types/base64-js@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@types/base64-js/-/base64-js-1.2.5.tgz#582b2476169a6cba460a214d476c744441d873d5"
-
 "@types/body-parser@*", "@types/body-parser@^1.16.4", "@types/body-parser@^1.17.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
@@ -1594,7 +1590,7 @@ base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
 
-base64-js@^1.0.2, base64-js@^1.2.1:
+base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 


### PR DESCRIPTION
- fix #4732 - one should be able to upload files via drag and drop without blocking UI and crashing the browser with out-of-memory.
- fix #4923 - extract upload to own service
- fix #969 - uploading a single file up to 2G is possible

It's breaking to redesign APIs. I've updated CHANGELOG with a record for it.

TODO:
- [x] firefox
  - [x] bogus percentage
  - [x] ~often bad request~ - it's a Gitpod proxy issue, i don't get it locally
  - [x] bogus progress styles
- [x] linux
  - [x] upload to the same device (cross-device link not permitted, i.e. from `/tmp` to `/home`) 
- [x] minimize sync fs access
- [x] retry on network failures
- [x] electron
  - [x] remove upload
  - [x] remove download