### PR TITLE
Fixed #4897: supported tab details to disambiguate identical names

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.spec.ts
+++ b/packages/core/src/browser/shell/tab-bars.spec.ts
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (C) 2019 Ericsson and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { enableJSDOM } from '../test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { expect } from 'chai';
+
+import { Title, Widget } from '@phosphor/widgets';
+import { TabBarRenderer } from './tab-bars';
+
+disableJSDOM();
+
+describe('tab bar', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('should disambiguate tabs that have identical names', () => {
+        const tabBar = new TabBarRenderer();
+        const owner = new Widget();
+
+        const tabLabels: string[] = ['index.ts', 'index.ts', 'index.ts', 'main.ts', 'main.ts', 'main.ts', 'uniqueFile.ts'];
+        const tabPaths: string[] = [
+            'root1/src/foo/bar/index.ts',
+            'root1/lib/foo/bar/index.ts',
+            'root2/src/foo/goo/bar/index.ts',
+            'root1/aaa/main.ts',
+            'root1/aaa/bbb/main.ts',
+            'root1/aaa/bbb/ccc/main.ts',
+            'root1/src/foo/bar/uniqueFile.ts'
+        ];
+        const tabs: Title<Widget>[] = tabLabels.map((label, i) => new Title<Widget>({
+            owner, label, caption: tabPaths[i]
+        }));
+        const pathMap = tabBar.findDuplicateLabels(tabs);
+
+        expect(pathMap.get(tabPaths[0])).to.be.equal('.../src/...');
+        expect(pathMap.get(tabPaths[1])).to.be.equal('.../lib/...');
+        expect(pathMap.get(tabPaths[2])).to.be.equal('root2/...');
+        expect(pathMap.get(tabPaths[3])).to.be.equal('root1/aaa');
+        expect(pathMap.get(tabPaths[4])).to.be.equal('root1/aaa/bbb');
+        expect(pathMap.get(tabPaths[5])).to.be.equal('.../ccc');
+        expect(pathMap.get(tabPaths[6])).to.be.equal(undefined);
+    });
+});

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -90,8 +90,21 @@
 
 .p-TabBar.theia-app-centers .p-TabBar-tabIcon,
 .p-TabBar.theia-app-centers .p-TabBar-tabLabel,
+.p-TabBar.theia-app-centers .p-TabBar-tabLabelDetails,
 .p-TabBar.theia-app-centers .p-TabBar-tabCloseIcon {
   display: inline-block;
+}
+
+.p-TabBar.theia-app-centers .p-TabBar-tabLabelDetails {
+  margin-left: 5px;
+  color: var(--theia-ui-font-color2);
+  flex: 1 1 auto;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.p-TabBar.theia-app-centers .p-TabBar-tabLabelWrapper {
+  display: flex;
 }
 
 .p-TabBar-tab-secondary-label {


### PR DESCRIPTION
#### What it does
Fixed #4897.
- Supported additional tab details for tabs with identical titles.
- If there existed multiple tabs with the same name, each tab would have its partial relative path displayed after the title.
![image](https://user-images.githubusercontent.com/25921074/61649688-f4d5ff00-ac7f-11e9-94bb-33630ef8f5fb.png)

#### How to test
- Open files with identical names in a tab bar (e.g., index.ts from different directories), and they should have a partial path displayed for the purpose of disambiguation.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
