### PR TITLE
[security] Bump lodash.mergewith from 4.6.1 to 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v0.9.0
 - [task] added support for VS Code task contribution points: `taskDefinitions`, `problemMatchers`, and `problemPatterns`
-
 - [plugin] added support of debug activation events [#5645](https://github.com/theia-ide/theia/pull/5645)
+- [security] Bump lodash.mergewith from 4.6.1 to 4.6.2
 
 Breaking changes:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6059,8 +6059,9 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
 lodash.mergewith@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.restparam@^3.0.0:
   version "3.6.1"


### PR DESCRIPTION
see: https://github.com/lodash/lodash/issues/4348

Note: at first I thought I would attempt to also cover the update of `lodash.template` in this PR, but:
- this is only a dev-dependency, that's not used in production, so somewhat less of a concern
- going down the rabbit hole, we would have to update to `lerna: 3.x`, which is a big change, that I do not have time to tackle ATM

I'll post a separate draft PR for `lodash.template`