### PR TITLE
[WIP] Enable file upload even when no file is selected

### DIFF
--- a/packages/core/src/common/selection-command-handler.ts
+++ b/packages/core/src/common/selection-command-handler.ts
@@ -28,17 +28,27 @@ export class SelectionCommandHandler<S> implements CommandHandler {
 
     execute(...args: any[]): Object | undefined {
         const selection = this.getSelection(...args);
-        return selection ? (this.options.execute as any)(selection, ...args) : undefined;
+        return selection ? (this.options.execute as any)(selection, ...args) : (this.options.execute as any)(undefined);
     }
 
     isVisible(...args: any[]): boolean {
         const selection = this.getSelection(...args);
-        return !!selection && (!this.options.isVisible || (this.options.isVisible as any)(selection as any, ...args));
+        //custom isVisible function overrides default checking mechanism
+        if (!this.options.isVisible) {
+            return !!selection;
+        } else {
+            return (this.options.isVisible as any)(selection as any, ...args);
+        }
     }
 
     isEnabled(...args: any[]): boolean {
         const selection = this.getSelection(...args);
-        return !!selection && (!this.options.isEnabled || (this.options.isEnabled as any)(selection as any, ...args));
+        //custom isEnabled function overrides default checking mechanism
+        if (!this.options.isEnabled) {
+            return !!selection;
+        } else {
+            return (this.options.isEnabled as any)(selection as any, ...args);
+        }
     }
 
     protected isMulti(): boolean {


### PR DESCRIPTION
This is an attempt to implement the feature request as mentioned in #5739 

The strategy is the following:

- if there is no file selection (i.e. undefined), then upload button will upload files to workspace root
- if the selection is a regular file instead of a folder, then the upload button (in the menu bar, not context menu) will upload files to the folder containing the selected file