### PR TITLE
 Reslove activation promise if the plugin was already activated

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -209,6 +209,10 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         }
 
         const deferred = new Deferred<void>();
+
+        if (this.activatedPlugins.get(pluginId)) {
+            deferred.resolve();
+        }
         this.pluginActivationPromises.set(pluginId, deferred);
         return deferred.promise;
     }


### PR DESCRIPTION
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

If a plugin was activated/started it should resolve its activation promise

Related issue: https://github.com/theia-ide/theia/issues/5077