### PR TITLE
Fix #5406: hints overflow

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -64,6 +64,6 @@
 	position: relative;
 }
 
-.monaco-editor .parameter-hints-widget>.wrapper {
+.monaco-editor .parameter-hints-widget > .wrapper {
     overflow: hidden;
 }

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -63,3 +63,7 @@
     border-bottom-color: var(--theia-accent-color2);
 	position: relative;
 }
+
+.monaco-editor .parameter-hints-widget>.wrapper {
+    overflow: hidden;
+}


### PR DESCRIPTION
Fix #5406: hints overflow

Fix a error when parameterHintsWidget contains long info