### PR TITLE
display source folder name for detected tasks in quick open

### DIFF
--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -252,7 +252,7 @@ export class TaskRunQuickOpenItem extends QuickOpenGroupItem {
         }
         if (ContributedTaskConfiguration.is(this.task)) {
             if (this.task._scope) {
-                return new URI(this.task._scope).path.toString();
+                return new URI(this.task._scope).displayName;
             }
             return this.task._source;
         } else {


### PR DESCRIPTION
- Full paths of source folders are displayed in the detected tasks' list. Only folder name should be displayed.

Signed-off-by: elaihau <liang.huang@ericsson.com>

