### PR TITLE
complete support of variable substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,10 @@ Breaking changes:
 - [plugin] files from 'plugin-ext/src/api' moved to 'plugin-ext/src/common', renamed 'model.ts' to 'plugin-api-rpc-model.ts', 'plugin-api.ts' to 'plugin-api-rpc.ts'
 - [task] ensure that plugin tasks are registered before accessing them [5869](https://github.com/theia-ide/theia/pull/5869)
   - `TaskProviderRegistry` and `TaskResolverRegistry` are promisified
-
-Breaking changes:
-  - [shell][plugin] integrated view containers and views [#5665](https://github.com/theia-ide/theia/pull/5665)
-    - `Source Control` and `Explorer` are view containers now and previous layout data cannot be loaded for them. Because of it the layout is completely reset.
-
+- [shell][plugin] integrated view containers and views [#5665](https://github.com/theia-ide/theia/pull/5665)
+  - `Source Control` and `Explorer` are view containers now and previous layout data cannot be loaded for them. Because of it the layout is completely reset.
+- [vscode] complete support of variable substitution [#5835](https://github.com/theia-ide/theia/pull/5835)
+  - inline `VariableQuickOpenItem`
 
 ## v0.9.0
 - [core] added `theia-widget-noInfo` css class to be used by widgets when displaying no information messages [#5717](https://github.com/theia-ide/theia/pull/5717)

--- a/packages/core/src/common/env-variables/env-variables-protocol.ts
+++ b/packages/core/src/common/env-variables/env-variables-protocol.ts
@@ -18,6 +18,7 @@ export const envVariablesPath = '/services/envs';
 
 export const EnvVariablesServer = Symbol('EnvVariablesServer');
 export interface EnvVariablesServer {
+    getExecPath(): Promise<string>
     getVariables(): Promise<EnvVariable[]>
     getValue(key: string): Promise<EnvVariable | undefined>
 }

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -16,6 +16,7 @@
 
 import { injectable } from 'inversify';
 import { EnvVariable, EnvVariablesServer } from '../../common/env-variables';
+import { isWindows } from '../../common/os';
 
 @injectable()
 export class EnvVariablesServerImpl implements EnvVariablesServer {
@@ -38,6 +39,9 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     }
 
     async getValue(key: string): Promise<EnvVariable | undefined> {
+        if (isWindows) {
+            key = key.toLowerCase();
+        }
         return this.envs[key];
     }
 }

--- a/packages/core/src/node/env-variables/env-variables-server.ts
+++ b/packages/core/src/node/env-variables/env-variables-server.ts
@@ -25,8 +25,12 @@ export class EnvVariablesServerImpl implements EnvVariablesServer {
     constructor() {
         const prEnv = process.env;
         Object.keys(prEnv).forEach((key: string) => {
-            this.envs[key] = {'name' : key, 'value' : prEnv[key]};
+            this.envs[key] = { 'name': key, 'value': prEnv[key] };
         });
+    }
+
+    async getExecPath(): Promise<string> {
+        return process.execPath;
     }
 
     async getVariables(): Promise<EnvVariable[]> {

--- a/packages/debug/src/browser/debug-schema-updater.ts
+++ b/packages/debug/src/browser/debug-schema-updater.ts
@@ -21,6 +21,7 @@ import { IJSONSchema } from '@theia/core/lib/common/json-schema';
 import URI from '@theia/core/lib/common/uri';
 import { DebugService } from '../common/debug-service';
 import { debugPreferencesSchema } from './debug-preferences';
+import { inputsSchema } from '@theia/variable-resolver/lib/browser/variable-input-schema';
 
 @injectable()
 export class DebugSchemaUpdater {
@@ -82,6 +83,7 @@ const launchSchema: IJSONSchema = {
                 'type': 'object',
                 oneOf: []
             }
-        }
+        },
+        inputs: inputsSchema.definitions!.inputs
     }
 };

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -167,7 +167,10 @@ export class DebugSessionManager {
         }
         const { workspaceFolderUri } = options;
         const resolvedConfiguration = await this.resolveDebugConfiguration(options.configuration, workspaceFolderUri);
-        const configuration = await this.variableResolver.resolve(resolvedConfiguration);
+        const configuration = await this.variableResolver.resolve(resolvedConfiguration, {
+            context: options.workspaceFolderUri ? new URI(options.workspaceFolderUri) : undefined,
+            configurationSection: 'launch'
+        });
         const key = configuration.name + workspaceFolderUri;
         const id = this.configurationIds.has(key) ? this.configurationIds.get(key)! + 1 : 0;
         this.configurationIds.set(key, id);

--- a/packages/editor/src/browser/editor-variable-contribution.ts
+++ b/packages/editor/src/browser/editor-variable-contribution.ts
@@ -34,6 +34,14 @@ export class EditorVariableContribution implements VariableContribution {
                 return editor ? `${editor.cursor.line + 1}` : undefined;
             }
         });
+        variables.registerVariable({
+            name: 'selectedText',
+            description: 'The current selected text in the active file',
+            resolve: () => {
+                const editor = this.getCurrentEditor();
+                return editor ? editor.document.getText(editor.selection) : undefined;
+            }
+        });
     }
 
     protected getCurrentEditor(): TextEditor | undefined {

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -18,6 +18,12 @@ import { injectable, inject } from 'inversify';
 import { VariableContribution, VariableRegistry } from './variable';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { CommandService } from '@theia/core/lib/common/command';
+import { PreferenceService } from '@theia/core/lib/browser/preferences/preference-service';
+import { ResourceContextKey } from '@theia/core/lib/browser/resource-context-key';
+import { VariableInput } from './variable-input';
+import { QuickInputService } from '@theia/core/lib/browser/quick-open/quick-input-service';
+import { QuickPickService, QuickPickItem } from '@theia/core/lib/common/quick-pick-service';
+import { MaybeArray, RecursivePartial } from '@theia/core/lib/common/types';
 
 @injectable()
 export class CommonVariableContribution implements VariableContribution {
@@ -27,6 +33,18 @@ export class CommonVariableContribution implements VariableContribution {
 
     @inject(CommandService)
     protected readonly commands: CommandService;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    @inject(ResourceContextKey)
+    protected readonly resourceContextKey: ResourceContextKey;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    @inject(QuickPickService)
+    protected readonly quickPickService: QuickPickService;
 
     async registerVariables(variables: VariableRegistry): Promise<void> {
         const execPath = await this.env.getExecPath();
@@ -42,10 +60,73 @@ export class CommonVariableContribution implements VariableContribution {
             }
         });
         variables.registerVariable({
+            name: 'config',
+            resolve: (resourceUri = this.resourceContextKey.get(), preferenceName) => {
+                if (!preferenceName) {
+                    return undefined;
+                }
+                return this.preferences.get(preferenceName, undefined, resourceUri && resourceUri.toString());
+            }
+        });
+        variables.registerVariable({
             name: 'command',
             resolve: async (_, command) =>
                 // tslint:disable-next-line:no-return-await
                 command && await this.commands.executeCommand(command)
+        });
+        variables.registerVariable({
+            name: 'input',
+            resolve: async (resourceUri = this.resourceContextKey.get(), variable, section) => {
+                if (!variable || !section) {
+                    return undefined;
+                }
+                const configuration = this.preferences.get<RecursivePartial<{ inputs: MaybeArray<VariableInput> }>>(section, undefined, resourceUri && resourceUri.toString());
+                const inputs = !!configuration && 'inputs' in configuration ? configuration.inputs : undefined;
+                const input = Array.isArray(inputs) && inputs.find(item => !!item && item.id === variable);
+                if (!input) {
+                    return undefined;
+                }
+                if (input.type === 'promptString') {
+                    if (typeof input.description !== 'string') {
+                        return undefined;
+                    }
+                    return this.quickInputService.open({
+                        prompt: input.description,
+                        value: input.default
+                    });
+                }
+                if (input.type === 'pickString') {
+                    if (typeof input.description !== 'string' || !Array.isArray(input.options)) {
+                        return undefined;
+                    }
+                    const elements: QuickPickItem<string>[] = [];
+                    for (const option of input.options) {
+                        if (typeof option !== 'string') {
+                            return undefined;
+                        }
+                        if (option === input.default) {
+                            elements.unshift({
+                                description: 'Default',
+                                label: option,
+                                value: option
+                            });
+                        } else {
+                            elements.push({
+                                label: option,
+                                value: option
+                            });
+                        }
+                    }
+                    return this.quickPickService.show(elements, { placeholder: input.description });
+                }
+                if (input.type === 'command') {
+                    if (typeof input.command !== 'string') {
+                        return undefined;
+                    }
+                    return this.commands.executeCommand(input.command, input.args);
+                }
+                return undefined;
+            }
         });
     }
 

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -56,7 +56,8 @@ export class CommonVariableContribution implements VariableContribution {
             name: 'env',
             resolve: async (_, envVariableName) => {
                 const envVariable = envVariableName && await this.env.getValue(envVariableName);
-                return envVariable && envVariable.value;
+                const envValue = envVariable && envVariable.value;
+                return envValue || '';
             }
         });
         variables.registerVariable({

--- a/packages/variable-resolver/src/browser/env-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/env-variable-contribution.ts
@@ -30,12 +30,13 @@ export class EnvVariableContribution implements VariableContribution {
             name: 'execPath',
             resolve: () => execPath
         });
-        for (const variable of await this.env.getVariables()) {
-            variables.registerVariable({
-                name: 'env:' + variable.name,
-                resolve: () => variable.value
-            });
-        }
+        variables.registerVariable({
+            name: 'env',
+            resolve: async (_, argument) => {
+                const envVariable = argument && await this.env.getValue(argument);
+                return envVariable && envVariable.value;
+            }
+        });
     }
 
 }

