### PR TITLE
Sort the extension names in the 'about' dialog

### DIFF
--- a/packages/core/src/browser/about-dialog.ts
+++ b/packages/core/src/browser/about-dialog.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, postConstruct } from 'inversify';
 import { AbstractDialog, DialogProps } from './dialogs';
-import { ApplicationServer } from '../common/application-protocol';
+import { ApplicationServer, ExtensionInfo } from '../common/application-protocol';
 
 export const ABOUT_CONTENT_CLASS = 'theia-aboutDialog';
 export const ABOUT_EXTENSIONS_CLASS = 'theia-aboutExtensions';
@@ -62,17 +62,20 @@ export class AboutDialog extends AbstractDialog<void> {
         extensionInfoContent.classList.add(ABOUT_EXTENSIONS_CLASS);
         messageNode.appendChild(extensionInfoContent);
 
-        const extensionsInfos = await this.appServer.getExtensionsInfos();
+        const extensionsInfos: ExtensionInfo[] = await this.appServer.getExtensionsInfos();
 
-        extensionsInfos.forEach(extension => {
-            const extensionInfo = document.createElement('li');
-            extensionInfo.textContent = extension.name + ' ' + extension.version;
-            extensionInfoContent.appendChild(extensionInfo);
-        });
+        extensionsInfos
+            .sort((a: ExtensionInfo, b: ExtensionInfo) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+            .forEach((extension: ExtensionInfo) => {
+                const extensionInfo = document.createElement('li');
+                extensionInfo.textContent = extension.name + ' ' + extension.version;
+                extensionInfoContent.appendChild(extensionInfo);
+            });
         messageNode.setAttribute('style', 'flex: 1 100%; padding-bottom: calc(var(--theia-ui-padding)*3);');
         this.contentNode.appendChild(messageNode);
         this.appendAcceptButton('Ok');
     }
 
     get value(): undefined { return undefined; }
+
 }


### PR DESCRIPTION
Fixes #3886

**Description**

Add minor enhancement to the example `about` dialog present in the example applications
to display the list of sorted extension names. Previously the list was unsorted which
meant it was harder to identify which extensions were in fact present, and a sorted
list is more adherent with good UI practices.

**Steps to Reproduce**
1. open the `about` dialog using the menu `Help` → `About`.
2. the extension names should be sorted.

<div align='center'>

<img width="1260" alt="Screen Shot 2019-06-20 at 9 42 41 PM" src="https://user-images.githubusercontent.com/40359487/59892109-cf668480-93a5-11e9-85a3-18da0c85b996.png">


</div>

**Note**

The example application defines it's own default `about` dialog which is likely to be updated by different products and overwritten ([comment](https://github.com/theia-ide/theia/issues/3886#issuecomment-449417034)). The enhancement is solely to sort the example-application's `about` dialog implementation.


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
