### PR TITLE
always show debug icon on first start

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -364,12 +364,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
     }
 
     async initializeLayout(): Promise<void> {
-        ((async () => {
-            const supported = await this.configurations.supported;
-            if (supported.next().value) {
-                await this.openView();
-            }
-        })());
+        await this.openView();
     }
 
     protected firstSessionStart = true;


### PR DESCRIPTION
Align with vscode behavior.
See discussion: https://spectrum.chat/theia/dev/debug-icon-appearance~a321c3d1-11f4-45ec-a5ed-2d5e1ba2b714

Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
