### PR TITLE
[cpp] Configure to support OpenCL

### DIFF
--- a/packages/cpp/src/browser/cpp-grammar-contribution.ts
+++ b/packages/cpp/src/browser/cpp-grammar-contribution.ts
@@ -87,7 +87,7 @@ export class CppGrammarContribution implements LanguageGrammarDefinitionContribu
         // cpp
         monaco.languages.register({
             id: CPP_LANGUAGE_ID,
-            extensions: ['.cpp', '.cc', '.cxx', '.hpp', '.hh', '.hxx', '.h', '.ino', '.inl', '.ipp'],
+            extensions: ['.cpp', '.cc', '.cxx', '.hpp', '.hh', '.hxx', '.h', '.ino', '.inl', '.ipp', 'cl'],
             aliases: ['C++', 'Cpp', 'cpp'],
         });
 

--- a/packages/cpp/src/common/index.ts
+++ b/packages/cpp/src/common/index.ts
@@ -19,7 +19,7 @@ export const CPP_LANGUAGE_ID = 'cpp';
 export const CPP_LANGUAGE_NAME = 'C/C++';
 // These should become preferences eventually and be forwarded to the server.
 export const HEADER_FILE_EXTENSIONS = ['h', 'hxx', 'hh', 'hpp', 'inc'];
-export const SOURCE_FILE_EXTENSIONS = ['c', 'cxx', 'C', 'c++', 'cc', 'cpp'];
+export const SOURCE_FILE_EXTENSIONS = ['c', 'cxx', 'C', 'c++', 'cc', 'cpp', 'cl'];
 export const HEADER_AND_SOURCE_FILE_EXTENSIONS = SOURCE_FILE_EXTENSIONS.concat(HEADER_FILE_EXTENSIONS);
 
 export const CLANGD_EXECUTABLE_DEFAULT = 'clangd';


### PR DESCRIPTION
Provide coloring and code intelligence for `.cl` files using clangd.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
