### PR TITLE
apply overlay keyboard events to the top most dialog

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -77,6 +77,7 @@ import { ApplicationShellMouseTracker } from './shell/application-shell-mouse-tr
 import { ViewContainer, ViewContainerIdentifier } from './view-container';
 import { QuickViewService } from './quick-view-service';
 import { QuickTitleBar } from './quick-open/quick-title-bar';
+import { DialogOverlayService } from './dialogs';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const themeService = ThemeService.get();
@@ -253,6 +254,9 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
 
     bind(QuickViewService).toSelf().inSingletonScope();
     bind(QuickOpenContribution).toService(QuickViewService);
+
+    bind(DialogOverlayService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(DialogOverlayService);
 });
 
 export function bindMessageService(bind: interfaces.Bind): interfaces.BindingWhenOnSyntax<MessageService> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #5859 - stack of dialogs is tracked and keyboard events are applied only to the top-most dialog from the single keyboard listener for the document body
- closes #5860 - superseded

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I've pushed a temporary commit which adds a button to the open file dialog that one can open another dialog from the first. One can use it to test that on esc and enter the top-most dialog receives events. I remove this commit after the review.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

