### PR TITLE
fix #3546: debug console auto-scrolls when it is located at the bottom

### DIFF
--- a/packages/console/src/browser/console-content-widget.tsx
+++ b/packages/console/src/browser/console-content-widget.tsx
@@ -14,11 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Message } from '@phosphor/messaging';
 import { interfaces, Container, injectable } from 'inversify';
 import { MenuPath, MessageType } from '@theia/core';
 import { TreeProps } from '@theia/core/lib/browser/tree';
 import { TreeSourceNode } from '@theia/core/lib/browser/source-tree';
-import { Message } from '@theia/core/lib/browser';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { ConsoleItem } from './console-session';
 
@@ -27,14 +27,14 @@ export class ConsoleContentWidget extends SourceTreeWidget {
 
     static CONTEXT_MENU: MenuPath = ['console-context-menu'];
 
-    private _shouldScrollToEnd: boolean = true;
+    protected _shouldScrollToEnd = true;
 
-    set shouldScrollToEnd(value: boolean) {
-        this._shouldScrollToEnd = value;
+    protected set shouldScrollToEnd(shouldScrollToEnd: boolean) {
+        this._shouldScrollToEnd = shouldScrollToEnd;
         this.shouldScrollToRow = this._shouldScrollToEnd;
     }
 
-    get shouldScrollToEnd() {
+    protected get shouldScrollToEnd() {
         return this._shouldScrollToEnd;
     }
 
@@ -50,9 +50,9 @@ export class ConsoleContentWidget extends SourceTreeWidget {
 
     protected onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
-        this.toDispose.push(this.onScrollUp(() => this.shouldScrollToEnd = false));
-        this.toDispose.push(this.onScrollYReachEnd(() => this.shouldScrollToEnd = true));
-        this.toDispose.push(this.model.onChanged(() => this.revealLastOutputIfNeeded()));
+        this.toDisposeOnDetach.push(this.onScrollUp(() => this.shouldScrollToEnd = false));
+        this.toDisposeOnDetach.push(this.onScrollYReachEnd(() => this.shouldScrollToEnd = true));
+        this.toDisposeOnDetach.push(this.model.onChanged(() => this.revealLastOutputIfNeeded()));
     }
 
     protected revealLastOutputIfNeeded(): void {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -135,7 +135,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
-    protected shouldScrollToRow: boolean = true;
+    protected shouldScrollToRow = true;
 
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
@@ -243,11 +243,18 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
 
     protected scrollToRow: number | undefined;
     protected updateScrollToRow(updateOptions?: TreeWidget.ForceUpdateOptions): void {
+        this.scrollToRow = this.getScrollToRow();
+        this.forceUpdate(updateOptions);
+    }
+
+    protected getScrollToRow(): number | undefined {
+        if (!this.shouldScrollToRow) {
+            return undefined;
+        }
         const selected = this.model.selectedNodes;
         const node: TreeNode | undefined = selected.find(SelectableTreeNode.hasFocus) || selected[0];
         const row = node && this.rows.get(node.id);
-        this.scrollToRow = !this.shouldScrollToRow ? undefined : (row && row.index);
-        this.forceUpdate(updateOptions);
+        return row && row.index;
     }
 
     protected readonly updateDecorations = debounce(() => this.doUpdateDecorations(), 150);

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -135,6 +135,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    protected shouldScrollToRow: boolean = true;
+
     constructor(
         @inject(TreeProps) readonly props: TreeProps,
         @inject(TreeModel) readonly model: TreeModel,
@@ -244,7 +246,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         const selected = this.model.selectedNodes;
         const node: TreeNode | undefined = selected.find(SelectableTreeNode.hasFocus) || selected[0];
         const row = node && this.rows.get(node.id);
-        this.scrollToRow = row && row.index;
+        this.scrollToRow = !this.shouldScrollToRow ? undefined : (row && row.index);
         this.forceUpdate(updateOptions);
     }
 

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -17,7 +17,7 @@
 import { injectable, decorate, unmanaged } from 'inversify';
 import { Widget } from '@phosphor/widgets';
 import { Message } from '@phosphor/messaging';
-import { Disposable, DisposableCollection, MaybePromise } from '../../common';
+import { Emitter, Event, Disposable, DisposableCollection, MaybePromise } from '../../common';
 import { KeyCode, KeysOrKeyCodes } from '../keyboard/keys';
 
 import PerfectScrollbar from 'perfect-scrollbar';
@@ -41,6 +41,10 @@ export class BaseWidget extends Widget {
     protected readonly toDisposeOnDetach = new DisposableCollection();
     protected scrollBar?: PerfectScrollbar;
     protected scrollOptions?: PerfectScrollbar.Options;
+    protected readonly onScrollYReachEndEmitter = new Emitter<void>();
+    readonly onScrollYReachEnd: Event<void> = this.onScrollYReachEndEmitter.event;
+    protected readonly onScrollUpEmitter = new Emitter<void>();
+    readonly onScrollUp: Event<void> = this.onScrollUpEmitter.event;
 
     dispose(): void {
         if (this.isDisposed) {
@@ -81,6 +85,8 @@ export class BaseWidget extends Widget {
                 const container = await this.getScrollContainer();
                 container.style.overflow = 'hidden';
                 this.scrollBar = new PerfectScrollbar(container, this.scrollOptions);
+                container.addEventListener('ps-y-reach-end', () => { this.onScrollYReachEndEmitter.fire(undefined); });
+                container.addEventListener('ps-scroll-up', () => { this.onScrollUpEmitter.fire(undefined); });
                 this.toDisposeOnDetach.push(Disposable.create(() => {
                     if (this.scrollBar) {
                         this.scrollBar.destroy();


### PR DESCRIPTION
1. Add 'ps-scroll-up' and 'ps-y-reach-end' event to widget scroll bar ([reference](https://github.com/utatti/perfect-scrollbar));
2. Register event in console-content-widget, so that auto-scroll is disabled when widget is scrolled up, and restored when widget is scrolled down to the bottom;
3. And 'shouldScrollToRow' variable, a switch, is added to 'widget' because 'forceUpdate' in widget-tree would make debug console jump to selection automatically so that free scroll is impossible.