### PR TITLE
[electron] Do not test ffmpeg replacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 install:
   - THEIA_SKIP_NPM_PREPARE=1 yarn install
-  - travis_retry npx electron-h264-test
+  - npx electron-h264-test
   - yarn prepare
   - scripts/check_git_status.sh
 script:

--- a/dev-packages/electron/electron-replace-ffmpeg.js
+++ b/dev-packages/electron/electron-replace-ffmpeg.js
@@ -60,7 +60,7 @@ async function main() {
 /**
  * @typedef {Object} File
  * @property {String} name
- * @property {String|undefined} folder
+ * @property {String} [folder]
  */
 
 /**

--- a/dev-packages/electron/package.json
+++ b/dev-packages/electron/package.json
@@ -28,6 +28,6 @@
     "unzipper": "^0.9.11"
   },
   "scripts": {
-    "postinstall": "node ./scripts/skip-replace-ffmpeg || (node ./electron-replace-ffmpeg && node ./electron-h264-test)"
+    "postinstall": "node ./scripts/skip-replace-ffmpeg || (node ./electron-replace-ffmpeg)"
   }
 }


### PR DESCRIPTION
Since the test is running an Electron application, it fails on some
CI/CD servers.

Remove the automatic test, but leave the automatic replacement.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
