### PR TITLE
fix #5406: hints overflow with long info

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -63,3 +63,7 @@
     border-bottom-color: var(--theia-accent-color2);
 	position: relative;
 }
+
+.monaco-editor .parameter-hints-widget > .wrapper {
+    overflow: hidden;
+}


### PR DESCRIPTION
Fix #5406: hints overflow

Fix a error when parameterHintsWidget contains long info
