### PR TITLE
Make WorkspaceCommandContribution rebindable by extensions

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-module.ts
+++ b/packages/workspace/src/browser/workspace-frontend-module.ts
@@ -70,7 +70,8 @@ export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Un
             createSaveFileDialogContainer(ctx.container, props).get(SaveFileDialog)
     );
 
-    bind(CommandContribution).to(WorkspaceCommandContribution).inSingletonScope();
+    bind(WorkspaceCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(WorkspaceCommandContribution);
     bind(MenuContribution).to(FileMenuContribution).inSingletonScope();
     bind(WorkspaceDeleteHandler).toSelf().inSingletonScope();
     bind(WorkspaceDuplicateHandler).toSelf().inSingletonScope();


### PR DESCRIPTION
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

This makes `WorkspaceCommandContribution` rebindable by extensions, so that methods such as `getDefaultFileConfig` can be overriden to e.g. provide a different default filename when creating a new file.