### PR TITLE
[task] display task label in terminal, when executing user tasks

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -323,14 +323,19 @@ export class TaskService implements TaskConfigurationClient {
     }
 
     async attach(terminalId: number, taskId: number): Promise<void> {
-        // create terminal widget to display an execution output of a Task that was launched as a command inside a shell
+        // Get the list of all available running tasks.
+        const runningTasks: TaskInfo[] = await this.getRunningTasks();
+        // Get the corresponding task information based on task id if available.
+        const taskInfo: TaskInfo | undefined = runningTasks.find((t: TaskInfo) => t.taskId === taskId);
+        // Create terminal widget to display an execution output of a task that was launched as a command inside a shell.
         const widget = <TerminalWidget>await this.widgetManager.getOrCreateWidget(
             TERMINAL_WIDGET_FACTORY_ID,
             <TerminalWidgetFactoryOptions>{
                 created: new Date().toString(),
                 id: 'terminal-' + terminalId,
-                caption: `Task #${taskId}`,
-                label: `Task #${taskId}`,
+                title: taskInfo
+                    ? `Task: ${taskInfo.config.label}`
+                    : `Task: #${taskId}`,
                 destroyTermOnClose: true
             }
         );


### PR DESCRIPTION
Fixes #5226

- Adds the `task` label to the terminal instance when executing tasks. If for whatever reason the task label cannot be found, the task number is displayed.

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/58422500-b4cc1480-8060-11e9-9bb4-1a1139bb2b28.png)


</div>

---

**Note:**

I did not include an incremental label to the tasks in the terminal (ex: `Task: Test 0`, `Task: Test 1`), as I felt it did not additional value or meaningful information to an end user. If others argue that it should be included however, then I'll update the PR to include the incremental value.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
