### PR TITLE
[Plugin API] Fix Theia workspace name getter if no folders are opened

### DIFF
--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -71,7 +71,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
     }
 
     get name(): string | undefined {
-        if (this.workspaceFolders) {
+        if (this.workspaceFolders && this.workspaceFolders.length > 0) {
             return new Path(this.workspaceFolders[0].uri.path).base;
         }
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Fixes `name` (of workspace) property of `WorkspaceExtImpl` class in case no folders are opened in Theia workspace.
