### PR TITLE
fix theia/#5018 Removed superfluous padding

### DIFF
--- a/packages/core/src/browser/style/alert-messages.css
+++ b/packages/core/src/browser/style/alert-messages.css
@@ -20,10 +20,6 @@
     padding: 10px;
 }
 
-.theia-side-panel .theia-alert-message-container {
-    padding-left: 20px;
-}
-
 .theia-alert-message-container i {
     padding-right: 3px;
 }


### PR DESCRIPTION
Signed-off-by: David Saunders <sauny@protonmail.com>

Removed CSS which added padding to the alert box.
