### PR TITLE
fix theia-ide#5114. Support multiple files to drag and drop.

### DIFF
--- a/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
+++ b/packages/filesystem/src/browser/file-tree/file-tree-widget.tsx
@@ -98,7 +98,13 @@ export class FileTreeWidget extends TreeWidget {
 
     protected handleDragStartEvent(node: TreeNode, event: React.DragEvent): void {
         event.stopPropagation();
-        this.setTreeNodeAsData(event.dataTransfer, node);
+        let selectedNodes;
+        if (this.model.selectedNodes.find(selected => TreeNode.equals(selected, node))) {
+            selectedNodes = [...this.model.selectedNodes];
+        } else {
+            selectedNodes = [node];
+        }
+        this.setSelectedTreeNodesAsData(event.dataTransfer, node, selectedNodes);
     }
 
     protected handleDragEnterEvent(node: TreeNode | undefined, event: React.DragEvent): void {
@@ -139,9 +145,11 @@ export class FileTreeWidget extends TreeWidget {
             event.dataTransfer.dropEffect = 'copy'; // Explicitly show this is a copy.
             const containing = DirNode.getContainingDir(node);
             if (containing) {
-                const source = this.getTreeNodeFromData(event.dataTransfer);
-                if (source) {
-                    await this.model.move(source, containing);
+                const resources = this.getSelectedTreeNodesFromData(event.dataTransfer);
+                if (resources.length > 0) {
+                    for (const treeNode of resources) {
+                        await this.model.move(treeNode, containing);
+                    }
                 } else {
                     await this.uploadService.upload(containing.uri, { source: event.dataTransfer });
                 }
@@ -157,9 +165,21 @@ export class FileTreeWidget extends TreeWidget {
         data.setData('tree-node', node.id);
     }
 
+    protected setSelectedTreeNodesAsData(data: DataTransfer, sourceNode: TreeNode, relatedNodes: TreeNode[]): void {
+        this.setTreeNodeAsData(data, sourceNode);
+        data.setData('selected-tree-nodes', JSON.stringify(relatedNodes.map(node => node.id)));
+    }
+
     protected getTreeNodeFromData(data: DataTransfer): TreeNode | undefined {
         const id = data.getData('tree-node');
         return this.model.getNode(id);
     }
-
+    protected getSelectedTreeNodesFromData(data: DataTransfer): TreeNode[] {
+        const resources = data.getData('selected-tree-nodes');
+        if (!resources) {
+            return [];
+        }
+        const ids: string[] = JSON.parse(resources);
+        return ids.map(id => this.model.getNode(id)).filter(node => node !== undefined) as TreeNode[];
+    }
 }

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -101,11 +101,8 @@ export class FileNavigatorWidget extends FileTreeWidget {
     protected enableDndOnMainPanel(): void {
         const mainPanelNode = this.shell.mainPanel.node;
         this.addEventListener(mainPanelNode, 'drop', async ({ dataTransfer }) => {
-            const treeNode = dataTransfer && this.getTreeNodeFromData(dataTransfer) || undefined;
-
-            if (FileNode.is(treeNode)) {
-                this.commandService.executeCommand(CommonCommands.OPEN.id, treeNode.uri);
-            }
+            const treeNodes = dataTransfer && this.getSelectedTreeNodesFromData(dataTransfer) || [];
+            treeNodes.filter(FileNode.is).forEach(treeNode => this.commandService.executeCommand(CommonCommands.OPEN.id, treeNode.uri));
         });
         const handler = (e: DragEvent) => {
             if (e.dataTransfer) {


### PR DESCRIPTION
fix #5114 

- [filesystem] Drag and drop event transfer node list instead of single node. 
- [filesystem] Support to move multiple files by dnd.
- [navigator] Support to open multiple files by dnd.
- ~~Rename `setTreeNodeAsData` to `setTreeNodesAsData` ,`getTreeNodeFromData` to `getTreeNodesFromData`~~
- [filesystem] Add getSelectedTreeNodesFromData api in file-tree-widget

Signed-off-by: Brokun <brokun0128@gmail.com>

 