### PR TITLE
[console] adjust the debug console user input alignment

### DIFF
--- a/packages/console/src/browser/style/index.css
+++ b/packages/console/src/browser/style/index.css
@@ -23,14 +23,15 @@
 
 .theia-console-input {
     padding-left: 20px;
-	border-top: var(--theia-panel-border-width) solid var(--theia-border-color1);
+    padding-top: 5px;
+    border-top: var(--theia-panel-border-width) solid var(--theia-border-color1);
 }
 
 .theia-console-input:before {
-	left: 8px;
-	position: absolute;
+    left: 8px;
+    position: absolute;
     content: '\276f';
-	line-height: 18px;
+    line-height: 18px;
     color: var(--theia-ui-font-color1);
 }
 


### PR DESCRIPTION
Fixes #5208

- adjusts the `debug console` user input alignment so that it is now evenly aligned.
- updates the tabbing in the console `index.css` to spaces.

<div align='center'>

|Before|After|
|:---:|:---:|
| <img width="185" alt="Screen Shot 2019-05-21 at 6 06 30 PM" src="https://user-images.githubusercontent.com/40359487/58134200-0a816680-7bf4-11e9-9930-f20cae049f8a.png"> | <img width="196" alt="Screen Shot 2019-05-21 at 6 05 33 PM" src="https://user-images.githubusercontent.com/40359487/58134211-0fdeb100-7bf4-11e9-8b31-7c5ca00fa13e.png"> |

</div>


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
