### PR TITLE
fix extensions webview route on windows

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -55,7 +55,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         // redefine property
         Object.defineProperty(panel.webview, 'html', {
             set: function (html: string) {
-                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
+                const newHtml = html.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
                 this.checkIsDisposed();
                 if (this._html !== newHtml) {
                     this._html = newHtml;
@@ -68,7 +68,7 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
         const originalPostMessage = panel.webview.postMessage;
         panel.webview.postMessage = (message: any): PromiseLike<boolean> => {
             const decoded = JSON.stringify(message);
-            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), '/webview/');
+            const newMessage = decoded.replace(new RegExp('vscode-resource:/', 'g'), 'webview/');
             return originalPostMessage.call(panel.webview, JSON.parse(newMessage));
         };
 

--- a/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
+++ b/packages/plugin-ext/src/main/browser/webview/theme-rules-service.ts
@@ -137,7 +137,7 @@ export class ThemeRulesService {
                 path = this.isDark() ? value.dark : value.light;
             }
             if (path.startsWith('/')) {
-                path = `/webview${path}`;
+                path = `webview${path}`;
             }
             cssRules.push(`.webview-icon.${key}-file-icon::before { background-image: url(${path}); }`);
         });

--- a/packages/plugin-ext/src/main/node/plugin-service.ts
+++ b/packages/plugin-ext/src/main/node/plugin-service.ts
@@ -16,6 +16,7 @@
 import * as express from 'express';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { injectable } from 'inversify';
+import { FileUri } from '@theia/core/lib/node';
 
 const pluginPath = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + './theia/plugins/';
 
@@ -28,11 +29,7 @@ export class PluginApiContribution implements BackendApplicationContribution {
         });
 
         app.get('/webview/:path(*)', (req, res) => {
-            let filePath: string = req.params.path;
-            if (filePath.charAt(0) !== '/') {
-                filePath = '/' + filePath;
-            }
-            res.sendFile(filePath);
+            res.sendFile(FileUri.fsPath('file:/' + req.params.path));
         });
     }
 }

--- a/packages/plugin-ext/src/plugin/webviews.ts
+++ b/packages/plugin-ext/src/plugin/webviews.ts
@@ -150,7 +150,7 @@ export class WebviewImpl implements theia.Webview {
         this.checkIsDisposed();
         // replace theia-resource: content in the given message
         const decoded = JSON.stringify(message);
-        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
+        let newMessage = decoded.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
         if (this._options && this._options.localResourceRoots) {
             newMessage = this.filterLocalRoots(newMessage, this._options.localResourceRoots);
         }
@@ -191,7 +191,7 @@ export class WebviewImpl implements theia.Webview {
     }
 
     set html(html: string) {
-        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), '/webview/');
+        let newHtml = html.replace(new RegExp('theia-resource:/', 'g'), 'webview/');
         if (this._options && this._options.localResourceRoots) {
             newHtml = this.filterLocalRoots(newHtml, this._options.localResourceRoots);
         }


### PR DESCRIPTION
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>

Removed what seems to be redundant check of having a leading slash on file path when serving /webview/ route.
This also made this flow not working on windows.