### PR TITLE
Fix overriding preferences

### DIFF
--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -158,8 +158,8 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
             if (this.schemaProvider.testOverrideValue(preferenceName, preferenceValue)) {
                 // tslint:disable-next-line:forin
                 for (const overriddenPreferenceName in preferenceValue) {
-                    const overriddeValue = preferenceValue[overriddenPreferenceName];
-                    preferences[`${preferenceName}.${overriddenPreferenceName}`] = overriddeValue;
+                    const overriddenValue = preferenceValue[overriddenPreferenceName];
+                    preferences[`${preferenceName}.${overriddenPreferenceName}`] = overriddenValue;
                 }
             } else {
                 preferences[preferenceName] = preferenceValue;


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do
It turns out that when we have overridden preferences in a configuration file
```
{
...
"xml" : {"editor.autoClosingBrackets": "never"}
}
```
`AbstractResourcePreferenceProvider` transforms it into  `"[xml].editor.autoClosingBrackets" : "never"` and it leads to that some [extensions](https://github.com/redhat-developer/vscode-xml/blob/master/src/extension.ts#L142) can't read these values. 
Debugging VS Code proved that it doesn't do this kind of transformation.

### Reference issue
https://github.com/eclipse/che/issues/12536
