### PR TITLE
Ensure node-based debug adapters spawn same node exec as Theia

### DIFF
--- a/packages/debug/src/common/debug-model.ts
+++ b/packages/debug/src/common/debug-model.ts
@@ -70,6 +70,7 @@ export interface DebugAdapterSpawnExecutable {
  */
 export interface DebugAdapterForkExecutable {
     modulePath: string;
+    execArgv?: string[];
     args?: string[];
 }
 

--- a/packages/debug/src/node/debug-adapter-factory.ts
+++ b/packages/debug/src/node/debug-adapter-factory.ts
@@ -35,9 +35,11 @@ import {
     CommunicationProvider,
     DebugAdapterSession,
     DebugAdapterSessionFactory,
-    DebugAdapterFactory
+    DebugAdapterFactory,
+    DebugAdapterForkExecutable
 } from '../common/debug-model';
 import { DebugAdapterSessionImpl } from './debug-adapter-session';
+import { environment } from '@theia/application-package';
 
 /**
  * [DebugAdapterFactory](#DebugAdapterFactory) implementation based on
@@ -67,10 +69,12 @@ export class LaunchBasedDebugAdapterFactory implements DebugAdapterFactory {
             !!forkOptions && !!forkOptions.modulePath;
 
         const processOptions: RawProcessOptions | RawForkOptions = { ...executable };
-        const options = { stdio: ['pipe', 'pipe', 2] };
+        const options: { stdio: (string | number)[], env?: object, execArgv?: string[] } = { stdio: ['pipe', 'pipe', 2] };
 
         if (isForkOptions(processOptions)) {
             options.stdio.push('ipc');
+            options.env = environment.electron.runAsNodeEnv();
+            options.execArgv = (executable as DebugAdapterForkExecutable).execArgv;
         }
 
         processOptions.options = options;

--- a/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
+++ b/packages/debug/src/node/vscode/vscode-debug-adapter-contribution.ts
@@ -229,12 +229,22 @@ export abstract class AbstractVSCodeDebugAdapterContribution implements DebugAda
         if (runtime && runtime.indexOf('./') === 0) {
             runtime = path.join(this.extensionPath, runtime);
         }
+
         const runtimeArgs = info && info.runtimeArgs || contribution.runtimeArgs || [];
-        const command = runtime ? runtime : program;
-        const args = runtime ? [...runtimeArgs, program, ...programArgs] : programArgs;
-        return {
-            command,
-            args
-        };
+        if (runtime === 'node') {
+            const modulePath = program;
+            return {
+                modulePath: modulePath,
+                execArgv: runtimeArgs,
+                args: programArgs
+            };
+        } else {
+            const command = runtime ? runtime : program;
+            const args = runtime ? [...runtimeArgs, program, ...programArgs] : programArgs;
+            return {
+                command,
+                args
+            };
+        }
     }
 }


### PR DESCRIPTION
Same as #5492, but forking instead of spawning.

Note that in this implementation, I get this error when trying to debug user code:
```
Starting inspector on 127.0.0.1:24166 failed: address already in use
```
