### PR TITLE
Implement 'Show Running Tasks...'

### DIFF
--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -18,7 +18,7 @@ import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution, QuickOpenContribution, KeybindingContribution } from '@theia/core/lib/browser';
 import { CommandContribution, MenuContribution, bindContributionProvider } from '@theia/core/lib/common';
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
-import { QuickOpenTask, TaskTerminateQuickOpen } from './quick-open-task';
+import { QuickOpenTask, TaskTerminateQuickOpen, TaskRunningQuickOpen } from './quick-open-task';
 import { TaskContribution, TaskProviderRegistry, TaskResolverRegistry } from './task-contribution';
 import { TaskService } from './task-service';
 import { TaskConfigurations } from './task-configurations';
@@ -43,6 +43,7 @@ export default new ContainerModule(bind => {
     }
 
     bind(QuickOpenTask).toSelf().inSingletonScope();
+    bind(TaskRunningQuickOpen).toSelf().inSingletonScope();
     bind(TaskTerminateQuickOpen).toSelf().inSingletonScope();
     bind(TaskConfigurations).toSelf().inSingletonScope();
     bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -313,7 +313,7 @@ export class TaskService implements TaskConfigurationClient {
             TERMINAL_WIDGET_FACTORY_ID,
             <TerminalWidgetFactoryOptions>{
                 created: new Date().toString(),
-                id: 'task-' + taskId,
+                id: 'terminal-' + terminalId,
                 caption: `Task #${taskId}`,
                 label: `Task #${taskId}`,
                 destroyTermOnClose: true


### PR DESCRIPTION
Fixes #5346
Fixed #1100

- Implement the command and terminal menu item `Show Running Tasks...`
which displays the list of currently running tasks, and upon selection,
sets the focus to the running task's terminal.
- Fixed issue regarding the creation of the task terminal id.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
