### PR TITLE
Pass process.env to child processes

### DIFF
--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -27,6 +27,7 @@ export interface ResolvedIPCConnectionOptions {
     readonly logger: ILogger
     readonly args: string[]
     readonly errorHandler?: ConnectionErrorHandler
+    readonly env?: NodeJS.ProcessEnv
 }
 export type IPCConnectionOptions = Partial<ResolvedIPCConnectionOptions> & {
     readonly serverName: string

--- a/packages/filesystem/src/node/filesystem-watcher-client.ts
+++ b/packages/filesystem/src/node/filesystem-watcher-client.ts
@@ -69,7 +69,8 @@ export class FileSystemWatcherServerClient implements FileSystemWatcherServer {
             errorHandler: new ConnectionErrorHandler({
                 serverName: NSFW_WATCHER,
                 logger: this.logger
-            })
+            }),
+            env: process.env
         }, connection => this.proxyFactory.listen(connection));
     }
 


### PR DESCRIPTION
Fixes theia-ide/theia#5389

To test this change:

1. run `FOOBAR=baz jwm &  FOOBAR=baz yarn --cwd examples/browser start ../..;`
2. wait until you see log message, such as `root INFO [nsfw-watcher: 14288] Started watching: /workspace/theia`
3. run `tr '\0' '\n' < /proc/14288/environ | grep -i foo` with the process id from (2) to verify the env is set. 
