### PR TITLE
[travis] Fix publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ jobs:
         if ! [ "$BEFORE_DEPLOY_RUN" ]; then
           export BEFORE_DEPLOY_RUN=1
           printf "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n" >> ~/.npmrc
-          yarn
+          THEIA_SKIP_NPM_PREPARE=1 yarn install --skip-integrity-check # fix cache we meddled-with
           yarn run docs
         fi
     deploy:


### PR DESCRIPTION
The electron-related packages we remove from the Travis cache are causing
publishing problems for "next" packages. Running "THEIA_SKIP_NPM_PREPARE=1
yarn install --skip-integrity-check" is a quick way to have yarn fetch a
fresh version of what's not in the cache.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
