### PR TITLE
Fixed #5315: added "Open Keyboard Shortcuts (JSON)" to the command palette

### DIFF
--- a/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
+++ b/packages/keymaps/src/browser/keymaps-frontend-contribution.ts
@@ -33,6 +33,11 @@ export namespace KeymapsCommands {
         category: 'Settings',
         label: 'Open Keyboard Shortcuts',
     };
+    export const OPEN_KEYMAPS_JSON: Command = {
+        id: 'keymaps:openJson',
+        category: 'Settings',
+        label: 'Open Keyboard Shortcuts (JSON)'
+    };
 }
 
 @injectable()
@@ -55,6 +60,10 @@ export class KeymapsFrontendContribution extends AbstractViewContribution<Keybin
         commands.registerCommand(KeymapsCommands.OPEN_KEYMAPS, {
             isEnabled: () => true,
             execute: () => this.openView({ activate: true })
+        });
+        commands.registerCommand(KeymapsCommands.OPEN_KEYMAPS_JSON, {
+            isEnabled: () => true,
+            execute: () => this.keymaps.open()
         });
     }
 


### PR DESCRIPTION
Fixed #5315.

Small PR to add the option to "Open Keyboard Shortcuts (JSON)" command that directly opens the `keymaps.json` file, one of the handy commands that VS Code has in the command palette.