### PR TITLE
fix  :The input box is always fixed in the upper left corner

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -1,10 +1,3 @@
-/* FIXME when https://github.com/Microsoft/monaco-editor/issues/113#issuecomment-240406949 is fixed */
-.monaco-editor .inputarea {
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-}
-
 .monaco-editor {
     padding-bottom: 5.6px;
     font-family: var(--theia-ui-font-family);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35068357/58307898-9e407600-7e32-11e9-8649-4bd1174a0b8d.png)
this issue (https://github.com/Microsoft/monaco-editor/issues/113#issuecomment-240406949) had been closed ,and textArea in monaco-editor  is no need to always float in the upper left corner,so this style can be deleted:
```css
/* FIXME when https://github.com/Microsoft/monaco-editor/issues/113#issuecomment-240406949 is fixed */
/* .monaco-editor .inputarea {
    position: fixed !important;
    top: 0 !important;
    left: 0 !important;
} */
```
![image](https://user-images.githubusercontent.com/35068357/58307872-8ec12d00-7e32-11e9-88e9-1edaaf3fa3dc.png)
Fixes #5237 