### PR TITLE
[plug-in] Return execution of TreeItem.command on selection

### DIFF
--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -443,6 +443,8 @@ export class TreeViewItem {
 
     contextValue?: string;
 
+    command?: Command;
+
 }
 
 export interface TreeViewSelection {

--- a/packages/plugin-ext/src/plugin/tree/tree-views.ts
+++ b/packages/plugin-ext/src/plugin/tree/tree-views.ts
@@ -251,7 +251,8 @@ class TreeViewExtImpl<T> extends Disposable {
                     resourceUri: treeItem.resourceUri,
                     tooltip: treeItem.tooltip,
                     collapsibleState: treeItem.collapsibleState,
-                    contextValue: treeItem.contextValue
+                    contextValue: treeItem.contextValue,
+                    command: treeItem.command
                 } as TreeViewItem;
 
                 treeItems.push(treeViewItem);


### PR DESCRIPTION
During recent refactoring we loose execution of [TreeItem#command](https://github.com/theia-ide/theia/blob/master/packages/plugin/src/theia.d.ts#L3625), so this pull return that functionality.

Related issue: https://github.com/eclipse/che/issues/13585
Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>

