### PR TITLE
[plugin] Fix ignoreFocusOut parameter for the QuickPick

### DIFF
--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -83,6 +83,7 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
             fuzzyMatchLabel: true,
             fuzzyMatchDetail: options.matchOnDetail,
             placeholder: options.placeHolder,
+            ignoreFocusOut: options.ignoreFocusLost,
             onClose: () => {
                 this.cleanUp();
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Pass `ignoreFocusOut` parameter to `QuickOpenService` on `showQuickPick` API function.

fixes https://github.com/theia-ide/theia/issues/5882
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open https://github.com/microsoft/vscode-extension-samples/tree/master/quickinput-sample project
2. Add `ignoreFocusOut: true,` after line https://github.com/microsoft/vscode-extension-samples/blob/5fb626a4e383c41b8878f94045cff987b92b6bca/quickinput-sample/src/basicInput.ts#L14
and build the plugin.
3. Start the plugin, launch F1 => Quick Input Samples => showQuickPick

The opened quick-pick must be visible after clicking to the area out of the widget.

Without the fix the quick pick widget hides after clicking to the area out of the widget, even if the `ignoreFocusOut` parameter is set.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

