### PR TITLE
Fixed #5090: corrected code that breaks the no-void-expression rule & raised the rule from warning to error

### DIFF
--- a/configs/errors.tslint.json
+++ b/configs/errors.tslint.json
@@ -45,6 +45,11 @@
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
+    "no-void-expression": {
+      "options": [
+        "ignore-arrow-function-shorthand"
+      ]
+    },
     "one-line": [
       true,
       "check-open-brace",

--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -43,12 +43,6 @@
     },
     "no-return-await": {
       "severity": "warning"
-    },
-    "no-void-expression": {
-      "severity": "warning",
-      "options": [
-        "ignore-arrow-function-shorthand"
-      ]
     }
   }
 }

--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -103,7 +103,8 @@ export class SourceTreeWidget extends TreeWidget {
         // no-op
     }
     protected superRestoreState(state: object): void {
-        return super.restoreState(state);
+        super.restoreState(state);
+        return;
     }
 
 }

--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -257,7 +257,8 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     async toggleNodeExpansion(raw?: Readonly<ExpandableTreeNode>): Promise<void> {
         for (const node of raw ? [raw] : this.selectedNodes) {
             if (ExpandableTreeNode.is(node)) {
-                return await this.expansionService.toggleNodeExpansion(node);
+                await this.expansionService.toggleNodeExpansion(node);
+                return;
             }
         }
     }

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -113,7 +113,8 @@ export class MenuModelRegistry {
 
         if (menuPath) {
             const parent = this.findGroup(menuPath);
-            return parent.removeNode(id);
+            parent.removeNode(id);
+            return;
         }
 
         // Recurse all menus, removing any menus matching the id

--- a/packages/cpp/src/browser/cpp-build-configurations-ui.ts
+++ b/packages/cpp/src/browser/cpp-build-configurations-ui.ts
@@ -85,7 +85,8 @@ export class CppBuildConfigurationChanger implements QuickOpenModel {
 
         // Only return 'Create New' when no build configurations present
         if (!configurations.length) {
-            return acceptor(items);
+            acceptor(items);
+            return;
         }
 
         // Item to de-select any active build config

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -119,7 +119,8 @@ export class DebugConfigurationManager {
         return this.getSupported();
     }
     protected async getSupported(): Promise<IterableIterator<DebugSessionOptions>> {
-        const [, debugTypes] = await Promise.all([await this.initialized, this.debug.debugTypes()]);
+        await this.initialized;
+        const debugTypes = await this.debug.debugTypes();
         return this.doGetSupported(new Set(debugTypes));
     }
     protected *doGetSupported(debugTypes: Set<string>): IterableIterator<DebugSessionOptions> {

--- a/packages/extension-manager/src/node/application-project.ts
+++ b/packages/extension-manager/src/node/application-project.ts
@@ -155,7 +155,7 @@ export class ApplicationProject implements Disposable {
                 reverting,
                 failed: true
             });
-            await this.revert(token);
+            this.revert(token);
         }
     }
 

