### PR TITLE
prompt user to choose parser to parse task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.11.0
 
 - [task] added `tasks.fetchTasks()` and `tasks.executeTask()` to plugins API [#6058](https://github.com/theia-ide/theia/pull/6058)
+- [task] prompt user to choose parser to parse task output [#5877](https://github.com/theia-ide/theia/pull/5877)
 
 Breaking changes:
 

--- a/packages/task/src/browser/task-problem-matcher-registry.ts
+++ b/packages/task/src/browser/task-problem-matcher-registry.ts
@@ -77,6 +77,18 @@ export class ProblemMatcherRegistry {
     }
 
     /**
+     * Returns all registered problem matchers in the registry.
+     */
+    getAll(): NamedProblemMatcher[] {
+        const all: NamedProblemMatcher[] = [];
+        for (const matcherName of Object.keys(this.matchers)) {
+            all.push(this.get(matcherName)!);
+        }
+        all.sort((one, other) => one.name.localeCompare(other.name));
+        return all;
+    }
+
+    /**
      * Transforms the `ProblemMatcherContribution` to a `ProblemMatcher`
      *
      * @return the problem matcher


### PR DESCRIPTION
- before a task runs, prompt the user to choose which parser to use to parse the task output, and write user's choice into `tasks.json`. Please note: tasks that are already assign problem matchers 
- part of #4212

#### How to test

![Peek 2019-08-06 22-41](https://user-images.githubusercontent.com/37082801/62592744-48f8fa00-b8a2-11e9-82a7-5b9151c40b67.gif)

1. Have a detected task prepared. A configured task with no defined problem matcher also works. If a detected task is involved in the testing, make sure it is successfully loaded as Theia currently has a bug where the detected tasks are not loaded in time https://github.com/theia-ide/theia/issues/5861#issuecomment-518253147

2. Run the prepared task, as a user I should see a list of options that advise me what to use to parse the task output.
- If the task is already assigned a parser, as a user I should not see the list show up.

3. After the task finishes running, 
- the problems found by the parser should be listed in the problems view
- the selected problem matcher should be written into the `tasks.json` as one property of the task.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
