### PR TITLE
[plug-ins] Implement Plug-in API method 'setTextDocumentLanguage'

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -1049,6 +1049,7 @@ export interface LanguagesExt {
 
 export interface LanguagesMain {
     $getLanguages(): Promise<string[]>;
+    $changeLanguage(resource: UriComponents, languageId: string): Promise<void>;
     $setLanguageConfiguration(handle: number, languageId: string, configuration: SerializedLanguageConfiguration): void;
     $unregister(handle: number): void;
     $registerCompletionSupport(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[], supportsResolveDetails: boolean): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -14,6 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Method `$changeLanguage` copied and modified
+// from https://github.com/microsoft/vscode/blob/e9c50663154c369a06355ce752b447af5b580dc3/src/vs/workbench/api/browser/mainThreadLanguages.ts#L30-L42
+
 import {
     LanguagesMain,
     SerializedLanguageConfiguration,
@@ -54,6 +62,20 @@ export class LanguagesMainImpl implements LanguagesMain {
 
     $getLanguages(): Promise<string[]> {
         return Promise.resolve(monaco.languages.getLanguages().map(l => l.id));
+    }
+
+    $changeLanguage(resource: URI, languageId: string): Promise<void> {
+        const uri = URI.revive(resource);
+        const model = monaco.editor.getModel(uri);
+        if (!model) {
+            return Promise.reject(new Error('Invalid uri'));
+        }
+        const langId = monaco.languages.getEncodedLanguageId(languageId);
+        if (!langId) {
+            return Promise.reject(new Error(`Unknown language ID: ${languageId}`));
+        }
+        monaco.editor.setModelLanguage(model, languageId);
+        return Promise.resolve(undefined);
     }
 
     $unregister(handle: number): void {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -121,6 +121,16 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.proxy.$getLanguages();
     }
 
+    changeLanguage(uri: URI, languageId: string): Promise<theia.TextDocument> {
+        return this.proxy.$changeLanguage(uri, languageId).then(() => {
+            const doc = this.documents.getDocumentData(uri);
+            if (!doc) {
+                throw new Error('No document found by URI ' + uri.toString());
+            }
+            return doc.document;
+        });
+    }
+
     setLanguageConfiguration(language: string, configuration: theia.LanguageConfiguration): theia.Disposable {
         const { wordPattern } = configuration;
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -507,6 +507,9 @@ export function createAPIFactory(
             getLanguages(): PromiseLike<string[]> {
                 return languagesExt.getLanguages();
             },
+            setTextDocumentLanguage(document: theia.TextDocument, languageId: string): PromiseLike<theia.TextDocument> {
+                return languagesExt.changeLanguage(document.uri, languageId);
+            },
             match(selector: theia.DocumentSelector, document: theia.TextDocument): number {
                 return score(fromDocumentSelector(selector), document.uri, document.languageId, true);
             },

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -6370,6 +6370,19 @@ declare module '@theia/plugin' {
         export function getLanguages(): PromiseLike<string[]>;
 
         /**
+         * Set (and change) the [language](#TextDocument.languageId) that is associated
+         * with the given document.
+         *
+         * *Note* that calling this function will trigger the [`onDidCloseTextDocument`](#workspace.onDidCloseTextDocument) event
+         * followed by the [`onDidOpenTextDocument`](#workspace.onDidOpenTextDocument) event.
+         *
+         * @param document The document which language is to be changed
+         * @param languageId The new language identifier.
+         * @returns A thenable that resolves with the updated document.
+         */
+        export function setTextDocumentLanguage(document: TextDocument, languageId: string): PromiseLike<TextDocument>;
+
+        /**
          * Compute the match between a document [selector](#DocumentSelector) and a document. Values
          * greater than zero mean the selector matches the document.
          *


### PR DESCRIPTION

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

This PR adds an implementation for Plug-in API method `setTextDocumentLanguage`.

fix https://github.com/theia-ide/theia/issues/4448


**Tests output**

```
root INFO [hosted-plugin: 25742]   languages namespace tests
root INFO [nsfw-watcher: 25712] Started watching: /tmp/drzbxeou
root INFO [hosted-plugin: 25742]     ✓ setTextDocumentLanguage -> close/open event (317ms)
root INFO [nsfw-watcher: 25712] Started watching: /tmp/ekxpe
root INFO [hosted-plugin: 25742]     ✓ setTextDocumentLanguage -> error when language does not exist (45ms)
```

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>
