### PR TITLE
[Plugin-Api] Add stub implementation of window.registerUriHandler()

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -346,6 +346,10 @@ export function createAPIFactory(
                         console.error('Progress location \'SourceControl\' is not supported.');
                     });
                 }
+            },
+            registerUriHandler(handler: theia.UriHandler): theia.Disposable {
+                // TODO Apply full implementation https://github.com/theia-ide/theia/issues/5119
+                return new Disposable(() => {});
             }
         };
 

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -2941,6 +2941,21 @@ declare module '@theia/plugin' {
     }
 
     /**
+     * A uri handler is responsible for handling system-wide [uris](#Uri).
+     *
+     * @see [window.registerUriHandler](#window.registerUriHandler).
+     */
+    export interface UriHandler {
+
+        /**
+         * Handle the provided system-wide [uri](#Uri).
+         *
+         * @see [window.registerUriHandler](#window.registerUriHandler).
+         */
+        handleUri(uri: Uri): ProviderResult<void>;
+    }
+
+    /**
      * Common namespace for dealing with window and editor, showing messages and user input.
      */
     export namespace window {
@@ -3371,6 +3386,29 @@ declare module '@theia/plugin' {
          * @returns a [TreeView](#TreeView).
          */
         export function createTreeView<T>(viewId: string, options: TreeViewOptions<T>): TreeView<T>;
+
+        /**
+         * Registers a [uri handler](#UriHandler) capable of handling system-wide [uris](#Uri).
+         * In case there are multiple windows open, the topmost window will handle the uri.
+         * A uri handler is scoped to the extension it is contributed from; it will only
+         * be able to handle uris which are directed to the extension itself. A uri must respect
+         * the following rules:
+         *
+         * - The uri-scheme must be the product name;
+         * - The uri-authority must be the extension id (eg. `my.extension`);
+         * - The uri-path, -query and -fragment parts are arbitrary.
+         *
+         * For example, if the `my.extension` extension registers a uri handler, it will only
+         * be allowed to handle uris with the prefix `product-name://my.extension`.
+         *
+         * An extension can only register a single uri handler in its entire activation lifetime.
+         *
+         * * *Note:* There is an activation event `onUri` that fires when a uri directed for
+         * the current extension is about to be handled.
+         *
+         * @param handler The uri handler to register for this extension.
+         */
+        export function registerUriHandler(handler: UriHandler): Disposable;
 
         /**
          * Show progress in the editor. Progress is shown while running the given callback


### PR DESCRIPTION
Add stub implementation of the VsCode `window.registerUriHandler()` Api function.
Full implementation is going to be done in https://github.com/theia-ide/theia/issues/5119
Is needed for https://github.com/eclipse/che/issues/11867