### PR TITLE
Move Output view toolbar from overlay to view toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
 - [preferences] refactored to integrate launch configurations as preferences
 - [filesystem] extracted `FileUploadService` and refactored `FileTreeWidget` to use it [#5086](https://github.com/theia-ide/theia/pull/5086)
   - moved `FileDownloadCommands.UPLOAD` to `FileSystemCommands.UPLOAD`
+- [output] moved the channel selection and clear icons to the toolbar.  The CLEAR_BUTTON and
+OVERLAY constants are no longer available.  Furthermore OutputChannelManager API has changed.
 - [scm] added Source Control Model
 - [git] bind Git UI to SCM  
 

--- a/packages/output/src/browser/output-contribution.ts
+++ b/packages/output/src/browser/output-contribution.ts
@@ -16,7 +16,19 @@
 
 import { injectable } from 'inversify';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { Widget } from '@theia/core/lib/browser';
 import { OUTPUT_WIDGET_KIND, OutputWidget } from './output-widget';
+import { Command, CommandRegistry } from '@theia/core/lib/common';
+
+export namespace OutputCommands {
+    const OUTPUT_CATEGORY = 'Output';
+    export const CLEAR_OUTPUT_TOOLBAR: Command = {
+        id: 'output:clear',
+        category: OUTPUT_CATEGORY,
+        label: 'Clear Output',
+        iconClass: 'clear-all'
+    };
+}
 
 @injectable()
 export class OutputContribution extends AbstractViewContribution<OutputWidget> {
@@ -31,6 +43,26 @@ export class OutputContribution extends AbstractViewContribution<OutputWidget> {
             toggleCommandId: 'output:toggle',
             toggleKeybinding: 'ctrlcmd+shift+u'
         });
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        super.registerCommands(commands);
+        commands.registerCommand(OutputCommands.CLEAR_OUTPUT_TOOLBAR, {
+            isEnabled: widget => this.withWidget(widget, () => true),
+            isVisible: widget => this.withWidget(widget, () => true),
+            execute: widget => this.withWidget(widget, outputWidget => this.clear(outputWidget))
+        });
+    }
+
+    protected async clear(widget: OutputWidget): Promise<void> {
+        widget.clear();
+    }
+
+    protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (problems: OutputWidget) => T): T | false {
+        if (widget instanceof OutputWidget && widget.id === OUTPUT_WIDGET_KIND) {
+            return cb(widget);
+        }
+        return false;
     }
 
 }

--- a/packages/output/src/browser/output-frontend-module.ts
+++ b/packages/output/src/browser/output-frontend-module.ts
@@ -18,8 +18,10 @@ import { ContainerModule, interfaces } from 'inversify';
 import { OutputWidget, OUTPUT_WIDGET_KIND } from './output-widget';
 import { WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
 import { OutputContribution } from './output-contribution';
+import { OutputToolbarContribution } from './output-toolbar-contribution';
 import { OutputChannelManager } from '../common/output-channel';
 import { bindOutputPreferences } from '../common/output-preferences';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bindOutputPreferences(bind);
@@ -32,4 +34,6 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
     }));
 
     bindViewContribution(bind, OutputContribution);
+    bind(OutputToolbarContribution).toSelf().inSingletonScope();
+    bind(TabBarToolbarContribution).toService(OutputToolbarContribution);
 });

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (C) 2019 Arm and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import { OutputWidget } from './output-widget';
+import { OutputChannelManager } from '../common/output-channel';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { OutputCommands } from './output-contribution';
+import * as React from 'react';
+
+@injectable()
+export class OutputToolbarContribution implements TabBarToolbarContribution {
+
+    @inject(OutputChannelManager)
+    protected readonly outputChannelManager: OutputChannelManager;
+
+    async registerToolbarItems(toolbarRegistry: TabBarToolbarRegistry): Promise<void> {
+        toolbarRegistry.registerItem({
+            id: 'channels',
+            render: () => this.renderChannelSelector(),
+            isVisible: widget => (widget instanceof OutputWidget),
+            onDidChange: this.outputChannelManager.onListOrSelectionChange
+        });
+
+        toolbarRegistry.registerItem({
+            id: OutputCommands.CLEAR_OUTPUT_TOOLBAR.id,
+            command: OutputCommands.CLEAR_OUTPUT_TOOLBAR.id,
+            tooltip: 'Clear Output',
+            priority: 1,
+        });
+    }
+
+    protected readonly NONE = '<no channels>';
+
+    protected renderChannelSelector(): React.ReactNode {
+        const channelOptionElements: React.ReactNode[] = [];
+        this.outputChannelManager.getVisibleChannels().forEach(channel => {
+            channelOptionElements.push(<option value={channel.name} key={channel.name}>{channel.name}</option>);
+        });
+        if (channelOptionElements.length === 0) {
+            channelOptionElements.push(<option key={this.NONE} value={this.NONE}>{this.NONE}</option>);
+        }
+        return <select
+            id={OutputWidget.IDs.CHANNEL_LIST}
+            value={this.outputChannelManager.selectedChannel ? this.outputChannelManager.selectedChannel.name : this.NONE}
+            onChange={ this.changeChannel}
+        >
+            {channelOptionElements}
+        </select>;
+    }
+
+    protected changeChannel = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const channelName = event.target.value;
+        if (channelName !== this.NONE) {
+            this.outputChannelManager.selectedChannel = this.outputChannelManager.getChannel(channelName);
+        }
+    }
+}

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -30,26 +30,6 @@
     margin-left: 14px;
 }
 
-#outputView #outputOverlay {
-    position: absolute;
-    right: 24px;
-    margin: 6px;
-    display: flex;
-}
-
-#outputView #outputOverlay > * {
-    /* Separation between elements.  */
-    margin-left: 6px;
-
-    height: 21px;
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--theia-border-color1);
-    box-sizing: border-box;
-
-    background: var(--theia-layout-color2);
-}
-
 #outputView #outputChannelList {
     line-height: var(--theia-content-line-height);
     font-size: var(--theia-ui-font-size1);


### PR DESCRIPTION
We've been having problems where text in the output view is covered up by the overlay controls.  I would like to move the controls to the view toolbar.  This has been tested on Windows, browser build.

![image](https://user-images.githubusercontent.com/87310/57648732-25355900-75be-11e9-8128-7dbfa943052e.png)
