### PR TITLE
[markers] support 'information' diagnostic severity

### DIFF
--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -82,7 +82,9 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     protected setStatusBarElement(problemStat: ProblemStat) {
         this.statusBar.setElement('problem-marker-status', {
-            text: `$(times-circle) ${problemStat.errors} $(exclamation-triangle) ${problemStat.warnings}`,
+            text: problemStat.infos <= 0
+                ? `$(times-circle) ${problemStat.errors} $(exclamation-triangle) ${problemStat.warnings}`
+                : `$(times-circle) ${problemStat.errors} $(exclamation-triangle) ${problemStat.warnings} $(info-circle) ${problemStat.infos}`,
             alignment: StatusBarAlignment.LEFT,
             priority: 10,
             command: this.toggleCommand ? this.toggleCommand.id : undefined

--- a/packages/markers/src/browser/problem/problem-manager.ts
+++ b/packages/markers/src/browser/problem/problem-manager.ts
@@ -24,6 +24,7 @@ import { Diagnostic } from 'vscode-languageserver-types';
 export interface ProblemStat {
     errors: number;
     warnings: number;
+    infos: number;
 }
 
 @injectable()
@@ -41,8 +42,9 @@ export class ProblemManager extends MarkerManager<Diagnostic> {
 
         const errors = allMarkers.filter(m => m.data.severity === 1).length;
         const warnings = allMarkers.filter(m => m.data.severity === 2).length;
+        const infos = allMarkers.filter(m => m.data.severity === 3).length;
 
-        return { errors, warnings };
+        return { errors, warnings, infos };
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed -->

Fixes #5762: support `information` diagnostic severity (markers)

- add support for `information` diagnostic severity.
- populate the `problems-view` with `info` markers.
- add a statusbar icon for `problems` to reflect `info` markers if present

#### How to test

1. clone the repository (https://github.com/vince-fugnitto/vscode-extension-samples)
2. `cd diagnostic-related-information-sample` and perform `npm i && npm run compile`.
3. start Theia using `diagnostic-related-information-sample` as a workspace
4. perform <kbd>F1</kbd> and `Hosted Plugin: Start Instance` and select `diagnostic-related-information-sample`
5. in the new hosted instance, open the file `sample-demo.rs`
6. there should be new `info` markers present from the file

In general, the guidelines from the following [wiki](https://github.com/theia-ide/theia/wiki/Testing-VS-Code-Extensions) was used.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)


Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
