### PR TITLE
fix: file icon centered

### DIFF
--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -25,17 +25,13 @@
 }
 
 /*
- * we need to disable the background image when using font awesome icons
+ * we need to disable the background image when using font awesome icons and file-icons
  */
-.monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.fa {
-    background-image: none;
-    margin-right: 0px;
-}
-
-/*
- * we need to disable the background image when using file-icons
- */
+.monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.fa,
 .monaco-quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.file-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     background-image: none;
     margin-right: 0px;
 }


### PR DESCRIPTION
Signed-off-by: hacke2 <hacke2cn@gmail.com>

The file icons don't seem to be in the right place when open quickopen widget.

before:
![image](https://user-images.githubusercontent.com/6399899/61300272-40b61d80-a814-11e9-9296-8f371f7bb8a9.png)

after:
![image](https://user-images.githubusercontent.com/6399899/61300295-4b70b280-a814-11e9-932b-45744ee96afa.png)


