### PR TITLE
[keybindings] Aligned keybindings with VSCode

### DIFF
--- a/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/keybindings/keybindings-contribution-handler.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject } from 'inversify';
 import { PluginContribution, Keybinding as PluginKeybinding } from '../../../common';
-import { Keybinding, KeybindingRegistry, KeybindingScope } from '@theia/core/lib/browser/keybinding';
+import { Keybinding, KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { OS } from '@theia/core/lib/common/os';
 
@@ -48,7 +48,7 @@ export class KeybindingsContributionPointHandler {
                 }
             }
         }
-        this.keybindingRegistry.setKeymap(KeybindingScope.USER, keybindings);
+        this.keybindingRegistry.registerKeybindings(...keybindings);
     }
 
     protected toKeybinding(pluginKeybinding: PluginKeybinding): Keybinding | undefined {
@@ -75,7 +75,7 @@ export class KeybindingsContributionPointHandler {
 
     private handlePartialKeybindings(keybinding: Keybinding, partialKeybindings: Keybinding[]) {
         partialKeybindings.forEach(partial => {
-            if (keybinding.context === undefined || keybinding.context === partial.context) {
+            if (keybinding.when === undefined || keybinding.when === partial.context) {
                 this.logger.warn(`Partial keybinding is ignored; ${Keybinding.stringify(keybinding)} shadows ${Keybinding.stringify(partial)}`);
             }
         });
@@ -84,8 +84,6 @@ export class KeybindingsContributionPointHandler {
     private handleShadingKeybindings(keybinding: Keybinding, shadingKeybindings: Keybinding[]) {
         shadingKeybindings.forEach(shadow => {
             if (shadow.context === undefined || shadow.context === keybinding.context) {
-                this.keybindingRegistry.unregisterKeybinding(shadow);
-
                 this.logger.warn(`Shadowing keybinding is ignored; ${Keybinding.stringify(shadow)}, shadows ${Keybinding.stringify(keybinding)}`);
             }
         });


### PR DESCRIPTION
This PR changes keybindings to align themselves with how VSCode keybinding policy works. In VSCode, keybindings always register even if there is a conflict and the one that is last registered (and has the highest priority wins i.e. scoping). For example, if I have a keybinding that opens the terminal and that same keybinding also creates a new file, when I press that keybinding the new file will be created because it was registered last.

It also makes it so that you are able to see all keybindings registered to a command, instead of just one and implements [removal rules](https://github.com/theia-ide/theia/issues/5303).






Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

