### PR TITLE
[search-in-workspace] add the 'search.collapseResults' preference

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-preferences.ts
@@ -24,12 +24,19 @@ export const searchInWorkspacePreferencesSchema: PreferenceSchema = {
             description: 'Controls whether to show line numbers for search results.',
             default: false,
             type: 'boolean',
+        },
+        'search.collapseResults': {
+            description: 'Controls whether the search results will be collapsed or expanded.',
+            default: 'auto',
+            type: 'string',
+            enum: ['auto', 'alwaysCollapse', 'alwaysExpand'],
         }
     }
 };
 
 export class SearchInWorkspaceConfiguration {
     'search.lineNumbers': boolean;
+    'search.collapseResults': string;
 }
 
 export const SearchInWorkspacePreferences = Symbol('SearchInWorkspacePreferences');

--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -198,6 +198,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
 
     async search(searchTerm: string, searchOptions: SearchInWorkspaceOptions): Promise<void> {
         this.searchTerm = searchTerm;
+        const collapseValue: string = this.searchInWorkspacePreferences['search.collapseResults'];
         this.resultTree.clear();
         this.cancelIndicator.cancel();
         this.cancelIndicator = new CancellationTokenSource();
@@ -222,11 +223,10 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                         if (fileNode.children.findIndex(lineNode => lineNode.id === line.id) < 0) {
                             fileNode.children.push(line);
                         }
-                        if (fileNode.children.length >= 20 && fileNode.expanded) {
-                            fileNode.expanded = false;
-                        }
+                        this.collapseFileNode(fileNode, collapseValue);
                     } else {
                         const newFileNode = this.createFileNode(result.root, name, path, result.fileUri, rootFolderNode);
+                        this.collapseFileNode(newFileNode, collapseValue);
                         const line = this.createResultLineNode(result, newFileNode);
                         newFileNode.children.push(line);
                         rootFolderNode.children.push(newFileNode);
@@ -235,8 +235,8 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 } else {
                     const newRootFolderNode = this.createRootFolderNode(result.root);
                     tree.set(result.root, newRootFolderNode);
-
                     const newFileNode = this.createFileNode(result.root, name, path, result.fileUri, newRootFolderNode);
+                    this.collapseFileNode(newFileNode, collapseValue);
                     newFileNode.children.push(this.createResultLineNode(result, newFileNode));
                     newRootFolderNode.children.push(newFileNode);
                 }
@@ -262,6 +262,20 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
                 this.node.focus();
                 this.model.selectNode(node);
             }
+        }
+    }
+
+    /**
+     * Collapse the search-in-workspace file node
+     * based on the preference value.
+     */
+    protected collapseFileNode(node: SearchInWorkspaceFileNode, preferenceValue: string): void {
+        if (preferenceValue === 'auto' && node.children.length >= 10) {
+            node.expanded = false;
+        } else if (preferenceValue === 'alwaysCollapse') {
+            node.expanded = false;
+        } else if (preferenceValue === 'alwaysExpand') {
+            node.expanded = true;
         }
     }
 


### PR DESCRIPTION
Fixes #5685

Added the new preference to the search-in-workspace widget to
control the display of the tree when rendering results.

The values are the following:
- `auto`: expand all nodes except those with over 10 matches
- `alwaysCollapse`: always collapse all nodes
- `alwaysExpand`: always expand all nodes

Aligned the setting with vscode, previously we used 20 results, but it's been updated to 10.

---

- [x] CQ Registered https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20355
- [x] CQ Approved

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
