### PR TITLE
[markers] enable single-click and keyboard arrow selection to navigate markers

### DIFF
--- a/packages/markers/src/browser/marker-tree-model.ts
+++ b/packages/markers/src/browser/marker-tree-model.ts
@@ -34,4 +34,14 @@ export class MarkerTreeModel extends TreeModelImpl {
     protected getOpenerOptionsByMarker(node: MarkerNode): OpenerOptions | undefined {
         return undefined;
     }
+
+    /**
+     * Reveal the corresponding node at the marker.
+     * @param node {TreeNode} the tree node.
+     */
+    revealNode(node: TreeNode): void {
+        if (MarkerNode.is(node)) {
+            open(this.openerService, node.uri, { ...this.getOpenerOptionsByMarker(node), mode: 'reveal' });
+        }
+    }
 }

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -61,11 +61,34 @@ export class ProblemWidget extends TreeWidget {
         return;
     }
 
+    protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        super.handleClickEvent(node, event);
+        if (MarkerNode.is(node)) {
+            this.model.revealNode(node);
+        }
+    }
+
     protected handleCopy(event: ClipboardEvent) {
         const uris = this.model.selectedNodes.filter(MarkerNode.is).map(node => node.uri.toString());
         if (uris.length > 0 && event.clipboardData) {
             event.clipboardData.setData('text/plain', uris.join('\n'));
             event.preventDefault();
+        }
+    }
+
+    protected handleDown(event: KeyboardEvent): void {
+        const node = this.model.getNextSelectableNode();
+        super.handleDown(event);
+        if (MarkerNode.is(node)) {
+            this.model.revealNode(node);
+        }
+    }
+
+    protected handleUp(event: KeyboardEvent): void {
+        const node = this.model.getPrevSelectableNode();
+        super.handleUp(event);
+        if (MarkerNode.is(node)) {
+            this.model.revealNode(node);
         }
     }
 


### PR DESCRIPTION
Fixes #5003

- the current implementation of the `problems-widget` requires double-clicking
nodes in order to navigate to the problems. This is an annoying behavior and
inconsistent with vscode where if you single-click a marker the corresponding
editor is revealed. The feature works both with single clicking markers, as well
as selecting them with the keyboard arrow keys.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
