### PR TITLE
Fixed #5273: added informative tooltips for items in the outline view

### DIFF
--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -105,6 +105,21 @@ export class OutlineViewWidget extends TreeWidget {
         return undefined;
     }
 
+    protected createNodeAttributes(node: TreeNode, props: NodeProps): React.Attributes & React.HTMLAttributes<HTMLElement> {
+        const elementAttrs = super.createNodeAttributes(node, props);
+        return {
+            ...elementAttrs,
+            title: this.getNodeTooltip(node)
+        };
+    }
+
+    protected getNodeTooltip(node: TreeNode): string | undefined {
+        if (OutlineSymbolInformationNode.is(node)) {
+            return node.name + ` (${node.iconClass})`;
+        }
+        return undefined;
+    }
+
     protected isExpandable(node: TreeNode): node is ExpandableTreeNode {
         return OutlineSymbolInformationNode.is(node) && node.children.length > 0;
     }


### PR DESCRIPTION
Fixed #5273.

Added VSCode-style tooltips to items in the outline view widget. The tooltip shows the node name + category.

![image](https://i.ibb.co/NTKrhtC/Screenshot-from-2019-05-28-13-05-33.png)