### PR TITLE
Fixed #2214: implemented "show all opened editors" in quick open

### DIFF
--- a/packages/editor/src/browser/editor-command.ts
+++ b/packages/editor/src/browser/editor-command.ts
@@ -92,6 +92,14 @@ export namespace EditorCommands {
         category: EDITOR_CATEGORY,
         label: 'Clear Editor History'
     };
+    /**
+     * Command that displays all editors that are currently opened.
+     */
+    export const SHOW_ALL_OPENED_EDITORS: Command = {
+        id: 'workbench.action.showAllEditors',
+        category: 'View',
+        label: 'Show All Opened Editors'
+    };
 }
 
 @injectable()

--- a/packages/editor/src/browser/editor-contribution.ts
+++ b/packages/editor/src/browser/editor-contribution.ts
@@ -24,9 +24,12 @@ import { Languages } from '@theia/languages/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { DisposableCollection } from '@theia/core';
 import { EditorCommands } from './editor-command';
+import { EditorQuickOpenService } from './editor-quick-open-service';
+import { CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { KeybindingRegistry, KeybindingContribution, QuickOpenContribution, QuickOpenHandlerRegistry } from '@theia/core/lib/browser';
 
 @injectable()
-export class EditorContribution implements FrontendApplicationContribution {
+export class EditorContribution implements FrontendApplicationContribution, CommandContribution, KeybindingContribution, QuickOpenContribution {
 
     @inject(StatusBar) protected readonly statusBar: StatusBar;
     @inject(EditorManager) protected readonly editorManager: EditorManager;
@@ -34,6 +37,9 @@ export class EditorContribution implements FrontendApplicationContribution {
 
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
+
+    @inject(EditorQuickOpenService)
+    protected readonly editorQuickOpenService: EditorQuickOpenService;
 
     onStart(): void {
         this.initEditorContextKeys();
@@ -118,5 +124,22 @@ export class EditorContribution implements FrontendApplicationContribution {
             alignment: StatusBarAlignment.RIGHT,
             priority: 100
         });
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(EditorCommands.SHOW_ALL_OPENED_EDITORS, {
+            execute: () => this.editorQuickOpenService.open()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: EditorCommands.SHOW_ALL_OPENED_EDITORS.id,
+            keybinding: 'ctrlcmd+k ctrlcmd+p'
+        });
+    }
+
+    registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
+        handlers.registerHandler(this.editorQuickOpenService);
     }
 }

--- a/packages/editor/src/browser/editor-frontend-module.ts
+++ b/packages/editor/src/browser/editor-frontend-module.ts
@@ -16,7 +16,7 @@
 
 import { ContainerModule } from 'inversify';
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
-import { OpenHandler, WidgetFactory, FrontendApplicationContribution, KeybindingContext, KeybindingContribution } from '@theia/core/lib/browser';
+import { OpenHandler, WidgetFactory, FrontendApplicationContribution, KeybindingContext, KeybindingContribution, QuickOpenContribution } from '@theia/core/lib/browser';
 import { VariableContribution } from '@theia/variable-resolver/lib/browser';
 import { EditorManager, EditorAccess, ActiveEditorAccess, CurrentEditorAccess } from './editor-manager';
 import { EditorContribution } from './editor-contribution';
@@ -32,6 +32,7 @@ import { NavigationLocationService } from './navigation/navigation-location-serv
 import { NavigationLocationSimilarity } from './navigation/navigation-location-similarity';
 import { EditorVariableContribution } from './editor-variable-contribution';
 import { SemanticHighlightingService } from './semantic-highlight/semantic-highlighting-service';
+import { EditorQuickOpenService } from './editor-quick-open-service';
 
 export default new ContainerModule(bind => {
     bindEditorPreferences(bind);
@@ -62,6 +63,11 @@ export default new ContainerModule(bind => {
     bind(VariableContribution).to(EditorVariableContribution).inSingletonScope();
 
     bind(SemanticHighlightingService).toSelf().inSingletonScope();
+
+    [CommandContribution, KeybindingContribution, QuickOpenContribution].forEach(serviceIdentifier => {
+        bind(serviceIdentifier).toService(EditorContribution);
+    });
+    bind(EditorQuickOpenService).toSelf().inSingletonScope();
 
     bind(CurrentEditorAccess).toSelf().inSingletonScope();
     bind(ActiveEditorAccess).toSelf().inSingletonScope();

--- a/packages/editor/src/browser/editor-quick-open-service.ts
+++ b/packages/editor/src/browser/editor-quick-open-service.ts
@@ -1,0 +1,140 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { inject, injectable } from 'inversify';
+import {
+    QuickOpenModel, QuickOpenItem, QuickOpenMode, PrefixQuickOpenService,
+    OpenerService, QuickOpenItemOptions,
+    QuickOpenHandler, QuickOpenOptions
+} from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { LabelProvider } from '@theia/core/lib/browser/label-provider';
+import { CancellationTokenSource } from '@theia/core/lib/common';
+import { EditorManager } from './editor-manager';
+import { EditorWidget } from './editor-widget';
+
+@injectable()
+export class EditorQuickOpenService implements QuickOpenModel, QuickOpenHandler {
+
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
+
+    @inject(PrefixQuickOpenService)
+    protected readonly prefixQuickOpenService: PrefixQuickOpenService;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    readonly prefix: string = 'edt ';
+
+    get description(): string {
+        return 'Show All Opened Editors';
+    }
+
+    getModel(): QuickOpenModel {
+        return this;
+    }
+
+    getOptions(): QuickOpenOptions {
+        return {
+            fuzzyMatchLabel: {
+                enableSeparateSubstringMatching: true
+            },
+            fuzzyMatchDescription: {
+                enableSeparateSubstringMatching: true
+            },
+            onClose: () => {
+                this.cancelIndicator.cancel();
+            }
+        };
+    }
+
+    open(): void {
+        this.prefixQuickOpenService.open(this.prefix);
+    }
+
+    private cancelIndicator = new CancellationTokenSource();
+
+    public async onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): Promise<void> {
+        this.cancelIndicator.cancel();
+        this.cancelIndicator = new CancellationTokenSource();
+        const token = this.cancelIndicator.token;
+
+        const editorItems: QuickOpenItem[] = [];
+
+        // Get the alphabetically sorted list of URIs of all currently opened editor widgets.
+        const widgets: URI[] = this.editorManager.all
+            .map((w: EditorWidget) => w.editor.uri)
+            .sort();
+
+        if (widgets.length === 0) {
+            editorItems.push(new QuickOpenItem({
+                label: 'List of opened editors is currently empty',
+                run: () => false
+            }));
+            acceptor(editorItems);
+            return;
+        }
+
+        for (const uri of widgets) {
+            const item = await this.toItem(uri);
+            if (!!token.isCancellationRequested) {
+                return;
+            }
+            editorItems.push(item);
+            acceptor(editorItems);
+        }
+        return;
+    }
+
+    protected async toItem(uri: URI): Promise<QuickOpenItem<QuickOpenItemOptions>> {
+        const description = this.labelProvider.getLongName(uri.parent);
+
+        const options: QuickOpenItemOptions = {
+            label: this.labelProvider.getName(uri),
+            iconClass: await this.labelProvider.getIcon(uri) + ' file-icon',
+            description: description,
+            tooltip: uri.path.toString(),
+            uri: uri,
+            hidden: false,
+            run: this.getRunFunction(uri)
+        };
+        return new QuickOpenItem<QuickOpenItemOptions>(options);
+    }
+
+    /**
+     * Gets the function that can open the editor file
+     * @param uri the file uri
+     * @returns the function that opens the file if mode === QuickOpenMode.OPEN
+     */
+    protected getRunFunction(uri: URI): (mode: QuickOpenMode) => boolean {
+        return (mode: QuickOpenMode) => {
+            if (mode !== QuickOpenMode.OPEN) {
+                return false;
+            }
+            this.openFile(uri);
+            return true;
+        };
+    }
+
+    protected openFile(uri: URI): void {
+        this.openerService.getOpener(uri)
+            .then(opener => opener.open(uri));
+    }
+}


### PR DESCRIPTION
Fixed #2214.

Implemented the "Show All Opened Editors" in the quick open menu. The command can display all the currently opened editor widgets, and the user can navigate to each of them by selection. Similar to VS Code, the command has a keybinding `ctrlcmd+k ctrlcmd+p` and the global prefix `edt`.