### PR TITLE
[mini-browser] don't resize all the time

### DIFF
--- a/packages/mini-browser/src/browser/mini-browser-open-handler.ts
+++ b/packages/mini-browser/src/browser/mini-browser-open-handler.ts
@@ -110,8 +110,12 @@ export class MiniBrowserOpenHandler extends NavigatableWidgetOpenHandler<MiniBro
     async open(uri: URI, options?: MiniBrowserOpenerOptions): Promise<MiniBrowser> {
         const widget = await super.open(uri, options);
         const area = this.shell.getAreaFor(widget);
-        if (area && area !== 'main') {
-            this.shell.resize(this.shell.mainPanel.node.offsetWidth / 2, area);
+        if (area === 'right' || area === 'left') {
+            const panelLayout = area === 'right' ? this.shell.getLayoutData().rightPanel : this.shell.getLayoutData().leftPanel;
+            const minSize = this.shell.mainPanel.node.offsetWidth / 2;
+            if (panelLayout && panelLayout.size && panelLayout.size <= minSize) {
+                requestAnimationFrame(() => this.shell.resize(minSize, area));
+            }
         }
         return widget;
     }

--- a/packages/mini-browser/src/browser/mini-browser.ts
+++ b/packages/mini-browser/src/browser/mini-browser.ts
@@ -46,7 +46,7 @@ export class MiniBrowser extends BaseWidget implements NavigatableWidget, Statef
         const { uri } = this.options;
         this.id = `${MiniBrowser.ID}:${uri.toString()}`;
         this.title.closable = true;
-        this.layout = new PanelLayout();
+        this.layout = new PanelLayout({ fitPolicy: 'set-no-constraint' });
     }
 
     getResourceUri(): URI | undefined {
@@ -59,6 +59,7 @@ export class MiniBrowser extends BaseWidget implements NavigatableWidget, Statef
 
     protected props: MiniBrowserProps | undefined;
     protected readonly toDisposeOnProps = new DisposableCollection();
+
     setProps(raw: MiniBrowserProps): void {
         const props: MiniBrowserProps = {
             toolbar: raw.toolbar,

--- a/packages/mini-browser/src/browser/style/index.css
+++ b/packages/mini-browser/src/browser/style/index.css
@@ -34,6 +34,7 @@
     display: flex;
     align-items: center;
     justify-content: space-evenly;
+    padding: 0 10px;
 }
 
 .theia-mini-browser-toolbar-read-only {
@@ -41,6 +42,7 @@
     display: flex;
     align-items: center;
     justify-content: space-evenly;
+    padding: 0 10px;
 }
 
 .theia-mini-browser-toolbar input {


### PR DESCRIPTION
this changes makes the preview only resize
when it is too small. Also it waits for an
animation frame so the sizes it is based on are computed properly.

Signed-off-by: Sven Efftinge <sven.efftinge@typefox.io>