### PR TITLE
[mini-browser] Clarify 'still loading' message, increase load timeout 3s → 4s

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-content.ts
+++ b/packages/mini-browser/src/browser/mini-browser-content.ts
@@ -451,7 +451,7 @@ export class MiniBrowserContent extends BaseWidget {
         clearTimeout(this.frameLoadTimeout);
         this.maybeResetBackground();
         this.hideLoadIndicator();
-        this.showErrorBar('Loading this page is taking longer than usual');
+        this.showErrorBar('Still loading...');
     }
 
     protected showLoadIndicator(): void {
@@ -657,7 +657,7 @@ export class MiniBrowserContent extends BaseWidget {
                     this.input.title = `Open ${url} In A New Window`;
                 }
                 clearTimeout(this.frameLoadTimeout);
-                this.frameLoadTimeout = window.setTimeout(this.onFrameTimeout.bind(this), 3000);
+                this.frameLoadTimeout = window.setTimeout(this.onFrameTimeout.bind(this), 4000);
                 if (showLoadIndicator) {
                     this.showLoadIndicator();
                 }


### PR DESCRIPTION
After some usage, it appears that the following warning could be clarified:

> Loading this page is taking longer than usual

Since it's a bit long, and displayed with a `(!)` icon + yellow background, it can be perceived as an error.

Maybe rephrasing it to:

> Still loading...

Could clarify the fact that it's a temporary status indicator (i.e. the page seems to still be loading, but it's taking a while).

Also, increasing the timeout when this message appears (3s → 4s) could make it show up less often.