### PR TITLE
[workspace] do not re-open an already currently opened workspace

### DIFF
--- a/packages/workspace/src/browser/workspace-frontend-contribution.ts
+++ b/packages/workspace/src/browser/workspace-frontend-contribution.ts
@@ -179,7 +179,7 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
             canSelectFolders: true,
             canSelectFiles: true
         }, rootStat);
-        if (destinationUri) {
+        if (destinationUri && this.getCurrentWorkspaceUri().toString() !== destinationUri.toString()) {
             const destination = await this.fileSystem.getFileStat(destinationUri.toString());
             if (destination) {
                 if (destination.isDirectory) {
@@ -235,7 +235,8 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         };
         const [rootStat] = await this.workspaceService.roots;
         const destinationFolderUri = await this.fileDialogService.showOpenDialog(props, rootStat);
-        if (destinationFolderUri) {
+        if (destinationFolderUri &&
+            this.getCurrentWorkspaceUri().toString() !== destinationFolderUri.toString()) {
             const destinationFolder = await this.fileSystem.getFileStat(destinationFolderUri.toString());
             if (destinationFolder && destinationFolder.isDirectory) {
                 this.workspaceService.open(destinationFolderUri);
@@ -274,7 +275,8 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
         const props = await this.openWorkspaceOpenFileDialogProps();
         const [rootStat] = await this.workspaceService.roots;
         const workspaceFolderOrWorkspaceFileUri = await this.fileDialogService.showOpenDialog(props, rootStat);
-        if (workspaceFolderOrWorkspaceFileUri) {
+        if (workspaceFolderOrWorkspaceFileUri &&
+            this.getCurrentWorkspaceUri().toString() !== workspaceFolderOrWorkspaceFileUri.toString()) {
             const destinationFolder = await this.fileSystem.getFileStat(workspaceFolderOrWorkspaceFileUri.toString());
             if (destinationFolder) {
                 this.workspaceService.open(workspaceFolderOrWorkspaceFileUri);
@@ -381,6 +383,15 @@ export class WorkspaceFrontendContribution implements CommandContribution, Keybi
 
     private isElectron(): boolean {
         return environment.electron.is();
+    }
+
+    /**
+     * Get the current workspace URI.
+     *
+     * @returns the current workspace URI.
+     */
+    private getCurrentWorkspaceUri(): URI {
+        return new URI(this.workspaceService.workspace && this.workspaceService.workspace.uri);
     }
 
 }


### PR DESCRIPTION
Fixes #5630

**Description**

- fixes an issue that allows users to open a workspace that is currently opened. If the user had the preference `"workspace.preserveWindow"` set to `false` it would open an identical workspace in a new tab, and if it was set to `true` it would reload the workspace. Instead, an additional
check is performed to determine if the current workspace and the new destination are equal, and if they are a NOOP is instead performed by returning `undefined`.
- fixes issue present in `OPEN` and `OPEN_WORKSPACE` for both the browser and electron based applications.

The PR was tested with both folders, files, and multi-root workspaces on both the **browser** and **electron**.

**How to test**
1. open a workspace (ex: `A`)
2. attempt to re-open the workspace `A` using the menu `File` and `Open`
3. the workspace should not be re-opened in a new tab or the current one should not be reloaded depending on the preference `workspace.preserveWindow`


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
