### PR TITLE
ensure that plugin tasks are registered before accessing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
 
 - [task] `TaskService.getConfiguredTasks()` returns `Promise<TaskConfiguration[]>` instead of `TaskConfiguration[]` [#5777](https://github.com/theia-ide/theia/pull/5777)
 - [plugin] files from 'plugin-ext/src/api' moved to 'plugin-ext/src/common', renamed 'model.ts' to 'plugin-api-rpc-model.ts', 'plugin-api.ts' to 'plugin-api-rpc.ts'
+- [task] ensure that plugin tasks are registered before accessing them [5869](https://github.com/theia-ide/theia/pull/5869)
+  - `TaskProviderRegistry` and `TaskResolverRegistry` are promisified
 
 Breaking changes:
   - [shell][plugin] integrated view containers and views [#5665](https://github.com/theia-ide/theia/pull/5665)

--- a/packages/cpp/src/browser/cpp-task-provider.ts
+++ b/packages/cpp/src/browser/cpp-task-provider.ts
@@ -78,7 +78,7 @@ export class CppTaskProvider implements TaskContribution, TaskProvider, TaskReso
     }
 
     async resolveTask(task: CppBuildTaskConfiguration): Promise<TaskConfiguration> {
-        const resolver = this.taskResolverRegistry.getResolver('shell');
+        const resolver = await this.taskResolverRegistry.getResolver('shell');
         if (!resolver) {
             throw new Error('No shell resolver found, cannot build.');
         }

--- a/packages/task/src/browser/provided-task-configurations.ts
+++ b/packages/task/src/browser/provided-task-configurations.ts
@@ -37,7 +37,7 @@ export class ProvidedTaskConfigurations {
 
     /** returns a list of provided tasks */
     async getTasks(): Promise<TaskConfiguration[]> {
-        const providers = this.taskProviderRegistry.getProviders();
+        const providers = await this.taskProviderRegistry.getProviders();
         const providedTasks: TaskConfiguration[] = (await Promise.all(providers.map(p => p.provideTasks())))
             .reduce((acc, taskArray) => acc.concat(taskArray), []);
         this.cacheTasks(providedTasks);

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -366,7 +366,7 @@ export class TaskService implements TaskConfigurationClient {
             }
         }
 
-        const resolver = this.taskResolverRegistry.getResolver(task.type);
+        const resolver = await this.taskResolverRegistry.getResolver(task.type);
         let resolvedTask: TaskConfiguration;
         try {
             resolvedTask = resolver ? await resolver.resolveTask(task) : task;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -126,6 +126,9 @@
       ],
       "@theia/userstorage/lib/*": [
         "packages/userstorage/src/*"
+      ],
+      "@theia/task/lib/*": [
+        "packages/task/src/*"
       ]
     },
     "plugins": [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #5861 - fire `onCommand:workbench.action.tasks.runTask` in order to activate VS Code extensions and register task providers

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

See https://github.com/theia-ide/theia/issues/5861#issue-476871756:
- install built-in npm vscode extension: https://registry.npmjs.org/@theia/vscode-builtin-npm/-/vscode-builtin-npm-0.2.1.tgz
- open a workspace with npm scripts defined in package.json
- try to run a task from the quick task palette without opening package.json
- check that npm scripts are detected as tasks

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

