### PR TITLE
Add 'reject-cycles' lerna option

### DIFF
--- a/scripts/lerna.js
+++ b/scripts/lerna.js
@@ -29,4 +29,7 @@ if (process.platform === 'win32') {
     }
     console.log('Running lerna as: ' + process.argv.join(' '));
 }
+if (process.argv.indexOf('--reject-cycles') === -1) {
+    process.argv.push('--reject-cycles');
+}
 require(lernaPath);


### PR DESCRIPTION
Now we have cyclic dependency problem  
[@theia/plugin-ext](https://github.com/theia-ide/theia/blob/8ab7d1d19e24e21b10ff19668a3b12aa9906d250/packages/plugin-ext/package.json#L19), [@theia/scm](https://github.com/theia-ide/theia/blob/8ab7d1d19e24e21b10ff19668a3b12aa9906d250/packages/scm/package.json#L9) depends on each other, and lerna provides this warning message:
```Encountered a cycle in the dependency graph.This may cause instability! Packages in cycle are: "@theia/git", "@theia/plugin-ext-vscode", "@theia/plugin-ext", "@theia/scm", "@theia/example-browser", "@theia/example-electron"```

This pull add `--reject-cycles` lerna option to fail build if any cyclic dependency exists

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
