### PR TITLE
[output] fix output error regarding the unique key prop

### DIFF
--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -55,8 +55,9 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
         }
         return <select
             id={OutputWidget.IDs.CHANNEL_LIST}
+            key={OutputWidget.IDs.CHANNEL_LIST}
             value={this.outputChannelManager.selectedChannel ? this.outputChannelManager.selectedChannel.name : this.NONE}
-            onChange={ this.changeChannel}
+            onChange={this.changeChannel}
         >
             {channelOptionElements}
         </select>;


### PR DESCRIPTION
Fixes #5369

Fixes a react error thrown when opening the `output` widget. The error argues that there is missing a unique `key` prop for the select element, which react uses in order to easily identify
which items have been changed, are added, or are removed.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
