### PR TITLE
[ci] Test replace ffmpeg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,11 @@ cache:
 # end_cache_directories
   - packages/java-debug/download
   - packages/debug-nodejs/download
+before_cache:
+  # Runs before the cache is updated, after successful CI
+  - rm -f node_modules/@theia/electron/post-install.log
+  - rm -rf node_modules/@theia/electron/download
+  - rm -rf node_modules/electron
 branches:
   only:
   - master
@@ -97,8 +102,9 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
   - export PATH=$HOME/.yarn/bin:$PATH
 install:
-  - THEIA_SKIP_NPM_PREPARE=1 yarn install
-  - npx electron-codecs-test
+  - THEIA_SKIP_NPM_PREPARE=1 yarn install --skip-integrity-check
+  - npx electron-replace-ffmpeg # re-download library (in case it was cached)
+  - npx electron-codecs-test # test library
   - yarn prepare
   - scripts/check_git_status.sh
 script:
@@ -132,7 +138,7 @@ jobs:
     install: skip
     before_deploy:
       - |
-        if ! [ "$BEFORE_DEPLOY_RUN" ]; then 
+        if ! [ "$BEFORE_DEPLOY_RUN" ]; then
           export BEFORE_DEPLOY_RUN=1
           printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc
           yarn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,8 @@ install:
   - netsh advfirewall firewall add rule name="SeleniumIn" dir=in action=allow protocol=TCP localport=4444
   - netsh advfirewall firewall add rule name="SeleniumOut" dir=out action=allow protocol=TCP localport=4444
   - cmd: set THEIA_SKIP_NPM_PREPARE=1 && yarn install
+  - npx rimraf node_modules/@theia/electron/download
+  - npx electron-replace-ffmpeg
   - npx electron-codecs-test
 
 before_build:

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -27,7 +27,7 @@ async function main() {
         console.log('@theia/electron last logs:');
         console.log(fs.readFileSync(electronCodecTestLogPath, { encoding: 'utf8' }).trimRight());
     } else if (!process.env.THEIA_ELECTRON_SKIP_REPLACE_FFMPEG) {
-        throw new Error('Cannot find the log file for the Electron codecs test.');
+        console.error('Cannot find the log file for the Electron codecs test.');
     }
 }
 


### PR DESCRIPTION
This way ensures that despite the caching done in our CI/CD, the
replacement scripts still work, and what we pull is clean.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
