### PR TITLE
[Plugin-Api] Apply window.createInput() function

### DIFF
--- a/packages/core/src/browser/quick-open/quick-input-service.ts
+++ b/packages/core/src/browser/quick-open/quick-input-service.ts
@@ -20,6 +20,7 @@ import { QuickOpenItem, QuickOpenMode } from './quick-open-model';
 import { Deferred } from '../../common/promise-util';
 import { MaybePromise } from '../../common/types';
 import { MessageType } from '../../common/message-service-protocol';
+import { Emitter, Event } from '../../common/event';
 
 export interface QuickInputOptions {
     /**
@@ -83,6 +84,7 @@ export class QuickInputService {
                     run: mode => {
                         if (!error && mode === QuickOpenMode.OPEN) {
                             result.resolve(currentText);
+                            this.onDidAcceptEmitter.fire(undefined);
                             return true;
                         }
                         return false;
@@ -103,6 +105,11 @@ export class QuickInputService {
     protected defaultPrompt = "Press 'Enter' to confirm your input or 'Escape' to cancel";
     protected createPrompt(prompt?: string): string {
         return prompt ? `${prompt} (${this.defaultPrompt})` : this.defaultPrompt;
+    }
+
+    readonly onDidAcceptEmitter: Emitter<void> = new Emitter();
+    get onDidAccept(): Event<void> {
+        return this.onDidAcceptEmitter.event;
     }
 
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -59,6 +59,7 @@ export class MonacoQuickOpenService extends QuickOpenService {
         container.style.position = 'absolute';
         container.style.top = '0px';
         container.style.right = '50%';
+        container.style.zIndex = '1000000';
         overlayWidgets.appendChild(container);
     }
 

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -283,6 +283,7 @@ export interface StatusBarMessageRegistryMain {
 export interface QuickOpenExt {
     $onItemSelected(handle: number): void;
     $validateInput(input: string): PromiseLike<string | undefined> | undefined;
+    $acceptInput(): Promise<void>;
 }
 
 /**

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -37,6 +37,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT);
         this.delegate = container.get(MonacoQuickOpenService);
         this.quickInput = container.get(QuickInputService);
+        this.quickInput.onDidAccept(() => this.proxy.$acceptInput());
     }
 
     private cleanUp() {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -98,7 +98,8 @@ import {
     ColorPresentation,
     OperatingSystem,
     WebviewPanelTargetArea,
-    FileSystemError
+    FileSystemError,
+    QuickInputButtons
 } from './types-impl';
 import { SymbolKind } from '../api/model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -346,6 +347,9 @@ export function createAPIFactory(
                         console.error('Progress location \'SourceControl\' is not supported.');
                     });
                 }
+            },
+            createInputBox(): theia.InputBox {
+                return quickOpenExt.createInputBox();
             }
         };
 
@@ -725,7 +729,8 @@ export function createAPIFactory(
             FoldingRangeKind,
             OperatingSystem,
             WebviewPanelTargetArea,
-            FileSystemError
+            FileSystemError,
+            QuickInputButtons
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1226,6 +1226,15 @@ export enum FileChangeType {
     Deleted = 3,
 }
 
+export interface QuickInputButton {
+    readonly iconPath: ThemeIcon;
+    readonly tooltip?: string | undefined;
+}
+
+export class QuickInputButtons {
+    static readonly Back: QuickInputButton;
+}
+
 export class FileSystemError extends Error {
 
     static FileExists(messageOrUri?: string | URI): FileSystemError {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2167,6 +2167,11 @@ declare module '@theia/plugin' {
          * Return `undefined`, or the empty string when 'value' is valid.
          */
         validateInput?(value: string): string | undefined | PromiseLike<string | undefined>;
+
+        /**
+         * An optional function that will be called on Enter key.
+         */
+        onAccept?(): void;
     }
 
     /**
@@ -3392,6 +3397,197 @@ declare module '@theia/plugin' {
          * @return The thenable the task-callback returned.
          */
         export function withProgress<R>(options: ProgressOptions, task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => PromiseLike<R>): PromiseLike<R>;
