### PR TITLE
Adjusted the plug-in related logging.

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -24,7 +24,7 @@ import { HostedPluginClient, ServerPluginRunner, PluginMetadata, PluginHostEnvir
 import { RPCProtocolImpl } from '../../api/rpc-protocol';
 import { MAIN_RPC_CONTEXT } from '../../api/plugin-api';
 import { HostedPluginCliContribution } from './hosted-plugin-cli-contribution';
-import {HostedPluginProcessesCache} from './hosted-plugin-processes-cache';
+import { HostedPluginProcessesCache } from './hosted-plugin-processes-cache';
 
 export interface IPCConnectionOptions {
     readonly serverName: string;
@@ -180,8 +180,8 @@ export class HostedPluginProcess implements ServerPluginRunner {
         }
 
         const childProcess = cp.fork(path.resolve(__dirname, 'plugin-host.js'), options.args, forkOptions);
-        childProcess.stdout.on('data', data => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${data.toString()}`));
-        childProcess.stderr.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString()}`));
+        childProcess.stdout.on('data', data => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
+        childProcess.stderr.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
 
         this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC started`);
         childProcess.once('exit', () => this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC exited`));

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -67,7 +67,8 @@ export class PluginHostRPC {
 
     // tslint:disable-next-line:no-any
     initContext(contextPath: string, plugin: Plugin): any {
-        console.log('PLUGIN_HOST(' + process.pid + '): initializing(' + contextPath + ')');
+        const { name, version } = plugin.rawModel;
+        console.log('PLUGIN_HOST(' + process.pid + '): initializing(' + name + '@' + version + ' with ' + contextPath + ')');
         try {
             const backendInit = require(contextPath);
             backendInit.doInitialization(this.apiFactory, plugin);


### PR DESCRIPTION
 - Got rid of the empty lines between the log entries.
 - Log the plug-in `name` and `version` when initializing.

From here: https://github.com/theia-ide/theia/pull/5622#issuecomment-508085371

Signed-off-by: Akos Kitta <kittaakos@typefox.io>


Before:
```
root INFO Theia app listening on http://localhost:3000.
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'command-activation-event-0.0.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/command-activation-event-0.0.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/command-activation-event-0.0.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'lang-activation-event-0.0.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/lang-activation-event-0.0.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/lang-activation-event-0.0.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'ms-vscode.Go-0.11.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/ms-vscode.Go-0.11.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/ms-vscode.Go-0.11.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix
root INFO Resolved "command-activation-event-0.0.1.vsix" to a VS Code extension "command-activation-event@0.0.1" with engines: { vscode: '^1.35.0' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix
root INFO Resolved "lang-activation-event-0.0.1.vsix" to a VS Code extension "lang-activation-event@0.0.1" with engines: { vscode: '^1.35.0' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix
root INFO Resolved "ms-vscode.Go-0.11.1.vsix" to a VS Code extension "Go@0.11.1" with engines: { vscode: '^1.25.0' }
root INFO Deploying backend plugin "command-activation-event@0.0.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix/extension/out/extension.js"
root INFO Deploying backend plugin "lang-activation-event@0.0.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix/extension/out/extension.js"
root INFO Deploying backend plugin "Go@0.11.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix/extension/out/src/goMain"
root WARN LanguagesFrontendContribution.onStart is slow, took: 132.11499998578802 ms
root INFO Using Git [2.20.1] from the PATH. (/usr/local/bin/git)
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/.theia
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/Desktop/vscode
root WARN EditorNavigationContribution.onStart is slow, took: 1096.8500000308268 ms
root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959) starting instance

root INFO Checking whether '--no-optional-locks' can be used with the current Git executable. Minimum required version is '2.15.0'.
root INFO '--no-optional-locks' is a valid Git option for the current Git version: '2.20.1'.
root INFO Config file tasks.json does not exist under file:///Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/Desktop/vscode/.vscode/launch.json
root INFO Started watching the git repository: file:///Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/Desktop/vscode/.vscode/settings.json
root INFO [nsfw-watcher: 64954] Started watching: /Users/akos.kitta/Desktop/vscode/build/lib/git.ts
root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): PluginManagerExtImpl/init()

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): initializing(/Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): initializing(/Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): initializing(/Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)

root INFO [hosted-plugin: 64959] Debugger contribution has been registered: go

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix/extension/out/extension.js)

root INFO [hosted-plugin: 64959] Congratulations, your extension "command-activation-event" is now active!

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix/extension/out/extension.js)

root INFO [hosted-plugin: 64959] PLUGIN_HOST(64959): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix/extension/out/src/goMain)

root INFO [hosted-plugin: 64959] Debug configuration provider has been registered: go
```


After:
```
root INFO Theia app listening on http://localhost:3000.
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'command-activation-event-0.0.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/command-activation-event-0.0.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/command-activation-event-0.0.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'lang-activation-event-0.0.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/lang-activation-event-0.0.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/lang-activation-event-0.0.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO unzipping the plugin ProxyPluginDeployerEntry {
  deployer:
   PluginVsCodeFileHandler {
     unpackedFolder:
      '/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked' },
  delegate:
   PluginDeployerEntryImpl {
     originId: 'local-dir:../../plugins',
     pluginId: 'ms-vscode.Go-0.11.1.vsix',
     map: Map {},
     changes: [],
     acceptedTypes: [],
     currentPath:
      '/Users/akos.kitta/git/theia/plugins/ms-vscode.Go-0.11.1.vsix',
     initPath:
      '/Users/akos.kitta/git/theia/plugins/ms-vscode.Go-0.11.1.vsix',
     resolved: true,
     resolvedByName: 'LocalDirectoryPluginDeployerResolver' },
  deployerName: 'PluginVsCodeFileHandler' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix
root INFO Resolved "command-activation-event-0.0.1.vsix" to a VS Code extension "command-activation-event@0.0.1" with engines: { vscode: '^1.35.0' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix
root INFO Resolved "lang-activation-event-0.0.1.vsix" to a VS Code extension "lang-activation-event@0.0.1" with engines: { vscode: '^1.35.0' }
root INFO PluginTheiaDirectoryHandler: accepting plugin with path /private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix
root INFO Resolved "ms-vscode.Go-0.11.1.vsix" to a VS Code extension "Go@0.11.1" with engines: { vscode: '^1.25.0' }
root INFO Deploying backend plugin "command-activation-event@0.0.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix/extension/out/extension.js"
root INFO Deploying backend plugin "lang-activation-event@0.0.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix/extension/out/extension.js"
root INFO Deploying backend plugin "Go@0.11.1" from "/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix/extension/out/src/goMain"
root WARN LanguagesFrontendContribution.onStart is slow, took: 140.46999998390675 ms
root INFO Using Git [2.20.1] from the PATH. (/usr/local/bin/git)
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/.theia
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/Desktop/vscode
root WARN EditorNavigationContribution.onStart is slow, took: 1016.5000000270084 ms
root INFO Checking whether '--no-optional-locks' can be used with the current Git executable. Minimum required version is '2.15.0'.
root INFO '--no-optional-locks' is a valid Git option for the current Git version: '2.20.1'.
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095) starting instance
root INFO Config file tasks.json does not exist under file:///Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/Desktop/vscode/.vscode/launch.json
root INFO Started watching the git repository: file:///Users/akos.kitta/Desktop/vscode
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/Desktop/vscode/.vscode/settings.json
root INFO [nsfw-watcher: 65090] Started watching: /Users/akos.kitta/Desktop/vscode/build/lib/git.ts
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): PluginManagerExtImpl/init()
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): initializing(command-activation-event@0.0.1 with /Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): initializing(lang-activation-event@0.0.1 with /Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): initializing(Go@0.11.1 with /Users/akos.kitta/git/theia/packages/plugin-ext-vscode/lib/node/plugin-vscode-init.js)
root INFO [hosted-plugin: 65095] Debugger contribution has been registered: go
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/command-activation-event-0.0.1.vsix/extension/out/extension.js)
root INFO [hosted-plugin: 65095] Congratulations, your extension "command-activation-event" is now active!
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/lang-activation-event-0.0.1.vsix/extension/out/extension.js)
root INFO [hosted-plugin: 65095] PLUGIN_HOST(65095): PluginManagerExtImpl/loadPlugin(/private/var/folders/k3/d2fkvv1j16v3_rz93k7f74180000gn/T/vscode-unpacked/ms-vscode.Go-0.11.1.vsix/extension/out/src/goMain)
root INFO [hosted-plugin: 65095] Debug configuration provider has been registered: go
```

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->