### PR TITLE
core: catch command handler errors

### DIFF
--- a/packages/core/src/browser/quick-open/quick-command-service.ts
+++ b/packages/core/src/browser/quick-open/quick-command-service.ts
@@ -221,8 +221,8 @@ export class CommandQuickOpenItem extends QuickOpenGroupItem {
     }
 
     getIconClass(): string | undefined {
-        const toggleHandler = this.commands.getToggledHandler(this.command.id);
-        if (toggleHandler && toggleHandler.isToggled && toggleHandler.isToggled()) {
+        const toggledHandler = this.commands.getToggledHandler(this.command.id);
+        if (toggledHandler) {
             return 'fa fa-check';
         }
         return super.getIconClass();

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -244,7 +244,7 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     isEnabled(command: string, ...args: any[]): boolean {
-        return this.getActiveHandler(command, ...args) !== undefined;
+        return typeof this.getActiveHandler(command, ...args) !== 'undefined';
     }
 
     /**
@@ -252,7 +252,7 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     isVisible(command: string, ...args: any[]): boolean {
-        return this.getVisibleHandler(command, ...args) !== undefined;
+        return typeof this.getVisibleHandler(command, ...args) !== 'undefined';
     }
 
     /**
@@ -260,8 +260,7 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     isToggled(command: string, ...args: any[]): boolean {
-        const handler = this.getToggledHandler(command);
-        return handler && handler.isToggled ? handler.isToggled(...args) : false;
+        return typeof this.getToggledHandler(command, ...args) !== 'undefined';
     }
 
     /**
@@ -297,8 +296,12 @@ export class CommandRegistry implements CommandService {
         const handlers = this._handlers[commandId];
         if (handlers) {
             for (const handler of handlers) {
-                if (!handler.isVisible || handler.isVisible(...args)) {
-                    return handler;
+                try {
+                    if (!handler.isVisible || handler.isVisible(...args)) {
+                        return handler;
+                    }
+                } catch (error) {
+                    console.error(error);
                 }
             }
         }
@@ -313,8 +316,12 @@ export class CommandRegistry implements CommandService {
         const handlers = this._handlers[commandId];
         if (handlers) {
             for (const handler of handlers) {
-                if (!handler.isEnabled || handler.isEnabled(...args)) {
-                    return handler;
+                try {
+                    if (!handler.isEnabled || handler.isEnabled(...args)) {
+                        return handler;
+                    }
+                } catch (error) {
+                    console.error(error);
                 }
             }
         }
@@ -324,12 +331,17 @@ export class CommandRegistry implements CommandService {
     /**
      * Get a toggled handler for the given command or `undefined`.
      */
-    getToggledHandler(commandId: string): CommandHandler | undefined {
+    // tslint:disable-next-line:no-any
+    getToggledHandler(commandId: string, ...args: any[]): CommandHandler | undefined {
         const handlers = this._handlers[commandId];
         if (handlers) {
             for (const handler of handlers) {
-                if (handler.isToggled) {
-                    return handler;
+                try {
+                    if (handler.isToggled && handler.isToggled(...args)) {
+                        return handler;
+                    }
+                } catch (error) {
+                    console.error(error);
                 }
             }
         }

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -144,14 +144,14 @@ export class ElectronMainMenuFactory {
                 items.push({
                     id: menu.id,
                     label: menu.label,
-                    type: this.commandRegistry.getToggledHandler(commandId) ? 'checkbox' : 'normal',
+                    type: this.commandRegistry.getToggledHandler(commandId, ...args) ? 'checkbox' : 'normal',
                     checked: this.commandRegistry.isToggled(commandId, ...args),
                     enabled: true, // https://github.com/theia-ide/theia/issues/446
                     visible: true,
                     click: () => this.execute(commandId, args),
                     accelerator
                 });
-                if (this.commandRegistry.getToggledHandler(commandId)) {
+                if (this.commandRegistry.getToggledHandler(commandId, ...args)) {
                     this._toggledCommands.add(commandId);
                 }
             }


### PR DESCRIPTION
#### What it does
fix https://github.com/theia-ide/theia/issues/5898 - catches command handler errors.

Also fix bug where `getToggledHandler` would stop on the first handler with a `isToggled` function defined, without executing it.

#### How to test
Modify some command handler to throw errors, without this patch it can prevent the command palette from opening. With this change, the error will be reported but it will not stop the processing of other contributions.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)