### PR TITLE
[search-in-workspace] update the 'Replace All' disabled state

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -420,11 +420,17 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
     protected handleBlurReplaceInputBox = () => this.contextKeyService.setReplaceInputBoxFocus(false);
 
     protected renderReplaceAllButtonContainer(): React.ReactNode {
+        // The `Replace All` button is enabled if there is a search term present with results.
+        const enabled: boolean = this.searchTerm !== '' && this.resultNumber > 0;
         return <div className='replace-all-button-container'>
             <span
                 title='Replace All'
-                className={`replace-all-button${this.searchTerm === '' ? ' disabled' : ''}`}
-                onClick={() => this.resultTreeWidget.replace(undefined)}>
+                className={`replace-all-button${enabled ? ' ' : ' disabled'}`}
+                onClick={() => {
+                    if (enabled) {
+                        this.resultTreeWidget.replace(undefined);
+                    }
+                }}>
             </span>
         </div>;
     }


### PR DESCRIPTION
Fixes #5610

- updated the logic for disabling the `Replace All` button in the search-in-workspace
to only enable the button if there currently is a search term and results are present.
- updated the `onClick` event to respect the `disabled` state.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
