### PR TITLE
Fix #5279 Leaking java debug process

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -29,6 +29,7 @@
     "getmac": "^1.4.6",
     "jsonc-parser": "^2.0.2",
     "lodash.clonedeep": "^4.5.0",
+    "ps-tree": "^1.2.0",
     "request": "^2.82.0",
     "uuid": "^3.2.1",
     "vscode-debugprotocol": "^1.32.0",
@@ -70,7 +71,8 @@
   "devDependencies": {
     "@theia/ext-scripts": "^0.9.0",
     "@types/decompress": "^4.2.2",
-    "@types/lodash.clonedeep": "^4.5.3"
+    "@types/lodash.clonedeep": "^4.5.3",
+    "@types/ps-tree": "^1.1.0"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,6 +342,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/ps-tree@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.0.tgz#7e2034e8ccdc16f6b0ced7a88529ebcb3b1dc424"
+  integrity sha512-rm5GU5sefQpg2d/DQ+fMDZnl9aPiJjJ9FYA12isIocNTZqu9VDZRgCRBx3oYFEdmDpmPmY4hxxmY/+1a84Rtzg==
+
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
@@ -3685,7 +3690,7 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-event-stream@~3.3.0:
+event-stream@=3.3.4, event-stream@~3.3.0:
   version "3.3.4"
   resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -7832,6 +7837,13 @@ ps-tree@1.1.0:
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
   dependencies:
     event-stream "~3.3.0"
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
When start debugging using vscode java-debug extension,
the debug process will remain in OS process list and
never be killed by theia process if the page is reloaded.

When terminate plugin server, kill all child processes
of plugin-host process.

Signed-off-by: tom-shan <swt0008411@163.com>