### PR TITLE
process: display process tasks in the terminal

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -392,8 +392,13 @@ export class TaskService implements TaskConfigurationClient {
 
         this.logger.debug(`Task created. Task id: ${taskInfo.taskId}`);
 
-        // open terminal widget if the task is based on a terminal process (type: shell)
-        if (taskInfo.terminalId !== undefined) {
+        /**
+         * open terminal widget if the task is based on a terminal process (type: 'shell' or 'process')
+         *
+         * @todo Use a different mechanism to determine if the task should be attached?
+         *       Reason: Maybe a new task type wants to also be displayed in a terminal.
+         */
+        if (typeof taskInfo.terminalId === 'number') {
             this.attach(taskInfo.terminalId, taskInfo.taskId);
         }
     }
@@ -436,7 +441,7 @@ export class TaskService implements TaskConfigurationClient {
         terminal.sendText(selectedText);
     }
 
-    async attach(terminalId: number, taskId: number): Promise<void> {
+    async attach(processId: number, taskId: number): Promise<void> {
         // Get the list of all available running tasks.
         const runningTasks: TaskInfo[] = await this.getRunningTasks();
         // Get the corresponding task information based on task id if available.
@@ -446,7 +451,7 @@ export class TaskService implements TaskConfigurationClient {
             TERMINAL_WIDGET_FACTORY_ID,
             <TerminalWidgetFactoryOptions>{
                 created: new Date().toString(),
-                id: 'terminal-' + terminalId,
+                id: 'terminal-' + processId,
                 title: taskInfo
                     ? `Task: ${taskInfo.config.label}`
                     : `Task: #${taskId}`,
@@ -455,7 +460,7 @@ export class TaskService implements TaskConfigurationClient {
         );
         this.shell.addWidget(widget, { area: 'bottom' });
         this.shell.activateWidget(widget.id);
-        widget.start(terminalId);
+        widget.start(processId);
     }
 
     async configure(task: TaskConfiguration): Promise<void> {

--- a/packages/task/src/node/process/process-task.ts
+++ b/packages/task/src/node/process/process-task.ts
@@ -124,8 +124,8 @@ export class ProcessTask extends Task {
             taskId: this.id,
             ctx: this.context,
             config: this.options.config,
-            terminalId: (this.processType === 'shell') ? this.process.id : undefined,
-            processId: this.processType === 'process' ? this.process.id : undefined
+            terminalId: this.process.id,
+            processId: this.process.id,
         };
     }
 

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -117,10 +117,10 @@ describe('Task server / back-end', function (): void {
         const p = new Promise((resolve, reject) => {
             const toDispose = taskWatcher.onTaskExit((event: TaskExitedEvent) => {
                 if (event.taskId === taskInfo.taskId && event.code === 0) {
-                    if (taskInfo.terminalId === undefined) {
+                    if (typeof taskInfo.terminalId === 'number') {
                         resolve();
                     } else {
-                        reject(new Error(`terminal id was expected to be undefined, actual: ${taskInfo.terminalId}`));
+                        reject(new Error(`terminal id was expected to be a number, got: ${typeof taskInfo.terminalId}`));
                     }
                     toDispose.dispose();
                 }


### PR DESCRIPTION
#### What it does

Displays `process` task output in a terminal like VS Code.

Fixes https://github.com/theia-ide/theia/issues/5908.

#### How to test

You can use the following task configuration to see that `process` task output is now displayed in a terminal:

```json
{
    "tasks": [
        {
            "label": "[Task] Echo a string",
            "type": "process",
            "cwd": "${workspaceFolder}",
            "command": "bash",
            "args": [
                "-c",
                "sleep 3 && echo 1 2 3"
            ]
        }
    ]
}
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
