### PR TITLE
Register the current EditorTheme and retrigger monaco tokenizing

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -16,14 +16,10 @@
 
 import { injectable, inject } from 'inversify';
 import { FrontendApplicationContribution, PreferenceSchemaProvider } from '@theia/core/lib/browser';
-import { ThemeService } from '@theia/core/lib/browser/theming';
 import { MonacoSnippetSuggestProvider } from './monaco-snippet-suggest-provider';
 
 @injectable()
 export class MonacoFrontendApplicationContribution implements FrontendApplicationContribution {
-
-    @inject(ThemeService)
-    protected readonly themeService: ThemeService;
 
     @inject(MonacoSnippetSuggestProvider)
     protected readonly snippetSuggestProvider: MonacoSnippetSuggestProvider;
@@ -32,10 +28,6 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
     protected readonly preferenceSchema: PreferenceSchemaProvider;
 
     async initialize() {
-        const currentTheme = this.themeService.getCurrentTheme();
-        this.changeTheme(currentTheme.editorTheme);
-        this.themeService.onThemeChange(event => this.changeTheme(event.newTheme.editorTheme));
-
         monaco.suggest.setSnippetSuggestSupport(this.snippetSuggestProvider);
 
         for (const language of monaco.languages.getLanguages()) {
@@ -48,9 +40,4 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         };
     }
 
-    protected changeTheme(editorTheme: string | undefined) {
-        const monacoTheme = editorTheme || this.themeService.defaultTheme.id;
-        monaco.editor.setTheme(monacoTheme);
-        document.body.classList.add(monacoTheme);
-    }
 }


### PR DESCRIPTION
...initially and after theme changed.
Additionally remove old css theme class from body.
Fixes #4550

As a test one should add a default theme to package.json different fro the dark theme. 

Thanks a lot to @akosyakov for helping with this fix!!!