### PR TITLE
[tasks] update 'show running tasks' statusbar icon

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -161,7 +161,7 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         const items = await this.taskService.getRunningTasks();
         if (!!items.length) {
             this.statusBar.setElement(id, {
-                text: `$(wrench) ${items.length}`,
+                text: `$(tools) ${items.length}`,
                 tooltip: 'Show Running Tasks',
                 alignment: StatusBarAlignment.LEFT,
                 priority: 2,


### PR DESCRIPTION
**Description**

Now that `octicons` are supported in the statusbar thanks to https://github.com/theia-ide/theia/pull/5416, the icon for `running tasks...` is now updated to match that of its vscode counterpart.

<div align='center'>

![image](https://user-images.githubusercontent.com/40359487/60093103-949e7c80-9716-11e9-81c0-ed2dcfd3ebe6.png)

</div>

**How to test**

1. open the folder `test-resources` from `packages/task/test-resources` as a workspace.
2. run the command `Run Task...`
3. notice the `Show Running Tasks...` statusbar item (displays the number of currently running tasks, and upon selection lists the tasks)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
