### PR TITLE
[documentation] update 'getting-started' documentation

### DIFF
--- a/packages/getting-started/README.md
+++ b/packages/getting-started/README.md
@@ -1,6 +1,14 @@
 # Theia - Getting Started Extension
 
-The extension provides a `getting started` page to users when opening Theia without a workspace. It provides useful commands for opening new or recent workspaces, commands to update user settings, and other helpful links.
+
+## Description
+
+The extension contributes a `getting-started` widget which is displayed when opening the application
+without a workspace present. The `getting-started` widget provides useful commands and functionality for quickly getting up to speed with the application:
+- `open commands`: commands which are used to open files, folders, and workspaces quickly.
+- `recent workspaces`: recently used workspaces are listed for easy and quick access.
+- `settings commands`: commands which are used to open the preferences and keyboard shortcuts widgets.
+- `help`: useful links pointing to documentation and/or guides.
 
 ## License
 - [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -21,6 +21,9 @@ import { GettingStartedWidget } from './getting-started-widget';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 
+/**
+ * Triggers opening the `GettingStartedWidget`.
+ */
 export const GettingStartedCommand = {
     id: GettingStartedWidget.ID,
     label: GettingStartedWidget.LABEL
@@ -48,7 +51,7 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
     async onStart(app: FrontendApplication): Promise<void> {
         if (!this.workspaceService.opened) {
             this.stateService.reachedState('ready').then(
-                a => this.openView({ reveal: true })
+                () => this.openView({ reveal: true })
             );
         }
     }

--- a/packages/getting-started/src/browser/getting-started-frontend-module.ts
+++ b/packages/getting-started/src/browser/getting-started-frontend-module.ts
@@ -15,13 +15,13 @@
  ********************************************************************************/
 
 import { GettingStartedContribution } from './getting-started-contribution';
-import { ContainerModule } from 'inversify';
+import { ContainerModule, interfaces } from 'inversify';
 import { GettingStartedWidget } from './getting-started-widget';
 import { WidgetFactory, FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
 
 import '../../src/browser/style/index.css';
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind: interfaces.Bind) => {
     bindViewContribution(bind, GettingStartedContribution);
     bind(FrontendApplicationContribution).toService(GettingStartedContribution);
     bind(GettingStartedWidget).toSelf();

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -23,25 +23,58 @@ import { WorkspaceCommands, WorkspaceService } from '@theia/workspace/lib/browse
 import { FileStat, FileSystem } from '@theia/filesystem/lib/common/filesystem';
 import { FileSystemUtils } from '@theia/filesystem/lib/common/filesystem-utils';
 import { KeymapsCommands } from '@theia/keymaps/lib/browser';
-import { CommonCommands } from '@theia/core/lib/browser';
+import { CommonCommands, LabelProvider } from '@theia/core/lib/browser';
 import { ApplicationInfo, ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
+/**
+ * Default implementation of the `GettingStartedWidget`.
+ * The widget is displayed when there are currently no workspaces present.
+ * Some of the features displayed include:
+ * - `open` commands.
+ * - `recently used workspaces`.
+ * - `settings` commands.
+ * - `help` commands.
+ * - helpful links.
+ */
 @injectable()
 export class GettingStartedWidget extends ReactWidget {
 
+    /**
+     * The widget `id`.
+     */
     static readonly ID = 'getting.started.widget';
+    /**
+     * The widget `label` which is used for display purposes.
+     */
     static readonly LABEL = 'Getting Started';
 
+    /**
+     * The `ApplicationInfo` for the application if available.
+     * Used in order to obtain the version number of the application.
+     */
     protected applicationInfo: ApplicationInfo | undefined;
+    /**
+     * The application name which is used for display purposes.
+     */
     protected applicationName = FrontendApplicationConfigProvider.get().applicationName;
 
     protected stat: FileStat | undefined;
     protected home: string | undefined;
 
-    protected readonly recentLimit = 5;
+    /**
+     * The recently used workspaces limit.
+     * Used in order to limit the number of recently used workspaces to display.
+     */
+    protected recentLimit = 5;
+    /**
+     * The list of recently used workspaces.
+     */
     protected recentWorkspaces: string[] = [];
 
+    /**
+     * Collection of useful links to display for end users.
+     */
     protected readonly documentationUrl = 'https://www.theia-ide.org/doc/';
     protected readonly extensionUrl = 'https://www.theia-ide.org/doc/Authoring_Extensions.html';
     protected readonly pluginUrl = 'https://www.theia-ide.org/doc/Authoring_Plugins.html';
@@ -54,6 +87,9 @@ export class GettingStartedWidget extends ReactWidget {
 
     @inject(FileSystem)
     protected readonly fileSystem: FileSystem;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
@@ -68,10 +104,13 @@ export class GettingStartedWidget extends ReactWidget {
         this.applicationInfo = await this.appServer.getApplicationInfo();
         this.recentWorkspaces = await this.workspaceService.recentWorkspaces();
         this.stat = await this.fileSystem.getCurrentUserHome();
-        this.home = (this.stat) ? new URI(this.stat.uri).path.toString() : undefined;
+        this.home = this.stat ? new URI(this.stat.uri).path.toString() : undefined;
         this.update();
     }
 
+    /**
+     * Render the content of the widget.
+     */
     protected render(): React.ReactNode {
         return <div className='gs-container'>
             {this.renderHeader()}
@@ -104,17 +143,25 @@ export class GettingStartedWidget extends ReactWidget {
         </div>;
     }
 
+    /**
+     * Render the widget header.
+     * Renders the title `{applicationName} Getting Started`.
+     */
     protected renderHeader(): React.ReactNode {
         return <div className='gs-header'>
             <h1>{this.applicationName}<span className='gs-sub-header'> Getting Started</span></h1>
         </div>;
     }
 
+    /**
+     * Render the `open` section.
+     * Displays a collection of `open` commands.
+     */
     protected renderOpen(): React.ReactNode {
         const requireSingleOpen = isOSX || !environment.electron.is();
-        const open = (requireSingleOpen) ? <div className='gs-action-container'><a href='#' onClick={this.doOpen}>Open</a></div> : '';
-        const openFile = (!requireSingleOpen) ? <div className='gs-action-container'><a href='#' onClick={this.doOpenFile}>Open File</a></div> : '';
-        const openFolder = (!requireSingleOpen) ? <div className='gs-action-container'><a href='#' onClick={this.doOpenFolder}>Open Folder</a></div> : '';
+        const open = requireSingleOpen && <div className='gs-action-container'><a href='#' onClick={this.doOpen}>Open</a></div>;
+        const openFile = !requireSingleOpen && <div className='gs-action-container'><a href='#' onClick={this.doOpenFile}>Open File</a></div>;
+        const openFolder = !requireSingleOpen && <div className='gs-action-container'><a href='#' onClick={this.doOpenFolder}>Open Folder</a></div>;
         const openWorkspace = <a href='#' onClick={this.doOpenWorkspace}>Open Workspace</a>;
         return <div className='gs-section'>
             <h3 className='gs-section-header'><i className='fa fa-folder-open'></i>Open</h3>
@@ -125,6 +172,9 @@ export class GettingStartedWidget extends ReactWidget {
         </div>;
     }
 
+    /**
+     * Render the recently used workspaces section.
+     */
     protected renderRecentWorkspaces(): React.ReactNode {
         const items = this.recentWorkspaces;
         const paths = this.buildPaths(items);
@@ -136,18 +186,21 @@ export class GettingStartedWidget extends ReactWidget {
                 </span>
             </div>
         );
-        const more = (paths.length > this.recentLimit) ? <div className='gs-action-container'>
-            <a href='#' onClick={this.doOpenRecentWorkspace}>More...</a>
-        </div> : <div />;
+        // If the recently used workspaces list exceeds the limit, display `More...` which triggers the recently used workspaces quick-open menu upon selection.
+        const more = paths.length > this.recentLimit && <div className='gs-action-container'><a href='#' onClick={this.doOpenRecentWorkspace}>More...</a></div>;
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
                 <i className='fa fa-clock-o'></i>Recent Workspaces
             </h3>
-            {(items.length > 0) ? content : <p className='gs-no-recent'>No Recent Workspaces</p>}
+            {items.length > 0 ? content : <p className='gs-no-recent'>No Recent Workspaces</p>}
             {more}
         </div>;
     }
 
+    /**
+     * Render the settings section.
+     * Generally used to display useful links.
+     */
     protected renderSettings(): React.ReactNode {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
@@ -163,6 +216,9 @@ export class GettingStartedWidget extends ReactWidget {
         </div>;
     }
 
+    /**
+     * Render the help section.
+     */
     protected renderHelp(): React.ReactNode {
         return <div className='gs-section'>
             <h3 className='gs-section-header'>
@@ -181,6 +237,9 @@ export class GettingStartedWidget extends ReactWidget {
         </div>;
     }
 
+    /**
+     * Render the version section.
+     */
     protected renderVersion(): React.ReactNode {
         return <div className='gs-section'>
             <div className='gs-action-container'>
@@ -191,22 +250,55 @@ export class GettingStartedWidget extends ReactWidget {
         </div>;
     }
 
+    /**
+     * Build the list of workspace paths.
+     * @param workspaces {string[]} the list of workspaces.
+     * @returns {string[]} the list of workspace paths.
+     */
     protected buildPaths(workspaces: string[]): string[] {
         const paths: string[] = [];
         workspaces.forEach(workspace => {
             const uri = new URI(workspace);
-            const path = (this.home) ? FileSystemUtils.tildifyPath(uri.path.toString(), this.home) : uri.path.toString();
+            const pathLabel = this.labelProvider.getLongName(uri);
+            const path = this.home ? FileSystemUtils.tildifyPath(pathLabel, this.home) : pathLabel;
             paths.push(path);
         });
         return paths;
     }
 
+    /**
+     * Trigger the open command.
+     */
     protected doOpen = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN.id);
+    /**
+     * Trigger the open file command.
+     */
     protected doOpenFile = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_FILE.id);
+    /**
+     * Trigger the open folder command.
+     */
     protected doOpenFolder = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_FOLDER.id);
+    /**
+     * Trigger the open workspace command.
+     */
     protected doOpenWorkspace = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_WORKSPACE.id);
+    /**
+     * Trigger the open recent workspace command.
+     */
     protected doOpenRecentWorkspace = () => this.commandRegistry.executeCommand(WorkspaceCommands.OPEN_RECENT_WORKSPACE.id);
+    /**
+     * Trigger the open preferences command.
+     * Used to open the preferences widget.
+     */
     protected doOpenPreferences = () => this.commandRegistry.executeCommand(CommonCommands.OPEN_PREFERENCES.id);
+    /**
+     * Trigger the open keyboard shortcuts command.
+     * Used to open the keyboard shortcuts widget.
+     */
     protected doOpenKeyboardShortcuts = () => this.commandRegistry.executeCommand(KeymapsCommands.OPEN_KEYMAPS.id);
-    protected open = (workspace: URI) => this.workspaceService.open(workspace);
+    /**
+     * Open a workspace given its uri.
+     * @param uri {URI} the workspace uri.
+     */
+    protected open = (uri: URI) => this.workspaceService.open(uri);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- update documentation of the `@theia/getting-started` extension
- simplified code
- updated react conditional rendering
- updated code to use `labelProvider` for displaying uris.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- the `getting-started` widget is opened when the application is started without a workspace.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
