### PR TITLE
[terminal] add preference to control terminal scrollback

### DIFF
--- a/packages/terminal/src/browser/terminal-preferences.ts
+++ b/packages/terminal/src/browser/terminal-preferences.ts
@@ -65,6 +65,11 @@ export const TerminalConfigSchema: PreferenceSchema = {
             minimum: 1,
             default: 1
         },
+        'terminal.integrated.scrollback': {
+            description: 'Controls the maximum amount of lines the terminal keeps in its buffer.',
+            type: 'number',
+            default: 1000,
+        }
     }
 };
 
@@ -76,7 +81,8 @@ export interface TerminalConfiguration {
     'terminal.integrated.fontWeight': FontWeight
     'terminal.integrated.fontWeightBold': FontWeight
     'terminal.integrated.letterSpacing': number
-    'terminal.integrated.lineHeight': number
+    'terminal.integrated.lineHeight': number,
+    'terminal.integrated.scrollback': number,
 }
 
 type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -108,6 +108,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             fontWeightBold: this.preferences['terminal.integrated.fontWeightBold'],
             letterSpacing: this.preferences['terminal.integrated.letterSpacing'],
             lineHeight: this.preferences['terminal.integrated.lineHeight'],
+            scrollback: this.preferences['terminal.integrated.scrollback'],
             theme: {
                 foreground: cssProps.foreground,
                 background: cssProps.background,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed -->

Fixes #5781

- added new preference `terminal.integrated.scrollback` to control the number of lines the terminal keeps in its buffer 
- aligned the `values`, `description` and `id` with vscode

#### How to test
<!-- Describe how a reviewer can verify changes within Theia repo -->

1. use the `terminal.integrated.scrollback` preference to test different values of scrollback (lines the terminal keeps in its buffer)

#### Review checklist

- [x] CQ registered (https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20459)
- [x] CQ approved
- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)






Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
