### PR TITLE
Fix 'enter' not working in the editor

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -92,15 +92,17 @@ export class DialogOverlayService implements FrontendApplicationContribution {
     protected handleEscape(event: KeyboardEvent): boolean | void {
         const dialog = this.currentDialog;
         if (dialog) {
-            dialog['handleEscape'](event);
+            return dialog['handleEscape'](event);
         }
+        return false;
     }
 
     protected handleEnter(event: KeyboardEvent): boolean | void {
         const dialog = this.currentDialog;
         if (dialog) {
-            dialog['handleEnter'](event);
+            return dialog['handleEnter'](event);
         }
+        return false;
     }
 
 }
@@ -421,6 +423,7 @@ export class SingleTextInputDialog extends AbstractDialog<string> {
         if (event.target instanceof HTMLInputElement) {
             return super.handleEnter(event);
         }
+        return false;
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes #5891

- fixes an issue where the `enter` key no longer works in the editor.
- caused by a regression present in the `dialog.ts#handleEnter` method
which was not returning `false` if a dialog was not present.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

#### How to test
- open an editor and attempt to add new lines using <kbd>enter</kbd>

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

