### PR TITLE
Implement registerDebugAdapterTrackerFactory

### DIFF
--- a/packages/debug/src/node/debug-adapter-session.ts
+++ b/packages/debug/src/node/debug-adapter-session.ts
@@ -64,18 +64,18 @@ export class DebugAdapterSessionImpl implements DebugAdapterSession {
         this.channel.onClose(() => this.channel = undefined);
 
         this.communicationProvider.output.on('data', (data: Buffer) => this.handleData(data));
-        this.communicationProvider.output.on('close', () => this.fireExited());
+        this.communicationProvider.output.on('close', () => this.onDebugAdapterExit(1, undefined)); // FIXME pass a proper exit code
         this.communicationProvider.output.on('error', error => this.onDebugAdapterError(error));
         this.communicationProvider.input.on('error', error => this.onDebugAdapterError(error));
     }
 
-    protected fireExited(): void {
+    protected onDebugAdapterExit(exitCode: number, signal: string | undefined): void {
         const event: DebugProtocol.ExitedEvent = {
             type: 'event',
             event: 'exited',
             seq: -1,
             body: {
-                exitCode: 1 // FIXME pass a proper exit code
+                exitCode
             }
         };
         this.send(JSON.stringify(event));

--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-session.ts
@@ -14,12 +14,13 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import * as theia from '@theia/plugin';
 import { CommunicationProvider } from '@theia/debug/lib/common/debug-model';
 import { DebugAdapterSessionImpl } from '@theia/debug/lib/node/debug-adapter-session';
+import * as theia from '@theia/plugin';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { IWebSocket } from 'vscode-ws-jsonrpc/lib/socket/socket';
 
-// tslint:disable
+// tslint:disable: no-any
 
 /**
  * Server debug adapter session.
@@ -27,6 +28,8 @@ import { DebugProtocol } from 'vscode-debugprotocol';
 export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implements theia.DebugSession {
     readonly type: string;
     readonly name: string;
+
+    protected tracker: theia.DebugAdapterTracker | undefined;
 
     constructor(
         readonly id: string,
@@ -38,5 +41,54 @@ export class PluginDebugAdapterSession extends DebugAdapterSessionImpl implement
 
         this.type = configuration.type;
         this.name = configuration.name;
+    }
+
+    async start(channel: IWebSocket): Promise<void> {
+        if (this.tracker && this.tracker.onWillStartSession) {
+            this.tracker.onWillStartSession();
+        }
+        await super.start(channel);
+    }
+
+    async stop(): Promise<void> {
+        if (this.tracker && this.tracker.onWillStopSession) {
+            this.tracker.onWillStopSession();
+        }
+        await super.stop();
+    }
+
+    configureTracker(tracker: theia.DebugAdapterTracker) {
+        this.tracker = tracker;
+    }
+
+    protected onDebugAdapterError(error: Error): void {
+        if (this.tracker && this.tracker.onError) {
+            this.tracker.onError(error);
+        }
+        super.onDebugAdapterError(error);
+    }
+
+    protected send(message: string): void {
+        try {
+            super.send(message);
+        } finally {
+            if (this.tracker && this.tracker.onDidSendMessage) {
+                this.tracker.onDidSendMessage(message);
+            }
+        }
+    }
+
+    protected write(message: string): void {
+        if (this.tracker && this.tracker.onWillReceiveMessage) {
+            this.tracker.onWillReceiveMessage(message);
+        }
+        super.write(message);
+    }
+
+    protected onDebugAdapterExit(exitCode: number, signal: string | undefined): void {
+        if (this.tracker && this.tracker.onExit) {
+            this.tracker.onExit(exitCode, signal);
+        }
+        super.onDebugAdapterExit(exitCode, signal);
     }
 }

--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-tracker.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-tracker.ts
@@ -1,0 +1,85 @@
+/********************************************************************************
+ * Copyright (C) 2019 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+// tslint:disable: no-any
+
+import * as theia from '@theia/plugin';
+
+export class PluginDebugAdapterTracker implements theia.DebugAdapterTracker {
+    constructor(protected readonly trackers: theia.DebugAdapterTracker[]) { }
+
+    static async create(session: theia.DebugSession, trackerFactories: [string, theia.DebugAdapterTrackerFactory][]): Promise<PluginDebugAdapterTracker> {
+        const trackers: theia.DebugAdapterTracker[] = [];
+
+        const factories = trackerFactories.filter(tuple => tuple[0] === '*' || tuple[0] === session.type).map(tuple => tuple[1]);
+        for (const factory of factories) {
+            const tracker = await factory.createDebugAdapterTracker(session);
+            if (tracker) {
+                trackers.push(tracker);
+            }
+        }
+
+        return new PluginDebugAdapterTracker(trackers);
+    }
+
+    onWillStartSession(): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onWillStartSession) {
+                tracker.onWillStartSession();
+            }
+        });
+    }
+
+    onWillReceiveMessage(message: any): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onWillReceiveMessage) {
+                tracker.onWillReceiveMessage(message);
+            }
+        });
+    }
+
+    onDidSendMessage(message: any): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onDidSendMessage) {
+                tracker.onDidSendMessage(message);
+            }
+        });
+    }
+
+    onWillStopSession(): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onWillStopSession) {
+                tracker.onWillStopSession();
+            }
+        });
+    }
+
+    onError(error: Error): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onError) {
+                tracker.onError(error);
+            }
+        });
+    }
+
+    onExit(code: number | undefined, signal: string | undefined): void {
+        this.trackers.forEach(tracker => {
+            if (tracker.onExit) {
+                tracker.onExit(code, signal);
+            }
+        });
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -211,7 +211,7 @@ export function createAPIFactory(
             },
             registerDiffInformationCommand(command: string, callback: (diff: LineChange[], ...args: any[]) => any, thisArg?: any): Disposable {
                 // Dummy implementation.
-                return new Disposable(() => {});
+                return new Disposable(() => { });
             }
         };
 
@@ -368,7 +368,7 @@ export function createAPIFactory(
                 return decorationsExt.registerDecorationProvider(provider);
             },
             registerUriHandler(handler: theia.UriHandler): theia.Disposable {
-                return new Disposable(() => {});
+                return new Disposable(() => { });
             }
         };
 
@@ -635,6 +635,9 @@ export function createAPIFactory(
             },
             registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider): Disposable {
                 return debugExt.registerDebugConfigurationProvider(debugType, provider);
+            },
+            registerDebugAdapterTrackerFactory(debugType: string, factory: theia.DebugAdapterTrackerFactory): Disposable {
+                return debugExt.registerDebugAdapterTrackerFactory(debugType, factory);
             },
             startDebugging(folder: theia.WorkspaceFolder | undefined, nameOrConfiguration: string | theia.DebugConfiguration): Thenable<boolean> {
                 return debugExt.startDebugging(folder, nameOrConfiguration);

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -7172,6 +7172,47 @@ declare module '@theia/plugin' {
         resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>;
     }
 
+	/**
+	 * A Debug Adapter Tracker is a means to track the communication between VS Code and a Debug Adapter.
+	 */
+    export interface DebugAdapterTracker {
+		/**
+		 * A session with the debug adapter is about to be started.
+		 */
+        onWillStartSession?(): void;
+		/**
+		 * The debug adapter is about to receive a Debug Adapter Protocol message from VS Code.
+		 */
+        onWillReceiveMessage?(message: any): void;
+		/**
+		 * The debug adapter has sent a Debug Adapter Protocol message to VS Code.
+		 */
+        onDidSendMessage?(message: any): void;
+		/**
+		 * The debug adapter session is about to be stopped.
+		 */
+        onWillStopSession?(): void;
+		/**
+		 * An error with the debug adapter has occurred.
+		 */
+        onError?(error: Error): void;
+		/**
+		 * The debug adapter has exited with the given exit code or signal.
+		 */
+        onExit?(code: number | undefined, signal: string | undefined): void;
+    }
+
+    export interface DebugAdapterTrackerFactory {
+		/**
+		 * The method 'createDebugAdapterTracker' is called at the start of a debug session in order
+		 * to return a "tracker" object that provides read-access to the communication between VS Code and a debug adapter.
+		 *
+		 * @param session The [debug session](#DebugSession) for which the debug adapter tracker will be used.
+		 * @return A [debug adapter tracker](#DebugAdapterTracker) or undefined.
+		 */
+        createDebugAdapterTracker(session: DebugSession): ProviderResult<DebugAdapterTracker>;
+    }
+
     /**
      * Represents the debug console.
      */
@@ -7328,6 +7369,15 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerDebugConfigurationProvider(debugType: string, provider: DebugConfigurationProvider): Disposable;
+
+		/**
+		 * Register a debug adapter tracker factory for the given debug type.
+		 *
+		 * @param debugType The debug type for which the factory is registered or '*' for matching all debug types.
+		 * @param factory The [debug adapter tracker factory](#DebugAdapterTrackerFactory) to register.
+		 * @return A [disposable](#Disposable) that unregisters this factory when being disposed.
+		 */
+        export function registerDebugAdapterTrackerFactory(debugType: string, factory: DebugAdapterTrackerFactory): Disposable;
 
         /**
          * Start debugging by using either a named launch or named compound configuration,


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do
Add VS Code api to register `DebugAdapterTrackerFactory` [1] 
[1] https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L8861

### Reference issue
https://github.com/theia-ide/theia/issues/4804

### How to test
I used my custom plugin [2] to print messages on console:
```
root INFO [hosted-plugin: 3553] onWillStartSession
root INFO [hosted-plugin: 3553] onWillReceiveMessage
root INFO [hosted-plugin: 3553] onWillStopSession
root INFO [hosted-plugin: 3553] onExit
```
[2] https://github.com/tolusha/pig-debugger-theia-plugin