### PR TITLE
Implement registration debug adapter descriptor factory

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-executable-resolver.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/plugin-debug-adapter-executable-resolver.ts
@@ -15,18 +15,18 @@
  ********************************************************************************/
 
 import * as path from 'path';
+import * as theia from '@theia/plugin';
 import { PlatformSpecificAdapterContribution, DebuggerContribution } from '../../../common';
 import { isWindows, isOSX } from '@theia/core/lib/common/os';
-import { DebugAdapterExecutable } from '@theia/debug/lib/common/debug-model';
 
 /**
  * Resolves [DebugAdapterExecutable](#DebugAdapterExecutable) based on contribution.
  */
-export async function resolveDebugAdapterExecutable(pluginPath: string, debuggerContribution: DebuggerContribution): Promise<DebugAdapterExecutable> {
+export async function resolveDebugAdapterExecutable(pluginPath: string, debuggerContribution: DebuggerContribution): Promise<theia.DebugAdapterExecutable | undefined> {
     const info = toPlatformInfo(debuggerContribution);
     let program = (info && info.program || debuggerContribution.program);
     if (!program) {
-        throw new Error('It is not possible to provide debug adapter executable. Program not found.');
+        return undefined;
     }
     program = path.join(pluginPath, program);
     const programArgs = info && info.args || debuggerContribution.args || [];

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -94,6 +94,8 @@ import {
     TaskRevealKind,
     TaskGroup,
     Task,
+    DebugAdapterExecutable,
+    DebugAdapterServer,
     Breakpoint,
     SourceBreakpoint,
     FunctionBreakpoint,
@@ -633,6 +635,9 @@ export function createAPIFactory(
             get onDidChangeBreakpoints(): theia.Event<theia.BreakpointsChangeEvent> {
                 return debugExt.onDidChangeBreakpoints;
             },
+            registerDebugAdapterDescriptorFactory(debugType: string, factory: theia.DebugAdapterDescriptorFactory): Disposable {
+                return debugExt.registerDebugAdapterDescriptorFactory(debugType, factory);
+            },
             registerDebugConfigurationProvider(debugType: string, provider: theia.DebugConfigurationProvider): Disposable {
                 return debugExt.registerDebugConfigurationProvider(debugType, provider);
             },
@@ -767,6 +772,8 @@ export function createAPIFactory(
             TaskPanelKind,
             TaskGroup,
             Task,
+            DebugAdapterExecutable,
+            DebugAdapterServer,
             Breakpoint,
             SourceBreakpoint,
             FunctionBreakpoint,

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1739,6 +1739,63 @@ export class Task {
     }
 }
 
+export class DebugAdapterExecutable {
+    /**
+     * The command or path of the debug adapter executable.
+     * A command must be either an absolute path of an executable or the name of an command to be looked up via the PATH environment variable.
+     * The special value 'node' will be mapped to VS Code's built-in Node.js runtime.
+     */
+    readonly command: string;
+
+    /**
+     * The arguments passed to the debug adapter executable. Defaults to an empty array.
+     */
+    readonly args?: string[];
+
+    /**
+     * Optional options to be used when the debug adapter is started.
+     * Defaults to undefined.
+     */
+    readonly options?: theia.DebugAdapterExecutableOptions;
+
+    /**
+     * Creates a description for a debug adapter based on an executable program.
+     *
+     * @param command The command or executable path that implements the debug adapter.
+     * @param args Optional arguments to be passed to the command or executable.
+     * @param options Optional options to be used when starting the command or executable.
+     */
+    constructor(command: string, args?: string[], options?: theia.DebugAdapterExecutableOptions) {
+        this.command = command;
+        this.args = args;
+        this.options = options;
+    }
+}
+
+/**
+ * Represents a debug adapter running as a socket based server.
+ */
+export class DebugAdapterServer {
+
+    /**
+     * The port.
+     */
+    readonly port: number;
+
+    /**
+     * The host.
+     */
+    readonly host?: string;
+
+    /**
+     * Create a description for a debug adapter running as a socket based server.
+     */
+    constructor(port: number, host?: string) {
+        this.port = port;
+        this.host = host;
+    }
+}
+
 /**
  * The base class of all breakpoint types.
  */

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -4472,35 +4472,35 @@ declare module '@theia/plugin' {
          */
         export function getQueryParameters(): { [key: string]: string | string[] } | undefined;
 
-		/**
-		 * The application name of the editor, like 'Eclipse Theia'.
-		 */
+        /**
+         * The application name of the editor, like 'Eclipse Theia'.
+         */
         export const appName: string;
 
-		/**
-		 * The application root folder from which the editor is running.
-		 */
+        /**
+         * The application root folder from which the editor is running.
+         */
         export const appRoot: string;
 
-		/**
-		 * The custom uri scheme the editor registers to in the operating system.
-		 */
+        /**
+         * The custom uri scheme the editor registers to in the operating system.
+         */
         export const uriScheme: string;
 
-		/**
-		 * Represents the preferred user-language, like `de-CH`, `fr`, or `en-US`.
-		 */
+        /**
+         * Represents the preferred user-language, like `de-CH`, `fr`, or `en-US`.
+         */
         export const language: string;
 
-		/**
-		 * A unique identifier for the computer.
-		 */
+        /**
+         * A unique identifier for the computer.
+         */
         export const machineId: string;
 
-		/**
-		 * A unique identifier for the current session.
-		 * Changes each time the editor is started.
-		 */
+        /**
+         * A unique identifier for the current session.
+         * Changes each time the editor is started.
+         */
         export const sessionId: string;
 
     }
@@ -7176,41 +7176,136 @@ declare module '@theia/plugin' {
 	 * A Debug Adapter Tracker is a means to track the communication between VS Code and a Debug Adapter.
 	 */
     export interface DebugAdapterTracker {
-		/**
-		 * A session with the debug adapter is about to be started.
-		 */
+        /**
+         * A session with the debug adapter is about to be started.
+         */
         onWillStartSession?(): void;
-		/**
-		 * The debug adapter is about to receive a Debug Adapter Protocol message from VS Code.
-		 */
+        /**
+         * The debug adapter is about to receive a Debug Adapter Protocol message from VS Code.
+         */
         onWillReceiveMessage?(message: any): void;
-		/**
-		 * The debug adapter has sent a Debug Adapter Protocol message to VS Code.
-		 */
+        /**
+         * The debug adapter has sent a Debug Adapter Protocol message to VS Code.
+         */
         onDidSendMessage?(message: any): void;
-		/**
-		 * The debug adapter session is about to be stopped.
-		 */
+        /**
+         * The debug adapter session is about to be stopped.
+         */
         onWillStopSession?(): void;
-		/**
-		 * An error with the debug adapter has occurred.
-		 */
+        /**
+         * An error with the debug adapter has occurred.
+         */
         onError?(error: Error): void;
-		/**
-		 * The debug adapter has exited with the given exit code or signal.
-		 */
+        /**
+         * The debug adapter has exited with the given exit code or signal.
+         */
         onExit?(code: number | undefined, signal: string | undefined): void;
     }
 
     export interface DebugAdapterTrackerFactory {
-		/**
-		 * The method 'createDebugAdapterTracker' is called at the start of a debug session in order
-		 * to return a "tracker" object that provides read-access to the communication between VS Code and a debug adapter.
-		 *
-		 * @param session The [debug session](#DebugSession) for which the debug adapter tracker will be used.
-		 * @return A [debug adapter tracker](#DebugAdapterTracker) or undefined.
-		 */
+        /**
+         * The method 'createDebugAdapterTracker' is called at the start of a debug session in order
+         * to return a "tracker" object that provides read-access to the communication between VS Code and a debug adapter.
+         *
+         * @param session The [debug session](#DebugSession) for which the debug adapter tracker will be used.
+         * @return A [debug adapter tracker](#DebugAdapterTracker) or undefined.
+         */
         createDebugAdapterTracker(session: DebugSession): ProviderResult<DebugAdapterTracker>;
+    }
+
+    /**
+     * Represents a debug adapter executable and optional arguments and runtime options passed to it.
+     */
+    export class DebugAdapterExecutable {
+
+        /**
+         * Creates a description for a debug adapter based on an executable program.
+         *
+         * @param command The command or executable path that implements the debug adapter.
+         * @param args Optional arguments to be passed to the command or executable.
+         * @param options Optional options to be used when starting the command or executable.
+         */
+        constructor(command: string, args?: string[], options?: DebugAdapterExecutableOptions);
+
+        /**
+         * The command or path of the debug adapter executable.
+         * A command must be either an absolute path of an executable or the name of an command to be looked up via the PATH environment variable.
+         * The special value 'node' will be mapped to VS Code's built-in Node.js runtime.
+         */
+        readonly command: string;
+
+        /**
+         * The arguments passed to the debug adapter executable. Defaults to an empty array.
+         */
+        readonly args: string[];
+
+        /**
+         * Optional options to be used when the debug adapter is started.
+         * Defaults to undefined.
+         */
+        readonly options?: DebugAdapterExecutableOptions;
+    }
+
+	/**
+	 * Options for a debug adapter executable.
+	 */
+    export interface DebugAdapterExecutableOptions {
+
+        /**
+         * The additional environment of the executed program or shell. If omitted
+         * the parent process' environment is used. If provided it is merged with
+         * the parent process' environment.
+         */
+        env?: { [key: string]: string };
+
+        /**
+         * The current working directory for the executed debug adapter.
+         */
+        cwd?: string;
+    }
+
+    /**
+     * Represents a debug adapter running as a socket based server.
+     */
+    export class DebugAdapterServer {
+
+        /**
+         * The port.
+         */
+        readonly port: number;
+
+        /**
+         * The host.
+         */
+        readonly host?: string;
+
+        /**
+         * Create a description for a debug adapter running as a socket based server.
+         */
+        constructor(port: number, host?: string);
+    }
+
+    export type DebugAdapterDescriptor = DebugAdapterExecutable | DebugAdapterServer;
+
+    export interface DebugAdapterDescriptorFactory {
+        /**
+         * 'createDebugAdapterDescriptor' is called at the start of a debug session to provide details about the debug adapter to use.
+         * These details must be returned as objects of type [DebugAdapterDescriptor](#DebugAdapterDescriptor).
+         * Currently two types of debug adapters are supported:
+         * - a debug adapter executable is specified as a command path and arguments (see [DebugAdapterExecutable](#DebugAdapterExecutable)),
+         * - a debug adapter server reachable via a communication port (see [DebugAdapterServer](#DebugAdapterServer)).
+         * If the method is not implemented the default behavior is this:
+         *   createDebugAdapter(session: DebugSession, executable: DebugAdapterExecutable) {
+         *      if (typeof session.configuration.debugServer === 'number') {
+         *         return new DebugAdapterServer(session.configuration.debugServer);
+         *      }
+         *      return executable;
+         *   }
+         * @param session The [debug session](#DebugSession) for which the debug adapter will be used.
+         * @param executable The debug adapter's executable information as specified in the package.json (or undefined if no such information exists).
+         * @return a [debug adapter descriptor](#DebugAdapterDescriptor) or undefined.
+         */
+        createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): ProviderResult<DebugAdapterDescriptor>;
     }
 
     /**
@@ -7361,6 +7456,17 @@ declare module '@theia/plugin' {
         export const onDidChangeBreakpoints: Event<BreakpointsChangeEvent>;
 
         /**
+         * Register a [debug adapter descriptor factory](#DebugAdapterDescriptorFactory) for a specific debug type.
+         * An extension is only allowed to register a DebugAdapterDescriptorFactory for the debug type(s) defined by the extension. Otherwise an error is thrown.
+         * Registering more than one DebugAdapterDescriptorFactory for a debug type results in an error.
+         *
+         * @param debugType The debug type for which the factory is registered.
+         * @param factory The [debug adapter descriptor factory](#DebugAdapterDescriptorFactory) to register.
+         * @return A [disposable](#Disposable) that unregisters this factory when being disposed.
+         */
+        export function registerDebugAdapterDescriptorFactory(debugType: string, factory: DebugAdapterDescriptorFactory): Disposable;
+
+        /**
          * Register a [debug configuration provider](#DebugConfigurationProvider) for a specific debug type.
          * More than one provider can be registered for the same type.
          *
@@ -7370,13 +7476,13 @@ declare module '@theia/plugin' {
          */
         export function registerDebugConfigurationProvider(debugType: string, provider: DebugConfigurationProvider): Disposable;
 
-		/**
-		 * Register a debug adapter tracker factory for the given debug type.
-		 *
-		 * @param debugType The debug type for which the factory is registered or '*' for matching all debug types.
-		 * @param factory The [debug adapter tracker factory](#DebugAdapterTrackerFactory) to register.
-		 * @return A [disposable](#Disposable) that unregisters this factory when being disposed.
-		 */
+        /**
+         * Register a debug adapter tracker factory for the given debug type.
+         *
+         * @param debugType The debug type for which the factory is registered or '*' for matching all debug types.
+         * @param factory The [debug adapter tracker factory](#DebugAdapterTrackerFactory) to register.
+         * @return A [disposable](#Disposable) that unregisters this factory when being disposed.
+         */
         export function registerDebugAdapterTrackerFactory(debugType: string, factory: DebugAdapterTrackerFactory): Disposable;
 
         /**


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### Reference issue
https://github.com/theia-ide/theia/issues/4804

### What does this PR do
Implements VS Code api `registerDebugAdapterDescriptorFactory`

[1] https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L8852

### How to test
Tested with cpp plugin [1]. No errors in console regarding descriptor factory.

[1] https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools