### PR TITLE
do not reopen current workspace

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -276,7 +276,8 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         const workspaceFolderOrWorkspaceFileUri = await this.fileDialogService.showOpenDialog(props, rootStat);
         if (workspaceFolderOrWorkspaceFileUri) {
             const destinationFolder = await this.fileSystem.getFileStat(workspaceFolderOrWorkspaceFileUri.toString());
-            if (destinationFolder) {
+            const current = this.workspaceService.workspace;
+            if (!current || (destinationFolder && current.uri !== destinationFolder.uri)) {
                 this.workspaceService.open(workspaceFolderOrWorkspaceFileUri);
                 return workspaceFolderOrWorkspaceFileUri;
             }


### PR DESCRIPTION
fixes  #5630
when do open workspace, check the selected file uri is not equal with current workspace uri
Signed-off-by: kpge <gekangping@126.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
