### PR TITLE
add 'title' to search result node

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -573,7 +573,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const icon = node.icon;
         return <div className='result'>
             <div className='result-head'>
-                <div className={`result-head-info noWrapInfo noselect ${node.selected ? 'selected' : ''}`}>
+                <div className={`result-head-info noWrapInfo noselect ${node.selected ? 'selected' : ''}`}
+                    title={new URI(node.fileUri).path.toString()}>
                     <span className={`file-icon ${icon || ''}`}></span>
                     <span className={'file-name'}>
                         {node.name}
@@ -593,7 +594,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
     protected renderResultLineNode(node: SearchInWorkspaceResultLineNode): React.ReactNode {
         const prefix = node.character > 26 ? '... ' : '';
-        return <div className={`resultLine noWrapInfo ${node.selected ? 'selected' : ''}`}>
+        return <div className={`resultLine noWrapInfo ${node.selected ? 'selected' : ''}`} title={node.lineText.trim()}>
             {this.searchInWorkspacePreferences['search.lineNumbers'] && <span className='theia-siw-lineNumber'>{node.line}</span>}
             <span>
                 {prefix + node.lineText.substr(0, node.character - 1).substr(-25)}


### PR DESCRIPTION
add feature:#5627
get file path when hover on the file node in the search result , get search result line when hover on the result, no need to click it and preview.
### demo:
![fix search result](https://user-images.githubusercontent.com/35068357/60577091-455ce980-9db1-11e9-80f0-8ffbdd2c7d9e.gif)
 


Signed-off-by: kpge <gekangping@126.com>
<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
