### PR TITLE
[search-in-workspace] fix search-in-workspace search result info

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -355,7 +355,6 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             } else {
                 this.searchTerm = (e.target as HTMLInputElement).value;
                 this.resultTreeWidget.search(this.searchTerm, (this.searchInWorkspaceOptions || {}));
-                this.update();
             }
         }
     }


### PR DESCRIPTION
Fixes #5698

- fixes an issue where the message `No Results Found.` is displayed
as a user types and attempts to search. The problem is that the message
is displayed before the search actually completes due to a `update()`.
Instead, the update to the widget is performed once the `search-in-workspace-tree`
completes it's search and fires the event `onDidChange()`.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
