### PR TITLE
Fix converting of task with custom type

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.spec.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.spec.ts
@@ -169,16 +169,18 @@ describe('Type converters:', () => {
     });
 
     describe('convert tasks:', () => {
-        const type = 'shell';
+        const customType = 'custom';
+        const shellType = 'shell';
         const label = 'yarn build';
         const source = 'source';
         const command = 'yarn';
+        const commandLine = 'yarn run build';
         const args = ['run', 'build'];
         const cwd = '/projects/theia';
         const additionalProperty = 'some property';
 
         const shellTaskDto: ProcessTaskDto = {
-            type,
+            type: shellType,
             label,
             source,
             scope: undefined,
@@ -192,7 +194,7 @@ describe('Type converters:', () => {
             name: label,
             source,
             definition: {
-                type,
+                type: shellType,
                 additionalProperty
             },
             execution: {
@@ -204,24 +206,39 @@ describe('Type converters:', () => {
             }
         };
 
-        const taskDtoWithCommandLine: ProcessTaskDto = {
-            type,
-            label,
-            source,
-            scope: undefined,
-            command,
-            args,
-            options: { cwd }
-        };
-
         const pluginTaskWithCommandLine: theia.Task = {
             name: label,
             source,
             definition: {
-                type
+                type: shellType,
+                additionalProperty
             },
             execution: {
-                commandLine: 'yarn run build',
+                commandLine,
+                options: {
+                    cwd
+                }
+            }
+        };
+
+        const customTaskDto: ProcessTaskDto = { ...shellTaskDto, type: customType };
+
+        const customPluginTask: theia.Task = {
+            ...shellPluginTask, definition: {
+                type: customType,
+                additionalProperty
+            }
+        };
+
+        const customPluginTaskWithCommandLine: theia.Task = {
+            name: label,
+            source,
+            definition: {
+                type: customType,
+                additionalProperty
+            },
+            execution: {
+                commandLine,
                 options: {
                     cwd
                 }
@@ -252,7 +269,34 @@ describe('Type converters:', () => {
 
             // then
             assert.notEqual(result, undefined);
-            assert.deepEqual(result, taskDtoWithCommandLine);
+            assert.deepEqual(result, shellTaskDto);
+        });
+
+        it('should convert task with custom type to dto', () => {
+            // when
+            const result: TaskDto | undefined = Converter.fromTask(customPluginTask);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, customTaskDto);
+        });
+
+        it('should convert task with custom type from dto', () => {
+            // when
+            const result: theia.Task = Converter.toTask(customTaskDto);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, customPluginTask);
+        });
+
+        it('should convert to task dto from custom task with commandline', () => {
+            // when
+            const result: TaskDto | undefined = Converter.fromTask(customPluginTaskWithCommandLine);
+
+            // then
+            assert.notEqual(result, undefined);
+            assert.deepEqual(result, customTaskDto);
         });
     });
 

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -651,7 +651,8 @@ export function toTask(taskDto: TaskDto): theia.Task {
         result.execution = getProcessExecution(taskDto as ProcessTaskDto);
     }
 
-    if (taskType === 'shell') {
+    const execution = { command, args, options };
+    if (taskType === 'shell' || types.ShellExecution.is(execution)) {
         result.execution = getShellExecution(taskDto as ProcessTaskDto);
     }
 


### PR DESCRIPTION
#### What it does
The PR allows to fix converting of a task configuration with custom type which has 'execution' field.

#### How to test
1. Tests [was provided](https://github.com/theia-ide/theia/pull/5591/files#diff-b3df0db75c45821ba2bcbd249d9f7eb7R275) within the PR.

2. [toTask](https://github.com/theia-ide/theia/blob/20d60b35d60c8a954787483e01d5d0d14fb30278/packages/plugin-ext/src/plugin/type-converters.ts#L625) method is used by [TaskProviderAdapter](https://github.com/theia-ide/theia/blob/master/packages/plugin-ext/src/plugin/tasks/task-provider.ts#L55), so I provided
the simple sample to have ability to test my changes.

So you can:
  - git clone https://github.com/RomanNikitenko/task-provider-plugin.git
  - build project and copy it to /theia/plugins folder
  - start theia project
  - go to Terminal -> Run task and configure 'build' task
  - run the configured 'build' task with 'customType'
 
The sample provides logs in 'Test Channel' of 'Output' tab.
So you can see a task configuration which is provided within `=== PLUGIN === provide task:` 
It contains `execution` section.

After task running you can see configuration for resolving  within `=== PLUGIN === resolve task:` 
It does not contain `execution` section for master branch but contains this section for branch with my changes. 
 

  

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

