### PR TITLE
Added fix for keybindings not showing when plugin installed

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -166,7 +166,8 @@ export class KeybindingRegistry {
     protected keybindingsChanged = new Emitter<void>();
 
     /**
-     * Event that is fired when the resolved keybindings change due to a different keyboard layout.
+     * Event that is fired when the resolved keybindings change due to a different keyboard layout
+     * or when a new keymap is being set
      */
     get onKeybindingsChanged() {
         return this.keybindingsChanged.event;
@@ -652,6 +653,7 @@ export class KeybindingRegistry {
     setKeymap(scope: KeybindingScope, bindings: Keybinding[]): void {
         this.resetKeybindingsForScope(scope);
         this.doRegisterKeybindings(bindings, scope);
+        this.keybindingsChanged.fire(undefined);
     }
 
     /**

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -240,9 +240,6 @@ export class KeybindingWidget extends ReactWidget {
         const commands = this.commandRegistry.commands.sort((a, b) => this.compareCommands(a, b));
         const items: KeybindingItem[] = [];
         for (let i = 0; i < commands.length; i++) {
-            if (!commands[i].label) {
-                continue;
-            }
             const keybindings = this.keybindingRegistry.getKeybindingsForCommand(commands[i].id);
             const item: KeybindingItem = {
                 id: commands[i].id,

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -56,6 +56,7 @@ export class KeymapsService {
         if (this.resource.onDidChangeContents) {
             this.resource.onDidChangeContents(() => this.reconcile());
         }
+        this.keyBindingRegistry.onKeybindingsChanged(() => this.changeKeymapEmitter.fire(undefined));
     }
 
     protected async reconcile(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

There are two things that this PR does. The first thing allows the keymaps view to update when a VSCode plugin containing keybindings is loaded. The second thing is removal of only showing keybindings when they have labels. The reason why this is required is because AFAIK vscode extensions don't define labels in their keymaps ([example](https://github.com/alphabotsec/vscode-eclipse-keybindings/blob/master/package.json#L27)) and without this change any keybinding that comes from a VSCode plugin cannot be shown in the keymaps extension.

This PR fixes https://github.com/theia-ide/theia/issues/5205.

