### PR TITLE
GH-5385: Do not spawn electron for the TS LS.

### DIFF
--- a/dev-packages/application-package/src/environment.ts
+++ b/dev-packages/application-package/src/environment.ts
@@ -49,6 +49,28 @@ class ElectronEnv {
             && ((process as any).defaultApp || /node_modules[/]electron[/]/.test(process.execPath)); // tslint:disable-line:no-any
     }
 
+    /**
+     * Creates and return with a new environment object which always contains the `ELECTRON_RUN_AS_NODE: 1` property pair.
+     * This should be used to `spawn` and `fork` a new Node.js process from the Node.js shipped with Electron. Otherwise, a new Electron
+     * process will be spawned which [has side-effects](https://github.com/theia-ide/theia/issues/5385).
+     *
+     * If called from the backend and the `env` argument is not defined, it falls back to `process.env` such as Node.js behaves
+     * with the [`SpawnOptions`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+     * If `env` is defined, it will be shallow-copied.
+     *
+     * Calling this function from the frontend does not make any sense, hence throw an error.
+     */
+    // tslint:disable-next-line:no-any
+    runAsNodeEnv(env?: any): any & { ELECTRON_RUN_AS_NODE: 1 } {
+        if (typeof process === 'undefined') {
+            throw new Error("'process' cannot be undefined.");
+        }
+        return {
+            ...(env === undefined ? process.env : env),
+            ELECTRON_RUN_AS_NODE: 1
+        };
+    }
+
 }
 
 const electron = new ElectronEnv();

--- a/packages/json/src/node/json-contribution.ts
+++ b/packages/json/src/node/json-contribution.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { BaseLanguageServerContribution, IConnection } from '@theia/languages/lib/node';
+import { environment } from '@theia/application-package';
 import { JSON_LANGUAGE_ID, JSON_LANGUAGE_NAME } from '../common';
 import * as path from 'path';
 
@@ -26,12 +27,13 @@ export class JsonContribution extends BaseLanguageServerContribution {
     readonly name = JSON_LANGUAGE_NAME;
 
     async start(clientConnection: IConnection): Promise<void> {
-        const command = 'node';
+        // Same as https://github.com/theia-ide/theia/commit/de45794a90fc1a1a590578026f8ad527127afa0a
+        const command = process.execPath;
         const args: string[] = [
             path.resolve(__dirname, './json-starter'),
             '--stdio'
         ];
-        const serverConnection = await this.createProcessStreamConnectionAsync(command, args);
+        const serverConnection = await this.createProcessStreamConnectionAsync(command, args, { env: environment.electron.runAsNodeEnv() });
         this.forward(clientConnection, serverConnection);
     }
 

--- a/packages/process/src/node/process.ts
+++ b/packages/process/src/node/process.ts
@@ -66,7 +66,7 @@ export interface ProcessOptions<T = string> {
 }
 
 /**
- * Options to fork a new process using the current Node interpeter (`fork`).
+ * Options to fork a new process using the current Node interpreter (`fork`).
  *
  * For more information please refer to the fork function of Node's
  * child_process module:

--- a/packages/typescript/src/node/typescript-contribution.ts
+++ b/packages/typescript/src/node/typescript-contribution.ts
@@ -16,7 +16,7 @@
 
 import { injectable, postConstruct, inject } from 'inversify';
 import *  as path from 'path';
-import { ApplicationPackage } from '@theia/application-package';
+import { ApplicationPackage, environment } from '@theia/application-package';
 import { BaseLanguageServerContribution, IConnection, LanguageServerStartOptions } from '@theia/languages/lib/node';
 import { TYPESCRIPT_LANGUAGE_ID, TYPESCRIPT_LANGUAGE_NAME, TypescriptStartParams } from '../common';
 import { TypeScriptPlugin, TypeScriptInitializeParams, TypeScriptInitializationOptions } from 'typescript-language-server/lib/ts-protocol';
@@ -66,7 +66,7 @@ export class TypeScriptContribution extends BaseLanguageServerContribution {
         if (tsServerPath) {
             args.push(`--tsserver-path=${tsServerPath}`);
         }
-        const serverConnection = await this.createProcessStreamConnectionAsync(command, args);
+        const serverConnection = await this.createProcessStreamConnectionAsync(command, args, { env: environment.electron.runAsNodeEnv() });
         this.forward(clientConnection, serverConnection);
     }
 


### PR DESCRIPTION
When spawning/forking a new node process with Node.js bundled into
electron, we have to explicitly disable the electron part.

Closes #5385.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
