### PR TITLE
Remove monaco prefix from commands

### DIFF
--- a/packages/monaco/src/browser/monaco-command-registry.ts
+++ b/packages/monaco/src/browser/monaco-command-registry.ts
@@ -28,6 +28,7 @@ export interface MonacoEditorCommandHandler {
 @injectable()
 export class MonacoCommandRegistry {
 
+    /* @deprecated Monaco command is registered as it is, without prefixing */
     public static MONACO_COMMAND_PREFIX = 'monaco.';
 
     constructor(
@@ -36,20 +37,18 @@ export class MonacoCommandRegistry {
         @inject(SelectionService) protected readonly selectionService: SelectionService
     ) { }
 
+    /* @deprecated Monaco command is registered as it is, without prefixing */
     protected prefix(command: string): string {
-        return MonacoCommandRegistry.MONACO_COMMAND_PREFIX + command;
+        return command;
     }
 
     validate(command: string): string | undefined {
-        const monacoCommand = this.prefix(command);
-        return this.commands.commandIds.indexOf(monacoCommand) !== -1 ? monacoCommand : undefined;
+        const monacoCommand = this.commands.getCommand(command);
+        return monacoCommand && monacoCommand.label ? monacoCommand.id : undefined;
     }
 
     registerCommand(command: Command, handler: MonacoEditorCommandHandler): void {
-        this.commands.registerCommand({
-            ...command,
-            id: this.prefix(command.id)
-        }, this.newHandler(handler));
+        this.commands.registerCommand(command, this.newHandler(handler));
     }
 
     registerHandler(command: string, handler: MonacoEditorCommandHandler): void {


### PR DESCRIPTION
This PR removes the monaco prefix from commands. It was extracted from this PR: https://github.com/theia-ide/theia/pull/4275

Previously, commands like formatSelection would be registered with command id monaco.editor.action.formatSelection whereas VSCode extensions would expect the command id to be editor.action.formatSelection. Although the problem looks like it can be solved from the plugin side by forwarding 'editor.action.formatSelection' to 'monaco.editor.action.formatSelection', if a user edited the keymaps.json themselves, the keymaps.json would expect 'monaco.editor.action.formatSelection'. 'editor.action.formatSelection' would not work because technically 'monaco.editor.action.formatSelection' is the command id registered.

I've manually verified that this PR works by calling the formatSelection command, and the goToLine command through a plugin in Theia and from what I can see there isn't any 0 vs 1-based issues but if anyone is seeing anything else that I'm not, please let me know.

I've also tested it ontop of https://github.com/theia-ide/theia/pull/5326 with the Eclipse keybindings VSCode extension and all the keybindings that have associated commands registered in Theia are working correctly.