+
+        /**
+         * Creates a [InputBox](#InputBox) to let the user enter some text input.
+         *
+         * Note that in many cases the more convenient [window.showInputBox](#window.showInputBox)
+         * is easier to use. [window.createInputBox](#window.createInputBox) should be used
+         * when [window.showInputBox](#window.showInputBox) does not offer the required flexibility.
+         *
+         * @return A new [InputBox](#InputBox).
+         */
+        export function createInputBox(): InputBox;
+    }
+
+    /**
+     * Predefined buttons for [QuickPick](#QuickPick) and [InputBox](#InputBox).
+     */
+    export class QuickInputButtons {
+
+        /**
+         * A back button for [QuickPick](#QuickPick) and [InputBox](#InputBox).
+         *
+         * When a navigation 'back' button is needed this one should be used for consistency.
+         * It comes with a predefined icon, tooltip and location.
+         */
+        static readonly Back: QuickInputButton;
+
+        /**
+         * @hidden
+         */
+        private constructor();
+    }
+
+    /**
+     * A concrete [QuickInput](#QuickInput) to let the user input a text value.
+     *
+     * Note that in many cases the more convenient [window.showInputBox](#window.showInputBox)
+     * is easier to use. [window.createInputBox](#window.createInputBox) should be used
+     * when [window.showInputBox](#window.showInputBox) does not offer the required flexibility.
+     */
+    export interface InputBox extends QuickInput {
+
+        /**
+         * Current input value.
+         */
+        value: string;
+
+        /**
+         * Optional placeholder in the filter text.
+         */
+        placeholder: string | undefined;
+
+        /**
+         * If the input value should be hidden. Defaults to false.
+         */
+        password: boolean;
+
+        /**
+         * An event signaling when the value has changed.
+         */
+        readonly onDidChangeValue: Event<string>;
+
+        /**
+         * An event signaling when the user indicated acceptance of the input value.
+         */
+        readonly onDidAccept: Event<void>;
+
+        /**
+         * Buttons for actions in the UI.
+         */
+        buttons: ReadonlyArray<QuickInputButton>;
+
+        /**
+         * An event signaling when a button was triggered.
+         */
+        readonly onDidTriggerButton: Event<QuickInputButton>;
+
+        /**
+         * An optional prompt text providing some ask or explanation to the user.
+         */
+        prompt: string | undefined;
+
+        /**
+         * An optional validation message indicating a problem with the current input value.
+         */
+        validationMessage: string | undefined;
+    }
+
+    /**
+     * A light-weight user input UI that is initially not visible. After
+     * configuring it through its properties the extension can make it
+     * visible by calling [QuickInput.show](#QuickInput.show).
+     *
+     * There are several reasons why this UI might have to be hidden and
+     * the extension will be notified through [QuickInput.onDidHide](#QuickInput.onDidHide).
+     * (Examples include: an explicit call to [QuickInput.hide](#QuickInput.hide),
+     * the user pressing Esc, some other input UI opening, etc.)
+     *
+     * A user pressing Enter or some other gesture implying acceptance
+     * of the current state does not automatically hide this UI component.
+     * It is up to the extension to decide whether to accept the user's input
+     * and if the UI should indeed be hidden through a call to [QuickInput.hide](#QuickInput.hide).
+     *
+     * When the extension no longer needs this input UI, it should
+     * [QuickInput.dispose](#QuickInput.dispose) it to allow for freeing up
+     * any resources associated with it.
+     *
+     * See [QuickPick](#QuickPick) and [InputBox](#InputBox) for concrete UIs.
+     */
+    export interface QuickInput {
+
+        /**
+         * An optional title.
+         */
+        title: string | undefined;
+
+        /**
+         * An optional current step count.
+         */
+        step: number | undefined;
+
+        /**
+         * An optional total step count.
+         */
+        totalSteps: number | undefined;
+
+        /**
+         * If the UI should allow for user input. Defaults to true.
+         *
+         * Change this to false, e.g., while validating user input or
+         * loading data for the next step in user input.
+         */
+        enabled: boolean;
+
+        /**
+         * If the UI should show a progress indicator. Defaults to false.
+         *
+         * Change this to true, e.g., while loading more data or validating
+         * user input.
+         */
+        busy: boolean;
+
+        /**
+         * If the UI should stay open even when loosing UI focus. Defaults to false.
+         */
+        ignoreFocusOut: boolean;
+
+        /**
+         * Makes the input UI visible in its current configuration. Any other input
+         * UI will first fire an [QuickInput.onDidHide](#QuickInput.onDidHide) event.
+         */
+        show(): void;
+
+        /**
+         * Hides this input UI. This will also fire an [QuickInput.onDidHide](#QuickInput.onDidHide)
+         * event.
+         */
+        hide(): void;
+
+        /**
+         * An event signaling when this input UI is hidden.
+         *
+         * There are several reasons why this UI might have to be hidden and
+         * the extension will be notified through [QuickInput.onDidHide](#QuickInput.onDidHide).
+         * (Examples include: an explicit call to [QuickInput.hide](#QuickInput.hide),
+         * the user pressing Esc, some other input UI opening, etc.)
+         */
+        onDidHide: Event<void>;
+
+        /**
+         * Dispose of this input UI and any associated resources. If it is still
+         * visible, it is first hidden. After this call the input UI is no longer
+         * functional and no additional methods or properties on it should be
+         * accessed. Instead a new input UI should be created.
+         */
+        dispose(): void;
+    }
+
+    /**
+     * Button for an action in a [QuickPick](#QuickPick) or [InputBox](#InputBox).
+     */
+    export interface QuickInputButton {
+
+        /**
+         * Icon for the button.
+         */
+        readonly iconPath: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+
+        /**
+         * An optional tooltip.
+         */
+        readonly tooltip?: string | undefined;
     }
     /**
      * Value-object describing where and how progress should show.


### PR DESCRIPTION
Apply `window.createInput()` plugin API function. The function wraps QuickOpenExtImpl to setup and show an input notification. Other functionality is not implemented because it require a lot of changes in the Theia quick-input model.

Tested in pair with https://github.com/theia-ide/theia/pull/5012 on https://github.com/Microsoft/vscode-extension-samples/tree/master/quickinput-sample

fixes #5107