### PR TITLE
[tasks] Fix execution of Configured tasks

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -234,7 +234,10 @@ export class TaskConfigurations implements Disposable {
                         console.error(`Error parsing ${uri}: error: ${e.error}, length:  ${e.length}, offset:  ${e.offset}`);
                     }
                 } else {
-                    return this.filterDuplicates(tasks['tasks']).map(t => Object.assign(t, { _source: t.source || this.getSourceFolderFromConfigUri(uri) }));
+                    return this.filterDuplicates(tasks['tasks']).map(task => {
+                        const { _source, _scope, ...configuration } = task;
+                        return { ...configuration, _source: this.getSourceFolderFromConfigUri(uri) };
+                    });
                 }
             } catch (err) {
                 console.error(`Error(s) reading config file: ${uri}`);
@@ -267,7 +270,7 @@ export class TaskConfigurations implements Disposable {
             await this.fileSystem.createFile(configFileUri);
         }
 
-        const { _source, $ident, ...preparedTask } = task;
+        const { _source, _scope, $ident, ...preparedTask } = task;
         try {
             const response = await this.fileSystem.resolveContent(configFileUri);
             const content = response.content;


### PR DESCRIPTION
1. Change way of filtering task configurations:
- 'configured' tasks have higher priority than 'detected' at adding to 'recently used' section
- do not display 'detected' task for running if 'configured' task is exist with the same label

2. Do not set ‘source’ of ‘detected’ task for configuration of ‘configured’ task - after saving the task is citizen of tasks.json file, so [according to the doc](https://github.com/theia-ide/theia/blob/deec2c4c04ec5b91c77bbad528810de5b6310ea2/packages/task/src/common/task-protocol.ts#L39-L44) should has corresponding source (path of root folder that the task config comes from)
3. Do not save '_scope' of 'detected' task at 'configure task' action - this field [is not supposed](https://github.com/theia-ide/theia/blob/deec2c4c04ec5b91c77bbad528810de5b6310ea2/packages/task/src/common/task-protocol.ts#L45-L48) to be used in `tasks.json`

Related issues: https://github.com/theia-ide/theia/issues/5064 and https://github.com/theia-ide/theia/issues/5067

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

