### PR TITLE
fix #5656: Fixed the position of the button on Notification when displaying multiple lines of text

### DIFF
--- a/packages/messages/src/browser/style/notifications.css
+++ b/packages/messages/src/browser/style/notifications.css
@@ -126,8 +126,6 @@
     flex-direction: row;
     order: 4;
     white-space: nowrap;
-    align-self: flex-end;
-    height: 40px;
 }
 
 .theia-Notification .buttons > button {


### PR DESCRIPTION
This is a long-standing problem, it seems that removing the useless style settings is fine.

Signed-off-by: Brokun <brokun0128@gmail.com>