### PR TITLE
Do not fail build if 'THEIA_ELECTRON_SKIP_REPLACE_FFMPEG' is set

### DIFF
--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -26,7 +26,7 @@ async function main() {
     if (fs.existsSync(electronCodecTestLogPath)) {
         console.log('@theia/electron last logs:');
         console.log(fs.readFileSync(electronCodecTestLogPath, { encoding: 'utf8' }).trimRight());
-    } else {
+    } else if (!process.env.THEIA_ELECTRON_SKIP_REPLACE_FFMPEG) {
         throw new Error('Cannot find the log file for the Electron codecs test.');
     }
 }


### PR DESCRIPTION
Now build fails if `THEIA_ELECTRON_SKIP_REPLACE_FFMPEG` is set, because post-install.js script check if  `dev-packages/electron/post-install.log` is present.

Signed-off-by: Yevhen Vydolob <yvydolob@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
