### PR TITLE
Fixed #5672: fixed the tree indentation issue caused by the expansion icon

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -411,7 +411,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return <div
             data-node-id={node.id}
             className={className}
-            style={{ paddingLeft: '4px' }}
+            style={{ paddingLeft: '4px', paddingRight: '4px' }}
             onClick={this.toggle}>
         </div>;
     }


### PR DESCRIPTION
- Fixed the indentation alignment issue in tree by adjusting the padding of the expansion toggle icon.

#### Before:
See #5672.

#### With this patch:

![image](https://user-images.githubusercontent.com/25921074/60902880-59d03480-a23e-11e9-83e1-6011ad9a8e41.png)
![image](https://user-images.githubusercontent.com/25921074/60902963-85531f00-a23e-11e9-8527-c7be2fe0c091.png)



<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
