### PR TITLE
[Eclipse Foundation] Update to follow branding guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Theia
+# Contributing to Eclipse Theia
 
 Theia is a young open-source project with a modular architecture. One of the
 goals is to make sure that we can customize and enhance any Theia application

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [**Feedback**](#feedback)
 - [**Roadmap**](#roadmap)
 - [**License**](#license)
+- [**Trademark**](#trademark)
 
 ## Website
 
@@ -103,4 +104,9 @@ Read below how to engage with Theia community:
 
 - [Eclipse Public License 2.0](LICENSE)
 - [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](LICENSE)
+
+
+## Trademark
+"Theia" is a trademark of the Eclipse Foundation 
+https://www.eclipse.org/theia
 


### PR DESCRIPTION
Update repo so that we follow the Eclipse Foundation
branding guidelines. In short:

"the project name needs to be "Eclipse Theia" in the first
and all prominent occurrences, add an indication that "Theia"
is a trademark of the Eclipse Foundation in the README, and
include a link to https://www.eclipse.org/theia."

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>