### PR TITLE
SingleTextInputDialog handle the enter key when mouse in the input box

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -363,4 +363,10 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         this.inputField.focus();
     }
 
+    protected handleEnter(event: KeyboardEvent): boolean | void {
+        if (event.target instanceof HTMLInputElement) {
+            return super.handleEnter(event);
+        }
+    }
+
 }


### PR DESCRIPTION
fix #5867 
SingleTextInputDialog handle the enter key only when mouse in the input box

before
![11](https://user-images.githubusercontent.com/50982164/62529202-c73ca880-b870-11e9-8c5e-52e8c0321051.gif)

after
![good](https://user-images.githubusercontent.com/50982164/62529233-d91e4b80-b870-11e9-8fa0-3656ef6bf5c3.gif)

How to test:
Open 'New Folder' or 'Rename File' and press 'enter' in the space；
