### PR TITLE
[git] Rename Merge Changes group

### DIFF
--- a/packages/git/src/browser/git-scm-provider.ts
+++ b/packages/git/src/browser/git-scm-provider.ts
@@ -151,7 +151,7 @@ export class GitScmProvider implements ScmProvider {
                 }
             }
         }
-        state.groups.push(await this.createGroup('merge', 'Merged Changes', state.mergeChanges, true));
+        state.groups.push(await this.createGroup('merge', 'Merge Changes', state.mergeChanges, true));
         if (token.isCancellationRequested) {
             return;
         }


### PR DESCRIPTION
Instead of `Merged Changes` it should be `Merge Changes` to properly indicate the state of changes.

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>