### PR TITLE
fix #5189: resolve deferred promise before it's returned in "activate…

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -210,6 +210,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
         const deferred = new Deferred<void>();
         this.pluginActivationPromises.set(pluginId, deferred);
+        deferred.resolve();
         return deferred.promise;
     }
 


### PR DESCRIPTION
The "deferred" in "activatePlugin" function should be resolved before its promise is returned. See more in issue #5189.