### PR TITLE
fix #5114. Support multiple files to drag and drop.

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -101,11 +101,8 @@ export class FileNavigatorWidget extends FileTreeWidget {
     protected enableDndOnMainPanel(): void {
         const mainPanelNode = this.shell.mainPanel.node;
         this.addEventListener(mainPanelNode, 'drop', async ({ dataTransfer }) => {
-            const treeNode = dataTransfer && this.getTreeNodeFromData(dataTransfer) || undefined;
-
-            if (FileNode.is(treeNode)) {
-                this.commandService.executeCommand(CommonCommands.OPEN.id, treeNode.uri);
-            }
+            const treeNodes = dataTransfer && this.getTreeNodesFromData(dataTransfer) || [];
+            treeNodes.filter(FileNode.is).forEach(treeNode => this.commandService.executeCommand(CommonCommands.OPEN.id, treeNode.uri));
         });
         const handler = (e: DragEvent) => {
             if (e.dataTransfer) {


### PR DESCRIPTION
Signed-off-by: Brokun <brokun0128@gmail.com>

fix #5114 

- [filesystem] Drag and drop event transfer node list instead of single node. 
- [filesystem] Support to move multiple files by dnd.
- [navigator] Support to open multiple files by dnd.
- Rename `setTreeNodeAsData` to `setTreeNodesAsData` ,`getTreeNodeFromData` to `getTreeNodesFromData`

 