### PR TITLE
[plugin] fix #5753: redetect languages on new grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [plugin] added support of debug activation events [#5645](https://github.com/theia-ide/theia/pull/5645)
 - [security] Bump lodash.mergewith from 4.6.1 to 4.6.2
 - [plugin] Fixed `Converting circular structure to JSON` Error [#5661](https://github.com/theia-ide/theia/pull/5661)
+- [plugin] fixed auto detection of new languages [#5753](https://github.com/theia-ide/theia/issues/5753)
 
 Breaking changes:
 

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -29,11 +29,16 @@ import { CommandRegistry, Command, CommandHandler } from '@theia/core/lib/common
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { Emitter } from '@theia/core/lib/common/event';
 import { TaskDefinitionRegistry, ProblemMatcherRegistry, ProblemPatternRegistry } from '@theia/task/lib/browser';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { EditorManager } from '@theia/editor/lib/browser';
 
 @injectable()
 export class PluginContributionHandler {
 
     private injections = new Map<string, string[]>();
+
+    @inject(EditorManager)
+    private readonly editorManager: EditorManager;
 
     @inject(TextmateRegistry)
     private readonly grammarsRegistry: TextmateRegistry;
@@ -109,7 +114,7 @@ export class PluginContributionHandler {
             }
         }
 
-        if (contributions.grammars) {
+        if (contributions.grammars && contributions.grammars.length) {
             for (const grammar of contributions.grammars) {
                 if (grammar.injectTo) {
                     for (const injectScope of grammar.injectTo) {
@@ -139,6 +144,11 @@ export class PluginContributionHandler {
                         tokenTypes: this.convertTokenTypes(grammar.tokenTypes)
                     });
                     monaco.languages.onLanguage(grammar.language, () => this.monacoTextmateService.activateLanguage(grammar.language!));
+                }
+            }
+            for (const editor of MonacoEditor.getAll(this.editorManager)) {
+                if (editor.languageAutoDeteceted) {
+                    editor.detectLanguage();
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed -->

fix #5753: redetect languages on new grammar

#### How to test
<!-- Describe how a reviewer can verify changes within Theia repo -->

- clone  https://github.com/zxh0/vscode-proto3/tree/master/example/protos/v3
- open proto file from examples, it should not have coloring
- run `Deploy Plugin by id` command -> vscode:extension/zxh404.vscode-proto3
- verify that an opened file is properly highlighted now
- it has to happen only if a language was auto-detected
- if a user changed a language before it should not be reset

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)
