### PR TITLE
support linux and osx specific command properties

### DIFF
--- a/packages/task/README.md
+++ b/packages/task/README.md
@@ -14,8 +14,7 @@ Each task configuration looks like this:
         "-alR"
     ],
     "options": {
-        "cwd": "${workspaceFolder}",
-
+        "cwd": "${workspaceFolder}"
     },
     "windows": {
         "command": "cmd.exe",
@@ -41,8 +40,13 @@ Each task configuration looks like this:
 - *env*: the environment of the executed program or shell. If omitted the parent process' environment is used.
 - *shell*: configuration of the shell when task type is `shell`, where users can specify the shell to use with *shell*, and the arguments to be passed to the shell executable to run in command mode with *args*.
 
+By default, *command* and *args* above are used on all platforms. However it's not always possible to express a task in the same way, both on Unix and Windows. The command and/or arguments may be different, for example. If a task needs to work on Linux, MacOS, and Windows, it is better to have separated command, command arguments, and options.
 
-*windows*: by default, *command* and *args* above are used on all platforms. However it's not always possible to express a task in the same way, both on Unix and Windows. The command and/or arguments may be different, for example. If a task needs to work on both Linux/MacOS and Windows, it can be better to have two separate process options. If *windows* is defined, it will be used instead of *command* and *args*, when a task is executed on a Windows backend.
+*windows*: if *windows* is defined, its command, command arguments, and options (i.e., *windows.command*, *windows.args*, and *windows.options*) will take precedence over the *command*, *args*, and *options*, when the task is executed on a Windows backend.
+
+*osx*: if *osx* is defined, its command, command arguments, and options (i.e., *osx.command*, *osx.args*, and *osx.options*) will take precedence over the *command*, *args*, and *options*, when the task is executed on a MacOS backend.
+
+*linux*: if *linux* is defined, its command, command arguments, and options (i.e., *linux.command*, *linux.args*, and *linux.options*) will take precedence over the *command*, *args*, and *options*, when the task is executed on a Linux backend.
 
 Here is a sample tasks.json that can be used to test tasks. Just add this content under the theia source directory, in directory `.theia`:
 ``` json
@@ -54,9 +58,9 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
             "type": "shell",
             "command": "./task",
             "args": [
-                "1",
-                "2",
-                "3"
+                "default 1",
+                "default 2",
+                "default 3"
             ],
             "options": {
                 "cwd": "${workspaceFolder}/packages/task/src/node/test-resources/"
@@ -66,7 +70,14 @@ Here is a sample tasks.json that can be used to test tasks. Just add this conten
                 "args": [
                     "/c",
                     "task.bat",
-                    "abc"
+                    "windows abc"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "linux 1",
+                    "linux 2",
+                    "linux 3"
                 ]
             }
         },
@@ -128,6 +139,13 @@ The variables are supported in the following properties, using `${variableName}`
 - `options.cwd`
 - `windows.command`
 - `windows.args`
+- `windows.options.cwd`
+- `osx.command`
+- `osx.args`
+- `osx.options.cwd`
+- `linux.command`
+- `linux.args`
+- `linux.options.cwd`
 
 See [here](https://www.theia-ide.org/doc/index.html) for a detailed documentation.
 

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -49,6 +49,16 @@ export class ProcessTaskResolver implements TaskResolver {
                 args: processTaskConfig.windows.args ? await this.variableResolverService.resolveArray(processTaskConfig.windows.args, variableResolverOptions) : undefined,
                 options: processTaskConfig.windows.options
             } : undefined,
+            osx: processTaskConfig.osx ? {
+                command: await this.variableResolverService.resolve(processTaskConfig.osx.command, variableResolverOptions),
+                args: processTaskConfig.osx.args ? await this.variableResolverService.resolveArray(processTaskConfig.osx.args, variableResolverOptions) : undefined,
+                options: processTaskConfig.osx.options
+            } : undefined,
+            linux: processTaskConfig.linux ? {
+                command: await this.variableResolverService.resolve(processTaskConfig.linux.command, variableResolverOptions),
+                args: processTaskConfig.linux.args ? await this.variableResolverService.resolveArray(processTaskConfig.linux.args, variableResolverOptions) : undefined,
+                options: processTaskConfig.linux.options
+            } : undefined,
             options: {
                 cwd: await this.variableResolverService.resolve(processTaskConfig.options && processTaskConfig.options.cwd || '${workspaceFolder}', variableResolverOptions),
                 env: processTaskConfig.options && processTaskConfig.options.env,

--- a/packages/task/src/browser/task-schema-updater.ts
+++ b/packages/task/src/browser/task-schema-updater.ts
@@ -59,10 +59,57 @@ export class TaskSchemaUpdater {
     }
 }
 
+const commandSchema: IJSONSchema = {
+    type: 'string',
+    description: 'The actual command or script to execute'
+};
+
+const commandArgSchema: IJSONSchema = {
+    type: 'array',
+    description: 'A list of strings, each one being one argument to pass to the command',
+    items: {
+        type: 'string'
+    }
+};
+
+const commandOptionsSchema: IJSONSchema = {
+    type: 'object',
+    description: 'The command options used when the command is executed',
+    properties: {
+        cwd: {
+            type: 'string',
+            description: 'The directory in which the command will be executed',
+            default: '${workspaceFolder}'
+        },
+        env: {
+            type: 'object',
+            description: 'The environment of the executed program or shell. If omitted the parent process\' environment is used'
+        },
+        shell: {
+            type: 'object',
+            description: 'Configuration of the shell when task type is `shell`',
+            properties: {
+                executable: {
+                    type: 'string',
+                    description: 'The shell to use'
+                },
+                args: {
+                    type: 'array',
+                    description: `The arguments to be passed to the shell executable to run in command mode
+                        (e.g ['-c'] for bash or ['/S', '/C'] for cmd.exe)`,
+                    items: {
+                        type: 'string'
+                    }
+                }
+            }
+        }
+    }
+};
+
 const taskConfigurationSchema: IJSONSchema = {
     oneOf: [
         {
-            'allOf': [
+            allOf: [
                 {
                     type: 'object',
                     required: ['type', 'label'],
@@ -77,68 +124,36 @@ const taskConfigurationSchema: IJSONSchema = {
                             default: 'shell',
                             description: 'Determines what type of process will be used to execute the task. Only shell types will have output shown on the user interface'
                         },
-                        command: {
-                            type: 'string',
-                            description: 'The actual command or script to execute'
-                        },
-                        args: {
-                            type: 'array',
-                            description: 'A list of strings, each one being one argument to pass to the command',
-                            items: {
-                                type: 'string'
-                            }
-                        },
-                        options: {
-                            type: 'object',
-                            description: 'The command options used when the command is executed',
-                            properties: {
-                                cwd: {
-                                    type: 'string',
-                                    description: 'The directory in which the command will be executed',
-                                    default: '${workspaceFolder}'
-                                },
-                                env: {
-                                    type: 'object',
-                                    description: 'The environment of the executed program or shell. If omitted the parent process\' environment is used'
-                                },
-                                shell: {
-                                    type: 'object',
-                                    description: 'Configuration of the shell when task type is `shell`',
-                                    properties: {
-                                        executable: {
-                                            type: 'string',
-                                            description: 'The shell to use'
-                                        },
-                                        args: {
-                                            type: 'array',
-                                            description: `The arguments to be passed to the shell executable to run in command mode
-                                                (e.g ['-c'] for bash or ['/S', '/C'] for cmd.exe)`,
-                                            items: {
-                                                type: 'string'
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
+                        command: commandSchema,
+                        args: commandArgSchema,
+                        options: commandOptionsSchema,
                         windows: {
                             type: 'object',
-                            description: 'Windows specific command configuration overrides command and args',
+                            description: 'Windows specific command configuration that overrides the command, args, and options',
                             properties: {
-                                command: {
-                                    type: 'string',
-                                    description: 'The actual command or script to execute'
-                                },
-                                args: {
-                                    type: 'array',
-                                    description: 'A list of strings, each one being one argument to pass to the command',
-                                    items: {
-                                        type: 'string'
-                                    }
-                                },
+                                command: commandSchema,
+                                args: commandArgSchema,
+                                options: commandOptionsSchema
+                            }
+                        },
+                        osx: {
+                            type: 'object',
+                            description: 'MacOS specific command configuration that overrides the command, args, and options',
+                            properties: {
+                                command: commandSchema,
+                                args: commandArgSchema,
+                                options: commandOptionsSchema
+                            }
+                        },
+                        linux: {
+                            type: 'object',
+                            description: 'Linux specific command configuration that overrides the default command, args, and options',
+                            properties: {
+                                command: commandSchema,
+                                args: commandArgSchema,
+                                options: commandOptionsSchema
                             }
                         }
-
                     }
                 }
             ]

--- a/packages/task/src/common/process/task-protocol.ts
+++ b/packages/task/src/common/process/task-protocol.ts
@@ -52,7 +52,7 @@ export interface CommandOptions {
 }
 
 export interface CommandProperties<T = string> {
-    readonly command: string;
+    readonly command?: string;
     readonly args?: T[];
     readonly options?: CommandOptions;
 }
@@ -62,9 +62,19 @@ export interface ProcessTaskConfiguration<T = string> extends TaskConfiguration,
     readonly type: ProcessType;
 
     /**
-     * Windows version of CommandProperties. Used in preference on Windows, if defined.
+     * Windows specific task configuration
      */
     readonly windows?: CommandProperties<T>;
+
+    /**
+     * macOS specific task configuration
+     */
+    readonly osx?: CommandProperties<T>;
+
+    /**
+     * Linux specific task configuration
+     */
+    readonly linux?: CommandProperties<T>;
 }
 
 export interface ProcessTaskInfo extends TaskInfo {

--- a/packages/task/test-resources/task-long-running-osx
+++ b/packages/task/test-resources/task-long-running-osx
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for i in {1..300}
+do
+   sleep 1
+   echo "tasking osx... $i"
+done

--- a/packages/task/test-resources/task-osx
+++ b/packages/task/test-resources/task-osx
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for i in $@
+do
+   sleep 1
+   echo "tasking osx... $i"
+done


### PR DESCRIPTION
- as per https://github.com/microsoft/vscode/blob/1.35.1/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts#L255, vsCode supports having separated command properties for Windows, OSX, and Linux. This change adds the same support to Theia.
- changed the `command` property in CommandProperties interface from mandatory to optional.
- part of #5516

Signed-off-by: elaihau <liang.huang@ericsson.com>
