### PR TITLE
[core] add sorting to prefixed quick-open commands

### DIFF
--- a/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/prefix-quick-open-service.ts
@@ -228,6 +228,7 @@ export class HelpQuickOpenHandler implements QuickOpenHandler, QuickOpenContribu
     init(): void {
         this.items = this.handlers.getHandlers()
             .filter(handler => handler.prefix !== this.prefix)
+            .sort((a, b) => this.comparePrefix(a.prefix, b.prefix))
             .map(handler => new QuickOpenItem({
                 label: handler.prefix,
                 description: handler.description,
@@ -262,5 +263,15 @@ export class HelpQuickOpenHandler implements QuickOpenHandler, QuickOpenContribu
 
     registerQuickOpenHandlers(handlers: QuickOpenHandlerRegistry): void {
         handlers.registerHandler(this);
+    }
+
+    /**
+     * Compare two prefixes.
+     *
+     * @param a {string} first prefix.
+     * @param b {string} second prefix.
+     */
+    protected comparePrefix(a: string, b: string): number {
+        return a.toLowerCase().localeCompare(b.toLowerCase());
     }
 }

--- a/packages/languages/src/browser/workspace-symbols.ts
+++ b/packages/languages/src/browser/workspace-symbols.ts
@@ -29,7 +29,7 @@ import { Range, Position } from 'vscode-languageserver-types';
 export class WorkspaceSymbolCommand implements QuickOpenModel, CommandContribution, KeybindingContribution, CommandHandler, QuickOpenHandler, QuickOpenContribution {
 
     readonly prefix = '#';
-    readonly description = 'Go to symbol in workspace';
+    readonly description = 'Go to Symbol in Workspace';
 
     private command: Command = {
         id: 'languages.workspace.symbol',


### PR DESCRIPTION
Fixes #5482

- added sorting to the `prefix` quick-open commands so they are easier to read,
and align with the same behavior as vscode.
- updated the prefix description of go to workspace symbol so it aligns with other commands.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
