### PR TITLE
Generates problem markers for a C++ project using clang-tidy

### DIFF
--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -81,14 +81,14 @@ To get this working, you need to enable clangd's global index using the
 
 ## Using the clang-tidy linter
 
-Note: This functionality is available when using clangd 9 and later.
+**Note: This functionality is available when using clangd 9 and later.**
 
-You can set the preference 'cpp.clangTidy' to enable the clang-tidy linter included in clangd. When the preference is set, there are two ways to chose which of its built-in checks clang-tidy will use:
+You can set the preference 'cpp.clangTidy' to enable the clang-tidy linter included in clangd. When the preference is enabled, there are two ways to choose which of its built-in checks clang-tidy will use:
 
 - using the preferences:  'cpp.clangTidyChecks'
-- using the file '.clang-tidy' . The file is located in the same folder of the files or a parent folder.
+- using the file '.clang-tidy' . This file is located in the same folder of the files or a parent folder.
 
-Note: using the preference checks will supersede the value found in the .clang-tidy file.
+**Note**: When the preference setting for "cpp.clangTidyChecks" is set, the configs will be merged with the configuration found in the ".clang-tidy" file. If you want to drop the configs from ".clang-tidy", you'd need to disable it in "cpp.clangTidyChecks" with **"cpp.clangTidyChecks": "-*"**.
 
 The syntax used to fill the checks can be found at http://clang.llvm.org/extra/clang-tidy/
 
@@ -101,6 +101,58 @@ There are two ways to configure clang-tidy's checks: through a Theia preference 
 
     - for the .clang-tidy file: Checks: "-*,readability-*"
         - Meaning: disable all list-checks and enable all readability-* checks
+
+### Running clang-tidy as a task
+
+To be able to run clang-tidy as a task, you need to install the program.
+
+```bash
+UNIX
+    sudo apt-get install clang-tidy
+Note: not all operating system are currently supported with this linter yet.
+```
+
+```
+The clang-tidy task will read the "checks" and other configuration fields from the ".clang-tidy" file located in the closest parent directory of the source file.
+P.S. You do not need to provide a value for each field.
+
+Those configurations fields can be:
+    Checks
+    CheckOptions
+    FormatStyle
+    HeaderFilterRegex
+    User
+    WarningsAsErrors
+
+You can run the following command to have an idea of the fields found in file ".clang-tidy"
+    clang-tidy -dump-config
+```
+
+In .theia/tasks.json, add the following:
+
+```json
+   {
+        "label": "[Task] clang-tidy",
+        "type": "shell",
+        "cwd": "${workspaceFolder}",
+        "command": "clang-tidy",
+        "args": [
+            "*"
+        ],
+        "options": {},
+        "problemMatcher": [
+            "$clangTidyMatcher"
+        ]
+   }
+```
+
+If you want a description for each task field, see [theia/packages/task/src/browser/task-schema-updater.ts]( https://github.com/theia-ide/theia/blob/531aa3bde8dea7f022ea41beaee3aace65ce54de/packages/task/src/browser/task-schema-updater.ts#L62 )
+
+```bash
+When there is no compilation database, clang-tidy could run but you may need to be more specific which files to select. One way is to replace the "args" from the "*" to
+"**/*.cpp" to only parse files with the "cpp" extension or
+"**/*.c" to parse the "c" files extension.
+```
 
 ## License
 

--- a/packages/cpp/src/browser/cpp-task-provider.spec.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.spec.ts
@@ -20,9 +20,11 @@ import { TaskResolverRegistry } from '@theia/task/lib/browser/task-contribution'
 import { CppBuildConfigurationManager, CppBuildConfiguration } from './cpp-build-configurations';
 import { Event } from '@theia/core';
 import { expect } from 'chai';
-import { TaskConfiguration } from '@theia/task/src/common';
+import { TaskConfiguration } from '@theia/task/lib/common';
 import { ProcessTaskConfiguration } from '@theia/task/lib/common/process/task-protocol';
-import { TaskDefinitionRegistry } from '@theia/task/lib/browser';
+import { TaskDefinitionRegistry } from '@theia/task/lib/browser/task-definition-registry';
+import { ProblemMatcherRegistry } from '@theia/task/lib/browser/task-problem-matcher-registry';
+import { ProblemPatternRegistry } from '@theia/task/lib/browser/task-problem-pattern-registry';
 
 // The object under test.
 let taskProvider: CppTaskProvider;
@@ -67,9 +69,12 @@ class MockCppBuildConfigurationManager implements CppBuildConfigurationManager {
 beforeEach(function () {
     const container: Container = new Container();
     container.bind(CppTaskProvider).toSelf().inSingletonScope();
+    container.bind(CppBuildConfigurationManager).to(MockCppBuildConfigurationManager);
     container.bind(TaskResolverRegistry).toSelf().inSingletonScope();
     container.bind(TaskDefinitionRegistry).toSelf().inSingletonScope();
-    container.bind(CppBuildConfigurationManager).to(MockCppBuildConfigurationManager);
+    container.bind(ProblemMatcherRegistry).toSelf().inSingletonScope();
+    container.bind(ProblemPatternRegistry).toSelf().inSingletonScope();
+
     taskProvider = container.get(CppTaskProvider);
 
     // Register a task resolver of type 'shell', on which the cpp build tasks


### PR DESCRIPTION
Fixes #5532 

**Description**

Run the C/C++ linting tool `clang-tidy` as a task to generate problem markers which can be later consumed by the `problems-view`.

**Setup**
1. Open a C/C++ project
2. Enable the preference `cpp.clangTidy`
3. - Test using the preference only: `"cpp.clangTidyChecks": "*"`
    - Test using the `.clang-tidy` file: create a `clang-tidy` file at the root of the workspace, and add the following: 
```
Checks: "read*"
WarningsAsErrors: "hicpp-*"
```
This will verify the linter with the selected files for the `"readability"` flaws.
If you happen to test for `"hicpp*` warnings, they will be reported as errors 
because of `WarningsAsErrors: "hicpp-*"`

**How to Test**
1. Create a `tasks.json` file under the directory `.theia` of the workspace.
2. Add the following task:

```json
{
    "tasks": [
        {
            "label": "[Task] clang-tidy",
            "type": "shell",
            "cwd": "${workspaceFolder}",
            "command": "clang-tidy",
            "args": [
                "*"
            ],
            "options": {},
            "problemMatcher": [
                "$clangTidyMatcher"
            ]
        }
    ]
}
```
3. Run the task: <kbd>F1</kbd> then `Tasks: Run Tasks` then `shell: [Task] clang-tidy`.

**Additional Information**
- Requires `clang-tidy` executable
- Requires `clangd` version 9 or later
 - **Note:** If you add the file and the preference, the linter will merge the preference option with the file options. If you want to apply only the preference option even if the .clang-tidy is present, just put :
 "cpp.clangTidyChecks": "-\*" will disable all default checks (-*)  and add you choice of linter after, reference http://clang.llvm.org/extra/clang-tidy/
