### PR TITLE
Resize octicons to match fontawesome icons

### DIFF
--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -195,7 +195,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
             if (!(typeof val === 'string') && LabelIcon.is(val)) {
                 const octicon = getIconByName(val.name);
                 if (octicon) {
-                    children.push(<span key={key} className={val.animation ? 'fa-' + val.animation : ''}><Octicon icon={octicon} /></span>);
+                    children.push(<span key={key} className={val.animation ? 'fa-' + val.animation : 'fa'}><Octicon icon={octicon} height={12.5} width={12.5} /></span>);
                 } else {
                     children.push(<span key={key} className={`fa fa-${val.name} ${val.animation ? 'fa-' + val.animation : ''}`}></span>);
                 }


### PR DESCRIPTION
Fixes theia-ide/theia#5534

The result looks like this (check the [tools](https://octicons.github.com/icon/tools/) octicon):

<img width="411" alt="Capture d’écran 2019-06-20 à 19 36 05" src="https://user-images.githubusercontent.com/167767/59871230-52cca980-9397-11e9-8adf-58fe71d2400e.png">