### PR TITLE
Update message about task start/stop

### DIFF
--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -97,6 +97,8 @@ export interface TaskExitedEvent {
     // Exactly one of code and signal will be set.
     readonly code?: number;
     readonly signal?: string;
+
+    readonly config?: TaskConfiguration;
 }
 
 export interface TaskClient {

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -48,7 +48,8 @@ export class ProcessTask extends Task {
                     taskId: this.taskId,
                     ctx: this.options.context,
                     code: event.code,
-                    signal: event.signal
+                    signal: event.signal,
+                    config: this.options.config
                 });
             });
 


### PR DESCRIPTION
According to [issue](https://github.com/eclipse/che/issues/13394) there is a changes proposal to update message that indicates about task start/stop operation. Changes replaces task number with human readable name.

<img width="660" alt="Снимок экрана 2019-05-29 в 12 07 47" src="https://user-images.githubusercontent.com/1968177/58545119-4bd4d000-820b-11e9-939a-10f6693383c3.png">
<img width="1086" alt="Снимок экрана 2019-05-29 в 12 07 08" src="https://user-images.githubusercontent.com/1968177/58545132-51cab100-820b-11e9-86b1-27508a7d161a.png">


Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>
