### PR TITLE
Use https to download JDT LS rather than http

### DIFF
--- a/packages/java/package.json
+++ b/packages/java/package.json
@@ -57,6 +57,6 @@
     "extends": "../../configs/nyc.json"
   },
   "ls": {
-    "downloadUrl": "http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz"
+    "downloadUrl": "https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz"
   }
 }


### PR DESCRIPTION
Our build machine doesn't allow `http` URLs downloads. Switching the JDT LS download URL to `https` should do it and doesn't seem to break anything