### PR TITLE
fix: [Plugin-API] complete QuickPick hide api

### DIFF
--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -17,6 +17,7 @@
 import { injectable } from 'inversify';
 import { QuickOpenModel } from './quick-open-model';
 import { MessageType } from '../../common/message-service-protocol';
+import { HideReason } from '../../common/quick-pick-service';
 
 export type QuickOpenOptions = Partial<QuickOpenOptions.Resolved>;
 export namespace QuickOpenOptions {
@@ -84,6 +85,7 @@ export class QuickOpenService {
      * It should be implemented by an extension, e.g. by the monaco extension.
      */
     open(model: QuickOpenModel, options?: QuickOpenOptions): void { }
+    hide(reason?: HideReason): void { }
     showDecoration(type: MessageType): void { }
     hideDecoration(): void { }
 }

--- a/packages/core/src/browser/quick-open/quick-open-service.ts
+++ b/packages/core/src/browser/quick-open/quick-open-service.ts
@@ -17,75 +17,20 @@
 import { injectable } from 'inversify';
 import { QuickOpenModel } from './quick-open-model';
 import { MessageType } from '../../common/message-service-protocol';
-import { HideReason } from '../../common/quick-pick-service';
+import * as common from '../../common/quick-open-service';
 
-export type QuickOpenOptions = Partial<QuickOpenOptions.Resolved>;
-export namespace QuickOpenOptions {
-    export interface FuzzyMatchOptions {
-        /**
-         * Default: `false`
-         */
-        enableSeparateSubstringMatching?: boolean
-    }
-    export interface Resolved {
-        readonly prefix: string;
-        readonly placeholder: string;
-        readonly ignoreFocusOut: boolean;
-
-        readonly fuzzyMatchLabel: boolean | FuzzyMatchOptions;
-        readonly fuzzyMatchDetail: boolean | FuzzyMatchOptions;
-        readonly fuzzyMatchDescription: boolean | FuzzyMatchOptions;
-        readonly fuzzySort: boolean;
-
-        /** The amount of first symbols to be ignored by quick open widget (e.g. don't affect matching). */
-        readonly skipPrefix: number;
-
-        /**
-         * Whether to display the items that don't have any highlight.
-         */
-        readonly showItemsWithoutHighlight: boolean;
-
-        /**
-         * `true` if the quick open widget provides a way for the user to securely enter a password.
-         * Otherwise, `false`.
-         */
-        readonly password: boolean;
-
-        selectIndex(lookFor: string): number;
-
-        onClose(canceled: boolean): void;
-    }
-    export const defaultOptions: Resolved = Object.freeze({
-        prefix: '',
-        placeholder: '',
-        ignoreFocusOut: false,
-
-        fuzzyMatchLabel: false,
-        fuzzyMatchDetail: false,
-        fuzzyMatchDescription: false,
-        fuzzySort: false,
-
-        skipPrefix: 0,
-
-        showItemsWithoutHighlight: false,
-        password: false,
-
-        onClose: () => { /* no-op*/ },
-
-        selectIndex: () => -1
-    });
-    export function resolve(options: QuickOpenOptions = {}, source: Resolved = defaultOptions): Resolved {
-        return Object.assign({}, source, options);
-    }
-}
+/**
+ * @deprecated import from `@theia/core/lib/common/quick-open-service` instead
+ */
+export { QuickOpenOptions } from '../../common/quick-open-service';
 
 @injectable()
 export class QuickOpenService {
     /**
      * It should be implemented by an extension, e.g. by the monaco extension.
      */
-    open(model: QuickOpenModel, options?: QuickOpenOptions): void { }
-    hide(reason?: HideReason): void { }
+    open(model: QuickOpenModel, options?: common.QuickOpenOptions): void { }
+    hide(reason?: common.QuickOpenHideReason): void { }
     showDecoration(type: MessageType): void { }
     hideDecoration(): void { }
 }

--- a/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
@@ -17,7 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { QuickOpenItem, QuickOpenMode, QuickOpenGroupItem, QuickOpenItemOptions } from './quick-open-model';
 import { QuickOpenService } from './quick-open-service';
-import { QuickPickService, QuickPickOptions, QuickPickItem, QuickPickSeparator, QuickPickValue } from '../../common/quick-pick-service';
+import { QuickPickService, QuickPickOptions, QuickPickItem, QuickPickSeparator, QuickPickValue, HideReason } from '../../common/quick-pick-service';
 
 @injectable()
 export class QuickPickServiceImpl implements QuickPickService {
@@ -82,6 +82,10 @@ export class QuickPickServiceImpl implements QuickPickService {
                 return true;
             }
         };
+    }
+
+    hide(reason?: HideReason): void {
+        this.quickOpenService.hide(reason);
     }
 
 }

