### PR TITLE
Rename "Clear All" to "Clear Search Results"

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-frontend-contribution.ts
@@ -60,7 +60,7 @@ export namespace SearchInWorkspaceCommands {
     export const CLEAR_ALL: Command = {
         id: 'search-in-workspace.clear-all',
         category: SEARCH_CATEGORY,
-        label: 'Clear All',
+        label: 'Clear Search Results',
         iconClass: 'clear-all'
     };
 }


### PR DESCRIPTION
Changed `Clear All` to `Clear Search Results` in
`search-in-workspace-frontend-contribution.ts` as this is more informative. 

Resolves #5204

Signed-off-by: Bolarinwa Balogun <bo.lariin@hotmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
