### PR TITLE
Implement command 'workbench.action.reloadWindow'

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -292,6 +292,13 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 }
             }
         });
+
+        commands.registerCommand({ id: 'workbench.action.reloadWindow' }, {
+            execute: () => {
+                window.location.reload();
+            }
+        });
+
         /**
          * TODO:
          * Keep Open	workbench.action.keepEditor


### PR DESCRIPTION
This implements the well know VS Code command mentioned in the title. This simply reloads the browser window. The plugin system in the back end will be restarted because it is bound to the connection to the front end: reloading the window starts a new front end, which starts a new connection in the back end which starts a new instance of the plugin engine.
I tested this by changing the JVM settings in the preferences of the VS Code Java extensions, which shows a window requesting a reload of the IDE.
 Fixes https://github.com/theia-ide/theia/issues/4567