### PR TITLE
[vscode] support `when` closure for views

### DIFF
--- a/packages/core/src/browser/context-key-service.ts
+++ b/packages/core/src/browser/context-key-service.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
+import { Emitter } from '../common/event';
 
 export interface ContextKey<T> {
     set(value: T | undefined): void;
@@ -30,8 +31,19 @@ export namespace ContextKey {
     });
 }
 
+export interface ContextKeyChangeEvent {
+    affects(keys: Set<string>): boolean;
+}
+
 @injectable()
 export class ContextKeyService {
+
+    protected readonly onDidChangeEmitter = new Emitter<ContextKeyChangeEvent>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    protected fireDidChange(event: ContextKeyChangeEvent): void {
+        this.onDidChangeEmitter.fire(event);
+    }
+
     createKey<T>(key: string, defaultValue: T | undefined): ContextKey<T> {
         return ContextKey.None;
     }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -412,7 +412,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             execute: () => {
                 const toHide = find(this.containerLayout.iter(), part => part.id === toRegister.id);
                 if (toHide) {
-                    this.toggleVisibility(toHide);
+                    toHide.setHidden(!toHide.isHidden);
                 }
             },
             isToggled: () => {
@@ -469,15 +469,6 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         return `${this.id}:toggle-visibility`;
     }
 
-    protected toggleVisibility(part: ViewContainerPart): void {
-        if (part.canHide) {
-            part.setHidden(!part.isHidden);
-            if (!part.isHidden) {
-                part.collapsed = false;
-            }
-        }
-    }
-
     protected moveBefore(toMovedId: string, moveBeforeThisId: string): void {
         const parts = this.getParts();
         const toMoveIndex = parts.findIndex(part => part.id === toMovedId);
@@ -519,7 +510,6 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
             return undefined;
         }
         part.setHidden(false);
-        part.collapsed = false;
         return part;
     }
 
@@ -695,6 +685,16 @@ export class ViewContainerPart extends BaseWidget {
         }
         this.update();
         this.collapsedEmitter.fire(collapsed);
+    }
+
+    setHidden(hidden: boolean): void {
+        if (!this.canHide) {
+            return;
+        }
+        super.setHidden(hidden);
+        if (!this.isHidden) {
+            this.collapsed = false;
+        }
     }
 
     get canHide(): boolean {

--- a/packages/monaco/src/browser/monaco-context-key-service.ts
+++ b/packages/monaco/src/browser/monaco-context-key-service.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, postConstruct } from 'inversify';
 import { ContextKeyService, ContextKey } from '@theia/core/lib/browser/context-key-service';
 
 @injectable()
@@ -22,6 +22,15 @@ export class MonacoContextKeyService extends ContextKeyService {
 
     @inject(monaco.contextKeyService.ContextKeyService)
     protected readonly contextKeyService: monaco.contextKeyService.ContextKeyService;
+
+    @postConstruct()
+    protected init(): void {
+        this.contextKeyService.onDidChangeContext(e =>
+            this.fireDidChange({
+                affects: keys => e.affectsSome(keys)
+            })
+        );
+    }
 
     createKey<T>(key: string, defaultValue: T | undefined): ContextKey<T> {
         return this.contextKeyService.createKey(key, defaultValue);

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1102,12 +1102,17 @@ declare module monaco.contextKeyService {
 
     export interface IContext { }
 
+    export interface IContextKeyChangeEvent {
+        affectsSome(keys: Set<string>): boolean;
+    }
+
     export class ContextKeyService implements IContextKeyService {
         constructor(configurationService: monaco.services.IConfigurationService);
         createScoped(target?: HTMLElement): IContextKeyService;
         getContext(target?: HTMLElement): IContext;
         createKey<T>(key: string, defaultValue: T | undefined): IContextKey<T>;
         contextMatchesRules(rules: monaco.contextkey.ContextKeyExpr | undefined): boolean;
+        onDidChangeContext: monaco.IEvent<IContextKeyChangeEvent>;
     }
 
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -88,6 +88,7 @@ export interface PluginPackageViewContainer {
 export interface PluginPackageView {
     id: string;
     name: string;
+    when?: string;
 }
 
 export interface PluginPackageCommand {
@@ -497,6 +498,7 @@ export interface ViewContainer {
 export interface View {
     id: string;
     name: string;
+    when?: string;
 }
 
 export interface PluginCommand {

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -286,7 +286,8 @@ export class TheiaPluginScanner implements PluginScanner {
     private readView(rawView: PluginPackageView): View {
         const result: View = {
             id: rawView.id,
-            name: rawView.name
+            name: rawView.name,
+            when: rawView.when
         };
 
         return result;

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -78,6 +78,24 @@ export class PluginViewWidget extends Panel implements StatefulWidget {
         }
     }
 
+    protected _suppressUpdateViewVisibility = false;
+    set suppressUpdateViewVisibility(suppressUpdateViewVisibility: boolean) {
+        this._suppressUpdateViewVisibility = !this.updatingViewVisibility && suppressUpdateViewVisibility;
+    }
+
+    protected updatingViewVisibility = false;
+    updateViewVisibility(cb: () => void): void {
+        if (this._suppressUpdateViewVisibility) {
+            return;
+        }
+        try {
+            this.updatingViewVisibility = true;
+            cb();
+        } finally {
+            this.updatingViewVisibility = false;
+        }
+    }
+
 }
 export namespace PluginViewWidget {
     export interface State {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #5853 - support `when` closure for views:
- a view visibility should be auto toggled based on `when` view closure
- if a user explicitly hides a view, then auto toggling should be disabled
- and it should be enabled again when a user explicitly unhides the view

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install vscode sample tree extension: https://github.com/microsoft/vscode-extension-samples/tree/master/tree-view-sample
- use json outline example, it should be toggled only when json file is opened

See for how install VS Code extension :https://github.com/theia-ide/theia/wiki/Testing-VS-Code-Extensions

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

