### PR TITLE
Improve support for empty Git repository in Git view

### DIFF
--- a/packages/git/src/common/git.ts
+++ b/packages/git/src/common/git.ts
@@ -583,6 +583,18 @@ export namespace Git {
 
         }
 
+        /**
+         * Options for the `git rev-parse` command.
+         */
+        export interface RevParse {
+
+            /**
+             * The reference to parse.
+             */
+            readonly ref: string;
+
+        }
+
     }
 }
 
@@ -796,6 +808,15 @@ export interface Git extends Disposable {
      * @param options optional configuration for further refining the `git log` command execution.
      */
     log(repository: Repository, options?: Git.Options.Log): Promise<CommitWithChanges[]>;
+
+    /**
+     * Returns the commit SHA of the given ref if the ref exists, or returns 'undefined' if the
+     * given ref does not exist.
+     *
+     * @param repository the repository where the ref may be found.
+     * @param options configuration containing the ref and optionally other properties for further refining the `git rev-parse` command execution.
+     */
+    revParse(repository: Repository, options: Git.Options.RevParse): Promise<string | undefined>;
 
     /**
      * Returns the annotations of each line in the given file.

--- a/packages/git/src/node/dugite-git.spec.ts
+++ b/packages/git/src/node/dugite-git.spec.ts
@@ -772,10 +772,18 @@ describe('log', function () {
         const repository = { localUri };
         const git = await createGit();
         const result = await git.log(repository, { uri: localUri });
-        expect(result.length === 1).to.be.true;
-        expect(result[0].author.email === 'jon@doe.com').to.be.true;
+        expect(result.length).to.be.equal(1);
+        expect(result[0].author.email).to.be.equal('jon@doe.com');
     });
 
+    it('should not fail when executed against an empty repository', async () => {
+        const root = await initRepository(track.mkdirSync('empty-log-test'));
+        const localUri = FileUri.create(root).toString();
+        const repository = { localUri };
+        const git = await createGit();
+        const result = await git.log(repository, { uri: localUri });
+        expect(result.length).to.be.equal(0);
+    });
 });
 
 function toPathSegment(repository: Repository, uri: string): string {

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -104,21 +104,20 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
         } else if (nextCommit === undefined && this.state.lastCommit === undefined) {
             // No change here
         } else if (this.transitionHint === 'none') {
-            if (this.state.lastCommit) {
-                // If the 'last' commit changes, but we are not expecting an 'amend'
-                // or 'unamend' to occur, then we clear out the list of amended commits.
-                // This is because an unexpected change has happened to the repoistory,
-                // perhaps the user commited, merged, or something.  The amended commits
-                // will no longer be valid.
-                await this.clearAmendingCommits();
-                // There is a change to the last commit, but no transition hint so
-                // the view just updates without transition.
-                this.setState({ amendingCommits: [], lastCommit: nextCommit });
-            } else {
-                // There should always be a previous 'last commit'
-                throw new Error('unexpected state');
-                // this.setState({ amendingCommits: await this.buildAmendingList(), lastCommit: nextCommit });
-            }
+            // If the 'last' commit changes, but we are not expecting an 'amend'
+            // or 'unamend' to occur, then we clear out the list of amended commits.
+            // This is because an unexpected change has happened to the repoistory,
+            // perhaps the user commited, merged, or something.  The amended commits
+            // will no longer be valid.
+
+            // Note that there may or may not have been a previous lastCommit (if the
+            // repository was previously empty with no initial commit then lastCommit
+            // will be undefined).  Either way we clear the amending commits.
+            await this.clearAmendingCommits();
+
+            // There is a change to the last commit, but no transition hint so
+            // the view just updates without transition.
+            this.setState({ amendingCommits: [], lastCommit: nextCommit });
         } else {
             if (this.state.lastCommit && nextCommit) {
                 const direction: 'up' | 'down' = this.transitionHint === 'amend' ? 'up' : 'down';


### PR DESCRIPTION
This fixes https://github.com/theia-ide/theia/issues/5435

There are two parts to this.  The first part changes 'log' function so that an empty array is returned when the Git repository is empty (no HEAD).  

Rather than check for an empty repository before every call to 'log', we check for the empty repository only after an error.  This was done to avoid an extra Git command on every 'log'.

Having made that change, a change to ScmAmendComponent was necessary to cause the 'last commit' section to appear when the initial commit is committed.

This can be tested by showing a newly-created empty repository in the Scm view.  Commit the initial commit and the 'last commit' section appears.  Remove the initial commit and it disappears.  You can remove the initial commit by deleting .git/refs/heads/master.

I recommend merging this PR before https://github.com/theia-ide/theia/pull/5451 .   I believe I can re-work that PR on top of this one to implement @svenefftinge's amending of the initial commit.