### PR TITLE
align "configure task" and "task quick open" with vs code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 ## v0.10.0
 
-- [vscode] added env variable substitution support [5811](https://github.com/theia-ide/theia/pull/5811)
+- [vscode] added env variable substitution support [#5811](https://github.com/theia-ide/theia/pull/5811)
+- [task] added support for VS Code task contribution points: `taskDefinitions`, `problemMatchers`, and `problemPatterns` [#5777](https://github.com/theia-ide/theia/pull/5777)
+- [task] added multi-root support to "configure task" and customizing tasks in `tasks.json` [#5777](https://github.com/theia-ide/theia/pull/5777)
+- [task] changed the way that "configure task" copies the entire task config, to only writting properties that define the detected task plus [#5777](https://github.com/theia-ide/theia/pull/5777)`problemMatcher`, into `tasks.json`
+- [task] fixed the problem where a detected task can be customized more than once [#5777](https://github.com/theia-ide/theia/pull/5777)
+- [task] displayed the customized tasks as "configured tasks" in the task quick open [#5777](https://github.com/theia-ide/theia/pull/5777)
+- [task] allowed users to override any task properties other than the ones used in the task definition [#5777](https://github.com/theia-ide/theia/pull/5777)
+
+Breaking changes:
+
+- [task] `TaskService.getConfiguredTasks()` returns `Promise<TaskConfiguration[]>` instead of `TaskConfiguration[]` [#5777](https://github.com/theia-ide/theia/pull/5777)
 
 ## v0.9.0
 - [core] added `theia-widget-noInfo` css class to be used by widgets when displaying no information messages [#5717](https://github.com/theia-ide/theia/pull/5717)

--- a/packages/task/src/browser/provided-task-configurations.spec.ts
+++ b/packages/task/src/browser/provided-task-configurations.spec.ts
@@ -17,6 +17,7 @@
 import { assert } from 'chai';
 import { Container } from 'inversify';
 import { ProvidedTaskConfigurations } from './provided-task-configurations';
+import { TaskDefinitionRegistry } from './task-definition-registry';
 import { TaskProviderRegistry } from './task-contribution';
 import { TaskConfiguration } from '../common';
 
@@ -26,6 +27,7 @@ describe('provided-task-configurations', () => {
         container = new Container();
         container.bind(ProvidedTaskConfigurations).toSelf().inSingletonScope();
         container.bind(TaskProviderRegistry).toSelf().inSingletonScope();
+        container.bind(TaskDefinitionRegistry).toSelf().inSingletonScope();
     });
 
     it('provided-task-search', async () => {

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -15,8 +15,10 @@
  ********************************************************************************/
 
 import { inject, injectable } from 'inversify';
-import { TaskConfiguration } from '../common/task-protocol';
 import { TaskProviderRegistry } from './task-contribution';
+import { TaskDefinitionRegistry } from './task-definition-registry';
+import { TaskConfiguration, TaskCustomization } from '../common';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class ProvidedTaskConfigurations {
@@ -30,13 +32,14 @@ export class ProvidedTaskConfigurations {
     @inject(TaskProviderRegistry)
     protected readonly taskProviderRegistry: TaskProviderRegistry;
 
+    @inject(TaskDefinitionRegistry)
+    protected readonly taskDefinitionRegistry: TaskDefinitionRegistry;
+
     /** returns a list of provided tasks */
     async getTasks(): Promise<TaskConfiguration[]> {
-        const providedTasks: TaskConfiguration[] = [];
         const providers = this.taskProviderRegistry.getProviders();
-        for (const provider of providers) {
-            providedTasks.push(...await provider.provideTasks());
-        }
+        const providedTasks: TaskConfiguration[] = (await Promise.all(providers.map(p => p.provideTasks())))
+            .reduce((acc, taskArray) => acc.concat(taskArray), []);
         this.cacheTasks(providedTasks);
         return providedTasks;
     }
@@ -50,6 +53,51 @@ export class ProvidedTaskConfigurations {
             await this.getTasks();
             return this.getCachedTask(source, taskLabel);
         }
+    }
+
+    /**
+     * Finds the detected task for the given task customization.
+     * The detected task is considered as a "match" to the task customization if it has all the `required` properties.
+     * In case that more than one customization is found, return the one that has the biggest number of matched properties.
+     *
+     * @param customization the task customization
+     * @return the detected task for the given task customization. If the task customization is not found, `undefined` is returned.
+     */
+    async getTaskToCustomize(customization: TaskCustomization, rootFolderPath: string): Promise<TaskConfiguration | undefined> {
+        const definition = this.taskDefinitionRegistry.getDefinition(customization);
+        if (!definition) {
+            return undefined;
+        }
+
+        const matchedTasks: TaskConfiguration[] = [];
+        let highest = -1;
+        const tasks = await this.getTasks();
+        for (const task of tasks) { // find detected tasks that match the `definition`
+            let score = 0;
+            if (!definition.properties.required.every(requiredProp => customization[requiredProp] !== undefined)) {
+                continue;
+            }
+            score += definition.properties.required.length; // number of required properties
+            const requiredProps = new Set(definition.properties.required);
+            // number of optional properties
+            score += definition.properties.all.filter(p => !requiredProps.has(p) && customization[p] !== undefined).length;
+            if (score >= highest) {
+                if (score > highest) {
+                    highest = score;
+                    matchedTasks.length = 0;
+                }
+                matchedTasks.push(task);
+            }
+        }
+
+        // find the task that matches the `customization`.
+        // The scenario where more than one match is found should not happen unless users manually enter multiple customizations for one type of task
+        // If this does happen, return the first match
+        const rootFolderUri = new URI(rootFolderPath).toString();
+        const matchedTask = matchedTasks.filter(t =>
+            rootFolderUri === t._scope && definition.properties.all.every(p => t[p] === customization[p])
+        )[0];
+        return matchedTask;
     }
 
     protected getCachedTask(source: string, taskLabel: string): TaskConfiguration | undefined {

--- a/packages/task/src/browser/quick-open-task.ts
+++ b/packages/task/src/browser/quick-open-task.ts
@@ -20,7 +20,7 @@ import {
     QuickOpenGroupItem, QuickOpenMode, QuickOpenHandler, QuickOpenOptions, QuickOpenActionProvider, QuickOpenGroupItemOptions
 } from '@theia/core/lib/browser/quick-open/';
 import { TaskService } from './task-service';
-import { TaskInfo, TaskConfiguration } from '../common/task-protocol';
+import { ContributedTaskConfiguration, TaskInfo, TaskConfiguration } from '../common/task-protocol';
 import { TaskConfigurations } from './task-configurations';
 import { TaskDefinitionRegistry } from './task-definition-registry';
 import URI from '@theia/core/lib/common/uri';
@@ -66,7 +66,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
     /** Initialize this quick open model with the tasks. */
     async init(): Promise<void> {
         const recentTasks = this.taskService.recentTasks;
-        const configuredTasks = this.taskService.getConfiguredTasks();
+        const configuredTasks = await this.taskService.getConfiguredTasks();
         const providedTasks = await this.taskService.getProvidedTasks();
 
         const { filteredRecentTasks, filteredConfiguredTasks, filteredProvidedTasks } = this.getFilteredTasks(recentTasks, configuredTasks, providedTasks);
@@ -213,7 +213,7 @@ export class QuickOpenTask implements QuickOpenModel, QuickOpenHandler {
 
         const filteredProvidedTasks: TaskConfiguration[] = [];
         providedTasks.forEach(provided => {
-            const exist = [...filteredRecentTasks, ...configuredTasks].some(t => TaskConfiguration.equals(provided, t));
+            const exist = [...filteredRecentTasks, ...configuredTasks].some(t => ContributedTaskConfiguration.equals(provided, t));
             if (!exist) {
                 filteredProvidedTasks.push(provided);
             }

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -15,7 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
-import { TaskDefinition, TaskConfiguration } from '../common';
+import { TaskConfiguration, TaskCustomization, TaskDefinition } from '../common';
 
 @injectable()
 export class TaskDefinitionRegistry {
@@ -41,7 +41,7 @@ export class TaskDefinitionRegistry {
      * @param taskConfiguration the task configuration
      * @return the task definition for the task configuration. If the task definition is not found, `undefined` is returned.
      */
-    getDefinition(taskConfiguration: TaskConfiguration): TaskDefinition | undefined {
+    getDefinition(taskConfiguration: TaskConfiguration | TaskCustomization): TaskDefinition | undefined {
         const definitions = this.getDefinitions(taskConfiguration.taskType || taskConfiguration.type);
         let matchedDefinition: TaskDefinition | undefined;
         let highest = -1;

--- a/packages/task/src/common/task-protocol.ts
+++ b/packages/task/src/common/task-protocol.ts
@@ -35,7 +35,8 @@ export interface TaskConfiguration extends TaskCustomization {
 }
 export namespace TaskConfiguration {
     export function equals(one: TaskConfiguration, other: TaskConfiguration): boolean {
-        return one.label === other.label && one._source === other._source;
+        return (one.taskType || one.type) === (other.taskType || other.type) &&
+            one.label === other.label && one._source === other._source;
     }
 }
 
@@ -51,6 +52,11 @@ export interface ContributedTaskConfiguration extends TaskConfiguration {
      * This field is not supposed to be used in `tasks.json`
      */
     readonly _scope: string | undefined;
+}
+export namespace ContributedTaskConfiguration {
+    export function equals(one: TaskConfiguration, other: TaskConfiguration): boolean {
+        return TaskConfiguration.equals(one, other) && one._scope === other._scope;
+    }
 }
 
 /** Runtime information about Task. */


### PR DESCRIPTION
- edit the right task.json when clicking "configure task" in multi-root
workspace (fixed #4919)

- in the current Theia, when users configure a detected task, the entire task config is written into tasks.json, which introduces redundancy. 
With this change, only properties that define the detected task, plus `problemMatcher`, are written into tasks.json. (fixed #5679)

- `TaskConfigurations.taskCustomizations` is a flat array, and the user can only customize one type of detected task in one way.
With this change Theia supports having different ways of task customization in different root folders.

- allow users to override any task properties other than `type`, and those that are used to define the in its task definition.

- The detected tasks, once customized, should be displayed as configured tasks in the quick open. (fixed #5747)

- The same task shouldn’t have more than one customization. Otherwise it would cause ambiguities and duplication in tasks.json (fixed #5719)

Signed-off-by: Liang Huang <liang.huang@ericsson.com>