### PR TITLE
fix #5294: 1. reopen file with another encoding; 2. set default encod…

### DIFF
--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -30,12 +30,13 @@ export interface Resource extends Disposable {
     saveContents?(content: string, options?: { encoding?: string }): Promise<void>;
     saveContentChanges?(changes: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<void>;
     readonly onDidChangeContents?: Event<void>;
+    guessEncoding?(): Promise<string | undefined>
 }
 export namespace Resource {
     export interface SaveContext {
         content: string
         changes?: TextDocumentContentChangeEvent[]
-        options?: { encoding?: string }
+        options?: { encoding?: string, overwriteEncoding?: string }
     }
     export async function save(resource: Resource, context: SaveContext, token?: CancellationToken): Promise<void> {
         if (!resource.saveContents) {

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -27,6 +27,7 @@ import { EditorCommands } from './editor-command';
 import { EditorQuickOpenService } from './editor-quick-open-service';
 import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
 import { KeybindingRegistry, KeybindingContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
+import { SUPPORTED_ENCODINGS } from './supported-encodings';
 
 @injectable()
 export class EditorContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution, QuickOpenContribution {
@@ -89,10 +90,12 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
         const widget = this.editorManager.currentEditor;
         const editor = widget && widget.editor;
         this.updateLanguageStatus(editor);
+        this.updateEncodingStatus(editor);
         this.setCursorPositionStatus(editor);
         if (editor) {
             this.toDisposeOnCurrentEditorChanged.pushAll([
                 editor.onLanguageChanged(() => this.updateLanguageStatus(editor)),
+                editor.onEncodingChanged(() => this.updateEncodingStatus(editor)),
                 editor.onCursorPositionChanged(() => this.setCursorPositionStatus(editor))
             ]);
         }
@@ -110,6 +113,19 @@ export class EditorContribution implements FrontendApplicationContribution, Comm
             alignment: StatusBarAlignment.RIGHT,
             priority: 1,
             command: EditorCommands.CHANGE_LANGUAGE.id
+        });
+    }
+
+    protected updateEncodingStatus(editor: TextEditor | undefined): void {
+        if (!editor) {
+            this.statusBar.removeElement('editor-status-encoding');
+            return;
+        }
+        this.statusBar.setElement('editor-status-encoding', {
+            text: SUPPORTED_ENCODINGS[editor.getEncoding()].labelShort,
+            alignment: StatusBarAlignment.RIGHT,
+            priority: 10,
+            command: EditorCommands.CHANGE_ENCODING.id
         });
     }
 

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -24,6 +24,7 @@ import {
     PreferenceChangeEvent
 } from '@theia/core/lib/browser/preferences';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { SUPPORTED_ENCODINGS } from './supported-encodings';
 
 const DEFAULT_WINDOWS_FONT_FAMILY = 'Consolas, \'Courier New\', monospace';
 const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospace';
@@ -518,6 +519,11 @@ export const editorPreferenceSchema: PreferenceSchema = {
             ],
             'default': 'auto',
             'description': 'The default end of line character.'
+        },
+        'files.encoding': {
+            'enum': Object.keys(SUPPORTED_ENCODINGS).sort(),
+            'default': 'utf8',
+            'description': 'The default character set encoding to use when reading and writing files.'
         }
     }
 };
@@ -597,6 +603,7 @@ export interface EditorConfiguration {
     'diffEditor.ignoreCharChanges'?: boolean
     'diffEditor.alwaysRevealFirst'?: boolean
     'files.eol': EndOfLinePreference
+    'files.encoding': string
 }
 export type EndOfLinePreference = '\n' | '\r\n' | 'auto';
 

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -148,6 +148,19 @@ export interface EditorMouseEvent {
     readonly target: MouseTarget;
 }
 
