### PR TITLE
Add 'theia-widget-noInfo' css class to fix message inconsistencies

### DIFF
--- a/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
+++ b/packages/callhierarchy/src/browser/callhierarchy-tree/callhierarchy-tree-widget.tsx
@@ -82,7 +82,7 @@ export class CallHierarchyTreeWidget extends TreeWidget {
 
     protected renderTree(model: TreeModel): React.ReactNode {
         return super.renderTree(model)
-            || <div className='noCallers'>No callers have been detected.</div>;
+            || <div className='theia-widget-noInfo'>No callers have been detected.</div>;
     }
 
     protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/callhierarchy/src/browser/style/index.css
+++ b/packages/callhierarchy/src/browser/style/index.css
@@ -28,10 +28,6 @@
     padding-right: 4px;
 }
 
-.theia-CallHierarchyTree .noCallers {
-    margin: 5px 19px;
-}
-
 .theia-CallHierarchyTree .definitionNode {
     display: flex;
 }

--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -196,3 +196,4 @@ textarea {
 @import './notification.css';
 @import './alert-messages.css';
 @import './icons.css';
+@import './widget.css';

--- a/packages/core/src/browser/style/widget.css
+++ b/packages/core/src/browser/style/widget.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2018 TypeFox and others.
+ * Copyright (C) 2019 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,15 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-.outline-view-tab-icon::before {
-    content: "\f03a"
-}
-
-.no-outline {
-    color: var(--theia-ui-font-color0);
-    text-align: left;
-}
-
-.theia-side-panel .no-outline {
-    margin-left: 9px;
+.theia-widget-noInfo {
+    padding: calc(var(--theia-ui-padding) * 2);
 }

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -96,7 +96,7 @@ export class ProblemWidget extends TreeWidget {
         if (MarkerRootNode.is(model.root) && model.root.children.length > 0) {
             return super.renderTree(model);
         }
-        return <div className='noMarkers'>No problems have been detected in the workspace so far.</div>;
+        return <div className='theia-widget-noInfo noMarkers'>No problems have been detected in the workspace so far.</div>;
     }
 
     protected renderCaption(node: TreeNode, props: NodeProps): React.ReactNode {

--- a/packages/markers/src/browser/style/index.css
+++ b/packages/markers/src/browser/style/index.css
@@ -19,10 +19,6 @@
     color: var(--theia-ui-font-color1);
 }
 
-.theia-marker-container .noMarkers {
-    padding: 5px;
-}
-
 .theia-side-panel .theia-marker-container .noMarkers {
     padding-left: 19px;
 }

--- a/packages/outline-view/src/browser/outline-view-widget.tsx
+++ b/packages/outline-view/src/browser/outline-view-widget.tsx
@@ -126,7 +126,7 @@ export class OutlineViewWidget extends TreeWidget {
 
     protected renderTree(model: TreeModel): React.ReactNode {
         if (CompositeTreeNode.is(this.model.root) && !this.model.root.children.length) {
-            return <div className='no-outline'>No outline information available.</div>;
+            return <div className='theia-widget-noInfo no-outline'>No outline information available.</div>;
         }
         return super.renderTree(model);
     }


### PR DESCRIPTION
Fixes #5716

**Description**

- fixed the inconsistent padding present in the `outline`, `call-hierarchy` and `problems` view when no information is present.
- added a new `widget.css` file which will be used to describe widget specific styling
- added the new css class `theia-widget-noInfo` used for widget messages

**Before**

<div align='left'>

<img src='https://user-images.githubusercontent.com/40359487/61257537-8ce35e00-a73f-11e9-9839-c7f35ac14973.png' alt='before'/>

</div>

<br />

**After**

<div align='left'>

<img width="1007" alt="Screen Shot 2019-07-15 at 8 53 57 PM" src="https://user-images.githubusercontent.com/40359487/61258264-ba7dd680-a742-11e9-8cdf-39cfd99cd9d9.png">


</div>

<br />

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
