### PR TITLE
[mobile] Prevent the IDE from scrolling along with the text (e.g. on iPad)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [plugin] Fixed `Converting circular structure to JSON` Error [#5661](https://github.com/theia-ide/theia/pull/5661)
 - [plugin] fixed auto detection of new languages [#5753](https://github.com/theia-ide/theia/issues/5753)
 - [vscode] unzip node_modules for built-in extensions [#5756](https://github.com/theia-ide/theia/pull/5756)
+- [core] prevent the IDE from scrolling along with the text on mobile (e.g. on iPad) [#5742](https://github.com/theia-ide/theia/pull/5742)
 
 Breaking changes:
 

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -162,6 +162,7 @@ export class FrontendApplication {
         });
         window.addEventListener('resize', () => this.shell.update());
         document.addEventListener('keydown', event => this.keybindings.run(event), true);
+        document.addEventListener('touchmove', event => { event.preventDefault(); }, { passive: false });
         // Prevent forward/back navigation by scrolling in OS X
         if (isOSX) {
             document.body.addEventListener('wheel', preventNavigation, { passive: false });


### PR DESCRIPTION
Part of #3557 (thanks a lot @EricRabil for the tip! 💯)

## Screencasts

Current scrolling behavior (IDE scrolls with code editor): https://youtu.be/T0So5v0GQBA

New scrolling behavior (fixed IDE): https://youtu.be/Q3oURvM4Dh0