### PR TITLE
Make the `Plugin folder` notification user friendly 

### DIFF
--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -265,7 +265,7 @@ export class HostedPluginManagerClient {
         if (UriSelection.is(result)) {
             if (await this.hostedPluginServer.isPluginValid(result.uri.toString())) {
                 this.pluginLocation = result.uri;
-                this.messageService.info('Plugin folder is set to: ' + result.uri.toString());
+                this.messageService.info('Plugin folder is set to: ' + decodeURI(result.uri.toString()));
             } else {
                 this.messageService.error('Specified folder does not contain valid plugin.');
             }

--- a/packages/plugin-ext/src/main/browser/view/view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/view-registry.ts
@@ -55,7 +55,7 @@ export class ViewRegistry {
         }
         const iconClass = 'plugin-view-container-icon-' + viewsContainer.id;
         this.style.insertRule('.' + iconClass, () => `
-            mask: : url('${viewsContainer.iconUrl}') no-repeat 50% 50%;
+            mask: url('${viewsContainer.iconUrl}') no-repeat 50% 50%;
             -webkit-mask: url('${viewsContainer.iconUrl}') no-repeat 50% 50%;
         `);
 


### PR DESCRIPTION
Fixes #5693.

The message displayed contained an encoded URI, added changes to decode it before displaying the message.