### PR TITLE
Implementation of some editor.action commands needed for plugin API

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -25,6 +25,18 @@ export namespace EditorCommands {
 
     const EDITOR_CATEGORY = 'Editor';
 
+    export const RENAME: Command = {
+        id: 'editor.action.rename'
+    };
+
+    export const FORMAT_SELECTION: Command = {
+        id: 'editor.action.formatSelection'
+    };
+
+    export const FORMAT_DOCUMENT: Command = {
+        id: 'editor.action.formatDocument'
+    };
+
     /**
      * Show editor references
      */
@@ -115,6 +127,9 @@ export class EditorCommandContribution implements CommandContribution {
     protected readonly editorManager: EditorManager;
 
     registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(EditorCommands.RENAME);
+        registry.registerCommand(EditorCommands.FORMAT_SELECTION);
+        registry.registerCommand(EditorCommands.FORMAT_DOCUMENT);
         registry.registerCommand(EditorCommands.SHOW_REFERENCES);
         registry.registerCommand(EditorCommands.CONFIG_INDENTATION);
         registry.registerCommand(EditorCommands.CONFIG_EOL);

--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -126,6 +126,9 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
         this.registry.registerHandler(EditorCommands.CONFIG_EOL.id, this.newConfigEolHandler());
         this.registry.registerHandler(EditorCommands.INDENT_USING_SPACES.id, this.newConfigTabSizeHandler(true));
         this.registry.registerHandler(EditorCommands.INDENT_USING_TABS.id, this.newConfigTabSizeHandler(false));
+        this.registry.registerHandler(EditorCommands.RENAME.id, this.newCommandHandler('monaco.editor.action.rename'));
+        this.registry.registerHandler(EditorCommands.FORMAT_SELECTION.id, this.newCommandHandler('monaco.editor.action.formatSelection'));
+        this.registry.registerHandler(EditorCommands.FORMAT_DOCUMENT.id, this.newCommandHandler('monaco.editor.action.formatDocument'));
     }
 
     protected newShowReferenceHandler(): MonacoEditorCommandHandler {

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -309,7 +309,6 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
          * Show Opened File in New Window	workbench.action.files.showOpenedFileInNewWindow
          * Compare Opened File With	workbench.files.action.compareFileWith
          */
-
     }
 
     private getHtml(body: String) {

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -310,21 +310,6 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
          * Compare Opened File With	workbench.files.action.compareFileWith
          */
 
-        commands.registerCommand({ id: 'editor.action.rename' }, {
-            execute: () => {
-                commands.executeCommand('monaco.editor.action.rename');
-            }
-        });
-        commands.registerCommand({ id: 'editor.action.formatSelection' }, {
-            execute: () => {
-                commands.executeCommand('monaco.editor.action.formatSelection');
-            }
-        });
-        commands.registerCommand({ id: 'editor.action.formatDocument' }, {
-            execute: () => {
-                commands.executeCommand('monaco.editor.action.formatDocument');
-            }
-        });
     }
 
     private getHtml(body: String) {

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -309,6 +309,22 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
          * Show Opened File in New Window	workbench.action.files.showOpenedFileInNewWindow
          * Compare Opened File With	workbench.files.action.compareFileWith
          */
+
+        commands.registerCommand({ id: 'editor.action.rename' }, {
+            execute: () => {
+                commands.executeCommand('monaco.editor.action.rename');
+            }
+        });
+        commands.registerCommand({ id: 'editor.action.formatSelection' }, {
+            execute: () => {
+                commands.executeCommand('monaco.editor.action.formatSelection');
+            }
+        });
+        commands.registerCommand({ id: 'editor.action.formatDocument' }, {
+            execute: () => {
+                commands.executeCommand('monaco.editor.action.formatDocument');
+            }
+        });
     }
 
     private getHtml(body: String) {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

This PR makes 'editor.action.rename', 'editor.action.formatSelection', 'editor.action.formatDocument' available.

Related issue: https://github.com/eclipse/che/issues/13007, https://github.com/theia-ide/theia/issues/5215, https://github.com/theia-ide/theia/issues/5216