### PR TITLE
[markers] fix the problem-widget markers from wrapping when re-sizing

### DIFF
--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -102,7 +102,9 @@ export class ProblemWidget extends TreeWidget {
             if (problemMarker.data.severity) {
                 severityClass = this.getSeverityClass(problemMarker.data.severity);
             }
-            return <div className='markerNode'>
+            return <div
+                className='markerNode'
+                title={`${problemMarker.data.message} (${problemMarker.data.range.start.line + 1}, ${problemMarker.data.range.start.character + 1})`}>
                 <div>
                     <i className={severityClass}></i>
                 </div>

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -77,6 +77,7 @@
 .theia-marker-container .markerNode .owner,
 .theia-marker-container .markerNode .code {
     color: var(--theia-ui-font-color2);
+    white-space: nowrap;
 }
 
 .theia-marker-container .markerNode .position,


### PR DESCRIPTION
Fixes #5423

- fixed the issue where the problem markers in the `problems-widget` would wrap when resizing causing an odd ui/ux experience.
- added a tooltip displaying the problem marker message, useful for when the `problem-widget` window has a limited size and users wish to see the entire message.

<div align='center'>

<img width="500" alt="Screen Shot 2019-06-11 at 8 29 56 PM" src="https://user-images.githubusercontent.com/40359487/59316932-cdf2d900-8c8e-11e9-99dc-45681b7b6dc3.png">

<br />

</div>

<br />

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
