### PR TITLE
fix #5829:ensure that no plugin can be loaded twice

### DIFF
--- a/packages/core/src/common/promise-util.ts
+++ b/packages/core/src/common/promise-util.ts
@@ -27,3 +27,18 @@ export class Deferred<T> {
         this.reject = reject;
     });
 }
+
+export class PromiseQueue {
+    protected queue = Promise.resolve();
+    push<T>(fn: () => Promise<T>): Promise<T> {
+        const deferred = new Deferred<T>();
+        this.queue = this.queue.then(async () => {
+            try {
+                deferred.resolve(await fn());
+            } catch (e) {
+                deferred.reject(e);
+            }
+        });
+        return deferred.promise;
+    }
+}

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -41,7 +41,7 @@ import { PluginServer } from '../../common/plugin-protocol';
 import { KeysToKeysToAnyValue } from '../../common/types';
 import { FileStat } from '@theia/filesystem/lib/common/filesystem';
 import { MonacoTextmateService } from '@theia/monaco/lib/browser/textmate';
-import { Deferred } from '@theia/core/lib/common/promise-util';
+import { Deferred, PromiseQueue } from '@theia/core/lib/common/promise-util';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { WaitUntilEvent } from '@theia/core/lib/common/event';
@@ -121,6 +121,8 @@ export class HostedPluginSupport {
 
     protected readonly activationEvents = new Set<string>();
 
+    private loadingQueue = new PromiseQueue();
+
     @postConstruct()
     protected init(): void {
         this.theiaReadyPromise = Promise.all([this.preferenceServiceImpl.ready, this.workspaceService.roots]);
@@ -161,7 +163,7 @@ export class HostedPluginSupport {
                 workspaceStates: metadata['5'],
                 roots: metadata['6']
             };
-            this.loadPlugins(pluginsInitData, this.container);
+            this.loadingQueue.push(() => this.loadPlugins(pluginsInitData, this.container));
         }).catch(e => console.error(e));
     }
 


### PR DESCRIPTION
#5829

What it does
fix #5829- ensure that no plugin can be loaded twice, loadPlugins is not thread-safe

How to test
I've pushed a temporary commit which adds PromiseQueue (come from the commit of Mr akosyakov ) that one can ensure  load plugin is thread-safe . I remove this PromiseQueue after the review.
