### PR TITLE
[vscode] unzip node_modules for built-in extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [security] Bump lodash.mergewith from 4.6.1 to 4.6.2
 - [plugin] Fixed `Converting circular structure to JSON` Error [#5661](https://github.com/theia-ide/theia/pull/5661)
 - [plugin] fixed auto detection of new languages [#5753](https://github.com/theia-ide/theia/issues/5753)
+- [vscode] unzip node_modules for built-in extensions [#5756](https://github.com/theia-ide/theia/pull/5756)
 
 Breaking changes:
 

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -16,6 +16,7 @@
 
 import { PluginDeployerFileHandler, PluginDeployerEntry, PluginDeployerFileHandlerContext } from '@theia/plugin-ext';
 import { injectable } from 'inversify';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import { getTempDir } from '@theia/plugin-ext';
 
@@ -41,6 +42,13 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
 
         const unpackedPath = path.resolve(this.unpackedFolder, path.basename(context.pluginEntry().path()));
         await context.unzip(context.pluginEntry().path(), unpackedPath);
+        if (context.pluginEntry().path().endsWith('.tgz')) {
+            const extensionPath = path.join(unpackedPath, 'package');
+            const vscodeNodeModulesPath = path.join(extensionPath, 'vscode_node_modules.zip');
+            if (await fs.pathExists(vscodeNodeModulesPath)) {
+                await context.unzip(vscodeNodeModulesPath, path.join(extensionPath, 'node_modules'));
+            }
+        }
 
         context.pluginEntry().updatePath(unpackedPath);
         return Promise.resolve();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed -->

fix #5756: unzip node_modules for built-in extensions

#### How to test
<!-- Describe how a reviewer can verify changes within Theia repo -->

- install latest emmet extension with https://registry.npmjs.org/@theia/vscode-builtin-emmet/-/vscode-builtin-emmet-0.2.1.tgz
- verify that emmet content assist is present in HTML files

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)
