### PR TITLE
[plugin-host] Path traversal + XSS fix

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -24,8 +24,8 @@
     "@theia/task": "^0.9.0",
     "@theia/terminal": "^0.9.0",
     "@theia/workspace": "^0.9.0",
-    "@types/request": "^2.0.3",
     "decompress": "^4.2.0",
+    "escape-html": "^1.0.3",
     "getmac": "^1.4.6",
     "jsonc-parser": "^2.0.2",
     "lodash.clonedeep": "^4.5.0",
@@ -71,8 +71,10 @@
   "devDependencies": {
     "@theia/ext-scripts": "^0.9.0",
     "@types/decompress": "^4.2.2",
+    "@types/escape-html": "^0.0.20",
     "@types/lodash.clonedeep": "^4.5.3",
-    "@types/ps-tree": "^1.1.0"
+    "@types/ps-tree": "^1.1.0",
+    "@types/request": "^2.0.3"
   },
   "nyc": {
     "extends": "../../configs/nyc.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,11 @@
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.5.1.tgz#30253f6e177564ad7da707b1ebe46d3eade71706"
 
+"@types/escape-html@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-0.0.20.tgz#cae698714dd61ebee5ab3f2aeb9a34ba1011735a"
+  integrity sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -3615,9 +3620,10 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-applescript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The plugin host used to send unescaped responses via HTML, leading to
a potential XSS vulnerability. Also, no constraint was applied to the file
serving functionality, which means that you can get served any file on
the filesystem if you add enough `../` parts in the requested path,
walking past the plugin's root being served.

This commit prevents clients to request something past the plugin's
root, and also encodes the plugin id -requested by the client- in its response.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
