### PR TITLE
[plug-in] Implement 'workbench.action.debug.restart` (vscode-java-deb…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Breaking changes:
 - [plugin] 'Hosted mode' extracted in `plugin-dev` extension
 - [core] `scheme` is mandatory for URI
   - `URI.withoutScheme` is removed, in order to get a path use `URI.path`
+- [debug] align commands with VS Code [#5102](https://github.com/theia-ide/theia/issues/5102)
+    - `debug.restart` renamed to `workbench.action.debug.restart`
 
 ## v0.7.0
 

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -72,7 +72,7 @@ export namespace DebugCommands {
         iconClass: 'fa fa-stop'
     };
     export const RESTART: Command = {
-        id: 'debug.restart',
+        id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart Debugging',
     };


### PR DESCRIPTION
…ug) command #5102

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

[debug] align commands with VS Code [#5102](https://github.com/theia-ide/theia/issues/5102)
- `debug.restart` renamed to `workbench.action.debug.restart`

As result, the command `workbench.action.debug.restart` in `CommandRegistry` is made it accessible from VSCode plugin extentions, like `vscode-java-debug`:

![t5102](https://user-images.githubusercontent.com/620781/58982782-8aebbe00-87d5-11e9-9757-9a1e2d7dd965.gif)
