### PR TITLE
Make the `Plugin folder` notification user friendly

### DIFF
--- a/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin-dev/src/browser/hosted-plugin-manager-client.ts
@@ -265,7 +265,7 @@ export class HostedPluginManagerClient {
         if (UriSelection.is(result)) {
             if (await this.hostedPluginServer.isPluginValid(result.uri.toString())) {
                 this.pluginLocation = result.uri;
-                this.messageService.info('Plugin folder is set to: ' + result.uri.toString());
+                this.messageService.info('Plugin folder is set to: ' + this.labelProvider.getLongName(result.uri));
             } else {
                 this.messageService.error('Specified folder does not contain valid plugin.');
             }


### PR DESCRIPTION
Fixes #5693.

The message displayed contained an encoded URI, added changes to decode it before displaying the message.