--- a/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
@@ -17,7 +17,8 @@
 import { injectable, inject } from 'inversify';
 import { QuickOpenItem, QuickOpenMode, QuickOpenGroupItem, QuickOpenItemOptions } from './quick-open-model';
 import { QuickOpenService } from './quick-open-service';
-import { QuickPickService, QuickPickOptions, QuickPickItem, QuickPickSeparator, QuickPickValue, HideReason } from '../../common/quick-pick-service';
+import { QuickPickService, QuickPickOptions, QuickPickItem, QuickPickSeparator, QuickPickValue } from '../../common/quick-pick-service';
+import { QuickOpenHideReason } from '../../common/quick-open-service';
 
 @injectable()
 export class QuickPickServiceImpl implements QuickPickService {
@@ -84,7 +85,7 @@ export class QuickPickServiceImpl implements QuickPickService {
         };
     }
 
-    hide(reason?: HideReason): void {
+    hide(reason?: QuickOpenHideReason): void {
         this.quickOpenService.hide(reason);
     }
 

--- a/packages/core/src/common/quick-open-service.ts
+++ b/packages/core/src/common/quick-open-service.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+export enum QuickOpenHideReason {
+    ELEMENT_SELECTED,
+    FOCUS_LOST,
+    CANCELED,
+}
+
+export type QuickOpenOptions = Partial<QuickOpenOptions.Resolved>;
+export namespace QuickOpenOptions {
+    export interface FuzzyMatchOptions {
+        /**
+         * Default: `false`
+         */
+        enableSeparateSubstringMatching?: boolean
+    }
+    export interface Resolved {
+        readonly prefix: string;
+        readonly placeholder: string;
+        readonly ignoreFocusOut: boolean;
+
+        readonly fuzzyMatchLabel: boolean | FuzzyMatchOptions;
+        readonly fuzzyMatchDetail: boolean | FuzzyMatchOptions;
+        readonly fuzzyMatchDescription: boolean | FuzzyMatchOptions;
+        readonly fuzzySort: boolean;
+
+        /** The amount of first symbols to be ignored by quick open widget (e.g. don't affect matching). */
+        readonly skipPrefix: number;
+
+        /**
+         * Whether to display the items that don't have any highlight.
+         */
+        readonly showItemsWithoutHighlight: boolean;
+
+        /**
+         * `true` if the quick open widget provides a way for the user to securely enter a password.
+         * Otherwise, `false`.
+         */
+        readonly password: boolean;
+
+        selectIndex(lookFor: string): number;
+
+        onClose(canceled: boolean): void;
+    }
+    export const defaultOptions: Resolved = Object.freeze({
+        prefix: '',
+        placeholder: '',
+        ignoreFocusOut: false,
+
+        fuzzyMatchLabel: false,
+        fuzzyMatchDetail: false,
+        fuzzyMatchDescription: false,
+        fuzzySort: false,
+
+        skipPrefix: 0,
+
+        showItemsWithoutHighlight: false,
+        password: false,
+
+        onClose: () => { /* no-op*/ },
+
+        selectIndex: () => -1
+    });
+    export function resolve(options: QuickOpenOptions = {}, source: Resolved = defaultOptions): Resolved {
+        return Object.assign({}, source, options);
+    }
+}

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+import { QuickOpenHideReason } from './quick-open-service';
 
 export type QuickPickItem<T> = QuickPickValue<T> | QuickPickSeparator;
 
@@ -54,12 +55,6 @@ export interface QuickPickService {
 
     show<T>(elements: QuickPickItem<T>[], options?: QuickPickOptions): Promise<T | undefined>;
 
-    hide(reason?: HideReason): void
+    hide(reason?: QuickOpenHideReason): void
 
-}
-
-export enum HideReason {
-    ELEMENT_SELECTED,
-    FOCUS_LOST,
-    CANCELED,
 }

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -54,4 +54,12 @@ export interface QuickPickService {
 
     show<T>(elements: QuickPickItem<T>[], options?: QuickPickOptions): Promise<T | undefined>;
 
+    hide(reason?: HideReason): void
+
+}
+
+export enum HideReason {
+    ELEMENT_SELECTED,
+    FOCUS_LOST,
+    CANCELED,
 }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -24,7 +24,7 @@ import {
 import { KEY_CODE_MAP } from './monaco-keycode-map';
 import { ContextKey } from '@theia/core/lib/browser/context-key-service';
 import { MonacoContextKeyService } from './monaco-context-key-service';
-import { HideReason } from '@theia/core/lib/common/quick-pick-service';
+import { QuickOpenHideReason } from '@theia/core/lib/common/quick-open-service';
 
 export interface MonacoQuickOpenControllerOpts extends monaco.quickOpen.IQuickOpenControllerOpts {
     readonly prefix?: string;
@@ -72,16 +72,16 @@ export class MonacoQuickOpenService extends QuickOpenService {
         this.internalOpen(new MonacoQuickOpenControllerOptsImpl(model, this.keybindingRegistry, options));
     }
 
-    hide(reason?: HideReason): void {
+    hide(reason?: QuickOpenHideReason): void {
         let hideReason: monaco.quickOpen.HideReason | undefined;
         switch (reason) {
-            case HideReason.ELEMENT_SELECTED:
+            case QuickOpenHideReason.ELEMENT_SELECTED:
                 hideReason = monaco.quickOpen.HideReason.ELEMENT_SELECTED;
                 break;
-            case HideReason.FOCUS_LOST:
+            case QuickOpenHideReason.FOCUS_LOST:
                 hideReason = monaco.quickOpen.HideReason.FOCUS_LOST;
                 break;
-            case HideReason.CANCELED:
+            case QuickOpenHideReason.CANCELED:
                 hideReason = monaco.quickOpen.HideReason.CANCELED;
                 break;
         }

--- a/packages/monaco/src/browser/monaco-quick-open-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-open-service.ts
@@ -24,6 +24,7 @@ import {
 import { KEY_CODE_MAP } from './monaco-keycode-map';
 import { ContextKey } from '@theia/core/lib/browser/context-key-service';
 import { MonacoContextKeyService } from './monaco-context-key-service';
+import { HideReason } from '@theia/core/lib/common/quick-pick-service';
 
 export interface MonacoQuickOpenControllerOpts extends monaco.quickOpen.IQuickOpenControllerOpts {
     readonly prefix?: string;
@@ -69,6 +70,22 @@ export class MonacoQuickOpenService extends QuickOpenService {
 
     open(model: QuickOpenModel, options?: QuickOpenOptions): void {
         this.internalOpen(new MonacoQuickOpenControllerOptsImpl(model, this.keybindingRegistry, options));
+    }
+
+    hide(reason?: HideReason): void {
+        let hideReason: monaco.quickOpen.HideReason | undefined;
+        switch (reason) {
+            case HideReason.ELEMENT_SELECTED:
+                hideReason = monaco.quickOpen.HideReason.ELEMENT_SELECTED;
+                break;
+            case HideReason.FOCUS_LOST:
+                hideReason = monaco.quickOpen.HideReason.FOCUS_LOST;
+                break;
+            case HideReason.CANCELED:
+                hideReason = monaco.quickOpen.HideReason.CANCELED;
+                break;
+        }
+        this.widget.hide(hideReason);
     }
 
     showDecoration(type: MessageType): void {

--- a/packages/plugin-ext/src/api/plugin-api.ts
+++ b/packages/plugin-ext/src/api/plugin-api.ts
@@ -388,6 +388,7 @@ export interface QuickOpenMain {
     $setItems(items: PickOpenItem[]): Promise<any>;
     $setError(error: Error): Promise<any>;
     $input(options: theia.InputBoxOptions, validateInput: boolean): Promise<string | undefined>;
+    $hide(): void;
 }
 
 export interface WorkspaceMain {

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -110,4 +110,8 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
         }
     }
 
+    $hide(): void {
+        this.delegate.hide();
+    }
+
 }

--- a/packages/plugin-ext/src/plugin/quick-open.ts
+++ b/packages/plugin-ext/src/plugin/quick-open.ts
@@ -129,8 +129,11 @@ export class QuickOpenExtImpl implements QuickOpenExt {
         return hookCancellationToken(token, promise);
     }
 
-}
+    hide(): void {
+        this.proxy.$hide();
+    }
 
+}
 /**
  * Base implementation of {@link QuickPick} that uses {@link QuickOpenExt}.
  * Missing functionality is going to be implemented in the scope of https://github.com/theia-ide/theia/issues/5059
@@ -231,6 +234,7 @@ export class QuickPickExt<T extends QuickPickItem> implements QuickPick<T> {
     }
 
     hide(): void {
+        this.quickOpen.hide();
         this.dispose();
     }
 


### PR DESCRIPTION
Fixes #5765 

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

See https://code.visualstudio.com/api/references/vscode-api#QuickPick. 
>Hides this input UI. This will also fire an QuickInput.onDidHide event.

when execute `hide` method, vscode will:

- Hide UI
- Emit onDidHide event

But theia only emit onDidHide event.

#### How to test

```typescript
import * as vscode from 'vscode';

export function activate(context: vscode.ExtensionContext) {
  const disposable = vscode.commands.registerCommand('hide QuickPick after 2000ms', () => {
    const quickOpen = vscode.window.createQuickPick();

    quickOpen.items = [
      { label: 'A' }, {label: 'B'}
    ];

    quickOpen.show();

    setTimeout(() => {
       quickOpen.hide();
     }, 2000);
  });

  context.subscriptions.push(disposable);
}

```

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
