### PR TITLE
[electron] Test codecs from ffmpeg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 install:
   - THEIA_SKIP_NPM_PREPARE=1 yarn install
-  - travis_retry npx electron-h264-test
+  - npx electron-codecs-test
+  - npx electron-h264-test # obsolete?
   - yarn prepare
   - scripts/check_git_status.sh
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,8 @@ install:
   - netsh advfirewall firewall add rule name="SeleniumIn" dir=in action=allow protocol=TCP localport=4444
   - netsh advfirewall firewall add rule name="SeleniumOut" dir=out action=allow protocol=TCP localport=4444
   - cmd: set THEIA_SKIP_NPM_PREPARE=1 && yarn install
-  - npx electron-h264-test
+  - npx electron-codecs-test
+  - npx electron-h264-test # obsolete?
 
 before_build:
   - node --version && npm --version && yarn --version && python --version

--- a/dev-packages/electron/electron-ffmpeg-lib.js
+++ b/dev-packages/electron/electron-ffmpeg-lib.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+// @ts-check
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+'use-strict'
+
+const path = require('path');
+const cp = require('child_process');
+
+class ProcessError extends Error {
+    constructor(options = {}) {
+        super(options.message);
+        this.code = options.code;
+        this.signal = options.signal;
+    }
+}
+
+/**
+ * @param {import('child_process').ChildProcess} subprocess
+ */
+async function process_exit(subprocess) {
+    return new Promise((resolve, reject) => {
+        subprocess.on('exit', (code, signal) => {
+            if (code || signal) reject(new ProcessError({ code, signal }));
+            else resolve();
+        })
+        subprocess.on('error', reject);
+    })
+}
+
+/**
+ * @param {import('child_process').ChildProcess} subprocess
+ */
+async function get_process_output(subprocess) {
+    return new Promise((resolve, reject) => {
+        let output = '';
+        subprocess.stdout.on('data', data => output += data);
+        subprocess.stdout.on('close', async () => {
+            resolve(output);
+        });
+    })
+}
+
+/**
+ * @param {NodeJS.Platform} [platform]
+ * @return {File}
+ */
+exports.libffmpeg = function (platform = process.platform) {
+    switch (platform) {
+        case 'darwin':
+            return {
+                name: 'libffmpeg.dylib',
+                folder: 'Electron.app/Contents/Frameworks/Electron Framework.framework/Libraries/',
+            };
+        case 'win32':
+            return {
+                name: 'ffmpeg.dll',
+            };
+        case 'linux':
+            return {
+                name: 'libffmpeg.so',
+            };
+        default:
+            throw new Error(`${process.platform} is not supported`);
+    }
+}
+
+/**
+ * @param {libffmpegPlatformOptions} [options]
+ * @return {String}
+ */
+exports.libffmpegRelativePath = function ({ platform } = {}) {
+    const libffmpeg = exports.libffmpeg(platform);
+    return `${libffmpeg.folder || ''}${libffmpeg.name}`;
+}
+
+/**
+ * @param {libffmpegDistributionOptions} [options]
+ * @return {String}
+ */
+exports.libffmpegAbsolutePath = function ({ platform, electronDist } = {}) {
+    if (!electronDist) electronDist = path.resolve(require.resolve('electron/index.js'), '..', 'dist');
+    return path.join(electronDist, exports.libffmpegRelativePath({ platform }));
+}
+
+/**
+ * Since MacOS is using spaces in their folder names (but could also happen
+ * on other OSes), we need to escape them for Gyp to understand.
+ *
+ * @param {libffmpegDistributionOptions} [options]
+ * @return {String}
+ */
+exports.libffmpegGypLibraryPath = function (options = {}) {
+    return exports.libffmpegAbsolutePath(options).replace(' ', '\\\\ ');
+}
+
+/**
+ * @param {libffmpegDistributionOptions} [options]
+ * @return {Promise<Codec[]>}
+ */
+exports.libffmpegCodecs = async function (options = {}) {
+    function dynamic_library_linking() {
+        switch (process.platform) {
+            case 'darwin':
+                return {
+                    DYLD_INSERT_LIBRARIES: exports.libffmpegAbsolutePath(options),
+                };
+            case 'linux':
+                return {
+                    LD_PRELOAD: exports.libffmpegAbsolutePath(options),
+                };
+        }
+    }
+    const subprocess = cp.spawn(require.resolve('./native/build/Release/electron-ffmpeg-codecs'), [], {
+        env: {
+            ...process.env,
+            ...dynamic_library_linking()
+        },
+    });
+    const outputPromise = get_process_output(subprocess);
+    outputPromise.catch(() => undefined); // suppress unhandledPromise
+    await process_exit(subprocess);
+
+    return JSON.parse(await outputPromise);
+}
+
+/**
+ * @typedef {Object} File
+ * @property {String} name
+ * @property {String} [folder]
+ */
+
+/**
+ * @typedef {Object} Codec
+ * @property {Number} id
+ * @property {String} name
+ * @property {String} longName
+ */
+
+/**
+ * @typedef {Object} libffmpegPlatformOptions
+ * @property {NodeJS.Platform} [platform]
+ */
+
+/**
+ * @typedef {Object} libffmpegDistributionOptions
+ * @property {NodeJS.Platform} [platform]
+ * @property {String} [electronDist]
+ */

