### PR TITLE
Fixed #5169: added "Collapse Folder in Explorer" to command palette

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -44,6 +44,8 @@ export namespace FileNavigatorCommands {
     };
     export const COLLAPSE_ALL: Command = {
         id: 'navigator.collapse.all',
+        category: 'File',
+        label: 'Collapse Folders in Explorer',
         iconClass: 'collapse-all'
     };
 }


### PR DESCRIPTION
Fixed #5169.

Added "File: Collapse Folder in Explorer" functionality back to the command palette, to be consistent with other File-category commands 
