### PR TITLE
Fixed #5096: fixed and improved the display of the git-history widget

### DIFF
--- a/packages/git/src/browser/git-navigable-list-widget.tsx
+++ b/packages/git/src/browser/git-navigable-list-widget.tsx
@@ -98,12 +98,12 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
         return result;
     }
 
-    protected renderHeaderRow({ name, value, classNames }: { name: string, value: React.ReactNode, classNames?: string[] }): React.ReactNode {
+    protected renderHeaderRow({ name, value, classNames, title }: { name: string, value: React.ReactNode, classNames?: string[], title?: string }): React.ReactNode {
         if (!value) {
             return;
         }
         const className = ['header-row', ...(classNames || [])].join(' ');
-        return <div key={name} className={className}>
+        return <div key={name} className={className} title={title}>
             <div className='theia-header'>{name}</div>
             <div className='header-value'>{value}</div>
         </div>;

--- a/packages/git/src/browser/history/git-history-widget.tsx
+++ b/packages/git/src/browser/history/git-history-widget.tsx
@@ -272,12 +272,13 @@ export class GitHistoryWidget extends GitNavigableListWidget<GitHistoryListNode>
     protected renderHistoryHeader(): React.ReactNode {
         if (this.options.uri) {
             const path = this.relativePath(this.options.uri);
+            const fileName = path.split('/').pop();
             return <div className='diff-header'>
                 {
                     this.renderHeaderRow({ name: 'repository', value: this.getRepositoryLabel(this.options.uri) })
                 }
                 {
-                    this.renderHeaderRow({ name: 'path', value: path })
+                    this.renderHeaderRow({ name: 'file', value: fileName, title: path })
                 }
                 <div className='theia-header'>
                     Commits

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -46,6 +46,9 @@
 
 .theia-git .header-value {
     margin: 9px 0px 5px 5px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .theia-git .gitItem.diff-file {


### PR DESCRIPTION
Fixed #5096.

![](https://media.giphy.com/media/WRpC4RNJuMhgc5zs5K/giphy.gif)

With the updated code, instead of displaying the entire path, the **Git History** panel would display the **File** name, which will not be truncated when it is resized. In order to be consistent with the display of the Commit History, the overflow text will instead be replaced by *ellipsis* (...), and the user would be able to see the entire path if he hovered over the text of **File**.