### PR TITLE
Fixed #5704: changed keybinding for `toggle outline view` to avoid conflict

### DIFF
--- a/packages/outline-view/src/browser/outline-view-contribution.ts
+++ b/packages/outline-view/src/browser/outline-view-contribution.ts
@@ -33,7 +33,7 @@ export class OutlineViewContribution extends AbstractViewContribution<OutlineVie
                 rank: 500
             },
             toggleCommandId: 'outlineView:toggle',
-            toggleKeybinding: 'ctrlcmd+shift+s'
+            toggleKeybinding: 'ctrlcmd+shift+i'
         });
     }
 


### PR DESCRIPTION
- The keybinding for `toggle outline view` before was in conflict with that of `save as`.
- The patch changed it to `ctrlcmd+shift+i`, as it stays consistent with keybindings for other `toggle xxx` commands, and has no conflict with any other command in Theia & VS Code.
