### PR TITLE
Fix plugin folder path in windows

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -85,9 +85,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
             if (!pluginPath) {
                 return undefined;
             }
-            if (!pluginPath.endsWith('/')) {
-                pluginPath += '/';
-            }
+            pluginPath = path.normalize(pluginPath + '/');
             return await this.loadPluginMetadata(pluginPath);
         } catch (e) {
             this.logger.error(`Failed to load plugin metadata from "${pluginPath}"`, e);


### PR DESCRIPTION
this caused loader not to find vscode API and some functionality like commands didn't work

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

