### PR TITLE
Fixed #5132: added copy & copy message features to the problem widget

### DIFF
--- a/packages/markers/src/browser/marker-tree.ts
+++ b/packages/markers/src/browser/marker-tree.ts
@@ -21,6 +21,7 @@ import { Marker } from '../common/marker';
 import { UriSelection } from '@theia/core/lib/common/selection';
 import URI from '@theia/core/lib/common/uri';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
+import { ProblemSelection } from './problem/problem-selection';
 
 export const MarkerOptions = Symbol('MarkerOptions');
 export interface MarkerOptions {
@@ -126,12 +127,12 @@ export abstract class MarkerTree<T extends object> extends TreeImpl {
     }
 }
 
-export interface MarkerNode extends UriSelection, SelectableTreeNode {
+export interface MarkerNode extends UriSelection, SelectableTreeNode, ProblemSelection {
     marker: Marker<object>;
 }
 export namespace MarkerNode {
     export function is(node: TreeNode | undefined): node is MarkerNode {
-        return UriSelection.is(node) && SelectableTreeNode.is(node) && 'marker' in node;
+        return UriSelection.is(node) && SelectableTreeNode.is(node) && ProblemSelection.is(node);
     }
 }
 

--- a/packages/markers/src/browser/problem/problem-container.ts
+++ b/packages/markers/src/browser/problem/problem-container.ts
@@ -23,7 +23,8 @@ import { PROBLEM_KIND } from '../../common/problem-marker';
 
 export const PROBLEM_TREE_PROPS = <TreeProps>{
     ...defaultTreeProps,
-    contextMenuPath: [PROBLEM_KIND]
+    contextMenuPath: [PROBLEM_KIND],
+    globalSelection: true
 };
 
 export const PROBLEM_OPTIONS = <MarkerOptions>{

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -18,17 +18,20 @@ import { injectable, inject } from 'inversify';
 import { FrontendApplication, FrontendApplicationContribution, CompositeTreeNode, SelectableTreeNode, Widget } from '@theia/core/lib/browser';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { PROBLEM_KIND } from '../../common/problem-marker';
+import { PROBLEM_KIND, ProblemMarker } from '../../common/problem-marker';
 import { ProblemManager, ProblemStat } from './problem-manager';
 import { ProblemWidget, PROBLEMS_WIDGET_ID } from './problem-widget';
 import { MenuPath, MenuModelRegistry } from '@theia/core/lib/common/menu';
-import { Command, CommandRegistry } from '@theia/core/lib/common';
+import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { SelectionService } from '@theia/core/lib/common/selection-service';
+import { ProblemSelection } from './problem-selection';
 
 export const PROBLEMS_CONTEXT_MENU: MenuPath = [PROBLEM_KIND];
 
 export namespace ProblemsMenu {
-    export const PROBLEMS = [...PROBLEMS_CONTEXT_MENU, '1_problems'];
+    export const CLIPBOARD = [...PROBLEMS_CONTEXT_MENU, '1_clipboard'];
+    export const PROBLEMS = [...PROBLEMS_CONTEXT_MENU, '2_problems'];
 }
 
 export namespace ProblemsCommands {
@@ -39,6 +42,12 @@ export namespace ProblemsCommands {
         id: 'problems.collapse.all.toolbar',
         iconClass: 'collapse-all'
     };
+    export const COPY: Command = {
+        id: 'problems.copy'
+    };
+    export const COPY_MESSAGE: Command = {
+        id: 'problems.copy.message',
+    };
 }
 
 @injectable()
@@ -46,6 +55,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
     @inject(StatusBar) protected readonly statusBar: StatusBar;
+    @inject(SelectionService) protected readonly selectionService: SelectionService;
 
     constructor() {
         super({
@@ -89,14 +99,40 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             isVisible: widget => this.withWidget(widget, () => true),
             execute: widget => this.withWidget(widget, () => this.collapseAllProblems())
         });
+        commands.registerCommand(ProblemsCommands.COPY,
+            new ProblemSelection.CommandHandler(this.selectionService, {
+                multi: false,
+                isEnabled: () => true,
+                isVisible: () => true,
+                execute: selection => this.copy(selection)
+            })
+        );
+        commands.registerCommand(ProblemsCommands.COPY_MESSAGE,
+            new ProblemSelection.CommandHandler(this.selectionService, {
+                multi: false,
+                isEnabled: () => true,
+                isVisible: () => true,
+                execute: selection => this.copyMessage(selection)
+            })
+        );
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
+        menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
+            commandId: ProblemsCommands.COPY.id,
+            label: 'Copy',
+            order: '0'
+        });
+        menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
+            commandId: ProblemsCommands.COPY_MESSAGE.id,
+            label: 'Copy Message',
+            order: '1'
+        });
         menus.registerMenuAction(ProblemsMenu.PROBLEMS, {
             commandId: ProblemsCommands.COLLAPSE_ALL.id,
             label: 'Collapse All',
-            order: '0'
+            order: '2'
         });
     }
 