--- a/dev-packages/electron/electron-replace-ffmpeg.js
+++ b/dev-packages/electron/electron-replace-ffmpeg.js
@@ -15,10 +15,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+'use-strict'
 
 const downloadElectron = require('electron-download');
 const unzipper = require('unzipper');
 const fs = require('fs');
+
+const { libffmpeg } = require('./electron-ffmpeg-lib')
 
 async function main() {
     const electronVersionFilePath = require.resolve('electron/dist/version');
@@ -40,7 +43,7 @@ async function main() {
     const {
         name: libffmpegFileName,
         folder: libffmpegFolder = '',
-    } = libffmpegFile();
+    } = libffmpeg();
 
     const libffmpegZip = await unzipper.Open.file(libffmpegZipPath);
     const file = libffmpegZip.files.find(file => file.path.endsWith(libffmpegFileName));
@@ -55,35 +58,6 @@ async function main() {
             .on('finish', resolve)
             .on('error', reject);
     });
-}
-
-/**
- * @typedef {Object} File
- * @property {String} name
- * @property {String|undefined} folder
- */
-
-/**
- * @return {File}
- */
-function libffmpegFile() {
-    switch (process.platform) {
-        case 'darwin':
-            return {
-                name: 'libffmpeg.dylib',
-                folder: 'Electron.app/Contents/Frameworks/Electron Framework.framework/Libraries/',
-            };
-        case 'linux':
-            return {
-                name: 'libffmpeg.so',
-            };
-        case 'win32':
-            return {
-                name: 'ffmpeg.dll',
-            };
-        default:
-            throw new Error(`${process.platform} is not supported`);
-    }
 }
 
 main().catch(error => {

--- a/dev-packages/electron/native/binding.gyp
+++ b/dev-packages/electron/native/binding.gyp
@@ -1,0 +1,12 @@
+{
+    'targets': [{
+        'target_name': 'electron-ffmpeg-codecs',
+        'type': 'executable',
+        'sources': [
+            'src/electron-ffmpeg-codecs.c',
+        ],
+        'libraries': [
+            "<!@(node -p \"require('../electron-ffmpeg-lib.js').libffmpegGypLibraryPath()\")",
+        ],
+    }],
+}

--- a/dev-packages/electron/native/src/electron-ffmpeg-codecs.c
+++ b/dev-packages/electron/native/src/electron-ffmpeg-codecs.c
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// This program must be linked against the ffmpeg library.
+
+#include <stdio.h>
+
+// ffmpeg data
+enum AVMediaType
+{
+    AVMEDIA_TYPE_UNKNOWN = -1, ///< Usually treated as AVMEDIA_TYPE_DATA
+};
+
+// ffmpeg data
+enum AVCodecID
+{
+    AV_CODEC_ID_H264 = 27,
+};
+
+// ffmpeg data
+typedef struct
+{
+    const char *name, *long_name;
+    enum AVMediaType type;
+    enum AVCodecID id;
+
+} AVCodec;
+
+// ffmpeg functions
+void avcodec_register_all(void);
+AVCodec *av_codec_next(const AVCodec *c);
+
+void output_json_entry(AVCodec *codec)
+{
+    fprintf(stdout, "{\"id\":%d,\"name\":\"%s\",\"longName\":\"%s\"}",
+            codec->id, codec->name, codec->long_name);
+}
+
+int main()
+{
+    avcodec_register_all();
+    AVCodec *codec = av_codec_next(NULL);
+    fprintf(stdout, "[");
+    while (1)
+    {
+        output_json_entry(codec);
+        codec = av_codec_next(codec);
+        if (codec != NULL)
+            printf(",");
+        else
+            break;
+    }
+    fprintf(stdout, "]\n");
+    return 0;
+}

--- a/dev-packages/electron/package.json
+++ b/dev-packages/electron/package.json
@@ -17,6 +17,7 @@
   "bin": {
     "electron": "electron-cli.js",
     "electron-h264-test": "electron-h264-test.js",
+    "electron-codecs-test": "electron-codecs-test.js",
     "electron-replace-ffmpeg": "electron-replace-ffmpeg.js"
   },
   "dependencies": {
@@ -25,9 +26,10 @@
     "electron-store": "^2.0.0",
     "fix-path": "^2.1.0",
     "native-keymap": "^1.2.5",
+    "node-gyp": "^3.6.0",
     "unzipper": "^0.9.11"
   },
   "scripts": {
-    "postinstall": "node ./scripts/skip-replace-ffmpeg || (node ./electron-replace-ffmpeg && node ./electron-h264-test)"
+    "postinstall": "cd native && npx node-gyp rebuild && cd .. && node ./scripts/skip-replace-ffmpeg || (node ./electron-replace-ffmpeg && node ./electron-codecs-test)"
   }
 }


### PR DESCRIPTION
Electron's ffmpeg can bundle proprietary codecs, which we want to avoid
having.

This commit adds a native module that will be built and run on the
client where the `@theia/electron` package will be installed. The
program will link against Electron's ffmpeg shared library and scan the
available codecs, failing if a proprietary one is found.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
