### PR TITLE
Add VS Code Api implementation for  extension.onDidChange event

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -78,6 +78,9 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         },
         getExtension(pluginId: string): any | undefined {
             return withExtensionPath(vscode.plugins.getPlugin(pluginId));
+        },
+        get onDidChange(): theia.Event<void> {
+            return vscode.plugins.onDidChange;
         }
     };
 

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -114,6 +114,7 @@ export interface PluginManager {
     getPluginExport(pluginId: string): PluginAPI | undefined;
     isRunning(pluginId: string): boolean;
     activatePlugin(pluginId: string): PromiseLike<void>;
+    onDidChange: theia.Event<void>;
 }
 
 export interface PluginAPIFactory {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -602,6 +602,9 @@ export function createAPIFactory(
                     return new Plugin(pluginManager, plg);
                 }
                 return undefined;
+            },
+            get onDidChange(): theia.Event<void> {
+                return pluginManager.onDidChange;
             }
         };
 

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -34,6 +34,7 @@ import { PreferenceRegistryExtImpl } from './preference-registry';
 import { Memento, KeyValueStorageProxy } from './plugin-storage';
 import { ExtPluginApi } from '../common/plugin-ext-api-contribution';
 import { RPCProtocol } from '../api/rpc-protocol';
+import { Emitter } from '@theia/core/lib/common/event';
 
 export interface PluginHost {
 
@@ -65,6 +66,11 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
     private pluginActivationPromises = new Map<string, Deferred<void>>();
     private pluginContextsMap: Map<string, theia.PluginContext> = new Map();
     private storageProxy: KeyValueStorageProxy;
+
+    private onDidChangeEmitter = new Emitter<void>();
+    protected fireOnDidChange(): void {
+        this.onDidChangeEmitter.fire(undefined);
+    }
 
     constructor(
         private readonly host: PluginHost,
@@ -98,8 +104,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         this.storageProxy = this.rpc.set(
             MAIN_RPC_CONTEXT.STORAGE_EXT,
             new KeyValueStorageProxy(this.rpc.getProxy(PLUGIN_RPC_CONTEXT.STORAGE_MAIN),
-                                     pluginInit.globalState,
-                                     pluginInit.workspaceState)
+                pluginInit.globalState,
+                pluginInit.workspaceState)
         );
 
         // init query parameters
@@ -139,6 +145,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         if (this.host.loadTests) {
             return this.host.loadTests();
         }
+        this.fireOnDidChange();
         return Promise.resolve();
     }
 
@@ -215,6 +222,10 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         }
         this.pluginActivationPromises.set(pluginId, deferred);
         return deferred.promise;
+    }
+
+    get onDidChange(): theia.Event<void> {
+        return this.onDidChangeEmitter.event;
     }
 
 }

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -155,6 +155,12 @@ declare module '@theia/plugin' {
          * All plug-ins currently known to the system.
          */
         export let all: Plugin<any>[];
+
+        /**
+         * An event which fires when `plugins.all` changes. This can happen when extensions are
+         * installed, uninstalled, enabled or disabled.
+         */
+        export let onDidChange: Event<void>;
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

### What does this PR do
Adds VS Code API implementation for `extension.onDidChange` [1] event

[1] https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L8966

### How to test
Put typescript [1] plugin into `plugin` folder. Start Theia and open any `js` file. No exception in console regarding extension.onDidChange` event.

https://github.com/che-incubator/ms-code.typescript/releases/download/v1.35.1/che-typescript-language-1.35.1.vsix