### PR TITLE
[explorer] fix inconsistent decorator size with the root workspace node

### DIFF
--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -55,6 +55,9 @@
 
 #files > div > div > div > div:first-child {
     background-color: var(--theia-layout-color4);
+}
+
+#files > div > div > div > div:first-child .theia-TreeNodeSegment.theia-TreeNodeSegmentGrow {
     text-transform: uppercase;
     font-size: 80%;
     font-weight: 500;


### PR DESCRIPTION
Fixes #5714

**Description**

Updated the styling of the root node in the `explorer` widget to only apply the font styling for the textual part of the node. The decorator at the tail of the node should remain untouched
and keeps the `100%` font-size.

**Before**

<div align='left'>

<img width="570" alt="Screen Shot 2019-07-15 at 8 18 56 PM" src="https://user-images.githubusercontent.com/40359487/61257259-548f5000-a73e-11e9-8b80-c65206eca507.png">

</div>

**After**

<div align='left'>

<img width="574" alt="Screen Shot 2019-07-15 at 8 15 58 PM" src="https://user-images.githubusercontent.com/40359487/61257271-5eb14e80-a73e-11e9-99f2-32e5203c0e75.png">

</div>

<br />

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
