### PR TITLE
GH-5116: Use `fork` to start the electron process.

### DIFF
--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -78,18 +78,20 @@ export class ApplicationPackageManager {
     }
 
     async startElectron(args: string[]): Promise<void> {
+        const { mainArgs, options } = this.adjustArgs([this.pck.frontend('electron-main.js'), ...args]);
         const electronCli = require.resolve('electron/cli.js', { paths: [this.pck.projectPath] });
-        this.process.spawn(electronCli, [this.pck.frontend('electron-main.js'), ...args],
-            { stdio: [0, 1, 2] });
+        this.__process.fork(electronCli, mainArgs, options);
     }
 
     async startBrowser(args: string[]): Promise<void> {
-        const options: cp.ForkOptions = {
-            stdio: [0, 1, 2, 'ipc'],
-            env: {
-                ...process.env,
-                THEIA_PARENT_PID: String(process.pid)
-            }
+        const { mainArgs, options } = this.adjustArgs(args);
+        this.__process.fork(this.pck.backend('main.js'), mainArgs, options);
+    }
+
+    private adjustArgs(args: string[], forkOptions: cp.ForkOptions = {}): Readonly<{ mainArgs: string[]; options: cp.ForkOptions }> {
+        const options = {
+            ...this.forkOptions,
+            forkOptions
         };
         const mainArgs = [...args];
         const inspectIndex = mainArgs.findIndex(v => v.startsWith('--inspect'));
@@ -97,7 +99,20 @@ export class ApplicationPackageManager {
             const inspectArg = mainArgs.splice(inspectIndex, 1)[0];
             options.execArgv = ['--nolazy', inspectArg];
         }
-        this.__process.fork(this.pck.backend('main.js'), mainArgs, options);
+        return {
+            mainArgs,
+            options
+        };
+    }
+
+    private get forkOptions(): cp.ForkOptions {
+        return {
+            stdio: [0, 1, 2, 'ipc'],
+            env: {
+                ...process.env,
+                THEIA_PARENT_PID: String(process.pid)
+            }
+        };
     }
 
 }


### PR DESCRIPTION
Windows cannot do much with the `#!/usr/bin/env node`
if not invoked as an `npm` script.

Closes #5116.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