@@ -117,6 +153,41 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         if (SelectableTreeNode.is(firstChild)) {
             model.selectNode(firstChild);
         }
+    }
+
+    protected addToClipboard(content: string): void {
+        const handleCopy = (e: ClipboardEvent) => {
+            document.removeEventListener('copy', handleCopy);
+            if (e.clipboardData) {
+                e.clipboardData.setData('text/plain', content);
+                e.preventDefault();
+            }
+        };
+        document.addEventListener('copy', handleCopy);
+        document.execCommand('copy');
+    }
+
+    protected copy(selection: ProblemSelection): void {
+        const marker = selection.marker as ProblemMarker;
+        const serializedProblem = JSON.stringify({
+            resource: marker.uri,
+            owner: marker.uri,
+            code: marker.data.code,
+            severity: marker.data.severity,
+            message: marker.data.message,
+            source: marker.data.source,
+            startLineNumber: marker.data.range.start.line,
+            startColumn: marker.data.range.start.character,
+            endLineNumber: marker.data.range.end.line,
+            endColumn: marker.data.range.end.character
+        }, undefined, '\t');
+
+        this.addToClipboard(serializedProblem);
+    }
+
+    protected copyMessage(selection: ProblemSelection): void {
+        const marker = selection.marker as ProblemMarker;
+        this.addToClipboard(marker.data.message);
     }
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (problems: ProblemWidget) => T): T | false {

--- a/packages/markers/src/browser/problem/problem-selection.ts
+++ b/packages/markers/src/browser/problem/problem-selection.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { SelectionService } from '@theia/core/lib/common/selection-service';
+import { SelectionCommandHandler } from '@theia/core/lib/common/selection-command-handler';
+import { Marker } from '../../common/marker';
+import { ProblemMarker } from '../../common/problem-marker';
+
+export interface ProblemSelection {
+    marker: Marker<object>;
+}
+export namespace ProblemSelection {
+    export function is(arg: Object | undefined): arg is ProblemSelection {
+        return typeof arg === 'object' && ('marker' in arg) && ProblemMarker.is(arg['marker']);
+    }
+
+    export class CommandHandler extends SelectionCommandHandler<ProblemSelection> {
+
+        constructor(
+            protected readonly selectionService: SelectionService,
+            protected readonly options: SelectionCommandHandler.Options<ProblemSelection>
+        ) {
+            super(
+                selectionService,
+                arg => ProblemSelection.is(arg) ? arg : undefined,
+                options
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
~~Added copy & copy message buttons (with appropriate tooltips on top of them) to the problem widget. This enables users to copy the problem message and copy the problem details in JSON format.~~ 

Fixed #5132.

Implemented copy & copy message functions for a problem node and added the options into the context menu.  Now for every problem displayed in the problem widget, one can right-click on it to copy the detailed problem info (in JSON format), or to copy the problem message only.