### PR TITLE
[tasks] add 'Terminate Task...' menu item

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -211,9 +211,15 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
             order: '3'
         });
 
-        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS, {
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_INFO, {
+            commandId: TaskCommands.TASK_TERMINATE.id,
+            label: 'Terminate Task...',
+            order: '0'
+        });
+
+        menus.registerMenuAction(TerminalMenus.TERMINAL_TASKS_CONFIG, {
             commandId: TaskCommands.TASK_CONFIGURE.id,
-            order: '4'
+            order: '0'
         });
     }
 

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -47,6 +47,8 @@ export namespace TerminalMenus {
     export const TERMINAL = [...MAIN_MENU_BAR, '7_terminal'];
     export const TERMINAL_NEW = [...TERMINAL, '1_terminal'];
     export const TERMINAL_TASKS = [...TERMINAL, '2_terminal'];
+    export const TERMINAL_TASKS_INFO = [...TERMINAL_TASKS, '3_terminal'];
+    export const TERMINAL_TASKS_CONFIG = [...TERMINAL_TASKS, '4_terminal'];
     export const TERMINAL_NAVIGATOR_CONTEXT_MENU = ['navigator-context-menu', 'navigation'];
 }
 


### PR DESCRIPTION
Fixes #5329

- add the `Terminate Task...` menu item under the terminal main menu.
- add two new terminal subgroups, and align the items based on vscode.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
