### PR TITLE
Plug-ins leaking CodeLens, etc. #4472

### DIFF
--- a/packages/plugin-ext/src/plugin/languages/lens.ts
+++ b/packages/plugin-ext/src/plugin/languages/lens.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,6 +20,7 @@ import { DocumentsExtImpl } from '../documents';
 import { CodeLensSymbol } from '../../api/model';
 import * as Converter from '../type-converters';
 import { ObjectIdentifier } from '../../common/object-identifier';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 
 /** Adapts the calls from main to extension thread for providing/resolving the code lenses. */
 export class CodeLensAdapter {
@@ -27,12 +28,20 @@ export class CodeLensAdapter {
     private static readonly BAD_CMD: theia.Command = { command: 'missing', title: '<<MISSING COMMAND>>' };
 
     private cacheId = 0;
-    private cache = new Map<number, theia.CodeLens>();
+    private cache = new Map<string, Map<number, theia.CodeLens>>();
+
+    protected readonly toDispose = new DisposableCollection();
 
     constructor(
         private readonly provider: theia.CodeLensProvider,
         private readonly documents: DocumentsExtImpl,
-    ) { }
+    ) {
+        this.toDispose.push(
+            this.documents.onDidRemoveDocument(
+                document => this.clearCache(document.uri.toString())
+            )
+        );
+    }
 
     provideCodeLenses(resource: URI, token: theia.CancellationToken): Promise<CodeLensSymbol[] | undefined> {
         const document = this.documents.getDocumentData(resource);
@@ -43,6 +52,8 @@ export class CodeLensAdapter {
         const doc = document.document;
 
         return Promise.resolve(this.provider.provideCodeLenses(doc, token)).then(lenses => {
+            this.clearCache(doc.uri.toString());
+
             if (Array.isArray(lenses)) {
                 return lenses.map(lens => {
                     const id = this.cacheId++;
@@ -50,7 +61,13 @@ export class CodeLensAdapter {
                         range: Converter.fromRange(lens.range)!,
                         command: lens.command ? Converter.toInternalCommand(lens.command) : undefined
                     }, id);
-                    this.cache.set(id, lens);
+                    let docCache = this.cache.get(doc.uri.toString());
+                    if (!docCache) {
+                        docCache = new Map<number, theia.CodeLens>();
+                        this.cache.set(doc.uri.toString(), docCache);
+                    }
+                    docCache.set(id, lens);
+
                     return lensSymbol;
                 });
             }
@@ -59,7 +76,11 @@ export class CodeLensAdapter {
     }
 
     resolveCodeLens(resource: URI, symbol: CodeLensSymbol, token: theia.CancellationToken): Promise<CodeLensSymbol | undefined> {
-        const lens = this.cache.get(ObjectIdentifier.of(symbol));
+        const docCache = this.cache.get(resource.toString());
+        if (!docCache) {
+            return Promise.resolve(undefined);
+        }
+        const lens = docCache.get(ObjectIdentifier.of(symbol));
         if (!lens) {
             return Promise.resolve(undefined);
         }
@@ -76,5 +97,14 @@ export class CodeLensAdapter {
             symbol.command = Converter.toInternalCommand(newLens.command ? newLens.command : CodeLensAdapter.BAD_CMD);
             return symbol;
         });
+    }
+
+    private clearCache(affectedUri?: string): void {
+        if (affectedUri) {
+            const cacheToClear = this.cache.get(affectedUri);
+            if (cacheToClear) {
+                cacheToClear.clear();
+            }
+        }
     }
 }

--- a/packages/plugin-ext/src/plugin/tasks/task-provider.ts
+++ b/packages/plugin-ext/src/plugin/tasks/task-provider.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Red Hat, Inc. and others.
+ * Copyright (C) 2018-2019 Red Hat, Inc. and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,6 +27,8 @@ export class TaskProviderAdapter {
 
     provideTasks(token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         return Promise.resolve(this.provider.provideTasks(token)).then(tasks => {
+            this.cache.clear();
+
             if (!Array.isArray(tasks)) {
                 return undefined;
             }


### PR DESCRIPTION
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

For the following adapters:
* CodeLensAdapter
* LinkProviderAdapter
* TaskProviderAdapter
* CompletionAdapter
 the cache of items gets cleared every time a new set of items is requested as well as a text document gets closed.