### PR TITLE
Fix plugin loading to cope with modules that have immutable exports

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -96,15 +96,22 @@ export class PluginHostRPC {
                 try {
                     // cleaning the cache for all files of that plug-in.
                     Object.keys(require.cache).forEach(function (key) {
-                        const mod = require.cache[key];
+                        const mod: NodeJS.Module = require.cache[key];
 
-                        // remove children that are extensions
+                        // attempting to reload a native module will throw an error, so skip them
+                        if (mod.id.endsWith('.node')) {
+                            return;
+                        }
+
+                        // remove children that are part of the plug-in
                         let i = mod.children.length;
                         while (i--) {
                             const childMod: NodeJS.Module = mod.children[i];
-                            if (childMod && childMod.id.startsWith(plugin.pluginFolder)) {
-                                // cleanup exports
-                                childMod.exports = {};
+                            // ensure the child module is not null, is in the plug-in folder, and is not a native module (see above)
+                            if (childMod && childMod.id.startsWith(plugin.pluginFolder) && !childMod.id.endsWith('.node')) {
+                                // cleanup exports - note that some modules (e.g. ansi-styles) define their
+                                // exports in an immutable manner, so overwriting the exports throws an error
+                                delete childMod.exports;
                                 mod.children.splice(i, 1);
                                 for (let j = 0; j < childMod.children.length; j++) {
                                     delete childMod.children[j];
@@ -115,9 +122,9 @@ export class PluginHostRPC {
                         if (key.startsWith(plugin.pluginFolder)) {
                             // delete entry
                             delete require.cache[key];
-                            const ix = mod.parent.children.indexOf(mod);
+                            const ix = mod.parent!.children.indexOf(mod);
                             if (ix >= 0) {
-                                mod.parent.children.splice(ix, 1);
+                                mod.parent!.children.splice(ix, 1);
                             }
                         }
 


### PR DESCRIPTION
Fixes #5514 

Some node modules, such as ansi-styles, define the `exports` property in an immutable manner: https://github.com/chalk/ansi-styles/blob/master/index.js#L159

Because the `exports` property has no setter, it throws an error when we try to overwrite it. We can just delete it instead.

Also, you cannot reload native modules - an error is thrown when you attempt to do so:

```
Error: Failed to load /Users/sstone1/git/blockchain-vscode-extension/client/ibm-blockchain-platform-1.0.3/extension/node_modules/grpc/src/node/extension_binary/node-v64-darwin-x64-unknown/grpc_node.node. Module did not self-register.
```

... so I've also fixed the code to skip doing anything with native modules (which have an ID that ends with `.node`).