### PR TITLE
[terminal] add extra handling before attempting to resize a terminal

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -468,7 +468,8 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     }
 
     protected resizeTerminalProcess(): void {
-        if (typeof this.terminalId !== 'number') {
+        if (!IBaseTerminalServer.validateId(this.terminalId)
+            && !this.terminalService.getById(this.terminalId.toString())) {
             return;
         }
         const { cols, rows } = this.term;


### PR DESCRIPTION
Added extra handling before resizing a terminal to check if it exists or not, and can be resized.
With this change, we should no longer get the following message and we should not attempt to resize a terminal which doesn't exist:

```
Couldn't resize terminal -1, because it doesn't exist.
```

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
