### PR TITLE
Fixed #5192: Fix multiple file uploads

### DIFF
--- a/packages/filesystem/src/browser/file-upload-service.ts
+++ b/packages/filesystem/src/browser/file-upload-service.ts
@@ -282,10 +282,13 @@ export class FileUploadService {
 
     protected async indexDataTransferItemList(targetUri: URI, items: DataTransferItemList, context: FileUploadService.Context): Promise<void> {
         checkCancelled(context.token);
+        const entries: WebKitEntry[] = [];
         for (let i = 0; i < items.length; i++) {
             const entry = items[i].webkitGetAsEntry() as WebKitEntry;
-            await this.indexEntry(targetUri, entry, context);
+            entries.push(entry);
         }
+        await this.indexEntries(targetUri, entries, context);
+
     }
 
     protected async indexEntry(targetUri: URI, entry: WebKitEntry | null, context: FileUploadService.Context): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Brokun <brokun0128@gmail.com>

 Fixed #5192: Fix multiple file uploads,  get all WebKitEntry before the asynchronous call.