### PR TITLE
[markdown] Indicate highlight.js license in tomorrow.css

### DIFF
--- a/packages/preview/src/browser/markdown/style/tomorrow.css
+++ b/packages/preview/src/browser/markdown/style/tomorrow.css
@@ -16,7 +16,10 @@
 
 /* Tomorrow Theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
-/* Original theme - https://github.com/chriskempson/tomorrow-theme */
+
+/* Original theme - Copyright (C) 2013 Chris Kempson http://chriskempson.com
+/* released under the MIT License */
+/* https://github.com/chriskempson/tomorrow-theme */
 
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.

--- a/packages/preview/src/browser/markdown/style/tomorrow.css
+++ b/packages/preview/src/browser/markdown/style/tomorrow.css
@@ -23,8 +23,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- /* copied from https://github.com/microsoft/vscode/blob/08537497eecd3172390194693d3d7c0ec8f52b70/extensions/markdown-language-features/media/tomorrow.css
-    with modifications */
+/* Copied from https://github.com/microsoft/vscode/blob/08537497eecd3172390194693d3d7c0ec8f52b70/extensions/markdown-language-features/media/tomorrow.css
+ * with modifications.
+ */
+
+/* This theme is used to style the output of the highlight.js library which is
+ * licensed under the BSD-3-Clause. See https://github.com/highlightjs/highlight.js/blob/master/LICENSE
+ */
 
 /* Tomorrow Comment */
 .theia-preview-widget .hljs-comment,


### PR DESCRIPTION
This PR adds a note on the highlight.js library to the tomorrow.css

cf. https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16798#c19

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>