### PR TITLE
the priority of mini browser should be bigger than editor preview

### DIFF
--- a/packages/mini-browser/src/node/mini-browser-endpoint.ts
+++ b/packages/mini-browser/src/node/mini-browser-endpoint.ts
@@ -190,7 +190,7 @@ export class MiniBrowserEndpoint implements BackendApplicationContribution, Mini
 }
 
 // See `EditorManager#canHandle`.
-const CODE_EDITOR_PRIORITY = 100;
+const CODE_EDITOR_PRIORITY = 200;
 
 /**
  * Endpoint handler contribution for HTML files.


### PR DESCRIPTION
the priority of  mini browser should be bigger than editor preview ,the priority of svg-handler  had been  changed to 1 by  Anton Kosyakov in 4ba7b01c ,so svg is still open its source.

![截图](https://user-images.githubusercontent.com/35068357/58314976-35152e80-7e43-11e9-9a3b-090ad8385236.PNG)

![image](https://user-images.githubusercontent.com/35068357/58314933-1d3daa80-7e43-11e9-9778-11aaaac0a7f3.png)

Fixes #5230