### PR TITLE
Rename overriden to overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
   - `URI.withoutScheme` is removed, in order to get a path use `URI.path`
 - [debug] align commands with VS Code [#5102](https://github.com/theia-ide/theia/issues/5102)
     - `debug.restart` renamed to `workbench.action.debug.restart`
+- [preferences] renamed overridenPreferenceName to overriddenPreferenceName
 
 ## v0.7.0
 

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -156,9 +156,9 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
 
                 const value = schemaProps.defaultValue = this.getDefaultValue(schemaProps, preferenceName);
                 if (this.testOverrideValue(preferenceName, value)) {
-                    for (const overridenPreferenceName in value) {
-                        const overrideValue = value[overridenPreferenceName];
-                        const overridePreferenceName = `${preferenceName}.${overridenPreferenceName}`;
+                    for (const overriddenPreferenceName in value) {
+                        const overrideValue = value[overriddenPreferenceName];
+                        const overridePreferenceName = `${preferenceName}.${overriddenPreferenceName}`;
                         changes.push(this.doSetPreferenceValue(overridePreferenceName, overrideValue, { scope, domain }));
                     }
                 } else {
@@ -283,14 +283,14 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     }
 
     getPreferenceProperty(preferenceName: string): PreferenceItem | undefined {
-        const overriden = this.overridenPreferenceName(preferenceName);
-        return this.combinedSchema.properties[overriden ? overriden.preferenceName : preferenceName];
+        const overridden = this.overriddenPreferenceName(preferenceName);
+        return this.combinedSchema.properties[overridden ? overridden.preferenceName : preferenceName];
     }
 
     overridePreferenceName({ preferenceName, overrideIdentifier }: OverridePreferenceName): string {
         return `[${overrideIdentifier}].${preferenceName}`;
     }
-    overridenPreferenceName(name: string): OverridePreferenceName | undefined {
+    overriddenPreferenceName(name: string): OverridePreferenceName | undefined {
         const index = name.indexOf('.');
         if (index === -1) {
             return undefined;

--- a/packages/core/src/browser/preferences/preference-proxy.ts
+++ b/packages/core/src/browser/preferences/preference-proxy.ts
@@ -46,15 +46,15 @@ export function createPreferenceProxy<T>(preferences: PreferenceService, schema:
     const onPreferenceChangedEmitter = new Emitter<PreferenceChangeEvent<T>>();
     toDispose.push(onPreferenceChangedEmitter);
     toDispose.push(preferences.onPreferenceChanged(e => {
-        const overriden = preferences.overridenPreferenceName(e.preferenceName);
-        const preferenceName: any = overriden ? overriden.preferenceName : e.preferenceName;
+        const overridden = preferences.overriddenPreferenceName(e.preferenceName);
+        const preferenceName: any = overridden ? overridden.preferenceName : e.preferenceName;
         if (schema.properties[preferenceName]) {
             const { newValue, oldValue } = e;
             onPreferenceChangedEmitter.fire({
                 newValue, oldValue, preferenceName,
                 affects: (resourceUri, overrideIdentifier) => {
                     if (overrideIdentifier !== undefined) {
-                        if (overriden && overriden.overrideIdentifier !== overrideIdentifier) {
+                        if (overridden && overridden.overrideIdentifier !== overrideIdentifier) {
                             return false;
                         }
                     }

--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -86,7 +86,7 @@ export interface PreferenceService extends Disposable {
     } | undefined;
 
     overridePreferenceName(options: OverridePreferenceName): string;
-    overridenPreferenceName(preferenceName: string): OverridePreferenceName | undefined;
+    overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined;
 
     resolve<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): PreferenceResolveResult<T>;
 }
@@ -183,10 +183,10 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
             for (const preferenceName of Object.keys(changes)) {
                 let change = changes[preferenceName];
                 if (change.newValue === undefined) {
-                    const overriden = this.overridenPreferenceName(change.preferenceName);
-                    if (overriden) {
+                    const overridden = this.overriddenPreferenceName(change.preferenceName);
+                    if (overridden) {
                         change = {
-                            ...change, newValue: this.doGet(overriden.preferenceName)
+                            ...change, newValue: this.doGet(overridden.preferenceName)
                         };
                     }
                 }
@@ -285,9 +285,9 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     } {
         const { value, configUri } = this.doResolve(preferenceName, defaultValue, resourceUri);
         if (value === undefined) {
-            const overriden = this.overridenPreferenceName(preferenceName);
-            if (overriden) {
-                return this.doResolve(overriden.preferenceName, defaultValue, resourceUri);
+            const overridden = this.overriddenPreferenceName(preferenceName);
+            if (overridden) {
+                return this.doResolve(overridden.preferenceName, defaultValue, resourceUri);
             }
         }
         return { value, configUri };
@@ -358,9 +358,9 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     protected inspectInScope<T>(preferenceName: string, scope: PreferenceScope, resourceUri?: string): T | undefined {
         const value = this.doInspectInScope<T>(preferenceName, scope, resourceUri);
         if (value === undefined) {
-            const overriden = this.overridenPreferenceName(preferenceName);
-            if (overriden) {
-                return this.doInspectInScope(overriden.preferenceName, scope, resourceUri);
+            const overridden = this.overriddenPreferenceName(preferenceName);
+            if (overridden) {
+                return this.doInspectInScope(overridden.preferenceName, scope, resourceUri);
             }
         }
         return value;
@@ -369,8 +369,8 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
     overridePreferenceName(options: OverridePreferenceName): string {
         return this.schema.overridePreferenceName(options);
     }
-    overridenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
-        return this.schema.overridenPreferenceName(preferenceName);
+    overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
+        return this.schema.overriddenPreferenceName(preferenceName);
     }
 
     protected doHas(preferenceName: string, resourceUri?: string): boolean {

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -52,7 +52,7 @@ export class MockPreferenceService implements PreferenceService {
     overridePreferenceName(options: OverridePreferenceName): string {
         return options.preferenceName;
     }
-    overridenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
+    overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
         return undefined;
     }
 }


### PR DESCRIPTION
Rename `overriden` to `overridden` in the following files:
- preference-contribution.ts
- preference-proxy.ts
- preference-service.ts 
- mock-preference-service.ts