### PR TITLE
improve prepare-travis for windows core.autocrlf=false

### DIFF
--- a/scripts/prepare-travis
+++ b/scripts/prepare-travis
@@ -45,9 +45,11 @@ while (match = regexp.exec(yarnList)) {
 
 const travisPath = path.resolve(__dirname, '../.travis.yml');
 const content = fs.readFileSync(travisPath).toString();
+// compute checked out travis line ending characters
+const endOfLine = content[content.indexOf('\n') - 1] === '\r' ? '\r\n' : '\n';
 const startIndex = content.indexOf('# start_cache_directories') + '# start_cache_directories'.length;
 const endIndex = content.indexOf('# end_cache_directories');
-const result = content.substr(0, startIndex) + os.EOL +
-    directories.sort((d, d2) => d.localeCompare(d2)).map(d => `  - ${d}${os.EOL}`).join('') +
+const result = content.substr(0, startIndex) + endOfLine +
+    directories.sort((d, d2) => d.localeCompare(d2)).map(d => `  - ${d}${endOfLine}`).join('') +
     content.substr(endIndex);
 fs.writeFileSync(travisPath, result);


### PR DESCRIPTION
Taking the end of line from the current checked out travis file content so that the file should not get dirty/warning when working on windows with core.autocrlf=true or false.

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
