### PR TITLE
[plugins] terminate hosted plugin instance on dispose only if it is running

### DIFF
--- a/packages/plugin-dev/src/node/hosted-plugin-service.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-service.ts
@@ -39,7 +39,10 @@ export class HostedPluginServerImpl implements HostedPluginServer {
     private readonly hostedPlugin: HostedPluginSupport;
 
     dispose(): void {
-        this.hostedInstanceManager.terminate();
+        // Terminate the hosted instance if it is currently running.
+        if (this.hostedInstanceManager.isRunning()) {
+            this.hostedInstanceManager.terminate();
+        }
     }
     setClient(client: HostedPluginClient): void {
 


### PR DESCRIPTION
Fixes #5358

- The `hosted-instance-manager` throws an error when calling the `terminate` method and no
hosted plugin instance is currently running. Instead of calling `terminate` on `dispose` each time,
trigger the termination of the hosted plugin only when there is a currently running instance.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
