### PR TITLE
[plug-in] Improve plugin node.js error handling

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -17,7 +17,7 @@
 import * as path from 'path';
 import * as cp from 'child_process';
 import { injectable, inject, named } from 'inversify';
-import { ILogger, ConnectionErrorHandler, ContributionProvider } from '@theia/core/lib/common';
+import { ILogger, ConnectionErrorHandler, ContributionProvider, MessageService } from '@theia/core/lib/common';
 import { Emitter } from '@theia/core/lib/common/event';
 import { createIpcEnv } from '@theia/core/lib/node/messaging/ipc-protocol';
 import { HostedPluginClient, ServerPluginRunner, PluginMetadata, PluginHostEnvironmentVariable } from '../../common/plugin-protocol';
@@ -49,9 +49,14 @@ export class HostedPluginProcess implements ServerPluginRunner {
     @named(PluginHostEnvironmentVariable)
     protected readonly pluginHostEnvironmentVariables: ContributionProvider<PluginHostEnvironmentVariable>;
 
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
     private childProcess: cp.ChildProcess | undefined;
 
     private client: HostedPluginClient;
+
+    private terminatingPluginServer = false;
 
     private async getClientId(): Promise<number> {
         return await this.pluginProcessCache.getLazyClientId(this.client);
@@ -103,6 +108,8 @@ export class HostedPluginProcess implements ServerPluginRunner {
         if (this.childProcess === undefined) {
             return;
         }
+
+        this.terminatingPluginServer = true;
         // tslint:disable-next-line:no-shadowed-variable
         const cp = this.childProcess;
         this.childProcess = undefined;
@@ -131,6 +138,7 @@ export class HostedPluginProcess implements ServerPluginRunner {
         if (this.childProcess) {
             this.terminatePluginServer();
         }
+        this.terminatingPluginServer = false;
         this.childProcess = this.fork({
             serverName: 'hosted-plugin',
             logger: this.logger,
@@ -184,9 +192,21 @@ export class HostedPluginProcess implements ServerPluginRunner {
         childProcess.stderr.on('data', data => this.logger.error(`[${options.serverName}: ${childProcess.pid}] ${data.toString().trim()}`));
 
         this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC started`);
-        childProcess.once('exit', () => this.logger.debug(`[${options.serverName}: ${childProcess.pid}] IPC exited`));
-
+        childProcess.once('exit', (code: number, signal: string) => this.onChildProcessExit(options.serverName, childProcess.pid, code, signal));
+        childProcess.on('error', err => this.onChildProcessError(err));
         return childProcess;
+    }
+
+    private onChildProcessExit(serverName: string, pid: number, code: number, signal: string): void {
+        if (this.terminatingPluginServer) {
+            return;
+        }
+        this.logger.error(`[${serverName}: ${pid}] IPC exited, with signal: ${signal}, and exit code: ${code}`);
+        this.messageService.error('Plugin runtime crashed unexpectedly, all plugins are not working, please reload...', { timeout: 15 * 60 * 1000 });
+    }
+
+    private onChildProcessError(err: Error): void {
+        this.logger.error(`Error from plugin host: ${err.message}`);
     }
 
     async getExtraPluginMetadata(): Promise<PluginMetadata[]> {


### PR DESCRIPTION
This PR do next:
- Improve logging `error` and `exit` events on plugin runtime node.js instance.
- Disable `exit` and `crash` function in plugin runtime node.js instance, so plugin cannot terminate it's runtime.
- Add handling of `unhandledRejection` and `uncaughtException` events inside plugin runtime.
- Add notification, if plugin runtime terminated unexpectedly.

This PR can be tested with this plugin [bad-theia-plugin](https://github.com/evidolob/bad-theia-plugin), it contains 3 commands with `Bad` prefix.
