### PR TITLE
Fix for VSCode plugin loading

### DIFF
--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -35,7 +35,13 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     }
 
     // tslint:disable-next-line:no-any
-    registerCommand(command: theia.CommandDescription, handler?: Handler, thisArg?: any): Disposable {
+    registerCommand(command: theia.CommandDescription | String, handler?: Handler, thisArg?: any): Disposable {
+
+        if (typeof command === 'string' || command instanceof String) {
+            const tCommand = { id: command };
+            command = tCommand as theia.CommandDescription;
+        }
+
         if (this.commands.has(command.id)) {
             throw new Error(`Command ${command.id} already exist`);
         }
@@ -47,7 +53,9 @@ export class CommandRegistryImpl implements CommandRegistryExt {
             toDispose.push(this.registerHandler(command.id, handler, thisArg));
         }
         toDispose.push(Disposable.create(() => {
+            // @ts-ignore
             this.commands.delete(command.id);
+            // @ts-ignore
             this.proxy.$unregisterCommand(command.id);
         }));
         return Disposable.from(...toDispose);


### PR DESCRIPTION
Some VSCode plugins send a string as the first parameter of their registerCommand() call, while Theia expects an object and uses the 'id' property of that object to register the plugin.  This will detect if a string is sent and convert it to an object if necessary so the plugin properly registers and executes.

Signed-off-by: Paige J. Sullivan <psullivan@ibm.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
