### PR TITLE
fix #5280: synchronize preview with editor when scrolls

### DIFF
--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -168,6 +168,9 @@ export interface TextEditor extends Disposable, TextEditorSelection, Navigatable
 
     readonly onMouseDown: Event<EditorMouseEvent>;
 
+    readonly onScrollChanged: Event<void>;
+    getVisibleRanges(): Range[];
+
     revealPosition(position: Position, options?: RevealPositionOptions): void;
     revealRange(range: Range, options?: RevealRangeOptions): void;
 

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -62,6 +62,7 @@ export class MonacoEditor implements TextEditor {
     protected readonly onMouseDownEmitter = new Emitter<EditorMouseEvent>();
     protected readonly onLanguageChangedEmitter = new Emitter<string>();
     readonly onLanguageChanged = this.onLanguageChangedEmitter.event;
+    protected readonly onScrollChangedEmitter = new Emitter<void>();
 
     readonly documents = new Set<MonacoEditorModel>();
 
@@ -80,7 +81,8 @@ export class MonacoEditor implements TextEditor {
             this.onFocusChangedEmitter,
             this.onDocumentContentChangedEmitter,
             this.onMouseDownEmitter,
-            this.onLanguageChangedEmitter
+            this.onLanguageChangedEmitter,
+            this.onScrollChangedEmitter
         ]);
         this.documents.add(document);
         this.autoSizing = options && options.autoSizing !== undefined ? options.autoSizing : false;
@@ -139,6 +141,13 @@ export class MonacoEditor implements TextEditor {
                 event: e.event.browserEvent
             });
         }));
+        this.toDispose.push(codeEditor.onDidScrollChange(e => {
+            this.onScrollChangedEmitter.fire(undefined);
+        }));
+    }
+
+    getVisibleRanges(): Range[] {
+        return this.editor.getVisibleRanges().map(range => this.m2p.asRange(range));
     }
 
     protected mapModelContentChange(change: monaco.editor.IModelContentChange): TextDocumentContentChangeDelta {
@@ -182,6 +191,10 @@ export class MonacoEditor implements TextEditor {
 
     get onSelectionChanged(): Event<Range> {
         return this.onSelectionChangedEmitter.event;
+    }
+
+    get onScrollChanged(): Event<void> {
+        return this.onScrollChangedEmitter.event;
     }
 
     revealPosition(raw: Position, options: RevealPositionOptions = { vertical: 'center' }): void {


### PR DESCRIPTION
Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Synchronize markdown preview with editor when scrolls on both sides.

Before:
![fix-markdown-preview-1](https://user-images.githubusercontent.com/17487291/59419894-75424e00-8dfe-11e9-8ac3-6a4b67f16d93.gif)

After:
![fix-markdown-preview-2](https://user-images.githubusercontent.com/17487291/59419994-a589ec80-8dfe-11e9-89e7-50f546030afc.gif)

