### PR TITLE
[tree] add extra options to the tree search input

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -154,7 +154,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     @postConstruct()
     protected init(): void {
         if (this.props.search) {
-            this.searchBox = this.searchBoxFactory(SearchBoxProps.DEFAULT);
+            this.searchBox = this.searchBoxFactory({ ...SearchBoxProps.DEFAULT, showButtons: true });
             this.toDispose.pushAll([
                 this.searchBox,
                 this.searchBox.onTextChange(async data => {
@@ -163,8 +163,18 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                     this.update();
                 }),
                 this.searchBox.onClose(data => this.treeSearch.filter(undefined)),
-                this.searchBox.onNext(() => this.model.selectNextNode()),
-                this.searchBox.onPrevious(() => this.model.selectPrevNode()),
+                this.searchBox.onNext(() => {
+                    // Enable next selection if there are currently highlights.
+                    if (this.searchHighlights.size > 1) {
+                        this.model.selectNextNode();
+                    }
+                }),
+                this.searchBox.onPrevious(() => {
+                    // Enable previous selection if there are currently highlights.
+                    if (this.searchHighlights.size > 1) {
+                        this.model.selectPrevNode();
+                    }
+                }),
                 this.treeSearch,
                 this.treeSearch.onFilteredNodesChanged(nodes => {
                     const node = nodes.find(SelectableTreeNode.is);


### PR DESCRIPTION
- added extra `showButtons` options to the tree search input.
- allows users to navigate their matches more easily using `next` and `previous` buttons.
- allows users to `close` the search input.
- fixed incorrect implementation of the `searchBox.onPrevious` callback.

<div align='center'>

<img width="673" alt="Screen Shot 2019-06-23 at 2 58 19 PM" src="https://user-images.githubusercontent.com/40359487/59980729-d240bf80-95c7-11e9-8feb-958479bc7284.png">


</div>

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
