### PR TITLE
use decache to unload plugin modules

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -20,6 +20,7 @@
     "@theia/search-in-workspace": "^0.8.0",
     "@theia/task": "^0.8.0",
     "@theia/workspace": "^0.8.0",
+    "decache": "^4.5.1",
     "decompress": "^4.2.0",
     "getmac": "^1.4.6",
     "jsonc-parser": "^2.0.2",

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -26,6 +26,7 @@ import { EditorsAndDocumentsExtImpl } from '../../plugin/editors-and-documents';
 import { WorkspaceExtImpl } from '../../plugin/workspace';
 import { MessageRegistryExt } from '../../plugin/message-registry';
 import { EnvNodeExtImpl } from '../../plugin/node/env-node-ext';
+import decache from 'decache';
 
 /**
  * Handle the RPC calls.
@@ -95,41 +96,7 @@ export class PluginHostRPC {
             loadPlugin(plugin: Plugin): void {
                 console.log('PLUGIN_HOST(' + process.pid + '): PluginManagerExtImpl/loadPlugin(' + plugin.pluginPath + ')');
                 try {
-                    // cleaning the cache for all files of that plug-in.
-                    Object.keys(require.cache).forEach(function (key) {
-                        const mod: NodeJS.Module = require.cache[key];
-
-                        // attempting to reload a native module will throw an error, so skip them
-                        if (mod.id.endsWith('.node')) {
-                            return;
-                        }
-
-                        // remove children that are part of the plug-in
-                        let i = mod.children.length;
-                        while (i--) {
-                            const childMod: NodeJS.Module = mod.children[i];
-                            // ensure the child module is not null, is in the plug-in folder, and is not a native module (see above)
-                            if (childMod && childMod.id.startsWith(plugin.pluginFolder) && !childMod.id.endsWith('.node')) {
-                                // cleanup exports - note that some modules (e.g. ansi-styles) define their
-                                // exports in an immutable manner, so overwriting the exports throws an error
-                                delete childMod.exports;
-                                mod.children.splice(i, 1);
-                                for (let j = 0; j < childMod.children.length; j++) {
-                                    delete childMod.children[j];
-                                }
-                            }
-                        }
-
-                        if (key.startsWith(plugin.pluginFolder)) {
-                            // delete entry
-                            delete require.cache[key];
-                            const ix = mod.parent!.children.indexOf(mod);
-                            if (ix >= 0) {
-                                mod.parent!.children.splice(ix, 1);
-                            }
-                        }
-
-                    });
+                    decache(plugin.pluginPath);
                     return require(plugin.pluginPath);
                 } catch (e) {
                     console.error(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,11 @@ caller-id@^0.1.0:
   dependencies:
     stack-trace "~0.0.7"
 
+callsite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -3058,6 +3063,13 @@ debug@^4.1.1:
 debug@~0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.8.1.tgz#20ff4d26f5e422cb68a1bacbbb61039ad8c1c130"
+
+decache@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/decache/-/decache-4.5.1.tgz#94a977a88a4188672c96550ec4889582ceecdf49"
+  integrity sha512-5J37nATc6FmOTLbcsr9qx7Nm28qQyg1SK4xyEHqM0IBkNhWFp0Sm+vKoWYHD8wq+OUEb9jLyaKFfzzd1A9hcoA==
+  dependencies:
+    callsite "^1.0.0"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed -->

fix #5756: use decache to unload plugin modules:
- don't touch exports!
- traverse only modules loaded by the plugin, not the entire require cache

#### How to test
<!-- Describe how a reviewer can verify changes within Theia repo -->

You can verify that modules' exports are not messed up  in anyway by:
- installing emmet (https://registry.npmjs.org/@theia/vscode-builtin-emmet/-/vscode-builtin-emmet-0.1.0.tgz) extension and using it
- installing IBM blockchain extension, see https://github.com/theia-ide/theia/pull/5520#issuecomment-507988958

I don't know how one can verify that there is no memory leak, because UI does not allow to load the same plugin twice in the vanilla Theia and decaching is not required. cc @benoitf 

I wonder should decaching belong to this repo at all since it is not used or it should be moved to a corresponding client? cc @svenefftinge

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)
