### PR TITLE
[keybindings] add 'Clear Keybindings Search Input` toolbar item

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -18,7 +18,7 @@ import React = require('react');
 import debounce = require('lodash.debounce');
 import * as fuzzy from 'fuzzy';
 import { injectable, inject, postConstruct } from 'inversify';
-import { CommandRegistry, Command } from '@theia/core/lib/common';
+import { CommandRegistry, Command, Emitter, Event } from '@theia/core/lib/common';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { KeybindingRegistry, SingleTextInputDialog, KeySequence, ConfirmDialog, Message, KeybindingScope } from '@theia/core/lib/browser';
 import { KeymapsParser } from './keymaps-parser';
@@ -68,6 +68,9 @@ export class KeybindingWidget extends ReactWidget {
         post: '</match>',
     };
 
+    protected readonly onDidUpdateEmitter = new Emitter<void>();
+    readonly onDidUpdate: Event<void> = this.onDidUpdateEmitter.event;
+
     protected readonly searchKeybindings: () => void = debounce(() => this.doSearchKeybindings(), 50);
 
     @postConstruct()
@@ -88,12 +91,33 @@ export class KeybindingWidget extends ReactWidget {
         }
     }
 
+    /**
+     * Determine if there currently is a search term.
+     * @returns `true` if a search term is present.
+     */
+    public hasSearch(): boolean {
+        return !!this.query.length;
+    }
+
+    /**
+     * Clear the search and reset the view.
+     */
+    public clearSearch(): void {
+        const search = this.findSearchField();
+        if (search) {
+            search.value = '';
+            this.query = '';
+            this.doSearchKeybindings();
+        }
+    }
+
     protected onActivateRequest(msg: Message) {
         super.onActivateRequest(msg);
         this.focusInputField();
     }
 
     protected doSearchKeybindings(): void {
+        this.onDidUpdateEmitter.fire(undefined);
         this.items = [];
         const searchField = this.findSearchField();
         this.query = searchField ? searchField.value.trim().toLocaleLowerCase() : '';


### PR DESCRIPTION
Fixes #5440

Added a `Clear Keybindings Search Input` toolbar item to easily reset the keybindings-widget when a user inputs a search query.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
