### PR TITLE
[plugin] [webview] Add min-height for webview icon as for other icons of tabs

### DIFF
--- a/packages/plugin-ext/src/main/browser/style/webview.css
+++ b/packages/plugin-ext/src/main/browser/style/webview.css
@@ -27,4 +27,5 @@
 
 .webview-icon {
     background: none !important;
+    min-height: 20px;
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse/che-theia/issues/174

webview icon was missing min-height after https://github.com/theia-ide/theia/pull/4600

related to https://github.com/theia-ide/theia/issues/4664 as well

https://github.com/theia-ide/theia/blob/4d74d28857cf994da063dac8672272d774c148b0/packages/core/src/browser/style/tabs.css#L136

before patch
![image](https://user-images.githubusercontent.com/436777/57780707-1b7c3480-7729-11e9-9712-de5b383c4b11.png)

after patch
![image](https://user-images.githubusercontent.com/436777/57780723-22a34280-7729-11e9-8a84-8f7d70c9149a.png)



Change-Id: I0e89d96052cd0b16073478f1d02ba9f309bd23e8
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
