### PR TITLE
Fixed #5793: fixed the alignment in search-in-workspace result node

### DIFF
--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -314,7 +314,8 @@
 .result-node-buttons > span {
     width: 15px;
     height: 15px;
-    margin-right: 3px;
+    margin-left: 2.5px;
+    margin-right: 0.5px;
     background-repeat:  no-repeat;
     background-position: center;
     background-size: contain;


### PR DESCRIPTION
- Fixed the alignment in the search-in-workspace result node. The `close` icon now is properly aligned with the notification count number icon.

![theia-result-node-align](https://user-images.githubusercontent.com/25921074/61906735-fc084180-aef9-11e9-974f-6c75f414dda1.gif)
