### PR TITLE
[typescript] re-use Theia launching program for TS LS

### DIFF
--- a/packages/typescript/src/node/typescript-contribution.ts
+++ b/packages/typescript/src/node/typescript-contribution.ts
@@ -55,7 +55,9 @@ export class TypeScriptContribution extends BaseLanguageServerContribution {
     }
 
     async start(clientConnection: IConnection, { parameters }: TypeScriptStartOptions): Promise<void> {
-        const command = 'node';
+        // Re-use the same tool used to launch Theia. e.g. for an Electron Theia packaging,
+        // this will be "electron" executable that is bundled with the application.
+        const command = process.execPath;
         const args: string[] = [
             path.join(__dirname, 'startserver.js'),
             '--stdio'


### PR DESCRIPTION
When we launch the TypeScript Language Server, we start it using
the hardcoded executable "node". This works well in practice for
most cases. However when we have a packaged Electron application,
installed by a user, it could be that the environment does not have
"node" immediately available in its path, or not a proper version,
as needed by tsserver.

So why not reuse the node executable that was used to launch
the Theia application, to launch the LS? In the Electron case,
it will be the Electron executable bundled with the packaging.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
