### PR TITLE
[tasks] add 'Terminate Task' command

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import { ILogger, ContributionProvider } from '@theia/core/lib/common';
-import { QuickOpenTask } from './quick-open-task';
+import { QuickOpenTask, TaskTerminateQuickOpen } from './quick-open-task';
 import { CommandContribution, Command, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core/lib/common';
 import {
     FrontendApplication, FrontendApplicationContribution, QuickOpenContribution,
@@ -66,6 +66,12 @@ export namespace TaskCommands {
         category: TASK_CATEGORY,
         label: 'Clear History'
     };
+
+    export const TASK_TERMINATE: Command = {
+        id: 'task:terminate',
+        category: TASK_CATEGORY,
+        label: 'Terminate Task'
+    };
 }
 
 const TASKS_STORAGE_KEY = 'tasks';
@@ -101,6 +107,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
 
     @inject(StorageService)
     protected readonly storageService: StorageService;
+
+    @inject(TaskTerminateQuickOpen)
+    protected readonly taskTerminateQuickOpen: TaskTerminateQuickOpen;
 
     onStart(): void {
         this.contributionProvider.getContributions().forEach(contrib => {
@@ -170,6 +179,13 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             TaskCommands.TASK_CLEAR_HISTORY,
             {
                 execute: () => this.taskService.clearRecentTasks()
+            }
+        );
+
+        registry.registerCommand(
+            TaskCommands.TASK_TERMINATE,
+            {
+                execute: () => this.taskTerminateQuickOpen.open()
             }
         );
     }

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution, QuickOpenContribution, KeybindingContribution } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
-import { QuickOpenTask } from './quick-open-task';
+import { QuickOpenTask, TaskTerminateQuickOpen } from './quick-open-task';
 import { TaskContribution, TaskProviderRegistry, TaskResolverRegistry } from './task-contribution';
 import { TaskService } from './task-service';
 import { TaskConfigurations } from './task-configurations';
@@ -43,6 +43,7 @@ export default new ContainerModule(bind => {
     }
 
     bind(QuickOpenTask).toSelf().inSingletonScope();
+    bind(TaskTerminateQuickOpen).toSelf().inSingletonScope();
     bind(TaskConfigurations).toSelf().inSingletonScope();
     bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();
 


### PR DESCRIPTION
Fixes #5159

**Description**

Added a new command **`Terminate Task`** which prompts users to select a running task if available in order to terminate it.

**How to test**

_Single Task Running_
1. Start a [long running task](https://github.com/theia-ide/theia/blob/87d8755b77091f0ab944936118a725c763fe7f09/packages/task/test-resources/.theia/tasks.json#L23) (<kbd>F1</kbd> → `Task: Run Task`).
2. Select the command **Task: Terminate Task** (<kbd>F1</kbd> → `Task: Terminate Task`).
3. When prompted, select the task from step 1 through the quick-open menu.
4. The selected task should be terminated.

_Multiple Tasks Running_
1. Start two long running tasks. 
2. Select the command **Task: Terminate Task** (<kbd>F1</kbd> → `Task: Terminate Task`).
3. When prompted, select a task through the quick-open menu.
4. The selected task should be terminated.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
