### PR TITLE
[vscode] basic support of activation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Breaking changes:
 
 - [plugin] fixed typo in 'HostedInstanceState' enum from RUNNNING to RUNNING in `plugin-dev` extension
 - [plugin] removed member `processOptions` from `AbstractHostedInstanceManager` as it is not initialized or used
-- [plugin] added basic support of activation events [#5622](https://github.com/theia-ide/theia/pull/5622)
+- [plugin] added support of activation events [#5622](https://github.com/theia-ide/theia/pull/5622)
   - `HostedPluginSupport` is refactored to support multiple `PluginManagerExt` properly
 
 ## v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
 
 - [plugin] fixed typo in 'HostedInstanceState' enum from RUNNNING to RUNNING in `plugin-dev` extension
 - [plugin] removed member `processOptions` from `AbstractHostedInstanceManager` as it is not initialized or used
+- [plugin] added basic support of activation events [#5622](https://github.com/theia-ide/theia/pull/5622)
+  - `HostedPluginSupport` is refactored to support multiple `PluginManagerExt` properly
 
 ## v0.8.0
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -36,10 +36,14 @@ export const doInitialization: BackendInitializationFn = (apiFactory: PluginAPIF
 
     // replace command API as it will send only the ID as a string parameter
     const registerCommand = vscode.commands.registerCommand;
-    vscode.commands.registerCommand = function (command: any, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): any {
+    vscode.commands.registerCommand = function (command: theia.CommandDescription | string, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): any {
         // use of the ID when registering commands
-        if (typeof command === 'string' && handler) {
-            return vscode.commands.registerHandler(command, handler, thisArg);
+        if (typeof command === 'string') {
+            const commands = plugin.model.contributes && plugin.model.contributes.commands;
+            if (handler && commands && commands.some(item => item.command === command)) {
+                return vscode.commands.registerHandler(command, handler, thisArg);
+            }
+            return registerCommand({ id: command }, handler, thisArg);
         }
         return registerCommand(command, handler, thisArg);
     };

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -80,6 +80,7 @@ export interface PluginInitData {
     workspaceState: KeysToKeysToAnyValue;
     env: EnvInit;
     extApi?: ExtPluginApi[];
+    activationEvents: string[]
 }
 
 export interface PreferenceData {
@@ -163,6 +164,8 @@ export interface PluginManagerExt {
     $init(pluginInit: PluginInitData, configStorage: ConfigStorage): PromiseLike<void>;
 
     $updateStoragePath(path: string | undefined): PromiseLike<void>;
+
+    $activateByEvent(event: string): Promise<void>;
 }
 
 export interface CommandRegistryMain {

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -49,6 +49,7 @@ export interface PluginPackage {
     description: string;
     contributes?: PluginPackageContribution;
     packagePath: string;
+    activationEvents?: string[];
 }
 export namespace PluginPackage {
     export function toPluginUrl(pck: PluginPackage, relativePath: string): string {

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -16,11 +16,10 @@
 
 // tslint:disable:no-any
 
-import { injectable, inject, interfaces, named } from 'inversify';
+import { injectable, inject, interfaces, named, postConstruct } from 'inversify';
 import { PluginWorker } from '../../main/browser/plugin-worker';
 import { HostedPluginServer, PluginMetadata, getPluginId } from '../../common/plugin-protocol';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
-import { MAIN_RPC_CONTEXT, ConfigStorage, PluginManagerExt } from '../../api/plugin-api';
 import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../api/rpc-protocol';
 import { ILogger, ContributionProvider } from '@theia/core';
@@ -35,6 +34,9 @@ import { getPreferences } from '../../main/browser/preference-registry-main';
 import { PluginServer } from '../../common/plugin-protocol';
 import { KeysToKeysToAnyValue } from '../../common/types';
 import { FileStat } from '@theia/filesystem/lib/common/filesystem';
+import { PluginManagerExt, MAIN_RPC_CONTEXT } from '../../common';
+
+export type PluginHost = 'frontend' | string;
 
 @injectable()
 export class HostedPluginSupport {
@@ -62,26 +64,31 @@ export class HostedPluginSupport {
     @inject(PreferenceProviderProvider)
     protected readonly preferenceProviderProvider: PreferenceProviderProvider;
 
+    @inject(PreferenceServiceImpl)
+    private readonly preferenceServiceImpl: PreferenceServiceImpl;
+
+    @inject(PluginPathsService)
+    private readonly pluginPathsService: PluginPathsService;
+
+    @inject(StoragePathService)
+    private readonly storagePathService: StoragePathService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
     private theiaReadyPromise: Promise<any>;
-    private frontendExtManagerProxy: PluginManagerExt;
-    private backendExtManagerProxy: PluginManagerExt;
+
+    protected readonly managers: PluginManagerExt[] = [];
 
     // loaded plugins per #id
-    private loadedPlugins: Set<string> = new Set<string>();
+    private readonly loadedPlugins = new Set<string>();
 
-    // per #hostKey
-    private rpc: Map<string, RPCProtocol> = new Map<string, RPCProtocol>();
+    protected readonly activationEvents = new Set<string>();
 
-    constructor(
-        @inject(PreferenceServiceImpl) private readonly preferenceServiceImpl: PreferenceServiceImpl,
-        @inject(PluginPathsService) private readonly pluginPathsService: PluginPathsService,
-        @inject(StoragePathService) private readonly storagePathService: StoragePathService,
-        @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService,
-    ) {
+    @postConstruct()
+    protected init(): void {
         this.theiaReadyPromise = Promise.all([this.preferenceServiceImpl.ready, this.workspaceService.roots]);
-        this.storagePathService.onStoragePathChanged(path => {
-            this.updateStoragePath(path);
-        });
+        this.storagePathService.onStoragePathChanged(path => this.updateStoragePath(path));
     }
 
     checkAndLoadPlugin(container: interfaces.Container): void {
@@ -112,93 +119,54 @@ export class HostedPluginSupport {
         }).catch(e => console.error(e));
     }
 
-    loadPlugins(initData: PluginsInitializationData, container: interfaces.Container): void {
+    async loadPlugins(initData: PluginsInitializationData, container: interfaces.Container): Promise<void> {
         // don't load plugins twice
         initData.plugins = initData.plugins.filter(value => !this.loadedPlugins.has(value.model.id));
 
-        const confStorage: ConfigStorage = {
-            hostLogPath: initData.logPath,
-            hostStoragePath: initData.storagePath || ''
-        };
-        const [frontend, backend] = this.initContributions(initData.plugins);
-        this.theiaReadyPromise.then(() => {
-            if (frontend) {
-                const worker = new PluginWorker();
-                const hostedExtManager = worker.rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
-                hostedExtManager.$init({
-                    plugins: initData.plugins,
-                    preferences: getPreferences(this.preferenceProviderProvider, initData.roots),
-                    globalState: initData.globalStates,
-                    workspaceState: initData.workspaceStates,
-                    env: { queryParams: getQueryParameters(), language: navigator.language },
-                    extApi: initData.pluginAPIs
-                }, confStorage);
-                setUpPluginApi(worker.rpc, container);
-                this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(worker.rpc, container));
-                this.frontendExtManagerProxy = hostedExtManager;
-            }
-
-            if (backend) {
-                // sort plugins per host
-                const pluginsPerHost = initData.plugins.reduce((map: any, pluginMetadata) => {
-                    const host = pluginMetadata.host;
-                    if (!map[host]) {
-                        map[host] = [pluginMetadata];
-                    } else {
-                        map[host].push(pluginMetadata);
-                    }
-                    return map;
-                }, {});
-
-                // create one RPC per host and init.
-                Object.keys(pluginsPerHost).forEach(hostKey => {
-                    const plugins: PluginMetadata[] = pluginsPerHost[hostKey];
-                    let pluginID = hostKey;
-                    if (plugins.length >= 1) {
-                        pluginID = getPluginId(plugins[0].model);
-                    }
-
-                    let rpc = this.rpc.get(hostKey);
-                    if (!rpc) {
-                        rpc = this.createServerRpc(pluginID, hostKey);
-                        setUpPluginApi(rpc, container);
-                        this.rpc.set(hostKey, rpc);
-                    }
-
-                    const hostedExtManager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
-                    hostedExtManager.$init({
-                        plugins: plugins,
-                        preferences: getPreferences(this.preferenceProviderProvider, initData.roots),
-                        globalState: initData.globalStates,
-                        workspaceState: initData.workspaceStates,
-                        env: { queryParams: getQueryParameters(), language: navigator.language },
-                        extApi: initData.pluginAPIs
-                    }, confStorage);
-                    this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(rpc!, container));
-                    this.backendExtManagerProxy = hostedExtManager;
-                });
-            }
-
-            // update list with loaded plugins
-            initData.plugins.forEach(value => this.loadedPlugins.add(value.model.id));
-        });
-    }
-
-    private initContributions(pluginsMetadata: PluginMetadata[]): [boolean, boolean] {
-        const result: [boolean, boolean] = [false, false];
-        for (const plugin of pluginsMetadata) {
-            if (plugin.model.entryPoint.frontend) {
-                result[0] = true;
-            } else {
-                result[1] = true;
-            }
-
+        const hostToPlugins = new Map<PluginHost, PluginMetadata[]>();
+        for (const plugin of initData.plugins) {
+            const host = plugin.model.entryPoint.frontend ? 'frontend' : plugin.host;
+            const plugins = hostToPlugins.get(plugin.host) || [];
+            plugins.push(plugin);
+            hostToPlugins.set(host, plugins);
             if (plugin.model.contributes) {
                 this.contributionHandler.handleContributions(plugin.model.contributes);
             }
         }
+        await this.theiaReadyPromise;
+        for (const [host, plugins] of hostToPlugins) {
+            const pluginId = getPluginId(plugins[0].model);
+            const rpc = this.initRpc(host, pluginId, container);
+            this.initPluginHostManager(rpc, { ...initData, plugins });
+        }
 
-        return result;
+        // update list with loaded plugins
+        initData.plugins.forEach(value => this.loadedPlugins.add(value.model.id));
+    }
+
+    protected initRpc(host: PluginHost, pluginId: string, container: interfaces.Container): RPCProtocol {
+        const rpc = host === 'frontend' ? new PluginWorker().rpc : this.createServerRpc(pluginId, host);
+        setUpPluginApi(rpc, container);
+        this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(rpc, container));
+        return rpc;
+    }
+
+    protected initPluginHostManager(rpc: RPCProtocol, data: PluginsInitializationData): void {
+        const manager = rpc.getProxy(MAIN_RPC_CONTEXT.HOSTED_PLUGIN_MANAGER_EXT);
+        this.managers.push(manager);
+
+        manager.$init({
+            plugins: data.plugins,
+            preferences: getPreferences(this.preferenceProviderProvider, data.roots),
+            globalState: data.globalStates,
+            workspaceState: data.workspaceStates,
+            env: { queryParams: getQueryParameters(), language: navigator.language },
+            extApi: data.pluginAPIs,
+            activationEvents: [...this.activationEvents]
+        }, {
+                hostLogPath: data.logPath,
+                hostStoragePath: data.storagePath || ''
+            });
     }
 
     private createServerRpc(pluginID: string, hostID: string): RPCProtocol {
@@ -214,11 +182,18 @@ export class HostedPluginSupport {
     }
 
     private updateStoragePath(path: string | undefined): void {
-        if (this.frontendExtManagerProxy) {
-            this.frontendExtManagerProxy.$updateStoragePath(path);
+        for (const manager of this.managers) {
+            manager.$updateStoragePath(path);
         }
-        if (this.backendExtManagerProxy) {
-            this.backendExtManagerProxy.$updateStoragePath(path);
+    }
+
+    activateByEvent(activationEvent: string): void {
+        if (this.activationEvents.has(activationEvent)) {
+            return;
+        }
+        this.activationEvents.add(activationEvent);
+        for (const manager of this.managers) {
+            manager.$activateByEvent(activationEvent);
         }
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -61,8 +61,12 @@ class ActivatedPlugin {
 
 export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
-    private registry = new Map<string, Plugin>();
-    private activatedPlugins = new Map<string, ActivatedPlugin>();
+    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*']);
+
+    private readonly registry = new Map<string, Plugin>();
+    private readonly activations = new Map<string, (() => Promise<void>)[] | undefined>();
+    private readonly loadedPlugins = new Set<string>();
+    private readonly activatedPlugins = new Map<string, ActivatedPlugin>();
     private pluginActivationPromises = new Map<string, Deferred<void>>();
     private pluginContextsMap: Map<string, theia.PluginContext> = new Map();
     private storageProxy: KeyValueStorageProxy;
@@ -121,32 +125,65 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
         const [plugins, foreignPlugins] = this.host.init(pluginInit.plugins);
         // add foreign plugins
         for (const plugin of foreignPlugins) {
-            this.registry.set(plugin.model.id, plugin);
+            this.registerPlugin(plugin, configStorage);
         }
         // add own plugins, before initialization
         for (const plugin of plugins) {
-            this.registry.set(plugin.model.id, plugin);
+            this.registerPlugin(plugin, configStorage);
         }
 
-        // run plugins
-        for (const plugin of plugins) {
-            if (!plugin.pluginPath) {
-                continue;
-            }
-            const pluginMain = this.host.loadPlugin(plugin);
-            // able to load the plug-in ?
-            if (pluginMain !== undefined) {
-                await this.startPlugin(plugin, configStorage, pluginMain);
-            } else {
-                console.error(`Unable to load a plugin from "${plugin.pluginPath}"`);
-            }
+        // run eager plugins
+        await this.$activateByEvent('*');
+        for (const activationEvent of pluginInit.activationEvents) {
+            await this.$activateByEvent(activationEvent);
         }
+        // TODO eager activate by `workspaceContains`
 
         if (this.host.loadTests) {
             return this.host.loadTests();
         }
         this.fireOnDidChange();
+
         return Promise.resolve();
+    }
+
+    protected registerPlugin(plugin: Plugin, configStorage: ConfigStorage): void {
+        this.registry.set(plugin.model.id, plugin);
+        if (plugin.pluginPath && Array.isArray(plugin.rawModel.activationEvents)) {
+            const activation = () => this.loadPlugin(plugin, configStorage);
+            const unsupportedActivationEvents = plugin.rawModel.activationEvents.filter(e => !PluginManagerExtImpl.SUPPORTED_ACTIVATION_EVENTS.has(e.split(':')[0]));
+            if (unsupportedActivationEvents.length) {
+                console.warn(`Unsupported activation events: ${unsupportedActivationEvents}, please open an issue. ${plugin.model.id} extension will be activated eagerly`);
+                this.setActivation('*', activation);
+            } else {
+                for (let activationEvent of plugin.rawModel.activationEvents) {
+                    if (activationEvent === 'onUri') {
+                        activationEvent = `onUri:${plugin.model.id}`;
+                    }
+                    this.setActivation(activationEvent, activation);
+                }
+            }
+        }
+    }
+    protected setActivation(activationEvent: string, activation: () => Promise<void>) {
+        const activations = this.activations.get(activationEvent) || [];
+        activations.push(activation);
+        this.activations.set(activationEvent, activations);
+    }
+
+    protected async loadPlugin(plugin: Plugin, configStorage: ConfigStorage): Promise<void> {
+        if (this.loadedPlugins.has(plugin.model.id)) {
+            return;
+        }
+        this.loadedPlugins.add(plugin.model.id);
+
+        const pluginMain = this.host.loadPlugin(plugin);
+        // able to load the plug-in ?
+        if (pluginMain !== undefined) {
+            await this.startPlugin(plugin, configStorage, pluginMain);
+        } else {
+            console.error(`Unable to load a plugin from "${plugin.pluginPath}"`);
+        }
     }
 
     $updateStoragePath(path: string | undefined): PromiseLike<void> {
@@ -154,6 +191,17 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             pluginContext.storagePath = path ? join(path, pluginId) : undefined;
         });
         return Promise.resolve();
+    }
+
+    async $activateByEvent(activationEvent: string): Promise<void> {
+        const activations = this.activations.get(activationEvent);
+        if (!activations) {
+            return;
+        }
+        this.activations.set(activationEvent, undefined);
+        while (activations.length) {
+            await activations.pop()!();
+        }
     }
 
     // tslint:disable-next-line:no-any

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -61,7 +61,7 @@ class ActivatedPlugin {
 
 export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
-    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*']);
+    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*', 'onLanguage']);
 
     private readonly registry = new Map<string, Plugin>();
     private readonly activations = new Map<string, (() => Promise<void>)[] | undefined>();

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -61,7 +61,7 @@ class ActivatedPlugin {
 
 export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
-    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*', 'onLanguage']);
+    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*', 'onLanguage', 'onCommand']);
 
     private readonly registry = new Map<string, Plugin>();
     private readonly activations = new Map<string, (() => Promise<void>)[] | undefined>();
@@ -153,7 +153,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             const activation = () => this.loadPlugin(plugin, configStorage);
             const unsupportedActivationEvents = plugin.rawModel.activationEvents.filter(e => !PluginManagerExtImpl.SUPPORTED_ACTIVATION_EVENTS.has(e.split(':')[0]));
             if (unsupportedActivationEvents.length) {
-                console.warn(`Unsupported activation events: ${unsupportedActivationEvents}, please open an issue. ${plugin.model.id} extension will be activated eagerly`);
+                console.warn(`${plugin.model.id} extension will be activated eagerly.`);
+                console.warn(`Unsupported activation events: ${unsupportedActivationEvents}, please open an issue: https://github.com/theia-ide/theia/issues/new`);
                 this.setActivation('*', activation);
             } else {
                 for (let activationEvent of plugin.rawModel.activationEvents) {
@@ -165,7 +166,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             }
         }
     }
-    protected setActivation(activationEvent: string, activation: () => Promise<void>) {
+    protected setActivation(activationEvent: string, activation: () => Promise<void>): void {
         const activations = this.activations.get(activationEvent) || [];
         activations.push(activation);
         this.activations.set(activationEvent, activations);


### PR DESCRIPTION
#### What it does
- https://github.com/theia-ide/theia/issues/4199 - provides basic mechanism for activation events:
  - compatibility: if an activation event is not supported yet then an extension will be activated eagerly with `*`
  - support of `onLanguage` activation event
  - support of `onCommand` activation event

#### How to test
- unsupported events: deploy vscode go extension and check that it is deployed eagerly since it has unsupported activation events
- `onLanguage` event: deploy https://github.com/akosyakov/lang-activation-event/blob/master/lang-activation-event-0.0.1.vsix and test that `Hello World` notification appears only when typescript file is opened
- `onCommand` event: deploy https://github.com/akosyakov/command-activation-event/blob/master/command-activation-event-0.0.1.vsix and test that `Hello World` command is available without a plugin activation and that it shows `Hello World` notification on the execution

See how to deploy vscode extension here: https://github.com/theia-ide/theia/wiki/Testing-VS-Code-Extensions

#### Review Checklist
<!-- For completed items, change [ ] to [x].  -->
<!-- For inapplicable items, cross out with `[ ] foo` to `[x] ~~foo~~`.  -->

- [x] as an author I have carefully reviewed and thoroughly tested my changes.
- [x] commits are signed-off: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md#sign-your-work
- [x] commit history is rebased on master and contains only meaningful commits and changes (less are usually better)
  - for example use `git pull -r` or `git fetch && git rebase` to pick up changes from the master
- [x] [changelog](https://github.com/theia-ide/theia/blob/master/CHANGELOG.md) is updated
- [x] breaking changes are justified and recorded in the changelog
- [x] ~~each new file has a proper copyright with the current year and the name of contributing entity (individual or company)~~
- [x] ~~new dependendencies are justified and [verified](https://github.com/theia-ide/theia/wiki/Registering-CQs#wip---new-ecd-theia-intellectual-property-clearance-approach-experimental)~~
- [x] ~~copied code is justified and [approved via a CQ](https://github.com/theia-ide/theia/wiki/Registering-CQs#case-3rd-party-project-code-copiedforked-from-another-project-into-eclipse-theia-maintained-by-us)~~
- [x] new code is aligned with [project organization](https://github.com/theia-ide/theia/wiki/Code-Organization) and [coding conventions](https://github.com/theia-ide/theia/wiki/Coding-Guidelines)
- [ ] each review approve is provided with a comment regarding whether functionallity is tested, design or code are aligned with project organization and conventions
  - an approve without comment should be dismissed
  - a reviewer should focus on requirements and design validation first, testing second and checking code alignment as the last