### PR TITLE
[tasks] allow comments in tasks.json

### DIFF
--- a/packages/task/package.json
+++ b/packages/task/package.json
@@ -6,6 +6,7 @@
     "@theia/core": "^0.7.0",
     "@theia/filesystem": "^0.7.0",
     "@theia/markers": "^0.7.0",
+    "@theia/monaco": "^0.7.0",
     "@theia/process": "^0.7.0",
     "@theia/terminal": "^0.7.0",
     "@theia/variable-resolver": "^0.7.0",

--- a/packages/task/src/browser/monaco.d.ts
+++ b/packages/task/src/browser/monaco.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@theia/monaco/src/typings/monaco/index"/>

--- a/packages/task/src/browser/task-frontend-module.ts
+++ b/packages/task/src/browser/task-frontend-module.ts
@@ -31,6 +31,7 @@ import { bindProcessTaskModule } from './process/process-task-frontend-module';
 import { TaskSchemaUpdater } from './task-schema-updater';
 import { TaskActionProvider, ConfigureTaskAction } from './task-action-provider';
 import '../../src/browser/style/index.css';
+import './tasks-monaco-contribution';
 
 export default new ContainerModule(bind => {
     bind(TaskFrontendContribution).toSelf().inSingletonScope();

--- a/packages/task/src/browser/tasks-monaco-contribution.ts
+++ b/packages/task/src/browser/tasks-monaco-contribution.ts
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+monaco.languages.register({
+    id: 'jsonc',
+    'aliases': [
+        'JSON with Comments'
+    ],
+    'filenames': [
+        'tasks.json'
+    ]
+});


### PR DESCRIPTION
Fixes #5505

- added support for comments in a user's `tasks.json` by setting the
file type as jsonc instead of standard json.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
