### PR TITLE
Allow not persistent changes for task before run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.9.0
 
+- [task] allowed running existing tasks with temporary, one-time changes
+
 Breaking changes:
 
 - [plugin] fixed typo in 'HostedInstanceState' enum from RUNNNING to RUNNING in `plugin-dev` extension

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -16,12 +16,9 @@
 
 import * as theia from '@theia/plugin';
 import * as Converter from '../type-converters';
-import { ObjectIdentifier } from '../../common/object-identifier';
 import { TaskDto } from '../../common';
 
 export class TaskProviderAdapter {
-    private cacheId = 0;
-    private cache = new Map<number, theia.Task>();
 
     constructor(private readonly provider: theia.TaskProvider) { }
 
@@ -37,9 +34,6 @@ export class TaskProviderAdapter {
                     continue;
                 }
 
-                const id = this.cacheId++;
-                ObjectIdentifier.mixin(data, id);
-                this.cache.set(id, task);
                 result.push(data);
             }
             return result;
@@ -50,9 +44,7 @@ export class TaskProviderAdapter {
         if (typeof this.provider.resolveTask !== 'function') {
             return Promise.resolve(undefined);
         }
-        const id = ObjectIdentifier.of(task);
-        const cached = this.cache.get(id);
-        const item = cached ? cached : Converter.toTask(task);
+        const item = Converter.toTask(task);
         if (!item) {
             return Promise.resolve(undefined);
         }

--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -11,6 +11,7 @@
     "@theia/terminal": "^0.8.0",
     "@theia/variable-resolver": "^0.8.0",
     "@theia/workspace": "^0.8.0",
+    "deepmerge": "2.0.1",
     "jsonc-parser": "^2.0.2"
   },
   "publishConfig": {

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -179,9 +179,9 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
                 isEnabled: () => true,
                 // tslint:disable-next-line:no-any
                 execute: (...args: any[]) => {
-                    const [source, label] = args;
+                    const [source, label, overrides] = args;
                     if (source && label) {
-                        return this.taskService.run(source, label);
+                        return this.taskService.run(source, label, overrides);
                     }
                     return this.quickOpenTask.open();
                 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### Description

This PR adds ability to run existing task with some temporary (one-time) changes.
It might be useful in some cases, especially when a parameter of task depends on some environment or UI state. For example, when task console command is the same, but path in which it should be run depends on current file opened in the editor, etc.

#### Depends on

https://github.com/theia-ide/theia/pull/5313 (`toTask` method patch in `type-converters.ts`)