### PR TITLE
[scm] fix error cannot read property 'forEach'

### DIFF
--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -23,11 +23,11 @@ import {
     StatusBarAlignment,
     StatusBarEntry
 } from '@theia/core/lib/browser';
-import {ScmCommand, ScmService} from './scm-service';
+import { ScmCommand, ScmService } from './scm-service';
 import { ScmWidget } from '../browser/scm-widget';
 import URI from '@theia/core/lib/common/uri';
-import {CommandRegistry} from '@theia/core';
-import {ScmQuickOpenService} from './scm-quick-open-service';
+import { CommandRegistry } from '@theia/core';
+import { ScmQuickOpenService } from './scm-quick-open-service';
 
 export const SCM_WIDGET_FACTORY_ID = 'scm';
 
@@ -41,7 +41,7 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
     @inject(ScmQuickOpenService) protected readonly scmQuickOpenService: ScmQuickOpenService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
 
-    private statusBarCommands: string[];
+    private statusBarCommands: string[] = [];
 
     constructor() {
         super({


### PR DESCRIPTION
Fixes #5363

If the application is started without a workspace, or with a workspace without a project under
source control, the error `cannot read property 'forEach` is thrown by the `scm` package.
This is due to the fact that **`this.statusBarCommands`** is not initialized unless a repository is present.
This means that when we try to iterate over the array, the error is thrown. 

The fix is to simply initialize `this.statusBarCommands` to an empty array.

- minor: format the import statements in **`scm-contribution.ts`**.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
