### PR TITLE
Fix debug adapter connecting to server

### DIFF
--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -324,7 +324,7 @@ export class DebugExtImpl implements DebugExt {
         }
 
         if ('debugServer' in debugConfiguration) {
-            return connectDebugAdapter(debugConfiguration.debugServer);
+            return connectDebugAdapter({ port: debugConfiguration.debugServer });
         } else {
             if (!executable) {
                 throw new Error('It is not possible to provide debug adapter executable.');


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### Reference issue
https://github.com/eclipse/che/issues/13576

### What does this PR do
Allows debug adapter connect to server

### How to test
Put the plugins below in `plugins` folder. Create a java sample. It is possible to debug sample.
http://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.45.0-1523.vsix
https://github.com/microsoft/vscode-java-debug/releases/download/0.19.0/vscode-java-debug-0.19.0.vsix