--- a/packages/filesystem/src/node/node-filesystem.ts
+++ b/packages/filesystem/src/node/node-filesystem.ts
@@ -208,7 +208,8 @@ export class FileSystemNode implements FileSystem {
             return new Promise<FileStat>((resolve, reject) => {
                 mv(FileUri.fsPath(_sourceUri), FileUri.fsPath(_targetUri), { mkdirp: true, clobber: overwrite }, async error => {
                     if (error) {
-                        return reject(error);
+                        reject(error);
+                        return;
                     }
                     resolve(await this.doGetStat(_targetUri, 1));
                 });
@@ -289,7 +290,8 @@ export class FileSystemNode implements FileSystem {
                 // tslint:disable-next-line:no-any
                 touch(FileUri.fsPath(_uri), async (error: any) => {
                     if (error) {
-                        return reject(error);
+                        reject(error);
+                        return;
                     }
                     resolve(await this.doGetStat(_uri, 1));
                 });
@@ -316,7 +318,8 @@ export class FileSystemNode implements FileSystem {
                 await new Promise<void>((resolve, reject) => {
                     fs.rename(filePath, outputRootPath, async error => {
                         if (error) {
-                            return reject(error);
+                            reject(error);
+                            return;
                         }
                         resolve();
                     });

--- a/packages/git/src/electron-node/askpass/askpass-main.ts
+++ b/packages/git/src/electron-node/askpass/askpass-main.ts
@@ -25,11 +25,13 @@ const expectedArgvCount = 5;
 function main(argv: string[]): void {
 
     if (argv.length !== expectedArgvCount) {
-        return fatal(`Wrong number of arguments. Expected ${expectedArgvCount}. Got ${argv.length} instead.`);
+        fatal(`Wrong number of arguments. Expected ${expectedArgvCount}. Got ${argv.length} instead.`);
+        return;
     }
 
     if (!process.env['THEIA_GIT_ASKPASS_HANDLE']) {
-        return fatal("Missing 'THEIA_GIT_ASKPASS_HANDLE' handle.");
+        fatal("Missing 'THEIA_GIT_ASKPASS_HANDLE' handle.");
+        return;
     }
 
     const handle = process.env['THEIA_GIT_ASKPASS_HANDLE'] as string;
@@ -48,7 +50,8 @@ function main(argv: string[]): void {
 
     const req = http.request(opts, res => {
         if (res.statusCode !== 200) {
-            return fatal(`Bad status code: ${res.statusCode}.`);
+            fatal(`Bad status code: ${res.statusCode}.`);
+            return;
         }
 
         const chunks: string[] = [];
@@ -61,7 +64,8 @@ function main(argv: string[]): void {
                 const result = JSON.parse(raw);
                 process.stdout.write(result);
             } catch (err) {
-                return fatal('Error parsing the response.');
+                fatal('Error parsing the response.');
+                return;
             }
 
             setTimeout(() => process.exit(0), 0);

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -115,7 +115,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         const firstChild = root.children[0];
         root.children.forEach(child => CompositeTreeNode.is(child) && model.collapseAll(child));
         if (SelectableTreeNode.is(firstChild)) {
-            await model.selectNode(firstChild);
+            model.selectNode(firstChild);
         }
     }
 

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -57,7 +57,8 @@ export class ProblemWidget extends TreeWidget {
         // no-op
     }
     protected superRestoreState(state: object): void {
-        return super.restoreState(state);
+        super.restoreState(state);
+        return;
     }
 
     protected handleCopy(event: ClipboardEvent) {

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -314,7 +314,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         // select first visible node
         const firstChild = WorkspaceNode.is(root) ? root.children[0] : root;
         if (SelectableTreeNode.is(firstChild)) {
-            await model.selectNode(firstChild);
+            model.selectNode(firstChild);
         }
     }
 

--- a/packages/plugin-ext/src/hosted/node/plugin-service.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-service.ts
@@ -117,7 +117,8 @@ export class HostedPluginServerImpl implements HostedPluginServer {
     }
 
     terminateHostedPluginInstance(): Promise<void> {
-        return Promise.resolve(this.hostedInstanceManager.terminate());
+        this.hostedInstanceManager.terminate();
+        return Promise.resolve();
     }
 
     isHostedPluginInstanceRunning(): Promise<boolean> {

--- a/packages/preview/src/browser/markdown/markdown-preview-handler.ts
+++ b/packages/preview/src/browser/markdown/markdown-preview-handler.ts
@@ -230,6 +230,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                         token.attrSet('data-line', line.toString());
                     }
                     return (originalRenderer)
+                        // tslint:disable-next-line:no-void-expression
                         ? originalRenderer(tokens, index, options, env, self)
                         : self.renderToken(tokens, index, options);
                 };
@@ -247,6 +248,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                         }
                     }
                 }
+                // tslint:disable-next-line:no-void-expression
                 return originalImageRenderer(tokens, index, options, env, self);
             };
 
@@ -285,6 +287,7 @@ export class MarkdownPreviewHandler implements PreviewHandler {
                         const documentUri = env.originUri;
                         currentToken.content = normalizeAllImgSrcInHTML(content, link => this.linkNormalizer.normalizeLink(documentUri, link));
                     }
+                    // tslint:disable-next-line:no-void-expression
                     return originalRenderer(tokens, index, options, env, self);
                 };
             }


### PR DESCRIPTION
Fixed #5090.

Abiding by the *[no-void-expression](https://palantir.github.io/tslint/rules/no-void-expression/)* rule, changed all occurrences of void expression that is not in the statement position.

For example, changed 

```ts
    ...
    return parent.removeNode(id); 
}
```
to
```ts
    ...
    parent.removeNode(id);
    return;
}
```

Also, as all the rule-offenders have been corrected, I propose to raise the tslint *no-void-expression* rule from a warning to an error. This would avoid this issue in the future and thus improve the readability of the code.