### PR TITLE
[terminal] fix random 1px white border on terminal in Firefox

### DIFF
--- a/packages/terminal/src/browser/terminal.css
+++ b/packages/terminal/src/browser/terminal.css
@@ -19,3 +19,8 @@
     height:100%;
     padding: var(--theia-code-padding);
 }
+
+.xterm .xterm-screen canvas {
+  /* fix random 1px white border on terminal in Firefox. See https://github.com/theia-ide/theia/issues/4665 */
+  border: 1px solid var(--theia-layout-color0);
+}


### PR DESCRIPTION
This should fix #4665, but unfortunately I wasn't able to reproduce the issue using Firefox.