### PR TITLE
fix: quickopen file icon centered

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -36,6 +36,9 @@
  * we need to disable the background image when using file-icons
  */
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     background-image: none;
     margin-right: 0px;
 }


### PR DESCRIPTION
The icon doesn't seem to be in the right place when use quickopen.

before:

![image](https://user-images.githubusercontent.com/6399899/61299252-4dd20d00-a812-11e9-96db-1d1760b4aa22.png)

after:

![image](https://user-images.githubusercontent.com/6399899/61299283-5a566580-a812-11e9-9d01-19ec6018f7ef.png)

