### PR TITLE
Add original part to PluginMetadata

### DIFF
--- a/packages/plugin-dev/src/node/hosted-plugin-reader.ts
+++ b/packages/plugin-dev/src/node/hosted-plugin-reader.ts
@@ -34,7 +34,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
     protected deployerHandler: HostedPluginDeployerHandler;
 
     async initialize() {
-        this.pluginReader.doGetPluginMetadata(process.env.HOSTED_PLUGIN)
+        this.pluginReader.getPluginMetadata(process.env.HOSTED_PLUGIN)
             .then(this.hostedPlugin.resolve.bind(this.hostedPlugin));
 
         const pluginPath = process.env.HOSTED_PLUGIN;

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -543,6 +543,7 @@ export interface PluginMetadata {
     source: PluginPackage;
     model: PluginModel;
     lifecycle: PluginLifecycle;
+    originalPath: string;
 }
 
 export const MetadataProcessor = Symbol('MetadataProcessor');

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-deployer-handler.ts
@@ -59,7 +59,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
     async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<void> {
         for (const plugin of frontendPlugins) {
-            const metadata = await this.reader.getPluginMetadata(plugin.path());
+            const metadata = await this.reader.getPluginMetadata(plugin.path(), plugin.originalPath());
             if (metadata) {
                 if (this.currentFrontendPluginsMetadata.some(value => value.model.id === metadata.model.id)) {
                     continue;
@@ -76,7 +76,7 @@ export class HostedPluginDeployerHandler implements PluginDeployerHandler {
 
     async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<void> {
         for (const plugin of backendPlugins) {
-            const metadata = await this.reader.getPluginMetadata(plugin.path());
+            const metadata = await this.reader.getPluginMetadata(plugin.path(), plugin.originalPath());
             if (metadata) {
                 if (this.currentBackendPluginsMetadata.some(value => value.model.id === metadata.model.id)) {
                     continue;

--- a/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
+++ b/packages/plugin-ext/src/hosted/node/metadata-scanner.ts
@@ -29,13 +29,14 @@ export class MetadataScanner {
         });
     }
 
-    getPluginMetadata(plugin: PluginPackage): PluginMetadata {
+    getPluginMetadata(plugin: PluginPackage, originalPath: string): PluginMetadata {
         const scanner = this.getScanner(plugin);
         return {
             host: 'main',
             source: plugin,
             model: scanner.getModel(plugin),
-            lifecycle: scanner.getLifecycle(plugin)
+            lifecycle: scanner.getLifecycle(plugin),
+            originalPath
         };
     }
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Adds original path to the Plugin Metadata.

In Che Plugin management we need to have this information to determine from which source plugin has been unpacked. This allows us to recognize whether the plugin is built-in or whether the plugin is deployed on the fly and many other cases.
