### PR TITLE
Clear the superfluous scrollbars at the DebugConfigurationWidget and DebugToolBar

### DIFF
--- a/packages/debug/src/browser/view/debug-configuration-widget.tsx
+++ b/packages/debug/src/browser/view/debug-configuration-widget.tsx
@@ -51,6 +51,7 @@ export class DebugConfigurationWidget extends ReactWidget {
         this.toDispose.push(this.manager.onDidChange(() => this.update()));
         this.toDispose.push(this.workspaceService.onWorkspaceChanged(() => this.update()));
         this.toDispose.push(this.workspaceService.onWorkspaceLocationChanged(() => this.update()));
+        this.scrollOptions = undefined;
         this.update();
     }
 

--- a/packages/debug/src/browser/view/debug-toolbar-widget.tsx
+++ b/packages/debug/src/browser/view/debug-toolbar-widget.tsx
@@ -34,6 +34,7 @@ export class DebugToolBar extends ReactWidget {
         this.addClass('debug-toolbar');
         this.toDispose.push(this.model);
         this.toDispose.push(this.model.onDidChange(() => this.update()));
+        this.scrollOptions = undefined;
         this.update();
     }
 


### PR DESCRIPTION
#### What it does
fix #5819 - Clear the superfluous scrollbars for debug widgets

before:
![62140406-3a7f7100-b2eb-11e9-9f69-bde4d4729418](https://user-images.githubusercontent.com/50982164/62622199-58cf1780-b950-11e9-8d4b-2ba367e62b82.gif)


after:
![after](https://user-images.githubusercontent.com/50982164/62621479-7d29f480-b94e-11e9-8d99-8d6c443d4ca0.gif)


#### How to test
Open debug
Moves the mouse to the right of the DebugConfigurationWidget or DebugToolBar border

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

