### PR TITLE
Update ls-files so it now works with Git 2.16 and later

### DIFF
--- a/packages/git/src/node/dugite-git.ts
+++ b/packages/git/src/node/dugite-git.ts
@@ -728,7 +728,8 @@ export class DugiteGit implements Git {
     async lsFiles(repository: Repository, uri: string, options?: Git.Options.LsFiles): Promise<any> {
         await this.ready.promise;
         const args = ['ls-files'];
-        const file = Path.relative(this.getFsPath(repository), this.getFsPath(uri));
+        const relativePath = Path.relative(this.getFsPath(repository), this.getFsPath(uri));
+        const file = (relativePath === '') ? '.' : relativePath;
         if (options && options.errorUnmatch) {
             args.push('--error-unmatch', file);
             const successExitCodes = new Set([0, 1]);


### PR DESCRIPTION
This fixes a problem that occurs when a Git repository is empty (the initial commit has not yet been made) and Git version 2.16 or later is being used.

With Git version 2.16, the ls-files command now requires '.' be specified to indicate all files.  It is no longer acceptable to omit the arg.  Without the fix, one got this:
![image](https://user-images.githubusercontent.com/87310/62428278-d8997f80-b6cd-11e9-81de-980f3d20ac54.png)

With the fix one gets:
![image](https://user-images.githubusercontent.com/87310/62428338-97559f80-b6ce-11e9-920e-6cbd94a7138a.png)

This will also fix the lsFiles for other users of the function. 