+export const enum EncodingMode {
+
+    /**
+     * Instructs the encoding support to encode the current input with the provided encoding
+     */
+    Encode,
+
+    /**
+     * Instructs the encoding support to decode the current input with the provided encoding
+     */
+    Decode
+}
+
 export interface TextEditor extends Disposable, TextEditorSelection, Navigatable {
     readonly node: HTMLElement;
 
@@ -219,6 +232,18 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
     detectLanguage(): void;
     setLanguage(languageId: string): void;
     readonly onLanguageChanged: Event<string>;
+
+    /**
+     * Gets the encoding of the input if known.
+     */
+    getEncoding(): string;
+
+    /**
+     * Sets the encoding for the input for saving.
+     */
+    setEncoding(encoding: string, mode: EncodingMode): void;
+
+    readonly onEncodingChanged: Event<string>;
 }
 
 export interface Dimension {

--- a/packages/editor/src/browser/supported-encodings.ts
+++ b/packages/editor/src/browser/supported-encodings.ts
@@ -1,0 +1,262 @@
+/********************************************************************************
+ * Copyright (C) 2019 Xuye Cai and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// copied from vscode: https://github.com/microsoft/vscode/blob/master/src/vs/workbench/services/textfile/common/textfiles.ts
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const SUPPORTED_ENCODINGS: { [encoding: string]: { labelLong: string; labelShort: string; order: number; encodeOnly?: boolean; alias?: string } } = {
+    utf8: {
+        labelLong: 'UTF-8',
+        labelShort: 'UTF-8',
+        order: 1,
+        alias: 'utf8bom'
+    },
+    utf8bom: {
+        labelLong: 'UTF-8 with BOM',
+        labelShort: 'UTF-8 with BOM',
+        encodeOnly: true,
+        order: 2,
+        alias: 'utf8'
+    },
+    utf16le: {
+        labelLong: 'UTF-16 LE',
+        labelShort: 'UTF-16 LE',
+        order: 3
+    },
+    utf16be: {
+        labelLong: 'UTF-16 BE',
+        labelShort: 'UTF-16 BE',
+        order: 4
+    },
+    windows1252: {
+        labelLong: 'Western (Windows 1252)',
+        labelShort: 'Windows 1252',
+        order: 5
+    },
+    iso88591: {
+        labelLong: 'Western (ISO 8859-1)',
+        labelShort: 'ISO 8859-1',
+        order: 6
+    },
+    iso88593: {
+        labelLong: 'Western (ISO 8859-3)',
+        labelShort: 'ISO 8859-3',
+        order: 7
+    },
+    iso885915: {
+        labelLong: 'Western (ISO 8859-15)',
+        labelShort: 'ISO 8859-15',
+        order: 8
+    },
+    macroman: {
+        labelLong: 'Western (Mac Roman)',
+        labelShort: 'Mac Roman',
+        order: 9
+    },
+    cp437: {
+        labelLong: 'DOS (CP 437)',
+        labelShort: 'CP437',
+        order: 10
+    },
+    windows1256: {
+        labelLong: 'Arabic (Windows 1256)',
+        labelShort: 'Windows 1256',
+        order: 11
+    },
+    iso88596: {
+        labelLong: 'Arabic (ISO 8859-6)',
+        labelShort: 'ISO 8859-6',
+        order: 12
+    },
+    windows1257: {
+        labelLong: 'Baltic (Windows 1257)',
+        labelShort: 'Windows 1257',
+        order: 13
+    },
+    iso88594: {
+        labelLong: 'Baltic (ISO 8859-4)',
+        labelShort: 'ISO 8859-4',
+        order: 14
+    },
+    iso885914: {
+        labelLong: 'Celtic (ISO 8859-14)',
+        labelShort: 'ISO 8859-14',
+        order: 15
+    },
+    windows1250: {
+        labelLong: 'Central European (Windows 1250)',
+        labelShort: 'Windows 1250',
+        order: 16
+    },
+    iso88592: {
+        labelLong: 'Central European (ISO 8859-2)',
+        labelShort: 'ISO 8859-2',
+        order: 17
+    },
+    cp852: {
+        labelLong: 'Central European (CP 852)',
+        labelShort: 'CP 852',
+        order: 18
+    },
+    windows1251: {
+        labelLong: 'Cyrillic (Windows 1251)',
+        labelShort: 'Windows 1251',
+        order: 19
+    },
+    cp866: {
+        labelLong: 'Cyrillic (CP 866)',
+        labelShort: 'CP 866',
+        order: 20
+    },
+    iso88595: {
+        labelLong: 'Cyrillic (ISO 8859-5)',
+        labelShort: 'ISO 8859-5',
+        order: 21
+    },
+    koi8r: {
+        labelLong: 'Cyrillic (KOI8-R)',
+        labelShort: 'KOI8-R',
+        order: 22
+    },
+    koi8u: {
+        labelLong: 'Cyrillic (KOI8-U)',
+        labelShort: 'KOI8-U',
+        order: 23
+    },
+    iso885913: {
+        labelLong: 'Estonian (ISO 8859-13)',
+        labelShort: 'ISO 8859-13',
+        order: 24
+    },
+    windows1253: {
+        labelLong: 'Greek (Windows 1253)',
+        labelShort: 'Windows 1253',
+        order: 25
+    },
+    iso88597: {
+        labelLong: 'Greek (ISO 8859-7)',
+        labelShort: 'ISO 8859-7',
+        order: 26
+    },
+    windows1255: {
+        labelLong: 'Hebrew (Windows 1255)',
+        labelShort: 'Windows 1255',
+        order: 27
+    },
+    iso88598: {
+        labelLong: 'Hebrew (ISO 8859-8)',
+        labelShort: 'ISO 8859-8',
+        order: 28
+    },
+    iso885910: {
+        labelLong: 'Nordic (ISO 8859-10)',
+        labelShort: 'ISO 8859-10',
+        order: 29
+    },
+    iso885916: {
+        labelLong: 'Romanian (ISO 8859-16)',
+        labelShort: 'ISO 8859-16',
+        order: 30
+    },
+    windows1254: {
+        labelLong: 'Turkish (Windows 1254)',
+        labelShort: 'Windows 1254',
+        order: 31
+    },
+    iso88599: {
+        labelLong: 'Turkish (ISO 8859-9)',
+        labelShort: 'ISO 8859-9',
+        order: 32
+    },
+    windows1258: {
+        labelLong: 'Vietnamese (Windows 1258)',
+        labelShort: 'Windows 1258',
+        order: 33
+    },
+    gbk: {
+        labelLong: 'Simplified Chinese (GBK)',
+        labelShort: 'GBK',
+        order: 34
+    },
+    gb18030: {
+        labelLong: 'Simplified Chinese (GB18030)',
+        labelShort: 'GB18030',
+        order: 35
+    },
+    cp950: {
+        labelLong: 'Traditional Chinese (Big5)',
+        labelShort: 'Big5',
+        order: 36
+    },
+    big5hkscs: {
+        labelLong: 'Traditional Chinese (Big5-HKSCS)',
+        labelShort: 'Big5-HKSCS',
+        order: 37
+    },
+    shiftjis: {
+        labelLong: 'Japanese (Shift JIS)',
+        labelShort: 'Shift JIS',
+        order: 38
+    },
+    eucjp: {
+        labelLong: 'Japanese (EUC-JP)',
+        labelShort: 'EUC-JP',
+        order: 39
+    },
+    euckr: {
+        labelLong: 'Korean (EUC-KR)',
+        labelShort: 'EUC-KR',
+        order: 40
+    },
+    windows874: {
+        labelLong: 'Thai (Windows 874)',
+        labelShort: 'Windows 874',
+        order: 41
+    },
+    iso885911: {
+        labelLong: 'Latin/Thai (ISO 8859-11)',
+        labelShort: 'ISO 8859-11',
+        order: 42
+    },
+    koi8ru: {
+        labelLong: 'Cyrillic (KOI8-RU)',
+        labelShort: 'KOI8-RU',
+        order: 43
+    },
+    koi8t: {
+        labelLong: 'Tajik (KOI8-T)',
+        labelShort: 'KOI8-T',
+        order: 44
+    },
+    gb2312: {
+        labelLong: 'Simplified Chinese (GB 2312)',
+        labelShort: 'GB 2312',
+        order: 45
+    },
+    cp865: {
+        labelLong: 'Nordic DOS (CP 865)',
+        labelShort: 'CP 865',
+        order: 46
+    },
+    cp850: {
+        labelLong: 'Western European DOS (CP 850)',
+        labelShort: 'CP 850',
+        order: 47
+    }
+};

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -20,7 +20,9 @@
     "touch": "^3.1.0",
     "trash": "^4.0.1",
     "uuid": "^3.2.1",
-    "zip-dir": "^1.0.2"
+    "zip-dir": "^1.0.2",
+    "iconv-lite": "0.4.23",
+    "jschardet": "1.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filesystem/src/common/filesystem.ts
+++ b/packages/filesystem/src/common/filesystem.ts
@@ -49,8 +49,17 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
 
     /**
      * Updates the content replacing its previous value.
+     *
+     * The optional parameter `overwriteEncoding` can be used to transform the encoding of a file.
+     *
+     * |   | encoding | overwriteEncoding | behaviour |
+     * |---|----------|-------------------|-----------|
+     * | 1 | undefined |    undefined     | read & write file in default encoding |
+     * | 2 | undefined |        ✓         | read file in default encoding; write file in `overwriteEncoding` |
+     * | 3 |     ✓    |     undefined     | read & write file in `encoding` |
+     * | 4 |     ✓    |        ✓         | read file in `encoding`; write file in `overwriteEncoding` |
      */
-    updateContent(file: FileStat, contentChanges: TextDocumentContentChangeEvent[], options?: { encoding?: string }): Promise<FileStat>;
+    updateContent(file: FileStat, contentChanges: TextDocumentContentChangeEvent[], options?: { encoding?: string, overwriteEncoding?: string }): Promise<FileStat>;
 
     /**
      * Moves the file to a new path identified by the resource.
@@ -104,6 +113,11 @@ export interface FileSystem extends JsonRpcServer<FileSystemClient> {
      * Returns the encoding of the given file resource.
      */
     getEncoding(uri: string): Promise<string>;
+
+    /**
+     * Guess encoding of a given file besed on its content.
+     */
+    guessEncoding(uri: string): Promise<string | undefined>;
 
     /**
      * Return list of available roots.

--- a/packages/filesystem/src/common/test/mock-filesystem.ts
+++ b/packages/filesystem/src/common/test/mock-filesystem.ts
@@ -77,6 +77,10 @@ export class MockFilesystem implements FileSystem {
         return Promise.resolve('');
     }
 
+    guessEncoding(uri: string): Promise<string | undefined> {
+        return Promise.resolve('');
+    }
+
     getRoots(): Promise<FileStat[]> {
         return Promise.resolve([mockFileStat]);
     }

--- a/packages/filesystem/src/node/encoding-util.ts
+++ b/packages/filesystem/src/node/encoding-util.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (C) 2019 Xuye Cai and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// copied from vscode: https://github.com/Microsoft/vscode/blob/master/src/vs/base/node/encoding.ts
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const jschardet = require('jschardet');
+const MINIMUM_THRESHOLD = 0.2;
+jschardet.Constants.MINIMUM_THRESHOLD = MINIMUM_THRESHOLD;
+
+export namespace EncodingUtil {
+    const IGNORE_ENCODINGS = ['ascii', 'utf-8', 'utf-16', 'utf-32'];
+    export async function guessEncodingByBuffer(buffer: Buffer): Promise<string | undefined> {
+        const guessed = jschardet.detect(buffer);
+        if (!guessed || !guessed.encoding) {
+            return undefined;
+        }
+        const enc = guessed.encoding.toLowerCase();
+        // Ignore encodings that cannot guess correctly
+        // (http://chardet.readthedocs.io/en/latest/supported-encodings.html)
+        if (0 <= IGNORE_ENCODINGS.indexOf(enc)) {
+            return undefined;
+        }
+        return toIconvLiteEncoding(guessed.encoding);
+    }
+
+    function toIconvLiteEncoding(encodingName: string): string {
+        const normalizedEncodingName = encodingName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+        const mapped = JSCHARDET_TO_ICONV_ENCODINGS[normalizedEncodingName];
+
+        return mapped || normalizedEncodingName;
+    }
+
+    const JSCHARDET_TO_ICONV_ENCODINGS: { [name: string]: string } = {
+        'ibm866': 'cp866',
+        'big5': 'cp950'
+    };
+}

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -59,10 +59,14 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     protected readonly onWillSaveModelEmitter = new Emitter<WillSaveMonacoModelEvent>();
     readonly onWillSaveModel = this.onWillSaveModelEmitter.event;
 
+    private preferredEncoding: string | undefined = undefined;
+    private readonly defaultEncoding: string | undefined;
+
     constructor(
         protected readonly resource: Resource,
         protected readonly m2p: MonacoToProtocolConverter,
-        protected readonly p2m: ProtocolToMonacoConverter
+        protected readonly p2m: ProtocolToMonacoConverter,
+        options?: { encoding?: string | undefined }
     ) {
         this.toDispose.push(resource);
         this.toDispose.push(this.toDisposeOnAutoSave);
@@ -70,11 +74,32 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         this.toDispose.push(this.onDidSaveModelEmitter);
         this.toDispose.push(this.onWillSaveModelEmitter);
         this.toDispose.push(this.onDirtyChangedEmitter);
-        this.resolveModel = resource.readContents().then(content => this.initialize(content));
+        this.resolveModel = resource.readContents(options).then(content => this.initialize(content));
+        this.defaultEncoding = options && options.encoding ? options.encoding : undefined;
     }
 
     dispose(): void {
         this.toDispose.dispose();
+    }
+
+    async reopenWithEncoding(encoding: string): Promise<void> {
+        if (encoding === this.preferredEncoding || (!this.preferredEncoding && encoding === this.defaultEncoding)) {
+            return;
+        }
+        if (this.dirty) {
+            return;
+        }
+        this.preferredEncoding = encoding;
+        return this.sync();
+    }
+
+    async saveWithEncoding(encoding: string): Promise<void> {
+        return this.scheduleSave(TextDocumentSaveReason.Manual, this.cancelSave(), encoding)
+            .then(() => { this.preferredEncoding = encoding; });
+    }
+
+    getEncoding(): string | undefined {
+        return this.preferredEncoding || this.defaultEncoding;
     }
 
     /**
@@ -234,7 +259,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
     }
     protected async readContents(): Promise<string | undefined> {
         try {
-            return await this.resource.readContents();
+            return await this.resource.readContents({ encoding: this.getEncoding() });
         } catch (e) {
             if (ResourceError.NotFound.is(e)) {
                 return undefined;
@@ -273,8 +298,8 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this.saveCancellationTokenSource.token;
     }
 
-    protected scheduleSave(reason: TextDocumentSaveReason, token: CancellationToken = this.cancelSave()): Promise<void> {
-        return this.run(() => this.doSave(reason, token));
+    protected scheduleSave(reason: TextDocumentSaveReason, token: CancellationToken = this.cancelSave(), overwriteEncoding?: string): Promise<void> {
+        return this.run(() => this.doSave(reason, token, overwriteEncoding));
     }
 
     protected ignoreContentChanges = false;
@@ -333,7 +358,7 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         }
     }
 
-    protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken): Promise<void> {
+    protected async doSave(reason: TextDocumentSaveReason, token: CancellationToken, overwriteEncoding?: string): Promise<void> {
         if (token.isCancellationRequested || !this.resource.saveContents) {
             return;
         }
@@ -344,12 +369,12 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         }
 
         const changes = this.popContentChanges();
-        if (changes.length === 0) {
+        if (changes.length === 0 && overwriteEncoding === undefined) {
             return;
         }
 
         const content = this.model.getValue();
-        await Resource.save(this.resource, { changes, content }, token);
+        await Resource.save(this.resource, { changes, content, options: { encoding: this.getEncoding(), overwriteEncoding } }, token);
         if (token.isCancellationRequested) {
             return;
         }

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -59,7 +59,7 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
     protected async loadModel(uri: URI): Promise<MonacoEditorModel> {
         await this.editorPreferences.ready;
         const resource = await this.resourceProvider(uri);
-        const model = await (new MonacoEditorModel(resource, this.m2p, this.p2m).load());
+        const model = await (new MonacoEditorModel(resource, this.m2p, this.p2m, { encoding: this.editorPreferences.get('files.encoding') }).load());
         this.updateModel(model);
         model.textEditorModel.onDidChangeLanguage(() => this.updateModel(model));
         const disposable = this.editorPreferences.onPreferenceChanged(change => this.updateModel(model, change));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5521,6 +5521,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jschardet@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.6.0.tgz#c7d1a71edcff2839db2f9ec30fc5d5ebd3c1a678"
+  integrity sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==
+
 jscodeshift@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.4.1.tgz#da91a1c2eccfa03a3387a21d39948e251ced444a"


### PR DESCRIPTION
…ing;

Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

- [x] Register [CQ](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20161)

#### What it does
1. Add "editor.defaultEncoding" configuration, so that one can specify a proper default encoding for his project;
2. Add encoding item to the status bar, which shows the current encoding used;
3. Pump out a list of encoding for one to choose from when clicking on the encoding status item, or command 'textEditor.change.encoding' is executed. In addition, a guessed encoding will be shown on top of the list if possible.

Added dependencies:
1. "iconv-lite"  of version 0.4.23 is used to encode/decode files.
2. The same version of ""jschardet" (1.6.0) as the one on VSCode is used to guess the encoding of a file based on its content.

#### How to test

**Test File**
>Encoding of each provided file is used as its filename
- [GB2312.txt](https://github.com/theia-ide/theia/files/3491974/GB2312.txt)
- [Shift-JIS.txt](https://github.com/theia-ide/theia/files/3491975/Shift-JIS.txt)
- Or create your own files

**TEST1**
>Make sure that the default encoding works fine.

Preparation:
- Set `files.encoding` to `utf8`
- Prepare some files that are encoded in UTF-8

Process:
1. Open a file that's encoded in UTF-8 and check its content;
2. Create a file, edit it, save it, close it, and reopen it. Just make some modification as you like, and check if the editor is working properly;
3. Also, the encoding item on the status bar should show "UFT-8";
4. Use another test file and repeat.

**TEST2**
>Make sure that the "Reopen with Encoding" action functions well.

Preparation:
- Set `files.encoding` to `utf8`
- Prepare some files that are encoded in something different from UTF-8

Process:
1. Open a test file, for example, GB2312.txt, and check it's content. There should be some weird chars like � in the editor, which shows that the file is not decoded correctly;
2. Run "Editor: Change File Encoding" command or click the block on the status bar that shows "UTF-8", and choose "Reopen with Encoding" action;
3. In the selection list, the first item should be a guessed encoding item. The encoding is guessed from the file's content;
4. If you open files that are provided above, the guessed encoding should be correct (the correct encodings are the same as their filenames). If other files are used, the guessed encoding could be either right or wrong, which is normal. But basically, guessed encoding have a better chance to win if more content is put into the file;
5. Choose the right encoding, either from the guessed item or from your own select, and check if it's reopened correctly;
6. Use another test file and repeat.

**TEST3**
>Make sure that the "Save with Encoding" action functions well.

Preparation:
- Set `files.encoding` to `utf8`
- Prepare some files that are encoded in something different from UTF-8

Process:
1. Follow 1-5 of TEST2, so that the test file is opened in a correct encoding;
2. Run "Editor: Change File Encoding" command or click the block on the status bar that shows "UTF-8", and choose "Save with Encoding" action;
3. Then choose "UTF-8" or any other encoding you want to test, and check if the encoding of the file is changed correctly. You can do the check by reopening it, opening it with other software, or executing `file -i ${FILENAME}` command on linux (though it could be wrong);
4. Also, you can make some modification, and check if "Save with Encoding" action could handle dirty file correctly (apply content changes and encoding change as well)
5. Use another test file and repeat.

**TEST4**
>Make sure that `files.encoding` configuration works.

Preparation:
- Prepare some files that are encoded in something different from UTF-8

Process:
1. Change `files.encoding` (Files -> encoding) to the encoding of your test file;
2. Open the test file, do some editing, and check if it works fine;
3. Use another test file and repeat.

**NOTE**
Currently, I have only tested it on Ubuntu.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