--- a/packages/variable-resolver/src/browser/env-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/env-variable-contribution.ts
@@ -25,6 +25,11 @@ export class EnvVariableContribution implements VariableContribution {
     protected readonly env: EnvVariablesServer;
 
     async registerVariables(variables: VariableRegistry): Promise<void> {
+        const execPath = await this.env.getExecPath();
+        variables.registerVariable({
+            name: 'execPath',
+            resolve: () => execPath
+        });
         for (const variable of await this.env.getVariables()) {
             variables.registerVariable({
                 name: 'env:' + variable.name,

--- a/packages/variable-resolver/src/browser/variable-input-schema.ts
+++ b/packages/variable-resolver/src/browser/variable-input-schema.ts
@@ -1,0 +1,131 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * copied from
+ * https://github.com/microsoft/vscode/blob/0a34756cae4fc67739e60c708b04637089f8bb0d/src/vs/workbench/services/configurationResolver/common/configurationResolverSchema.ts#L23
+ */
+
+const idDescription = "The input's id is used to associate an input with a variable of the form ${input:id}.";
+const typeDescription = 'The type of user input prompt to use.';
+const descriptionDescription = 'The description is shown when the user is prompted for input.';
+const defaultDescription = 'The default value for the input.';
+
+import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+
+export const inputsSchema: IJSONSchema = {
+    definitions: {
+        inputs: {
+            type: 'array',
+            description: 'User inputs. Used for defining user input prompts, such as free string input or a choice from several options.',
+            items: {
+                oneOf: [
+                    {
+                        type: 'object',
+                        required: ['id', 'type', 'description'],
+                        additionalProperties: false,
+                        properties: {
+                            id: {
+                                type: 'string',
+                                description: idDescription
+                            },
+                            type: {
+                                type: 'string',
+                                description: typeDescription,
+                                enum: ['promptString'],
+                                enumDescriptions: [
+                                    "The 'promptString' type opens an input box to ask the user for input."
+                                ]
+                            },
+                            description: {
+                                type: 'string',
+                                description: descriptionDescription
+                            },
+                            default: {
+                                type: 'string',
+                                description: defaultDescription
+                            },
+                        }
+                    },
+                    {
+                        type: 'object',
+                        required: ['id', 'type', 'description', 'options'],
+                        additionalProperties: false,
+                        properties: {
+                            id: {
+                                type: 'string',
+                                description: idDescription
+                            },
+                            type: {
+                                type: 'string',
+                                description: typeDescription,
+                                enum: ['pickString'],
+                                enumDescriptions: [
+                                    "The 'pickString' type shows a selection list.",
+                                ]
+                            },
+                            description: {
+                                type: 'string',
+                                description: descriptionDescription
+                            },
+                            default: {
+                                type: 'string',
+                                description: defaultDescription
+                            },
+                            options: {
+                                type: 'array',
+                                description: 'An array of strings that defines the options for a quick pick.',
+                                items: {
+                                    type: 'string'
+                                }
+                            }
+                        }
+                    },
+                    {
+                        type: 'object',
+                        required: ['id', 'type', 'command'],
+                        additionalProperties: false,
+                        properties: {
+                            id: {
+                                type: 'string',
+                                description: idDescription
+                            },
+                            type: {
+                                type: 'string',
+                                description: typeDescription,
+                                enum: ['command'],
+                                enumDescriptions: [
+                                    "The 'command' type executes a command.",
+                                ]
+                            },
+                            command: {
+                                type: 'string',
+                                description: 'The command to execute for this input variable.'
+                            },
+                            args: {
+                                type: 'object',
+                                description: 'Optional arguments passed to the command.'
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+};

--- a/packages/variable-resolver/src/browser/variable-input.ts
+++ b/packages/variable-resolver/src/browser/variable-input.ts
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+/*
+ * copied from
+ * https://github.com/microsoft/vscode/blob/0a34756cae4fc67739e60c708b04637089f8bb0d/src/vs/workbench/services/configurationResolver/common/configurationResolver.ts#L41-L63
+ */
+export interface VariablePromptStringInput {
+    id: string;
+    type: 'promptString';
+    description: string;
+    default?: string;
+}
+
+export interface VariablePickStringInput {
+    id: string;
+    type: 'pickString';
+    description: string;
+    options: string[];
+    default?: string;
+}
+
+export interface VariableCommandInput {
+    id: string;
+    type: 'command';
+    command: string;
+    // tslint:disable-next-line:no-any
+    args?: any;
+}
+
+export type VariableInput = VariablePromptStringInput | VariablePickStringInput | VariableCommandInput;

--- a/packages/variable-resolver/src/browser/variable-quick-open-service.ts
+++ b/packages/variable-resolver/src/browser/variable-quick-open-service.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable } from 'inversify';
 import { MessageService } from '@theia/core/lib/common/message-service';
-import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/browser/quick-open';
+import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickInputService } from '@theia/core/lib/browser/quick-open';
 import { VariableRegistry, Variable } from './variable';
 
 @injectable()
@@ -26,6 +26,9 @@ export class VariableQuickOpenService implements QuickOpenModel {
 
     @inject(MessageService)
     protected readonly messages: MessageService;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
 
     constructor(
         @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
@@ -38,7 +41,7 @@ export class VariableQuickOpenService implements QuickOpenModel {
             detail: v.description,
             run: mode => {
                 if (mode === QuickOpenMode.OPEN) {
-                    this.showValue(v);
+                    setTimeout(() => this.showValue(v));
                     return true;
                 }
                 return false;
@@ -58,7 +61,10 @@ export class VariableQuickOpenService implements QuickOpenModel {
     }
 
     protected async showValue(variable: Variable): Promise<void> {
-        const value = await variable.resolve();
+        const argument = await this.quickInputService.open({
+            placeHolder: 'Type a variable argument'
+        });
+        const value = await variable.resolve(undefined, argument);
         if (value) {
             this.messages.info(value);
         }

--- a/packages/variable-resolver/src/browser/variable-quick-open-service.ts
+++ b/packages/variable-resolver/src/browser/variable-quick-open-service.ts
@@ -16,8 +16,11 @@
 
 import { inject, injectable } from 'inversify';
 import { MessageService } from '@theia/core/lib/common/message-service';
-import { QuickOpenService, QuickOpenModel, QuickOpenItem, QuickOpenMode, QuickInputService } from '@theia/core/lib/browser/quick-open';
+import { QuickOpenModel, QuickOpenItem, QuickOpenMode } from '@theia/core/lib/common/quick-open-model';
+import { QuickOpenService } from '@theia/core/lib/browser/quick-open/quick-open-service';
+import { QuickInputService } from '@theia/core/lib/browser/quick-open/quick-input-service';
 import { VariableRegistry, Variable } from './variable';
+import { VariableResolverService } from './variable-resolver-service';
 
 @injectable()
 export class VariableQuickOpenService implements QuickOpenModel {
@@ -29,6 +32,9 @@ export class VariableQuickOpenService implements QuickOpenModel {
 
     @inject(QuickInputService)
     protected readonly quickInputService: QuickInputService;
+
+    @inject(VariableResolverService)
+    protected readonly variableResolver: VariableResolverService;
 
     constructor(
         @inject(VariableRegistry) protected readonly variableRegistry: VariableRegistry,
@@ -64,8 +70,8 @@ export class VariableQuickOpenService implements QuickOpenModel {
         const argument = await this.quickInputService.open({
             placeHolder: 'Type a variable argument'
         });
-        const value = await variable.resolve(undefined, argument);
-        if (value) {
+        const value = await this.variableResolver.resolve('${' + variable.name + ':' + argument + '}');
+        if (typeof value === 'string') {
             this.messages.info(value);
         }
     }

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-contribution.spec.ts
@@ -20,7 +20,6 @@ let disableJSDOM = enableJSDOM();
 
 import * as chai from 'chai';
 import { Container, ContainerModule } from 'inversify';
-import { QuickOpenService } from '@theia/core/lib/browser';
 import { ILogger, bindContributionProvider } from '@theia/core/lib/common';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { VariableContribution, VariableRegistry } from './variable';
@@ -52,8 +51,8 @@ describe('variable-resolver-frontend-contribution', () => {
             bind(ILogger).to(MockLogger);
             bind(VariableRegistry).toSelf().inSingletonScope();
 
-            bind(QuickOpenService).toSelf();
-            bind(VariableQuickOpenService).toSelf();
+            // tslint:disable-next-line:no-any mocking VariableQuickOpenService
+            bind(VariableQuickOpenService).toConstantValue({} as any);
 
             bind(VariableResolverFrontendContribution).toSelf();
         });

--- a/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-frontend-module.ts
@@ -21,7 +21,7 @@ import { VariableRegistry, VariableContribution } from './variable';
 import { VariableQuickOpenService } from './variable-quick-open-service';
 import { VariableResolverFrontendContribution } from './variable-resolver-frontend-contribution';
 import { VariableResolverService } from './variable-resolver-service';
-import { EnvVariableContribution } from './env-variable-contribution';
+import { CommonVariableContribution } from './common-variable-contribution';
 
 export default new ContainerModule(bind => {
     bind(VariableRegistry).toSelf().inSingletonScope();
@@ -35,6 +35,6 @@ export default new ContainerModule(bind => {
 
     bind(VariableQuickOpenService).toSelf().inSingletonScope();
 
-    bind(EnvVariableContribution).toSelf().inSingletonScope();
-    bind(VariableContribution).toService(EnvVariableContribution);
+    bind(CommonVariableContribution).toSelf().inSingletonScope();
+    bind(VariableContribution).toService(CommonVariableContribution);
 });

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -131,8 +131,15 @@ export namespace VariableResolverService {
                 return;
             }
             try {
-                const variable = this.variableRegistry.getVariable(name);
-                const value = variable && await variable.resolve(this.options.context);
+                let variableName = name;
+                let argument: string | undefined;
+                const parts = name.split(':');
+                if (parts.length > 1) {
+                    variableName = parts[0];
+                    argument = parts[1];
+                }
+                const variable = this.variableRegistry.getVariable(variableName);
+                const value = variable && await variable.resolve(this.options.context, argument);
                 this.resolved.set(name, value);
             } catch (e) {
                 console.error(`Failed to resolved '${name}' variable`, e);

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -23,6 +23,10 @@ import { JSONExt, ReadonlyJSONValue } from '@phosphor/coreutils/lib/json';
 
 export interface VariableResolveOptions {
     context?: URI;
+    /**
+     * Used for resolving inputs, see https://code.visualstudio.com/docs/editor/variables-reference#_input-variables
+     */
+    configurationSection?: string;
 }
 
 /**
@@ -140,7 +144,7 @@ export namespace VariableResolverService {
                     argument = parts[1];
                 }
                 const variable = this.variableRegistry.getVariable(variableName);
-                const value = variable && await variable.resolve(this.options.context, argument);
+                const value = variable && await variable.resolve(this.options.context, argument, this.options.configurationSection);
                 const stringValue = value !== undefined && value !== null && JSONExt.isPrimitive(value as ReadonlyJSONValue) ? String(value) : undefined;
                 this.resolved.set(name, stringValue);
             } catch (e) {

--- a/packages/variable-resolver/src/browser/variable-resolver-service.ts
+++ b/packages/variable-resolver/src/browser/variable-resolver-service.ts
@@ -19,6 +19,7 @@
 import { injectable, inject } from 'inversify';
 import { VariableRegistry } from './variable';
 import URI from '@theia/core/lib/common/uri';
+import { JSONExt, ReadonlyJSONValue } from '@phosphor/coreutils/lib/json';
 
 export interface VariableResolveOptions {
     context?: URI;
@@ -140,7 +141,8 @@ export namespace VariableResolverService {
                 }
                 const variable = this.variableRegistry.getVariable(variableName);
                 const value = variable && await variable.resolve(this.options.context, argument);
-                this.resolved.set(name, value);
+                const stringValue = value !== undefined && value !== null && JSONExt.isPrimitive(value as ReadonlyJSONValue) ? String(value) : undefined;
+                this.resolved.set(name, stringValue);
             } catch (e) {
                 console.error(`Failed to resolved '${name}' variable`, e);
                 this.resolved.set(name, undefined);

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -38,7 +38,7 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(context?: URI): MaybePromise<string | undefined>;
+    resolve(context?: URI, argment?: string): MaybePromise<string | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -38,7 +38,7 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(context?: URI, argment?: string): MaybePromise<string | undefined>;
+    resolve(context?: URI, argment?: string): MaybePromise<Object | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');

--- a/packages/variable-resolver/src/browser/variable.ts
+++ b/packages/variable-resolver/src/browser/variable.ts
@@ -38,7 +38,7 @@ export interface Variable {
      * `undefined` if variable cannot be resolved.
      * Never reject.
      */
-    resolve(context?: URI, argment?: string): MaybePromise<Object | undefined>;
+    resolve(context?: URI, argment?: string, configurationSection?: string): MaybePromise<Object | undefined>;
 }
 
 export const VariableContribution = Symbol('VariableContribution');

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -15,7 +15,6 @@
  ********************************************************************************/
 
 import { injectable, inject, postConstruct } from 'inversify';
-import { JSONExt, ReadonlyJSONValue } from '@phosphor/coreutils/lib/json';
 import URI from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core/lib/common/path';
 import { FileSystem } from '@theia/filesystem/lib/common';
@@ -73,8 +72,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
                     return undefined;
                 }
                 const resourceUri = context || this.getResourceUri();
-                const value = this.preferences.get<ReadonlyJSONValue>(preferenceName, undefined, resourceUri && resourceUri.toString());
-                return value !== undefined && value !== null && JSONExt.isPrimitive(value) ? String(value) : undefined;
+                return this.preferences.get(preferenceName, undefined, resourceUri && resourceUri.toString());
             }
         });
 
@@ -124,8 +122,8 @@ export class WorkspaceVariableContribution implements VariableContribution {
         const scoped = (variable: Variable): Variable => ({
             name: variable.name,
             description: variable.description,
-            resolve: (context, argument) => {
-                const workspaceRoot = argument && this.workspaceService.tryGetRoots().find(r => new URI(r.uri).path.name === argument);
+            resolve: (context, workspaceRootName) => {
+                const workspaceRoot = workspaceRootName && this.workspaceService.tryGetRoots().find(r => new URI(r.uri).path.name === workspaceRootName);
                 return variable.resolve(workspaceRoot ? new URI(workspaceRoot.uri) : context);
             }
         });

--- a/packages/workspace/src/browser/workspace-variable-contribution.ts
+++ b/packages/workspace/src/browser/workspace-variable-contribution.ts
@@ -19,7 +19,7 @@ import URI from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core/lib/common/path';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-import { ApplicationShell, NavigatableWidget, PreferenceService } from '@theia/core/lib/browser';
+import { ApplicationShell, NavigatableWidget } from '@theia/core/lib/browser';
 import { VariableContribution, VariableRegistry, Variable } from '@theia/variable-resolver/lib/browser';
 import { WorkspaceService } from './workspace-service';
 
@@ -32,8 +32,6 @@ export class WorkspaceVariableContribution implements VariableContribution {
     protected readonly shell: ApplicationShell;
     @inject(FileSystem)
     protected readonly fileSystem: FileSystem;
-    @inject(PreferenceService)
-    protected readonly preferences: PreferenceService;
 
     protected currentWidget: NavigatableWidget | undefined;
 
@@ -64,17 +62,6 @@ export class WorkspaceVariableContribution implements VariableContribution {
 
     registerVariables(variables: VariableRegistry): void {
         this.registerWorkspaceRootVariables(variables);
-
-        variables.registerVariable({
-            name: 'config',
-            resolve: (context, preferenceName) => {
-                if (!preferenceName) {
-                    return undefined;
-                }
-                const resourceUri = context || this.getResourceUri();
-                return this.preferences.get(preferenceName, undefined, resourceUri && resourceUri.toString());
-            }
-        });
 
         variables.registerVariable({
             name: 'file',
@@ -191,6 +178,7 @@ export class WorkspaceVariableContribution implements VariableContribution {
     }
 
     getResourceUri(): URI | undefined {
+        // TODO replace with ResourceContextKey.get?
         return this.currentWidget && this.currentWidget.getResourceUri();
     }
 


### PR DESCRIPTION
#### What it does

- fix #3434 - complete support of vscode variable substitution
  - only [input variables for tasks](https://code.visualstudio.com/docs/editor/variables-reference#_input-variables) are left out, since it depends on #5013 and requires substantial refactoring of the task extension first
- fixed resolution of env variables, see https://github.com/theia-ide/theia/pull/5835/commits/fa3016e44c0b143530aa763dd217437c5f1f7e58
- [x] a CQ for copied input schema and types: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20504

#### How to test

- look at https://code.visualstudio.com/docs/editor/variables-reference and test different variables
- you can also follow commit history to see support for which variables were added
- for most variables, you can use `Variables: List All` command
  - then select a variable to test
  - then you will be prompted to provide an argument for a variable, an argument is a part of ':' in variable substitution expression
  - if a variable does not accept argument just press enter, if it accepts then provide a proper argument
  - you should see a variable value if it can be computed in the given context, or raw expression if it cannot
- alternatively, you can define variables in tasks.json and launch.json and then try to run a task or launch configuration
  - like defined [here](https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented) for example, there is a bug though that an output for short-lived task is lost, you may want to add `watch echo` in order to keep a task running
- for [command variables](https://code.visualstudio.com/docs/editor/variables-reference#_command-variables) you may want to install vscode node js extensions instead of native and test with `extension.pickNodeProcess`, don't forget that you need both vscode nodejs extension to use them
- for input variables you can follow: https://code.visualstudio.com/docs/editor/variables-reference#_input-variables
  - tasks.json is not supported, since the task extension is not ready for it, see #5836

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully reviewed following [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/ak/pr_template/doc/pull-requests.md#reviewing)
