### PR TITLE
Fixed #5732, #5735: fixed `box-shadow` and `background-color` in quick-open menu 

### DIFF
--- a/packages/core/src/browser/style/scrollbars.css
+++ b/packages/core/src/browser/style/scrollbars.css
@@ -172,3 +172,7 @@
 .monaco-scrollable-element > .scrollbar.horizontal > .slider {
     height: var(--theia-scrollbar-width) !important;
 }
+
+.monaco-scrollable-element > .shadow.top {
+    box-shadow: var(--theia-scrollbar-box-shadow-color) 0px 6px 6px -6px inset !important;
+}

--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -196,6 +196,7 @@ is not optimized for dense, information rich UIs.
   --theia-scrollbar-rail-color: transparent;
   --theia-scrollbar-active-thumb-color: hsla(0,0%,39%,.4);
   --theia-scrollbar-active-rail-color: transparent;
+  --theia-scrollbar-box-shadow-color: #DDD;
 
   /* Menu */
   --theia-menu-color0: var(--theia-layout-color3);

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -196,6 +196,7 @@ is not optimized for dense, information rich UIs.
   --theia-scrollbar-rail-color: transparent;
   --theia-scrollbar-active-thumb-color: hsla(0,0%,61%,.4);
   --theia-scrollbar-active-rail-color: transparent;
+  --theia-scrollbar-box-shadow-color: #000;
 
   /* Menu */
   --theia-menu-color0: var(--theia-layout-color4);

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -40,6 +40,10 @@
     margin-right: 0px;
 }
 
+.monaco-quick-open-widget {
+    background-color: var(--theia-layout-color1) !important;
+}
+
 .quick-open-entry .quick-open-row .monaco-icon-label .monaco-icon-label-description-container .monaco-highlighted-label .highlight {
     color: var(--theia-accent-color1);
 }


### PR DESCRIPTION
- This patch added dark-theme support for the `box-shadow` on the quick-open menu. To be aligned with VS Code and the current UI, the top divider (shadow) would be black in the dark theme and light-grey in the light theme.
- Also, aligned `background-color` of the quick-open menu with other widgets (e.g. the side-panel widget). This would also make the top shadow line more visible in the dark mode.

### Before
![theia-quickopen-line](https://user-images.githubusercontent.com/25921074/61315124-150f4500-a7cc-11e9-86c9-aff5bb27df5a.gif)

### After
![image](https://user-images.githubusercontent.com/25921074/61382121-26168f80-a87a-11e9-94f0-adf3976de5a5.png)
