### PR TITLE
Call `node-gyp install` before rebuilds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "prepare": "node scripts/skip-prepare || ( yarn prepare:travis && yarn rebuild:clean && yarn build:clean && yarn prepare:hoisting )",
     "prepare:travis": "node scripts/prepare-travis",
     "prepare:hoisting": "theia check:hoisted -s",
+    "preinstall": "node-gyp install",
     "build": "run build",
     "build:clean": "run prepare",
     "docs": "rimraf gh-pages/docs/next && typedoc --tsconfig configs/typedoc-tsconfig.json --options configs/typedoc.json",


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

yarn will call `node-gyp install` at `preinstall` process (means before called `node-gyp rebuild` in parallel).

It will suppress sporadic build errors like eclipse/che-theia#283 #5168.
(As far as I tested, it won't fix errors completely but will reduce.)

As [the comment by the dev of node-gyp](https://github.com/nodejs/node-gyp/issues/1780#issuecomment-503976718), this will work as a workaround.