### PR TITLE
Fixed #5402, #5502: fixed Keybinding widget UI issues

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -277,15 +277,19 @@ export class KeybindingWidget extends ReactWidget {
                 this.items.map((item, index) =>
                     <tr className='kb-item-row' key={index} onDoubleClick={a => this.editKeybinding(item)}>
                         <td className='kb-actions'>{this.renderActions(item)}</td>
-                        <td title={this.getRawValue(item.command)}>{this.renderMatchedData(item.command)}</td>
-                        <td title={(item.keybinding) ? this.getRawValue(item.keybinding) : ''} className='monaco-keybinding'>
+                        <td className='kb-label' title={this.getRawValue(item.command)}>{this.renderMatchedData(item.command)}</td>
+                        <td title={(item.keybinding) ? this.getRawValue(item.keybinding) : ''} className='kb-keybinding monaco-keybinding'>
                             {item.keybinding ? this.renderKeybinding(item.keybinding) : ''}
                         </td>
-                        <td title={(item.scope) ? this.getRawValue(item.scope) : ''}>
+                        <td className='kb-scope' title={(item.scope) ? this.getRawValue(item.scope) : ''}>
                             <code className='td-scope'>{item.scope ? this.renderMatchedData(item.scope) : ''}</code>
                         </td>
-                        <td title={(item.context) ? this.getRawValue(item.context) : ''}><code>{(item.context) ? this.renderMatchedData(item.context) : ''}</code></td>
-                        <td title={this.getRawValue(item.id)}><code>{this.renderMatchedData(item.id)}</code></td>
+                        <td className='kb-context' title={(item.context) ? this.getRawValue(item.context) : ''}>
+                            <code>{(item.context) ? this.renderMatchedData(item.context) : ''}</code>
+                        </td>
+                        <td className='kb-command' title={this.getRawValue(item.id)}>
+                            <code>{this.renderMatchedData(item.id)}</code>
+                        </td>
                     </tr>
                 )
             }
@@ -293,7 +297,7 @@ export class KeybindingWidget extends ReactWidget {
     }
 
     protected renderActions(item: KeybindingItem): React.ReactNode {
-        return <span>{this.renderEdit(item)}{this.renderReset(item)}</span>;
+        return <span className='kb-actions-icons'>{this.renderEdit(item)}{this.renderReset(item)}</span>;
     }
 
     protected renderEdit(item: KeybindingItem): React.ReactNode {

--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -52,8 +52,26 @@
     min-height: 16px;
 }
 
-.kb table th,
-.kb table td {
+.th-action, .th-keybinding,
+.kb-actions, .kb-keybinding {
+    min-height: 18px;
+    overflow: hidden;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.th-action,
+.kb-actions {
+    padding: 2px 0px 5px 0px;
+}
+
+.th-keybinding,
+.kb-keybinding {
+    padding: 2px 10px 5px 10px;
+}
+
+.th-label, .th-scope, .th-context, .th-command,
+.kb-label, .kb-scope, .kb-context, .kb-command {
     padding: 2px 10px 5px 10px;
     min-height: 18px;
     overflow: hidden;
@@ -86,7 +104,7 @@
     background-color: var(--theia-accent-color4);
 }
 
-.kb table tbody tr:hover .kb-action-item{
+.kb table tbody tr:hover .kb-action-item {
     visibility: visible;
     color: var(--theia-ui-font-color1);
     text-decoration: none;
@@ -105,28 +123,29 @@
 }
 
 .kb table .th-action {
-    width: 20px;
-}
-
-.kb table .th-command {
-    width: 200px;
-}
-
-.kb table .th-context {
-    width: 70px;
+    width: 35px;
 }
 
 .kb table .th-label {
-    width: 150px;
+    width: 25%;
 }
 
 .kb table .th-keybinding {
-    width: 70px;
+    width: 20%;
 }
 
 .kb table .th-scope {
-    width: 30px;
+    width: 10%;
 }
+
+.kb table .th-context {
+    width: 15%;
+}
+
+.kb table .th-command {
+    width: 30%;
+}
+
 
 .message-container {
     align-items: center;
@@ -162,4 +181,11 @@
 .kb-item-row td a:focus {
     outline: 0;
     border: none;
+}
+
+.kb-actions-icons {
+    display: block;
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
 }


### PR DESCRIPTION
Fixed #5402, #5502.

- ~~Made `Label` and `Keybinding` columns fixed width so that their contents are always displayed properly on resize.~~
- Fixed the display of the edit and reset icons.

