### PR TITLE
[keybindings] remove link to 'keymaps.json' in the keybindings-widget

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -215,9 +215,6 @@ export class KeybindingWidget extends ReactWidget {
                     className={(this.items.length > 0) ? '' : 'no-kb'}
                     type='text' placeholder='Search keybindings' onKeyUp={this.searchKeybindings}></input >
             </div>
-            <div className='kb-json'>For more detailed keybinding customizations open and edit&nbsp;
-                <a href='#' onClick={this.openKeybindings}>keymaps.json</a>
-            </div>
         </div>;
     }
 

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -40,22 +40,6 @@
     padding-right: 5px;
 }
 
-.kb-json {
-    color: var(--theia-ui-font-color1);
-    font-size: calc(var(--theia-ui-font-size1) * 0.85);
-    padding: 2px 10px 10px 10px;
-}
-
-.kb-json a {
-    color: var(--theia-brand-color1);
-    text-decoration: none;
-    font-weight: 600;
-}
-
-.kb-json a:hover {
-    text-decoration: underline;
-}
-
 .kb table {
     border-spacing: 0;
     border-collapse: separate;


### PR DESCRIPTION
Fixes #5461

The link to the `keymaps.json` has recently been updated to a toolbar item (similarly to vscode) so there is no real reason to have it included in the widget anymore. Having three different
ways to open the `keymaps.json` (link, toolbar, and command) is little excessive.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
