### PR TITLE
Add ability to match browser displayed node with the plugin created node

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -28,6 +28,7 @@ import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-document
 import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
 import { WorkerEnvExtImpl } from './worker-env-ext';
+import { SelectionServiceExt } from '../../../plugin/selection-provider-ext';
 
 // tslint:disable-next-line:no-any
 const ctx = self as any;
@@ -55,6 +56,7 @@ const messageRegistryExt = new MessageRegistryExt(rpc);
 const workspaceExt = new WorkspaceExtImpl(rpc, editorsAndDocuments, messageRegistryExt);
 const preferenceRegistryExt = new PreferenceRegistryExtImpl(rpc, workspaceExt);
 const debugExt = createDebugExtStub(rpc);
+const selectionServiceExt = new SelectionServiceExt();
 
 const pluginManager = new PluginManagerExtImpl({
     // tslint:disable-next-line:no-any
@@ -133,7 +135,8 @@ const apiFactory = createAPIFactory(
     preferenceRegistryExt,
     editorsAndDocuments,
     workspaceExt,
-    messageRegistryExt
+    messageRegistryExt,
+    selectionServiceExt
 );
 let defaultApi: typeof theia;
 

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -26,6 +26,7 @@ import { EditorsAndDocumentsExtImpl } from '../../plugin/editors-and-documents';
 import { WorkspaceExtImpl } from '../../plugin/workspace';
 import { MessageRegistryExt } from '../../plugin/message-registry';
 import { EnvNodeExtImpl } from '../../plugin/node/env-node-ext';
+import { SelectionServiceExt } from '../../plugin/selection-provider-ext';
 
 /**
  * Handle the RPC calls.
@@ -47,6 +48,7 @@ export class PluginHostRPC {
         const messageRegistryExt = new MessageRegistryExt(this.rpc);
         const workspaceExt = new WorkspaceExtImpl(this.rpc, editorsAndDocumentsExt, messageRegistryExt);
         const preferenceRegistryExt = new PreferenceRegistryExtImpl(this.rpc, workspaceExt);
+        const selectionServiceExt = new SelectionServiceExt();
         this.pluginManager = this.createPluginManager(envExt, preferenceRegistryExt, this.rpc);
         this.rpc.set(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT, this.pluginManager);
         this.rpc.set(MAIN_RPC_CONTEXT.EDITORS_AND_DOCUMENTS_EXT, editorsAndDocumentsExt);
@@ -61,7 +63,8 @@ export class PluginHostRPC {
             preferenceRegistryExt,
             editorsAndDocumentsExt,
             workspaceExt,
-            messageRegistryExt
+            messageRegistryExt,
+            selectionServiceExt
         );
     }
 

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -19,6 +19,7 @@ import { CommandRegistryExt, PLUGIN_RPC_CONTEXT as Ext, CommandRegistryMain } fr
 import { RPCProtocol } from '../api/rpc-protocol';
 import { Disposable } from './types-impl';
 import { KnownCommands } from './type-converters';
+import { SelectionServiceExt } from './selection-provider-ext';
 
 // tslint:disable-next-line:no-any
 export type Handler = <T>(...args: any[]) => T | PromiseLike<T>;
@@ -29,7 +30,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     private readonly commands = new Set<string>();
     private readonly handlers = new Map<string, Handler>();
 
-    constructor(rpc: RPCProtocol) {
+    constructor(rpc: RPCProtocol, private selectionService: SelectionServiceExt) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
     }
 
@@ -98,7 +99,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     private executeLocalCommand<T>(id: string, ...args: any[]): PromiseLike<T> {
         const handler = this.handlers.get(id);
         if (handler) {
-            return Promise.resolve(handler(...args));
+            return Promise.resolve(this.selectionService.selection !== undefined ? handler(this.selectionService.selection) : handler(...args));
         } else {
             return Promise.reject(new Error(`Command ${id} doesn't exist`));
         }

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -124,6 +124,7 @@ import { TasksExtImpl } from './tasks/tasks';
 import { DebugExtImpl } from './node/debug/debug';
 import { FileSystemExtImpl } from './file-system';
 import { QuickPick, QuickPickItem } from '@theia/plugin';
+import { SelectionServiceExt } from './selection-provider-ext';
 
 export function createAPIFactory(
     rpc: RPCProtocol,
@@ -133,10 +134,11 @@ export function createAPIFactory(
     preferenceRegistryExt: PreferenceRegistryExtImpl,
     editorsAndDocumentsExt: EditorsAndDocumentsExtImpl,
     workspaceExt: WorkspaceExtImpl,
-    messageRegistryExt: MessageRegistryExt
+    messageRegistryExt: MessageRegistryExt,
+    selectionServiceExt: SelectionServiceExt
 ): PluginAPIFactory {
 
-    const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
+    const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc, selectionServiceExt));
     const quickOpenExt = rpc.set(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT, new QuickOpenExtImpl(rpc));
     const dialogsExt = new DialogsExtImpl(rpc);
     const windowStateExt = rpc.set(MAIN_RPC_CONTEXT.WINDOW_STATE_EXT, new WindowStateExtImpl());
@@ -148,7 +150,7 @@ export function createAPIFactory(
     const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
     const outputChannelRegistryExt = new OutputChannelRegistryExt(rpc);
     const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents));
-    const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
+    const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry, selectionServiceExt));
     const webviewExt = rpc.set(MAIN_RPC_CONTEXT.WEBVIEWS_EXT, new WebviewsExtImpl(rpc));
     const tasksExt = rpc.set(MAIN_RPC_CONTEXT.TASKS_EXT, new TasksExtImpl(rpc));
     const connectionExt = rpc.set(MAIN_RPC_CONTEXT.CONNECTION_EXT, new ConnectionExtImpl(rpc));

--- a/packages/plugin-ext/src/plugin/selection-provider-ext.ts
+++ b/packages/plugin-ext/src/plugin/selection-provider-ext.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export class SelectionServiceExt {
+
+    private currentSelection: Object | undefined;
+
+    get selection(): Object | undefined {
+        return this.currentSelection;
+    }
+
+    set selection(selection: Object | undefined) {
+        this.currentSelection = selection;
+    }
+}


### PR DESCRIPTION
This changes proposal adds ability to use plugin created node instead of displayed browser node. To be able to use natively created objects, not serialized between browser and server side.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
