### PR TITLE
[task] implement quick-open item to terminate all running tasks

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -360,6 +360,20 @@ export class TaskTerminateQuickOpen implements QuickOpenModel {
                     }
                 }));
             });
+            if (runningTasks.length > 1) {
+                items.push(new QuickOpenItem({
+                    label: 'All running tasks',
+                    run: (mode: QuickOpenMode): boolean => {
+                        if (mode !== QuickOpenMode.OPEN) {
+                            return false;
+                        }
+                        runningTasks.forEach((t: TaskInfo) => {
+                            this.taskService.kill(t.taskId);
+                        });
+                        return true;
+                    }
+                }));
+            }
         }
         acceptor(items);
     }


### PR DESCRIPTION
**Description**

Fixes #5203

- added the new `Terminate Task` quick-open item used to terminate all running tasks.
- the new item is displayed whenever there are more than one running tasks currently in execution.

**How to test:**

1. Open the `test-resources` folder under `theia/packages/task` as a workspace.
2. Execute multiple tasks using the command `Task: Run Task`.
3. If **more than one** task is currently in execution, the quick-open item `All running tasks` will be displayed.
4. Click the `All running tasks` item, and all running tasks should be terminated.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
