### PR TITLE
GH-5284: Debounced the menu update for electron.

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -23,6 +23,7 @@ import {
 import { PreferenceService, KeybindingRegistry, Keybinding } from '../../browser';
 import { ContextKeyService } from '../../browser/context-key-service';
 import { Anchor } from '../../browser/context-menu-renderer';
+import debounce = require('lodash.debounce');
 
 @injectable()
 export class ElectronMainMenuFactory {
@@ -39,12 +40,12 @@ export class ElectronMainMenuFactory {
         @inject(MenuModelRegistry) protected readonly menuProvider: MenuModelRegistry,
         @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry
     ) {
-        preferencesService.onPreferenceChanged(() => {
+        preferencesService.onPreferenceChanged(debounce(() => {
             for (const item of this._toggledCommands) {
                 this._menu.getMenuItemById(item).checked = this.commandRegistry.isToggled(item);
-                electron.remote.getCurrentWindow().setMenu(this._menu);
             }
-        });
+            electron.remote.getCurrentWindow().setMenu(this._menu);
+        }, 10));
         keybindingRegistry.onKeybindingsChanged(() => {
             const createdMenuBar = this.createMenuBar();
             if (isOSX) {


### PR DESCRIPTION
At application startup, we send out thousands of preference change
events. Each of them triggers a menu update. It seems to be expensive.
Debounced it.

Closes #5284.

Before:
![Screen Shot 2019-06-06 at 22 44 45](https://user-images.githubusercontent.com/1405703/59065385-dae98400-88ac-11e9-96ea-c42769010188.jpg)

After:
![Screen Shot 2019-06-06 at 22 43 46](https://user-images.githubusercontent.com/1405703/59065425-f0f74480-88ac-11e9-887f-14d79232c86d.jpg)


Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->