### PR TITLE
[markdown] Fix error with anchor library

### DIFF
--- a/packages/preview/package.json
+++ b/packages/preview/package.json
@@ -12,7 +12,7 @@
     "@types/markdown-it-anchor": "^4.0.1",
     "highlight.js": "^9.12.0",
     "markdown-it": "^8.4.0",
-    "markdown-it-anchor": "^5.0.0"
+    "markdown-it-anchor": "~5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,9 +6207,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it-anchor@^5.0.0:
+markdown-it-anchor@~5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz#cdd917a05b7bf92fb736a6dae3385c6d0d0fa552"
+  integrity sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==
 
 markdown-it@^8.4.0:
   version "8.4.2"


### PR DESCRIPTION
This PR pins the version of `markdown-it-anchor`. Its module export was changed recently without any significant features. Now the type definitions seems to be out of sync.

Fixes #5337
