### PR TITLE
throttle debug console output

### DIFF
--- a/packages/debug/src/browser/console/debug-console-session.ts
+++ b/packages/debug/src/browser/console/debug-console-session.ts
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import throttle = require('lodash.throttle');
 import { injectable, inject, postConstruct } from 'inversify';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { MessageType } from '@theia/core/lib/common';
@@ -169,8 +170,6 @@ export class DebugConsoleSession extends ConsoleSession {
         this.fireDidChange();
     }
 
-    protected fireDidChange(): void {
-        this.onDidChangeEmitter.fire(undefined);
-    }
+    protected fireDidChange = throttle(() => super.fireDidChange(), 50);
 
 }


### PR DESCRIPTION
fix #5491 - UI should not freeze with huge amount of output to the debug console

Also found https://github.com/theia-ide/theia/issues/5493 during testing. It will be addressed with a separate PR.

#### How to test
- clone https://github.com/in28minutes/SpringBootForBeginners
- create launch java configuration
- launch it and open the debug console
- UI should not freeze and the output should be displayed

