### PR TITLE
support debug activation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## v0.9.0
 
+- [plugin] added support of debug activation events [#5645](https://github.com/theia-ide/theia/pull/5645)
+
 Breaking changes:
 
 - [plugin] fixed typo in 'HostedInstanceState' enum from RUNNNING to RUNNING in `plugin-dev` extension
 - [plugin] removed member `processOptions` from `AbstractHostedInstanceManager` as it is not initialized or used
-- [plugin] added support of activation events [#5622](https://github.com/theia-ide/theia/pull/5622)
+- [plugin] added basic support of activation events [#5622](https://github.com/theia-ide/theia/pull/5622)
   - `HostedPluginSupport` is refactored to support multiple `PluginManagerExt` properly
 
 ## v0.8.0

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -243,3 +243,46 @@ export class Emitter<T> {
         this._disposed = true;
     }
 }
+
+export interface WaitUntilEvent {
+    // tslint:disable:no-any
+    /**
+     * Allows to pause the event loop until the provided thenable resolved.
+     *
+     * *Note:* It can only be called during event dispatch and not in an asynchronous manner
+     *
+     * @param thenable A thenable that delays execution.
+     */
+    waitUntil(thenable: Promise<any>): void;
+    // tslint:enable:no-any
+}
+export namespace WaitUntilEvent {
+    export async function fire<T extends WaitUntilEvent>(
+        emitter: Emitter<T>,
+        event: Pick<T, Exclude<keyof T, 'waitUntil'>>,
+        timeout: number | undefined = undefined
+    ): Promise<void> {
+        const waitables: Promise<void>[] = [];
+        const asyncEvent = Object.assign(event, {
+            // tslint:disable-next-line:no-any
+            waitUntil: (thenable: Promise<any>) => {
+                if (Object.isFrozen(waitables)) {
+                    throw new Error('waitUntil cannot be called asynchronously.');
+                }
+                waitables.push(thenable);
+            }
+        }) as T;
+        emitter.fire(asyncEvent);
+        // Asynchronous calls to `waitUntil` should fail.
+        Object.freeze(waitables);
+        delete asyncEvent['waitUntil'];
+        if (!waitables.length) {
+            return;
+        }
+        if (timeout !== undefined) {
+            await Promise.race([Promise.all(waitables), new Promise(resolve => setTimeout(resolve, timeout))]);
+        } else {
+            await Promise.all(waitables);
+        }
+    }
+}

--- a/packages/debug/src/browser/view/debug-threads-widget.ts
+++ b/packages/debug/src/browser/view/debug-threads-widget.ts
@@ -17,7 +17,6 @@
 import { injectable, inject, postConstruct, interfaces, Container } from 'inversify';
 import { MenuPath } from '@theia/core';
 import { TreeNode, NodeProps, SelectableTreeNode } from '@theia/core/lib/browser';
-import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { SourceTreeWidget, TreeElementNode } from '@theia/core/lib/browser/source-tree';
 import { DebugThreadsSource } from './debug-threads-source';
 import { DebugSession } from '../debug-session';
@@ -52,9 +51,6 @@ export class DebugThreadsWidget extends SourceTreeWidget {
 
     @inject(DebugViewModel)
     protected readonly viewModel: DebugViewModel;
-
-    @inject(SelectionService)
-    protected readonly selectionService: SelectionService;
 
     @inject(DebugCallStackItemTypeKey)
     protected readonly debugCallStackItemTypeKey: DebugCallStackItemTypeKey;
@@ -95,7 +91,6 @@ export class DebugThreadsWidget extends SourceTreeWidget {
         }
         this.updatingSelection = true;
         try {
-            let selection: number | undefined;
             const node = this.model.selectedNodes[0];
             if (TreeElementNode.is(node)) {
                 if (node.element instanceof DebugSession) {
@@ -104,13 +99,18 @@ export class DebugThreadsWidget extends SourceTreeWidget {
                 } else if (node.element instanceof DebugThread) {
                     node.element.session.currentThread = node.element;
                     this.debugCallStackItemTypeKey.set('thread');
-                    selection = node.element.raw.id;
                 }
             }
-            this.selectionService.selection = selection;
         } finally {
             this.updatingSelection = false;
         }
+    }
+
+    protected toContextMenuArgs(node: SelectableTreeNode): [number] | undefined {
+        if (TreeElementNode.is(node) && node.element instanceof DebugThread) {
+            return [node.element.raw.id];
+        }
+        return undefined;
     }
 
     protected getDefaultNodeStyle(node: TreeNode, props: NodeProps): React.CSSProperties | undefined {

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -49,6 +49,7 @@ import { PluginWebSocketChannel } from '../../../common/connection';
 import { PluginDebugAdapterContributionRegistrator, PluginDebugService } from './plugin-debug-service';
 import { DebugSchemaUpdater } from '@theia/debug/lib/browser/debug-schema-updater';
 import { FileSystem } from '@theia/filesystem/lib/common';
+import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 
 export class DebugMainImpl implements DebugMain {
     private readonly debugExt: DebugExt;
@@ -67,6 +68,7 @@ export class DebugMainImpl implements DebugMain {
     private readonly adapterContributionRegistrator: PluginDebugAdapterContributionRegistrator;
     private readonly debugSchemaUpdater: DebugSchemaUpdater;
     private readonly fileSystem: FileSystem;
+    private readonly pluginService: HostedPluginSupport;
 
     private readonly toDispose = new Map<string, DisposableCollection>();
 
@@ -86,6 +88,7 @@ export class DebugMainImpl implements DebugMain {
         this.sessionContributionRegistrator = container.get(PluginDebugSessionContributionRegistry);
         this.debugSchemaUpdater = container.get(DebugSchemaUpdater);
         this.fileSystem = container.get(FileSystem);
+        this.pluginService = container.get(HostedPluginSupport);
 
         this.breakpointsManager.onDidChangeBreakpoints(({ added, removed, changed }) => {
             // TODO can we get rid of all to reduce amount of data set each time, should not it be possible to recover on another side from deltas?
@@ -135,7 +138,7 @@ export class DebugMainImpl implements DebugMain {
 
         disposable.pushAll([
             this.adapterContributionRegistrator.registerDebugAdapterContribution(
-                new PluginDebugAdapterContribution(description, this.debugExt)
+                new PluginDebugAdapterContribution(description, this.debugExt, this.pluginService)
             ),
             this.sessionContributionRegistrator.registerDebugSessionContribution({
                 debugType: description.type,

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-adapter-contribution.ts
@@ -19,6 +19,7 @@ import { DebugConfiguration } from '@theia/debug/lib/common/debug-configuration'
 import { IJSONSchemaSnippet, IJSONSchema } from '@theia/core/lib/common/json-schema';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
+import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
 
 /**
  * Plugin [DebugAdapterContribution](#DebugAdapterContribution).
@@ -26,7 +27,8 @@ import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
 export class PluginDebugAdapterContribution {
     constructor(
         protected readonly description: DebuggerDescription,
-        protected readonly debugExt: DebugExt) { }
+        protected readonly debugExt: DebugExt,
+        protected readonly pluginService: HostedPluginSupport) { }
 
     get type(): string {
         return this.description.type;
@@ -57,6 +59,7 @@ export class PluginDebugAdapterContribution {
     }
 
     async createDebugSession(config: DebugConfiguration): Promise<string> {
+        await this.pluginService.activateByDebug('onDebugAdapterProtocolTracker', config.type);
         return this.debugExt.$createDebugSession(config);
     }
 

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -107,6 +107,16 @@ export class MenusContributionPointHandler {
                     const menuPath = inline ? ScmWidget.RESOURCE_INLINE_MENU : ScmWidget.RESOURCE_CONTEXT_MENU;
                     this.registerScmMenuAction(menuPath, menu);
                 }
+            } else if (location === 'debug/callstack/context') {
+                for (const menu of allMenus[location]) {
+                    for (const menuPath of [DebugStackFramesWidget.CONTEXT_MENU, DebugThreadsWidget.CONTEXT_MENU]) {
+                        this.registerMenuAction(menuPath, menu, {
+                            execute: (...args) => this.commands.executeCommand(menu.command, args[0]),
+                            isEnabled: (...args) => this.commands.isEnabled(menu.command, args[0]),
+                            isVisible: (...args) => this.commands.isVisible(menu.command, args[0])
+                        });
+                    }
+                }
             } else if (allMenus.hasOwnProperty(location)) {
                 const menuPaths = MenusContributionPointHandler.parseMenuPaths(location);
                 if (!menuPaths.length) {
@@ -127,7 +137,6 @@ export class MenusContributionPointHandler {
         switch (value) {
             case 'editor/context': return [EDITOR_CONTEXT_MENU];
             case 'explorer/context': return [NAVIGATOR_CONTEXT_MENU];
-            case 'debug/callstack/context': return [DebugStackFramesWidget.CONTEXT_MENU, DebugThreadsWidget.CONTEXT_MENU];
         }
         return [];
     }
@@ -216,13 +225,11 @@ export class MenusContributionPointHandler {
     protected registerGlobalMenuAction(menuPath: MenuPath, menu: Menu): void {
         const selectedResource = () => {
             const selection = this.selectionService.selection;
-
             if (TreeWidgetSelection.is(selection) && selection.source instanceof TreeViewWidget && selection[0]) {
                 return selection.source.toTreeViewSelection(selection[0]);
             }
-
             const uri = this.resourceContextKey.get();
-            return uri ? uri['codeUri'] : (typeof selection !== 'object' && typeof selection !== 'function') ? selection : undefined;
+            return uri ? uri['codeUri'] : undefined;
         };
         this.registerMenuAction(menuPath, menu, {
             execute: () => this.commands.executeCommand(menu.command, selectedResource()),

--- a/packages/plugin-ext/src/plugin/node/debug/debug.ts
+++ b/packages/plugin-ext/src/plugin/node/debug/debug.ts
@@ -270,19 +270,20 @@ export class DebugExtImpl implements DebugExt {
     async $resolveDebugConfigurations(debugConfiguration: theia.DebugConfiguration, workspaceFolderUri: string | undefined): Promise<theia.DebugConfiguration | undefined> {
         let current = debugConfiguration;
 
-        const providers = this.configurationProviders.get(debugConfiguration.type);
-        if (providers) {
-            for (const provider of providers) {
-                if (provider.resolveDebugConfiguration) {
-                    try {
-                        const next = await provider.resolveDebugConfiguration(this.toWorkspaceFolder(workspaceFolderUri), current);
-                        if (next) {
-                            current = next;
-                        } else {
-                            return current;
+        for (const providers of [this.configurationProviders.get(debugConfiguration.type), this.configurationProviders.get('*')]) {
+            if (providers) {
+                for (const provider of providers) {
+                    if (provider.resolveDebugConfiguration) {
+                        try {
+                            const next = await provider.resolveDebugConfiguration(this.toWorkspaceFolder(workspaceFolderUri), current);
+                            if (next) {
+                                current = next;
+                            } else {
+                                return current;
+                            }
+                        } catch (e) {
+                            console.error(e);
                         }
-                    } catch (e) {
-                        console.error(e);
                     }
                 }
             }

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -61,7 +61,12 @@ class ActivatedPlugin {
 
 export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
 
-    static SUPPORTED_ACTIVATION_EVENTS = new Set(['*', 'onLanguage', 'onCommand']);
+    static SUPPORTED_ACTIVATION_EVENTS = new Set([
+        '*',
+        'onLanguage',
+        'onCommand',
+        'onDebug', 'onDebugInitialConfigurations', 'onDebugResolve', 'onDebugAdapterProtocolTracker'
+    ]);
 
     private readonly registry = new Map<string, Plugin>();
     private readonly activations = new Map<string, (() => Promise<void>)[] | undefined>();
@@ -153,8 +158,8 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             const activation = () => this.loadPlugin(plugin, configStorage);
             const unsupportedActivationEvents = plugin.rawModel.activationEvents.filter(e => !PluginManagerExtImpl.SUPPORTED_ACTIVATION_EVENTS.has(e.split(':')[0]));
             if (unsupportedActivationEvents.length) {
+                console.warn(`Unsupported activation events: ${unsupportedActivationEvents.join(', ')}, please open an issue: https://github.com/theia-ide/theia/issues/new`);
                 console.warn(`${plugin.model.id} extension will be activated eagerly.`);
-                console.warn(`Unsupported activation events: ${unsupportedActivationEvents}, please open an issue: https://github.com/theia-ide/theia/issues/new`);
                 this.setActivation('*', activation);
             } else {
                 for (let activationEvent of plugin.rawModel.activationEvents) {


### PR DESCRIPTION
#### What it does

- https://github.com/theia-ide/theia/issues/4199: implement `onDebug*` activation events, see docs:
  - https://code.visualstudio.com/api/references/activation-events#onDebug
  - `onDebugAdapterProtocolTracker` in https://code.visualstudio.com/updates/v1_30
- bugs fixed in order to verify `onDebug*` activation events:
  - fix #5639: plugin system should be able to register debug configuration providers for any debug type with `*`, before such debug type was not respected cc @tolusha
  - fix #5641: arguments to `debug/callstack/context` menu actions are passed directly instead of passing them through the global selection service
- it introduces [WaitUntilEvent](https://github.com/theia-ide/theia/commit/6574bcd48f8e0a0559cc241fc04ce465ccf8c712#diff-ed39e3c7eddce4e269ac86cb16c0ffddR247) in order to generalise firing of async events

#### How to test

Hint: you can install and test all extensions together. All plugins (node + test): https://github.com/akosyakov/debug-activation-events/blob/master/plugins.tar

- remove debug-nodejs from the example browser application and rebuild it
- install https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug
- install https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug2
- node-debug extensions should be properly activated when you do tests below
- node-debug2 extension should be activated when you try to toggle skip file in the stackframe, the command should work
  - it verifies #5641 as well
- test `onDebug`: install [on-debug-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-0.0.1.vsix) and check that `onDebug` notification appears on any debug activation event
- test `onDebugInitialConfigurations`:
  - install [on-debug-initial-configurations-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-initial-configurations-0.0.1.vsix)
  - delete launch.json file
  - try to add a new configuration with markdown file opened 
  - you should see `onDebugInitialConfigurations` and `provideDebugConfigurations` notifications plus mock debug configuration should be generated dynamically
- test `onDebugResolve`:
  - install [on-debug-resolve-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-resolve-0.0.1.vsix)
  - try to run any launch configuration
  - you should see `onDebugResolve` and `resolveDebugConfiguration` notifications
    - it also verifies a fix to #5639, otherwise you won't see `resolveDebugConfiguration` notification
- test `onDebugResolve:<debug type>`:
  - install [on-debug-resolve-node-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-resolve-node-0.0.1.vsix)
  - try to run any node launch configuration
  - you should see `onDebugResolve:node` and `resolveDebugConfiguration:node` notifications
- test `onDebugAdapterProtocolTracker`:
  - install [on-debug-adapter-protocol-tracker-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-adapter-protocol-tracker-0.0.1.vsix)
  - try to run any launch configuration
  - you should see `onDebugAdapterProtocolTracker` and `createDebugAdapterTracker` notifications
- test `onDebugAdapterProtocolTracker:<debug type>`:
  - install [on-debug-adapter-protocol-tracker-node-0.0.1.vsix](https://github.com/akosyakov/debug-activation-events/blob/master/on-debug-adapter-protocol-tracker-node-0.0.1.vsix)
  - try to run any node launch configuration
  - you should see `onDebugAdapterProtocolTracker:node` and `createDebugAdapterTracker:node` notifications

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed in accordance with [the review guideline](https://github.com/theia-ide/theia/pull/5616/files#diff-195a635ad245ded9076330e31134bd80R18)

#### Reminder for reviewers

- each approve should have supporting comments in accordance with [the review guideline](https://github.com/theia-ide/theia/pull/5616/files#diff-195a635ad245ded9076330e31134bd80R18)
- the approve without a comment should be dismissed