### PR TITLE
[vscode] support env variable substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.10.0
+
+- [vscode] added env variable substitution support [5811](https://github.com/theia-ide/theia/pull/5811)
+
 ## v0.9.0
 - [core] added `theia-widget-noInfo` css class to be used by widgets when displaying no information messages [#5717](https://github.com/theia-ide/theia/pull/5717)
 - [core] added additional options to the tree search input [#5566](https://github.com/theia-ide/theia/pull/5566)

--- a/packages/variable-resolver/src/browser/env-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/env-variable-contribution.ts
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable, inject } from 'inversify';
+import { VariableContribution, VariableRegistry } from './variable';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+
+@injectable()
+export class EnvVariableContribution implements VariableContribution {
+
+    @inject(EnvVariablesServer)
+    protected readonly env: EnvVariablesServer;
+
+    async registerVariables(variables: VariableRegistry): Promise<void> {
+        for (const variable of await this.env.getVariables()) {
+            variables.registerVariable({
+                name: 'env:' + variable.name,
+                resolve: () => variable.value
+            });
+        }
+    }
+
+}

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
@@ -21,6 +21,7 @@ import { VariableRegistry, VariableContribution } from './variable';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
 import { VariableResolverService } from './variable-resolver-service';
+import { EnvVariableContribution } from './env-variable-contribution';
 
 export default new ContainerModule(bind => {
     bind(VariableRegistry).toSelf().inSingletonScope();
@@ -33,4 +34,7 @@ export default new ContainerModule(bind => {
     }
 
     bind(VariableQuickOpenService).toSelf().inSingletonScope();
+
+    bind(EnvVariableContribution).toSelf().inSingletonScope();
+    bind(VariableContribution).toService(EnvVariableContribution);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.
Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

support `env:NAME` variable substitution, see VS Code doc: https://code.visualstudio.com/docs/editor/variables-reference#_environment-variables


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Modify launch configuration to reference some env variable and launch it. See for example how `PATH` env variable is referenced in `Run Mocha Test` configuration below, and then PATH value is printed to the debug console:

<img width="1792" alt="Screen Shot 2019-07-29 at 15 11 50" src="https://user-images.githubusercontent.com/3082655/62051908-a8a53480-b214-11e9-83d5-94b7e4109f4f.png">

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
