### PR TITLE
[plug-in] Fix webview resize

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -73,6 +73,7 @@ import { ContextKeyService } from './context-key-service';
 import { ResourceContextKey } from './resource-context-key';
 import { KeyboardLayoutService } from './keyboard/keyboard-layout-service';
 import { MimeService } from './mime-service';
+import { ApplicationShellMouseTracker } from './shell/application-shell-mouse-tracker';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const themeService = ThemeService.get();
@@ -235,6 +236,9 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bindCorePreferences(bind);
 
     bind(MimeService).toSelf().inSingletonScope();
+
+    bind(ApplicationShellMouseTracker).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ApplicationShellMouseTracker);
 });
 
 export function bindMessageService(bind: interfaces.Bind): interfaces.BindingWhenOnSyntax<MessageService> {

--- a/packages/core/src/browser/shell/application-shell-mouse-tracker.ts
+++ b/packages/core/src/browser/shell/application-shell-mouse-tracker.ts
@@ -1,0 +1,103 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { FrontendApplicationContribution } from '../frontend-application';
+import { ApplicationShell } from './application-shell';
+import { injectable, inject } from 'inversify';
+import { DisposableCollection, Disposable } from '../../common/disposable';
+import { Emitter, Event } from '../../common/event';
+import { FocusTracker, PanelLayout, SplitPanel } from '@phosphor/widgets';
+import { addEventListener, Widget } from '../widgets';
+/**
+ * Contribution that tracks `mouseup` and `mousedown` events.
+ *
+ * This is required to be able to track the `TabBar`, `DockPanel`, and `SidePanel` resizing and drag and drop events correctly
+ * all over the application. By default, when the mouse is over an `iframe` we lose the mouse tracking ability, so whenever
+ * we click (`mousedown`), we overlay a transparent `div` over the `iframe` in the Mini Browser, then we set the `display` of
+ * the transparent `div` to `none` on `mouseup` events.
+ */
+@injectable()
+export class ApplicationShellMouseTracker implements FrontendApplicationContribution {
+
+    @inject(ApplicationShell)
+    protected readonly applicationShell: ApplicationShell;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly toDisposeOnActiveChange = new DisposableCollection();
+
+    protected readonly mouseupEmitter = new Emitter<MouseEvent>();
+    protected readonly mousedownEmitter = new Emitter<MouseEvent>();
+    protected readonly mouseupListener: (e: MouseEvent) => void = e => this.mouseupEmitter.fire(e);
+    protected readonly mousedownListener: (e: MouseEvent) => void = e => this.mousedownEmitter.fire(e);
+
+    onStart(): void {
+        // Here we need to attach a `mousedown` listener to the `TabBar`s, `DockPanel`s and the `SidePanel`s. Otherwise, Phosphor handles the event and stops the propagation.
+        // Track the `mousedown` on the `TabBar` for the currently active widget.
+        this.applicationShell.activeChanged.connect((shell: ApplicationShell, args: FocusTracker.IChangedArgs<Widget>) => {
+            this.toDisposeOnActiveChange.dispose();
+            if (args.newValue) {
+                const tabBar = shell.getTabBarFor(args.newValue);
+                if (tabBar) {
+                    this.toDisposeOnActiveChange.push(addEventListener(tabBar.node, 'mousedown', this.mousedownListener, true));
+                }
+            }
+        });
+
+        // Track the `mousedown` events for the `SplitPanel`s, if any.
+        const { layout } = this.applicationShell;
+        if (layout instanceof PanelLayout) {
+            this.toDispose.pushAll(
+                layout.widgets.filter(ApplicationShellMouseTracker.isSplitPanel).map(splitPanel => addEventListener(splitPanel.node, 'mousedown', this.mousedownListener, true))
+            );
+        }
+        // Track the `mousedown` on each `DockPanel`.
+        const { mainPanel, bottomPanel, leftPanelHandler, rightPanelHandler } = this.applicationShell;
+        this.toDispose.pushAll([mainPanel, bottomPanel, leftPanelHandler.dockPanel, rightPanelHandler.dockPanel]
+            .map(panel => addEventListener(panel.node, 'mousedown', this.mousedownListener, true)));
+
+        // The `mouseup` event has to be tracked on the `document`. Phosphor attaches to there.
+        document.addEventListener('mouseup', this.mouseupListener, true);
+
+        // Make sure it is disposed in the end.
+        this.toDispose.pushAll([
+            this.mousedownEmitter,
+            this.mouseupEmitter,
+            Disposable.create(() => document.removeEventListener('mouseup', this.mouseupListener, true))
+        ]);
+    }
+
+    onStop(): void {
+        this.toDispose.dispose();
+        this.toDisposeOnActiveChange.dispose();
+    }
+
+    get onMouseup(): Event<MouseEvent> {
+        return this.mouseupEmitter.event;
+    }
+
+    get onMousedown(): Event<MouseEvent> {
+        return this.mousedownEmitter.event;
+    }
+
+}
+
+export namespace ApplicationShellMouseTracker {
+
+    export function isSplitPanel(arg: Widget): arg is SplitPanel {
+        return arg instanceof SplitPanel;
+    }
+
+}

--- a/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
+++ b/packages/mini-browser/src/browser/mini-browser-frontend-module.ts
@@ -30,7 +30,7 @@ import { NavigatableWidgetOptions } from '@theia/core/lib/browser/navigatable';
 import { MiniBrowserOpenHandler } from './mini-browser-open-handler';
 import { MiniBrowserService, MiniBrowserServicePath } from '../common/mini-browser-service';
 import { MiniBrowser, MiniBrowserOptions } from './mini-browser';
-import { MiniBrowserProps, MiniBrowserContentFactory, MiniBrowserMouseClickTracker, MiniBrowserContent } from './mini-browser-content';
+import { MiniBrowserProps, MiniBrowserContentFactory, MiniBrowserContent } from './mini-browser-content';
 import {
     LocationMapperService,
     FileLocationMapper,
@@ -41,8 +41,6 @@ import {
 } from './location-mapper-service';
 
 export default new ContainerModule(bind => {
-    bind(MiniBrowserMouseClickTracker).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(MiniBrowserMouseClickTracker);
 
     bind(MiniBrowserContent).toSelf();
     bind(MiniBrowserContentFactory).toFactory(context => (props: MiniBrowserProps) => {

--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -31,6 +31,7 @@ import { fromViewColumn } from '@theia/plugin-ext/lib/plugin/type-converters';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser';
 import { createUntitledResource } from '@theia/plugin-ext/lib/main/browser/editor/untitled-resource';
 import { DocumentsMainImpl } from '@theia/plugin-ext/lib/main/browser/documents-main';
+import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 
 export namespace VscodeCommands {
     export const OPEN: Command = {
@@ -66,6 +67,8 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
     protected readonly diffService: DiffService;
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
+    @inject(ApplicationShellMouseTracker)
+    protected readonly mouseTracker: ApplicationShellMouseTracker;
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(VscodeCommands.OPEN, {
@@ -126,7 +129,7 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             // tslint:disable-next-line: no-any
             execute: async (resource: URI, position?: any, label?: string, options?: any) => {
                 label = label || resource.fsPath;
-                const view = new WebviewWidget(label, { allowScripts: true }, {});
+                const view = new WebviewWidget(label, { allowScripts: true }, {}, this.mouseTracker);
                 const res = await this.resources(new TheiaURI(resource));
                 const str = await res.readContents();
                 const html = this.getHtml(str);

--- a/packages/plugin-ext/src/main/browser/webviews-main.ts
+++ b/packages/plugin-ext/src/main/browser/webviews-main.ts
@@ -26,6 +26,7 @@ import { ThemeService } from '@theia/core/lib/browser/theming';
 import { ThemeRulesService } from './webview/theme-rules-service';
 import { DisposableCollection } from '@theia/core';
 import { ViewColumnService } from './view-column-service';
+import { ApplicationShellMouseTracker } from '@theia/core/lib/browser/shell/application-shell-mouse-tracker';
 
 import debounce = require('lodash.debounce');
 
@@ -48,9 +49,12 @@ export class WebviewsMainImpl implements WebviewsMain {
         visible: boolean;
     }>();
 
+    protected readonly mouseTracker: ApplicationShellMouseTracker;
+
     constructor(rpc: RPCProtocol, container: interfaces.Container) {
         this.proxy = rpc.getProxy(MAIN_RPC_CONTEXT.WEBVIEWS_EXT);
         this.shell = container.get(ApplicationShell);
+        this.mouseTracker = container.get(ApplicationShellMouseTracker);
         this.keybindingRegistry = container.get(KeybindingRegistry);
         this.viewColumnService = container.get(ViewColumnService);
         this.updateViewOptions = debounce<() => void>(() => {
@@ -101,7 +105,8 @@ export class WebviewsMainImpl implements WebviewsMain {
                         this.themeRulesService.setRules(<HTMLElement>styleElement, this.themeRulesService.getCurrentThemeRules());
                     }));
                 }
-            });
+            },
+            this.mouseTracker);
         view.disposed.connect(() => {
             toDispose.dispose();
             this.onCloseView(panelId);


### PR DESCRIPTION
This pull fixed webview resize issue, when user try to resize webview widget with split panel.
Pull reuse approach and `MiniBrowserMouseClickTracker` class to provide fix.

Original issue: https://github.com/eclipse/che-theia/issues/151