### PR TITLE
Fix getting value from Memento

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-storage.ts
+++ b/packages/plugin-ext/src/plugin/plugin-storage.ts
@@ -40,7 +40,7 @@ export class Memento implements theia.Memento {
     get<T>(key: string): T | undefined;
     get<T>(key: string, defaultValue: T): T;
     get<T>(key: string, defaultValue?: T): T | undefined {
-        if (key && this.cache[key]) {
+        if (key && this.cache.hasOwnProperty(key)) {
             return this.cache[key];
         } else {
             return defaultValue;


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

While working on C++ plugin for Eclipse Che I faced the error when Theia IDE starts with VS Code C++ extension [1]:

```
root INFO [hosted-plugin: 11842] TypeError: Cannot set property 'includePath' of undefined
    at CppProperties.applyDefaultConfigurationValues (/tmp/vscode-unpacked/ms-vscode.cpptools-0.24.1.vsix/extension/dist/main.js:35151:39)
    at CppProperties.applyDefaultIncludePathsAndFrameworks (/tmp/vscode-unpacked/ms-vscode.cpptools-0.24.1.vsix/extension/dist/main.js:35139:18)
    at CppProperties.handleConfigurationChange (/tmp/vscode-unpacked/ms-vscode.cpptools-0.24.1.vsix/extension/dist/main.js:35558:14)
    at CppProperties.set CompilerDefaults [as CompilerDefaults] (/tmp/vscode-unpacked/ms-vscode.cpptools-0.24.1.vsix/extension/dist/main.js:35104:14)
    at languageClient.sendRequest.then (/tmp/vscode-unpacked/ms-vscode.cpptools-0.24.1.vsix/extension/dist/main.js:27401:57)
root WARN A command C_Cpp.BuildAndDebugActiveFile is already registered.
root ERROR C/C++: I[09:01:49.337] <-- initialize(0)
```
Digging the code I figured out that the root cause is that `Memento.get` sometimes returns a default value instead of cached one:
```js
 if (key && this.cache[key]) {
            return this.cache[key];
        } else {
            return defaultValue;
        }
```

If `this.cache[key]` is equal to `false` or to `0` then `key && this.cache[key` is false and the default value will be returned. This patch adds the proper way to check if json contains field. 

### How to test
1. Put the VS Code extension [1] in the plugin folder.
2. Start Theia IDE.
3. The error above is not observed.
4. Create a `cpp` file, for instance [2], make sure LS works correctly.

[1] https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools
[2] https://www.programiz.com/cpp-programming/examples/print-

![screencast-localhost_3000-2019 07 25-12_02_46](https://user-images.githubusercontent.com/1640675/61861500-bdac5b80-aed4-11e9-9c6b-be2f5e449f65.gif)

This issue is needed for https://github.com/eclipse/che/issues/13698