### PR TITLE
[file-search] remove separator when no recent results are found in the quick-file-open

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -192,7 +192,7 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
                 const first = sortedResults[0];
                 sortedResults.shift();
                 if (first) {
-                    const item = await this.toItem(first.getUri()!, { groupLabel: 'file results', showBorder: true });
+                    const item = await this.toItem(first.getUri()!, { groupLabel: 'file results', showBorder: !!recentlyUsedItems.length });
                     if (token.isCancellationRequested) {
                         return;
                     }


### PR DESCRIPTION
Fixes #5547

Currently, when no recent results are found when performing the quick-file-open, we display a separator incorrectly. The separator should only be displayed to differentiate between two groups of items and thus
should only be displayed if there currently are recent results. The PR addresses the issue by only displaying the separator if the recent results list has one or more values.

| With Recent Results | Without Recent Results |
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/40359487/59873773-ba203480-936a-11e9-8e12-b3cb7901fff7.png)|![image](https://user-images.githubusercontent.com/40359487/59873848-e0de6b00-936a-11e9-8c29-4aa012a9d816.png) |



Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
