### PR TITLE
Add missed stub Comment API

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -107,7 +107,8 @@ import {
     OperatingSystem,
     WebviewPanelTargetArea,
     FileSystemError,
-    CommentThreadCollapsibleState
+    CommentThreadCollapsibleState,
+    CommentMode
 } from './types-impl';
 import { SymbolKind } from '../api/model';
 import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
@@ -701,7 +702,7 @@ export function createAPIFactory(
             createCommentController(id: string, label: string): theia.CommentController {
                 return {
                     id, label, inputBox: undefined,
-                    createCommentThread(commentId: string, resource: Uri, range: Range, comments: Comment[]): theia.CommentThread {
+                    createCommentThread(commentId: string, resource: Uri, range: Range, comments: theia.Comment[]): theia.CommentThread {
                         return {
                             id: commentId,
                             resource,
@@ -809,7 +810,8 @@ export function createAPIFactory(
             OperatingSystem,
             WebviewPanelTargetArea,
             FileSystemError,
-            CommentThreadCollapsibleState
+            CommentThreadCollapsibleState,
+            CommentMode
         };
     };
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -1231,6 +1231,11 @@ export enum CommentThreadCollapsibleState {
     Expanded = 1
 }
 
+export enum CommentMode {
+    Editing = 0,
+    Preview = 1
+}
+
 export class FileSystemError extends Error {
 
     static FileExists(messageOrUri?: string | URI): FileSystemError {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8131,6 +8131,21 @@ declare module '@theia/plugin' {
         Expanded = 1
     }
 
+	/**
+	 * Comment mode of a [comment](#Comment)
+	 */
+	export enum CommentMode {
+		/**
+		 * Displays the comment editor
+		 */
+		Editing = 0,
+
+		/**
+		 * Displays the preview of the comment
+		 */
+		Preview = 1
+	}
+
     /**
      * A collection of [comments](#Comment) representing a conversation at a particular range in a document.
      */
@@ -8318,6 +8333,84 @@ declare module '@theia/plugin' {
          * and Comments Panel.
          */
         dispose(): void;
+    }
+
+	/**
+	 * Author information of a [comment](#Comment)
+	 */
+	export interface CommentAuthorInformation {
+		/**
+		 * The display name of the author of the comment
+		 */
+		name: string;
+
+		/**
+		 * The optional icon path for the author
+		 */
+		iconPath?: Uri;
+	}
+
+	/**
+	 * Reactions of a [comment](#Comment)
+	 */
+	export interface CommentReaction {
+		/**
+		 * The human-readable label for the reaction
+		 */
+		readonly label: string;
+
+		/**
+		 * Icon for the reaction shown in UI.
+		 */
+		readonly iconPath: string | Uri;
+
+		/**
+		 * The number of users who have reacted to this reaction
+		 */
+		readonly count: number;
+
+		/**
+		 * Whether the [author](CommentAuthorInformation) of the comment has reacted to this reaction
+		 */
+		readonly authorHasReacted: boolean;
+	}
+
+    /**
+     * A comment is displayed within the editor or the Comments Panel, depending on how it is provided.
+     */
+    export interface Comment {
+		/**
+		 * The human-readable comment body
+		 */
+        body: string | MarkdownString;
+
+		/**
+		 * [Comment mode](#CommentMode) of the comment
+		 */
+        mode: CommentMode;
+
+		/**
+		 * The [author information](#CommentAuthorInformation) of the comment
+		 */
+        author: CommentAuthorInformation;
+
+		/**
+		 * Context value of the comment. This can be used to contribute comment specific actions.
+		 * For example, a comment is given a context value as `editable`. When contributing actions to `comments/comment/title`
+		 * using `menus` extension point, you can specify context value for key `comment` in `when` expression like `comment == editable`.
+		 */
+        contextValue?: string;
+
+		/**
+		 * Optional reactions of the [comment](#Comment)
+		 */
+        reactions?: CommentReaction[];
+
+		/**
+		 * Optional label describing the [Comment](#Comment)
+		 * Label will be rendered next to authorName if exists.
+		 */
+        label?: string;
     }
 
     namespace comment {


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->

Plugin API lacks some of necessary interfaces that makes Theia plugins fail on build. That was introduced in [[Plugin-Api] Add stub comment Plugin-Api ](https://github.com/theia-ide/theia/pull/5118). 
This PR adds missed interfaces which fixes the problem.

fix https://github.com/eclipse/che/issues/14028 