### PR TITLE
Add 'typedef' tslint check

### DIFF
--- a/configs/warnings.tslint.json
+++ b/configs/warnings.tslint.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "deprecation": true,
     "await-promise": {
       "severity": "warning",
       "options": [
@@ -8,8 +7,14 @@
         "PromiseLike"
       ]
     },
+    "deprecation": true,
     "no-return-await": {
       "severity": "warning"
-    }
+    },
+    "typedef": [
+      true,
+      "call-signature",
+      "property-declaration"
+    ]
   }
 }


### PR DESCRIPTION
**Description**

Added the [`typedef`](https://palantir.github.io/tslint/rules/typedef/) rule to explicitly require type definitions to exist. 

**Motivated By**
- [coding guideline rule](https://github.com/theia-ide/theia/wiki/Coding-Guidelines#explicit-return-type)
- https://github.com/theia-ide/theia/pull/5830#discussion_r309779100

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

<!-- Please provide a clear and meaningful description to the CHANGELOG.md file if this PR contributes some significant changes -->
