### PR TITLE
Fix execution of configured tasks

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -234,7 +234,7 @@ export class TaskConfigurations implements Disposable {
                         console.error(`Error parsing ${uri}: error: ${e.error}, length:  ${e.length}, offset:  ${e.offset}`);
                     }
                 } else {
-                    return this.filterDuplicates(tasks['tasks']).map(t => Object.assign(t, { _source: t.source || this.getSourceFolderFromConfigUri(uri) }));
+                    return this.filterDuplicates(tasks['tasks']).map(t => Object.assign(t, { _source: this.getSourceFolderFromConfigUri(uri) }));
                 }
             } catch (err) {
                 console.error(`Error(s) reading config file: ${uri}`);
@@ -267,7 +267,7 @@ export class TaskConfigurations implements Disposable {
             await this.fileSystem.createFile(configFileUri);
         }
 
-        const { _source, $ident, ...preparedTask } = task;
+        const { _source, _scope, $ident, ...preparedTask } = task;
         try {
             const response = await this.fileSystem.resolveContent(configFileUri);
             const content = response.content;

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -23,7 +23,7 @@ import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions } from '@theia
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { MessageService } from '@theia/core/lib/common/message-service';
-import { TaskServer, TaskExitedEvent, TaskInfo, TaskConfiguration, ContributedTaskConfiguration } from '../common/task-protocol';
+import { TaskServer, TaskExitedEvent, TaskInfo, TaskConfiguration } from '../common/task-protocol';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
 import { TaskWatcher } from '../common/task-watcher';
@@ -114,8 +114,8 @@ export class TaskService implements TaskConfigurationClient {
                 const task = event.config;
                 const taskIdentifier =
                     task
-                        ? ContributedTaskConfiguration.is(task)
-                            ? `${task._source}: ${task.label}`
+                        ? task.source
+                            ? `${task.source}: ${task.label}`
                             : `${task.type}: ${task.label}`
                         : `${event.taskId}`;
                 this.messageService.info(`Task ${taskIdentifier} has been started`);
@@ -131,8 +131,8 @@ export class TaskService implements TaskConfigurationClient {
             const taskConfiguration = event.config;
             const taskIdentifier =
                 taskConfiguration
-                    ? ContributedTaskConfiguration.is(taskConfiguration)
-                        ? `${taskConfiguration._source}: ${taskConfiguration.label}`
+                    ? taskConfiguration.source
+                        ? `${taskConfiguration.source}: ${taskConfiguration.label}`
                         : `${taskConfiguration.type}: ${taskConfiguration.label}`
                     : `${event.taskId}`;
 


### PR DESCRIPTION
### What does this PR do?
Fix execution of configured tasks

### What issues does this PR fix or reference?
- fixes for tasks provided by plugins: https://github.com/theia-ide/theia/issues/5064 and  https://github.com/theia-ide/theia/issues/5067

### How to test
Use the components in your devfile

```
- 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/RomanNikitenko/che-plugin-registry/master/v3/plugins/eclipse/che-theia/custom/meta.yaml
    type: cheEditor
  
  - 
    id: che-incubator/typescript/1.30.2
    type: chePlugin
    memoryLimit: 2048M

``` 
Try to configure some `detected` task and then run it. Also you can try to run the task after refreshing page from `recently used` section
Note: you can not see output for tasks provided by plugins, because of https://github.com/eclipse/che/issues/13876, but you can see events that task has started or completed.

Please see the video:https://youtu.be/3KB1GvwXH_M

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

