### PR TITLE
Optimize build (removing comments + helpers)

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -1,25 +1,28 @@
 {
-    "compilerOptions": {
-        "skipLibCheck": true,
-        "declaration": true,
-        "declarationMap": true,
-        "noImplicitAny": true,
-        "noEmitOnError": false,
-        "noImplicitThis": true,
-        "noUnusedLocals": true,
-        "strictNullChecks": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "downlevelIteration": true,
-        "resolveJsonModule": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "target": "es5",
-        "jsx": "react",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "sourceMap": true
-    }
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es5",
+    "jsx": "react",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "sourceMap": true,
+
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "declarationMap": true,
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "noEmitOnError": false,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "reconnecting-websocket": "^3.0.7",
     "reflect-metadata": "^0.1.10",
     "route-parser": "^0.0.5",
+    "tslib": "^1.9.3",
     "vscode-languageserver-types": "^3.10.0",
     "vscode-uri": "^1.0.1",
     "vscode-ws-jsonrpc": "^0.0.2-1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9549,7 +9549,7 @@ ts-md5@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ts-md5/-/ts-md5-1.2.4.tgz#7030d7ba9134449deedf6f609d4b4509b94a5712"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 


### PR DESCRIPTION
When transpiling TypeScript sources into JS (ES5), the compiler add a
bunch of helper functions, such as `__extend`, `__await` or others. This
is required for our code to work with older Javascript targets.

Problem is that these helper functions are added to each and everything
file that requires it, and when bundling the frontend application it
doesn't get refactored either.

But TypeScript allows us to depend on a package that implements all the
helper functions in one place, and then replace each definitions in the
file headers by 1 line that requires the package.

This commit also removes the comments when transpiling, since it ins't
that useful at runtime (we still have source-maps)

Size difference of some folders:
- `packages`: -4MB
- `examples/browser/lib`: -2MB

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
