### PR TITLE
Provide a safe operation for the dialog

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -148,15 +148,30 @@ export abstract class AbstractDialog<T> extends BaseWidget {
         this.addKeyListener(document.body, Key.ENTER, e => this.handleEnter(e));
     }
 
+    protected canHandle(event: KeyboardEvent): boolean {
+        let result: boolean = false;
+        if (this.id && event.currentTarget) {
+            const dialogOverlay: HTMLElement = event.currentTarget as HTMLElement;
+            if (dialogOverlay.lastElementChild && this.id.localeCompare(dialogOverlay.lastElementChild.id) === 0) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
     protected handleEscape(event: KeyboardEvent): boolean | void {
-        this.close();
+        if (this.canHandle(event)) {
+            this.close();
+        }
     }
 
     protected handleEnter(event: KeyboardEvent): boolean | void {
-        if (event.target instanceof HTMLTextAreaElement) {
-            return false;
+        if (this.canHandle(event)) {
+            if (event.target instanceof HTMLTextAreaElement) {
+                return false;
+            }
+            this.accept();
         }
-        this.accept();
     }
 
     protected onActivateRequest(msg: Message): void {
@@ -277,7 +292,7 @@ export class ConfirmDialog extends AbstractDialog<boolean> {
         @inject(ConfirmDialogProps) protected readonly props: ConfirmDialogProps
     ) {
         super(props);
-
+        this.id = 'theia-confirm-dialog';
         this.contentNode.appendChild(this.createMessageNode(this.props.msg));
         this.appendCloseButton(props.cancel);
         this.appendAcceptButton(props.ok);
@@ -324,7 +339,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         @inject(SingleTextInputDialogProps) protected readonly props: SingleTextInputDialogProps
     ) {
         super(props);
-
+        this.id = 'theia-single-text-input-dialog';
         this.inputField = document.createElement('input');
         this.inputField.type = 'text';
         this.inputField.setAttribute('style', 'flex: 0;');
@@ -361,6 +376,12 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
 
     protected onActivateRequest(msg: Message): void {
         this.inputField.focus();
+    }
+
+    protected handleEnter(event: KeyboardEvent): boolean | void {
+        if (event.target instanceof HTMLInputElement) {
+            return super.handleEnter(event);
+        }
     }
 
 }

--- a/packages/filesystem/src/browser/file-dialog/file-dialog.ts
+++ b/packages/filesystem/src/browser/file-dialog/file-dialog.ts
@@ -242,6 +242,7 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         @inject(FileDialogWidget) readonly widget: FileDialogWidget
     ) {
         super(props, widget);
+        this.id = 'theia-open-file-dialog';
         if (props.canSelectFiles !== undefined) {
             this.widget.disableFileSelection = !props.canSelectFiles;
         }
@@ -276,6 +277,7 @@ export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {
         }
         super.accept();
     }
+
 }
 
 @injectable()
@@ -288,6 +290,7 @@ export class SaveFileDialog extends FileDialog<URI | undefined> {
         @inject(FileDialogWidget) readonly widget: FileDialogWidget
     ) {
         super(props, widget);
+        this.id = 'theia-save-file-dialog';
         widget.addClass(SAVE_DIALOG_CLASS);
     }
 


### PR DESCRIPTION
#5859
**before:**
![11](https://user-images.githubusercontent.com/50982164/62472988-737b8200-b7d2-11e9-8ae4-697fb67c5835.gif)
![112](https://user-images.githubusercontent.com/50982164/62472997-78403600-b7d2-11e9-8f4c-5599c9ecc890.gif)
**after:**
1、For ‘SingleTextInputDialog’, the enter key is only responded when the mouse is focused in the input box；
2、For dialogue boxes, press ESC to exit from the outermost layer；

![good](https://user-images.githubusercontent.com/50982164/62471687-c30c7e80-b7cf-11e9-9704-bf0d97f49a09.gif)




How to test:
1、Open 'SingleText InputDialog' and press 'enter' in the space；
2、In 'OpenFileDialog', add a button to open 'SingleText InputDialog', then open 'OpenFileDialog' and 'SingleText InputDialog' in turn, and finally press the 'ESC' or 'enter' button in the blank.

eg:
import { SingleTextInputDialog } from '@theia/core/lib/browser/dialogs';

@injectable()
export class OpenFileDialog extends FileDialog<MaybeArray<FileStatNode>> {

    protected openButton: HTMLButtonElement | undefined;

    constructor(
        @inject(OpenFileDialogProps) readonly props: OpenFileDialogProps,
        @inject(FileDialogWidget) readonly widget: FileDialogWidget
    ) {
        super(props, widget);
        this.id = 'theia-open-file-dialog';
        this.openButton = this.createButton('open single text');
        this.controlPanel.appendChild(this.openButton);
        this.openButton.classList.add('main');
        this.openButton.addEventListener('click', () => this.openInputDialog());
        if (props.canSelectFiles !== undefined) {
            this.widget.disableFileSelection = !props.canSelectFiles;
        }
    }

private openInputDialog(): void {
        const dialog = new SingleTextInputDialog({
            title: 'New File',
            initialValue: '12131'
        });

        dialog.open().then((name: string) => {
            if (name) {
                console.log(name);
            }
        });
    }
