### PR TITLE
fix #5506: Make processId and cwd in TerminalWidget return promise when throw error

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -205,7 +205,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     get cwd(): Promise<URI> {
         if (!IBaseTerminalServer.validateId(this.terminalId)) {
-            throw new Error('terminal is not started');
+            return Promise.reject(new Error('terminal is not started'));
         }
         if (this.terminalService.getById(this.id)) {
             return this.shellTerminalServer.getCwdURI(this.terminalId)
@@ -216,7 +216,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     get processId(): Promise<number> {
         if (!IBaseTerminalServer.validateId(this.terminalId)) {
-            throw new Error('terminal is not started');
+            return Promise.reject(new Error('terminal is not started'));
         }
         return this.shellTerminalServer.getProcessId(this.terminalId);
     }


### PR DESCRIPTION
Add the ready interface to ensure that the correct processId can be obtained.

Signed-off-by: Brokun <brokun0128@gmail.com>

