### PR TITLE
move 'cursor: pointer' from tabBar to tabBar-content

### DIFF
--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -17,7 +17,6 @@
   color: var(--theia-ui-font-color1);
   background: var(--theia-layout-color1);
   font-size: var(--theia-ui-font-size1);
-  cursor: pointer;
 }
 
 .p-TabBar[data-orientation='horizontal'].theia-app-bottom {
@@ -41,6 +40,10 @@
   overflow-x: hidden;
   overflow-y: hidden;
   min-height: calc(var(--theia-private-horizontal-tab-height) + var(--theia-private-horizontal-tab-scrollbar-rail-height) / 2);
+}
+
+.p-TabBar .p-TabBar-content {
+  cursor: pointer;
 }
 
 .p-TabBar[data-orientation='horizontal'] .p-TabBar-content {


### PR DESCRIPTION
Signed-off-by: kpge <gekangping@126.com>
move 'cursor: pointer' from tabBar to tabBar-content 
* fix:#5538

![cursor fixed](https://user-images.githubusercontent.com/35068357/59848698-60366380-9398-11e9-949a-893372fce337.gif)

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
