### PR TITLE
upgrading to LSP 5.3.0 and Monaco 0.17.0

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -28,8 +28,13 @@
     "test": "theiaext test"
   },
   "dependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/plugin-transform-classes": "^7.5.5",
+    "@babel/plugin-transform-runtime": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
     "@theia/application-package": "^0.10.0",
     "@types/fs-extra": "^4.0.2",
+    "babel-loader": "^8.0.6",
     "bunyan": "^1.8.10",
     "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -133,6 +133,26 @@ module.exports = {
                 test: /\\.plist$/,
                 loader: "file-loader",
             },
+            {
+                test: /\\.js$/,
+                // include only es6 dependencies to transpile them to es5 classes
+                include: /monaco-languageclient|vscode-ws-jsonrpc|vscode-jsonrpc|vscode-languageserver-protocol|vscode-languageserver-types|vscode-languageclient/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: ['@babel/preset-env'],
+                        plugins: [
+                            // reuse runtime babel lib instead of generating it in each js file
+                            '@babel/plugin-transform-runtime',
+                            // ensure that classes are transpiled
+                            '@babel/plugin-transform-classes'
+                        ],
+                        // see https://github.com/babel/babel/issues/8900#issuecomment-431240426
+                        sourceType: 'unambiguous',
+                        cacheDirectory: true
+                    }
+                }
+            }
         ]
     },
     resolve: {

--- a/packages/callhierarchy/src/browser/callhierarchy-context.ts
+++ b/packages/callhierarchy/src/browser/callhierarchy-context.ts
@@ -17,7 +17,7 @@
 import { ILanguageClient } from '@theia/languages/lib/browser';
 import {
     ReferencesRequest, DocumentSymbolRequest, DefinitionRequest, TextDocumentPositionParams,
-    TextDocumentIdentifier, SymbolInformation, Location, Position, DocumentSymbol, ReferenceParams
+    TextDocumentIdentifier, SymbolInformation, Location, Position, DocumentSymbol, ReferenceParams, LocationLink
 } from 'monaco-languageclient/lib/services';
 import * as utils from './utils';
 import { ILogger, Disposable } from '@theia/core';
@@ -59,7 +59,7 @@ export class CallHierarchyContext implements Disposable {
 
         // Definition can be null
         // tslint:disable-next-line:no-null-keyword
-        let locations: Location | Location[] | null = null;
+        let locations: Location | Location[] | LocationLink[] | null = null;
         try {
             locations = await this.languageClient.sendRequest(DefinitionRequest.type, <TextDocumentPositionParams>{
                 position: Position.create(line, character),
@@ -71,7 +71,11 @@ export class CallHierarchyContext implements Disposable {
         if (!locations) {
             return undefined;
         }
-        return Array.isArray(locations) ? locations[0] : locations;
+        const targetLocation =  Array.isArray(locations) ? locations[0] : locations;
+        return LocationLink.is(targetLocation) ? {
+            uri: targetLocation.targetUri,
+            range: targetLocation.targetSelectionRange
+        } : targetLocation;
     }
 
     async getCallerReferences(definition: Location): Promise<Location[]> {

--- a/packages/console/src/browser/console-keybinding-contexts.ts
+++ b/packages/console/src/browser/console-keybinding-contexts.ts
@@ -83,7 +83,7 @@ export class ConsoleNavigationBackEnabled extends ConsoleInputFocusContext {
             return false;
         }
         const editor = console.input.getControl();
-        return editor.getPosition().equals({ lineNumber: 1, column: 1 });
+        return editor.getPosition()!.equals({ lineNumber: 1, column: 1 });
     }
 
 }
@@ -98,10 +98,10 @@ export class ConsoleNavigationForwardEnabled extends ConsoleInputFocusContext {
             return false;
         }
         const editor = console.input.getControl();
-        const model = console.input.getControl().getModel();
+        const model = console.input.getControl().getModel()!;
         const lineNumber = model.getLineCount();
         const column = model.getLineMaxColumn(lineNumber);
-        return editor.getPosition().equals({ lineNumber, column });
+        return editor.getPosition()!.equals({ lineNumber, column });
     }
 
 }

--- a/packages/console/src/browser/console-widget.ts
+++ b/packages/console/src/browser/console-widget.ts
@@ -193,8 +193,8 @@ export class ConsoleWidget extends BaseWidget implements StatefulWidget {
         const value = this.history.next || '';
         const editor = this.input.getControl();
         editor.setValue(value);
-        const lineNumber = editor.getModel().getLineCount();
-        const column = editor.getModel().getLineMaxColumn(lineNumber);
+        const lineNumber = editor.getModel()!.getLineCount();
+        const column = editor.getModel()!.getLineMaxColumn(lineNumber);
         editor.setPosition({ lineNumber, column });
     }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "main": "lib/common/index.js",
   "typings": "lib/common/index.d.ts",
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "@phosphor/widgets": "^1.5.0",
     "@primer/octicons-react": "^9.0.0",
     "@theia/application-package": "^0.10.0",
@@ -39,9 +40,9 @@
     "reconnecting-websocket": "^3.0.7",
     "reflect-metadata": "^0.1.10",
     "route-parser": "^0.0.5",
-    "vscode-languageserver-types": "^3.10.0",
+    "vscode-languageserver-types": "^3.15.0-next",
     "vscode-uri": "^1.0.8",
-    "vscode-ws-jsonrpc": "^0.0.2-1",
+    "vscode-ws-jsonrpc": "^0.1.1",
     "ws": "^5.2.2",
     "yargs": "^11.1.0"
   },

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -274,7 +274,7 @@ export class KeybindingRegistry {
     containsKeybinding(bindings: Keybinding[], binding: Keybinding): boolean {
         const bindingKeySequence = this.resolveKeybinding(binding);
         const collisions = this.getKeySequenceCollisions(bindings, bindingKeySequence)
-            .filter(b => b.context === binding.context);
+            .filter(b => b.context === binding.context && !b.when && !binding.when);
 
         if (collisions.full.length > 0) {
             this.logger.warn('Collided keybinding is ignored; ',

--- a/packages/core/src/node/messaging/ipc-bootstrap.ts
+++ b/packages/core/src/node/messaging/ipc-bootstrap.ts
@@ -26,7 +26,8 @@ const writer = new IPCMessageWriter(process);
 const logger = new ConsoleLogger();
 const connection = createMessageConnection(reader, writer, logger);
 connection.trace(Trace.Off, {
-    log: (message, data) => console.log(`${message} ${data}`)
+    // tslint:disable-next-line:no-any
+    log: (message: any, data?: string) => console.log(message, data)
 });
 
 const entryPoint = require(ipcEntryPoint!).default as IPCEntryPoint;

--- a/packages/core/src/node/messaging/ipc-connection-provider.ts
+++ b/packages/core/src/node/messaging/ipc-connection-provider.ts
@@ -84,7 +84,8 @@ export class IPCConnectionProvider {
             log: (message: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}`)
         });
         connection.trace(Trace.Off, {
-            log: (message, data) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message} ${data}`)
+            // tslint:disable-next-line:no-any
+            log: (message: any, data?: string) => this.logger.info(`[${options.serverName}: ${childProcess.pid}] ${message}` + (typeof data === 'string' ? ' ' + data : ''))
         });
         return connection;
     }

--- a/packages/debug/src/browser/debug-configuration-manager.ts
+++ b/packages/debug/src/browser/debug-configuration-manager.ts
@@ -208,7 +208,7 @@ export class DebugConfigurationManager {
             },
             onArrayBegin: offset => {
                 if (lastProperty === 'configurations' && depthInArray === 0) {
-                    position = editor.getModel().getPositionAt(offset + 1);
+                    position = editor.getModel()!.getPositionAt(offset + 1);
                 }
                 depthInArray++;
             },
@@ -220,12 +220,12 @@ export class DebugConfigurationManager {
             return;
         }
         // Check if there are more characters on a line after a "configurations": [, if yes enter a newline
-        if (editor.getModel().getLineLastNonWhitespaceColumn(position.lineNumber) > position.column) {
+        if (editor.getModel()!.getLineLastNonWhitespaceColumn(position.lineNumber) > position.column) {
             editor.setPosition(position);
             editor.trigger('debug', 'lineBreakInsert', undefined);
         }
         // Check if there is already an empty line to insert suggest, if yes just place the cursor
-        if (editor.getModel().getLineLastNonWhitespaceColumn(position.lineNumber + 1) === 0) {
+        if (editor.getModel()!.getLineLastNonWhitespaceColumn(position.lineNumber + 1) === 0) {
             editor.setPosition({ lineNumber: position.lineNumber + 1, column: 1 << 30 });
             await commandService.executeCommand('editor.action.deleteLines');
         }

--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -79,7 +79,7 @@ export class DebugEditorModel implements Disposable {
 
     @postConstruct()
     protected init(): void {
-        this.uri = new URI(this.editor.getControl().getModel().uri.toString());
+        this.uri = new URI(this.editor.getControl().getModel()!.uri.toString());
         this.toDispose.pushAll([
             this.hover,
             this.breakpointWidget,
@@ -87,7 +87,7 @@ export class DebugEditorModel implements Disposable {
             this.editor.getControl().onMouseMove(event => this.handleMouseMove(event)),
             this.editor.getControl().onMouseLeave(event => this.handleMouseLeave(event)),
             this.editor.getControl().onKeyDown(() => this.hover.hide({ immediate: false })),
-            this.editor.getControl().getModel().onDidChangeDecorations(() => this.updateBreakpoints()),
+            this.editor.getControl().getModel()!.onDidChangeDecorations(() => this.updateBreakpoints()),
             this.sessions.onDidChange(() => this.renderFrames())
         ]);
         this.renderFrames();
@@ -176,7 +176,7 @@ export class DebugEditorModel implements Disposable {
     protected updateBreakpointRanges(): void {
         this.breakpointRanges.clear();
         for (const decoration of this.breakpointDecorations) {
-            const range = this.editor.getControl().getModel().getDecorationRange(decoration);
+            const range = this.editor.getControl().getModel()!.getDecorationRange(decoration)!;
             this.breakpointRanges.set(decoration, range);
         }
     }
@@ -214,7 +214,7 @@ export class DebugEditorModel implements Disposable {
             return false;
         }
         for (const decoration of this.breakpointDecorations) {
-            const range = this.editor.getControl().getModel().getDecorationRange(decoration);
+            const range = this.editor.getControl().getModel()!.getDecorationRange(decoration);
             const oldRange = this.breakpointRanges.get(decoration)!;
             if (!range || !range.equalsRange(oldRange)) {
                 return true;
@@ -227,7 +227,7 @@ export class DebugEditorModel implements Disposable {
         const lines = new Set<number>();
         const breakpoints: SourceBreakpoint[] = [];
         for (const decoration of this.breakpointDecorations) {
-            const range = this.editor.getControl().getModel().getDecorationRange(decoration);
+            const range = this.editor.getControl().getModel()!.getDecorationRange(decoration);
             if (range && !lines.has(range.startLineNumber)) {
                 const line = range.startLineNumber;
                 const oldRange = this.breakpointRanges.get(decoration);
@@ -242,7 +242,7 @@ export class DebugEditorModel implements Disposable {
 
     protected _position: monaco.Position | undefined;
     get position(): monaco.Position {
-        return this._position || this.editor.getControl().getPosition();
+        return this._position || this.editor.getControl().getPosition()!;
     }
     get breakpoint(): DebugBreakpoint | undefined {
         return this.getBreakpoint();
@@ -285,12 +285,12 @@ export class DebugEditorModel implements Disposable {
     protected handleMouseDown(event: monaco.editor.IEditorMouseEvent): void {
         if (event.target && event.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
             if (event.event.rightButton) {
-                this._position = event.target.position;
+                this._position = event.target.position!;
                 this.contextMenu.render(DebugEditorModel.CONTEXT_MENU, event.event.browserEvent, () =>
                     setTimeout(() => this._position = undefined)
                 );
             } else {
-                this.doToggleBreakpoint(event.target.position);
+                this.doToggleBreakpoint(event.target.position!);
             }
         }
         this.hintBreakpoint(event);
@@ -299,7 +299,7 @@ export class DebugEditorModel implements Disposable {
         this.showHover(event);
         this.hintBreakpoint(event);
     }
-    protected handleMouseLeave(event: monaco.editor.IEditorMouseEvent): void {
+    protected handleMouseLeave(event: monaco.editor.IPartialEditorMouseEvent): void {
         this.hideHover(event);
         this.deltaHintDecorations([]);
     }
@@ -313,7 +313,7 @@ export class DebugEditorModel implements Disposable {
         this.hintDecorations = this.deltaDecorations(this.hintDecorations, hintDecorations);
     }
     protected createHintDecorations(event: monaco.editor.IEditorMouseEvent): monaco.editor.IModelDeltaDecoration[] {
-        if (event.target && event.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
+        if (event.target && event.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN && event.target.position) {
             const lineNumber = event.target.position.lineNumber;
             if (!!this.sessions.getBreakpoint(this.uri, lineNumber)) {
                 return [];
@@ -337,14 +337,14 @@ export class DebugEditorModel implements Disposable {
         }
         if (targetType === monaco.editor.MouseTargetType.CONTENT_TEXT) {
             this.hover.show({
-                selection: mouseEvent.target.range,
+                selection: mouseEvent.target.range!,
                 immediate: false
             });
         } else {
             this.hover.hide({ immediate: false });
         }
     }
-    protected hideHover({ event }: monaco.editor.IEditorMouseEvent): void {
+    protected hideHover({ event }: monaco.editor.IPartialEditorMouseEvent): void {
         const rect = this.hover.getDomNode().getBoundingClientRect();
         if (event.posx < rect.left || event.posx > rect.right || event.posy < rect.top || event.posy > rect.bottom) {
             this.hover.hide({ immediate: false });
@@ -354,7 +354,7 @@ export class DebugEditorModel implements Disposable {
     protected deltaDecorations(oldDecorations: string[], newDecorations: monaco.editor.IModelDeltaDecoration[]): string[] {
         this.updatingDecorations = true;
         try {
-            return this.editor.getControl().getModel().deltaDecorations(oldDecorations, newDecorations);
+            return this.editor.getControl().getModel()!.deltaDecorations(oldDecorations, newDecorations);
         } finally {
             this.updatingDecorations = false;
         }

--- a/packages/debug/src/browser/editor/debug-editor-service.ts
+++ b/packages/debug/src/browser/editor/debug-editor-service.ts
@@ -62,7 +62,7 @@ export class DebugEditorService {
         if (!(editor instanceof MonacoEditor)) {
             return;
         }
-        const uri = editor.getControl().getModel().uri.toString();
+        const uri = editor.getControl().getModel()!.uri.toString();
         const debugModel = this.factory(editor);
         this.models.set(uri, debugModel);
         editor.getControl().onDidDispose(() => {
@@ -122,15 +122,15 @@ export class DebugEditorService {
     showHover(): void {
         const { model } = this;
         if (model) {
-            const selection = model.editor.getControl().getSelection();
+            const selection = model.editor.getControl().getSelection()!;
             model.hover.show({ selection, focus: true });
         }
     }
     canShowHover(): boolean {
         const { model } = this;
         if (model) {
-            const selection = model.editor.getControl().getSelection();
-            return !!model.editor.getControl().getModel().getWordAtPosition(selection.getStartPosition());
+            const selection = model.editor.getControl().getSelection()!;
+            return !!model.editor.getControl().getModel()!.getWordAtPosition(selection.getStartPosition());
         }
         return false;
     }

--- a/packages/debug/src/browser/editor/debug-hover-widget.ts
+++ b/packages/debug/src/browser/editor/debug-hover-widget.ts
@@ -159,7 +159,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
         }
         super.show();
         this.options = options;
-        const expression = this.expressionProvider.get(this.editor.getControl().getModel(), options.selection);
+        const expression = this.expressionProvider.get(this.editor.getControl().getModel()!, options.selection);
         if (!expression) {
             this.hide();
             return;
@@ -181,7 +181,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
     protected isEditorFrame(): boolean {
         const { currentFrame } = this.sessions;
         return !!currentFrame && !!currentFrame.source &&
-            this.editor.getControl().getModel().uri.toString() === currentFrame.source.uri.toString();
+            this.editor.getControl().getModel()!.uri.toString() === currentFrame.source.uri.toString();
     }
 
     getPosition(): monaco.editor.IContentWidgetPosition {
@@ -189,7 +189,7 @@ export class DebugHoverWidget extends SourceTreeWidget implements monaco.editor.
             return undefined!;
         }
         const position = this.options && this.options.selection.getStartPosition();
-        const word = position && this.editor.getControl().getModel().getWordAtPosition(position);
+        const word = position && this.editor.getControl().getModel()!.getWordAtPosition(position);
         return position && word ? {
             position: new monaco.Position(position.lineNumber, word.startColumn),
             preference: [

--- a/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
@@ -18,7 +18,7 @@
 // disable no-unused-expression for chai.
 // tslint:disable:no-any no-unused-expression
 
-import {enableJSDOM} from '@theia/core/lib/browser/test/jsdom';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJsDom = enableJSDOM();
 
 import URI from '@theia/core/lib/common/uri';
@@ -38,7 +38,7 @@ sinon.stub(mockEditorWidget, 'id').get(() => 'mockEditorWidget');
 
 const mockPreviewWidget = sinon.createStubInstance(EditorPreviewWidget);
 sinon.stub(mockPreviewWidget, 'id').get(() => 'mockPreviewWidget');
-sinon.stub(mockPreviewWidget, 'disposed').get(() => ({connect: () => 1}));
+sinon.stub(mockPreviewWidget, 'disposed').get(() => ({ connect: () => 1 }));
 let onPinnedListeners: Function[] = [];
 sinon.stub(mockPreviewWidget, 'onPinned').get(() => (fn: Function) => onPinnedListeners.push(fn));
 
@@ -50,10 +50,10 @@ let onCreateListners: Function[] = [];
 mockWidgetManager.onDidCreateWidget = sinon.stub().callsFake((fn: Function) => onCreateListners.push(fn));
 (mockWidgetManager.getOrCreateWidget as sinon.SinonStub).returns(mockPreviewWidget);
 
-const mockShell = sinon.createStubInstance(ApplicationShell);
+const mockShell = sinon.createStubInstance(ApplicationShell) as ApplicationShell;
 
 const mockPreference = sinon.createStubInstance(PreferenceServiceImpl);
-mockPreference.onPreferenceChanged = sinon.stub().returns({dispose: () => {}});
+mockPreference.onPreferenceChanged = sinon.stub().returns({ dispose: () => { } });
 
 let testContainer: Container;
 
@@ -62,7 +62,7 @@ before(() => {
     // Mock out injected dependencies.
     testContainer.bind(EditorManager).toDynamicValue(ctx => mockEditorManager);
     testContainer.bind(WidgetManager).toDynamicValue(ctx => mockWidgetManager);
-    testContainer.bind(ApplicationShell).toDynamicValue(ctx => mockShell);
+    testContainer.bind(ApplicationShell).toConstantValue(mockShell);
     testContainer.bind(PreferenceService).toDynamicValue(ctx => mockPreference);
 
     testContainer.load(previewFrontEndModule.default);
@@ -77,6 +77,8 @@ describe('editor-preview-manager', () => {
 
     beforeEach(() => {
         previewManager = testContainer.get<EditorPreviewManager>(OpenHandler);
+        sinon.stub(previewManager as any, 'onActive').resolves();
+        sinon.stub(previewManager as any, 'onReveal').resolves();
     });
     afterEach(() => {
         onCreateListners = [];
@@ -86,23 +88,23 @@ describe('editor-preview-manager', () => {
     it('should handle preview requests if editor.enablePreview enabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(true);
         (mockPreference.validate as sinon.SinonStub).returns(true);
-        expect(await previewManager.canHandle(new URI(), {preview: true})).to.be.greaterThan(0);
+        expect(await previewManager.canHandle(new URI(), { preview: true })).to.be.greaterThan(0);
     });
     it('should not handle preview requests if editor.enablePreview disabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(false);
         (mockPreference.validate as sinon.SinonStub).returns(true);
-        expect(await previewManager.canHandle(new URI(), {preview: true})).to.equal(0);
+        expect(await previewManager.canHandle(new URI(), { preview: true })).to.equal(0);
     });
     it('should not handle requests that are not preview or currently being previewed', async () => {
         expect(await previewManager.canHandle(new URI())).to.equal(0);
     });
     it('should create a preview editor and replace where required.', async () => {
-        const w = await previewManager.open(new URI(), {preview: true});
+        const w = await previewManager.open(new URI(), { preview: true });
         expect(w instanceof EditorPreviewWidget).to.be.true;
         expect((w as any).replaceEditorWidget.calledOnce).to.be.false;
 
         // Replace the EditorWidget with another open call to an editor that doesn't exist.
-        const afterReplace = await previewManager.open(new URI(), {preview: true});
+        const afterReplace = await previewManager.open(new URI(), { preview: true });
         expect((afterReplace as any).replaceEditorWidget.calledOnce).to.be.true;
 
         // Ensure the same preview widget was re-used.
@@ -116,7 +118,7 @@ describe('editor-preview-manager', () => {
 
         // Activate existing preview
         mockEditorWidget.parent = mockPreviewWidget;
-        expect(await previewManager.open(new URI(), {preview: true})).to.equal(mockPreviewWidget);
+        expect(await previewManager.open(new URI(), { preview: true })).to.equal(mockPreviewWidget);
         // Ensure it is not pinned.
         expect((mockPreviewWidget.pinEditorWidget as sinon.SinonStub).calledOnce).to.be.false;
 
@@ -126,9 +128,9 @@ describe('editor-preview-manager', () => {
     });
     it('should should transition the editor to perminent on pin events.', async () => {
         // Fake creation call.
-        await onCreateListners.pop()!({factoryId: EditorPreviewWidgetFactory.ID, widget: mockPreviewWidget});
+        await onCreateListners.pop()!({ factoryId: EditorPreviewWidgetFactory.ID, widget: mockPreviewWidget });
         // Fake pinned call
-        onPinnedListeners.pop()!({preview: mockPreviewWidget, editorWidget: mockEditorWidget});
+        onPinnedListeners.pop()!({ preview: mockPreviewWidget, editorWidget: mockEditorWidget });
 
         expect(mockPreviewWidget.dispose.calledOnce).to.be.true;
         expect(mockEditorWidget.close.calledOnce).to.be.false;

--- a/packages/editor-preview/src/browser/editor-preview-manager.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.ts
@@ -22,7 +22,6 @@ import { EditorPreviewWidget } from './editor-preview-widget';
 import { EditorPreviewWidgetFactory, EditorPreviewWidgetOptions } from './editor-preview-factory';
 import { EditorPreviewPreferences } from './editor-preview-preferences';
 import { WidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser';
-import { Deferred } from '@theia/core/lib/common/promise-util';
 
 /**
  * Opener options containing an optional preview flag.
@@ -109,38 +108,40 @@ export class EditorPreviewManager extends WidgetOpenHandler<EditorPreviewWidget 
         return 0;
     }
 
-    async open(uri: URI, options?: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | EditorWidget> {
-        options = { ...options, mode: 'open' };
-
-        const deferred = new Deferred<EditorPreviewWidget | undefined>();
-        const previousPreview = await this.currentEditorPreview;
-        this.currentEditorPreview = deferred.promise;
-
-        if (await this.editorManager.getByUri(uri)) {
-            let widget: EditorWidget | EditorPreviewWidget = await this.editorManager.open(uri, options);
-            if (widget.parent instanceof EditorPreviewWidget) {
-                if (!options.preview) {
-                    widget.parent.pinEditorWidget();
-                }
-                widget = widget.parent;
-            }
-            this.shell.revealWidget(widget.id);
-            deferred.resolve(previousPreview);
+    async open(uri: URI, options: PreviewEditorOpenerOptions = {}): Promise<EditorPreviewWidget | EditorWidget> {
+        let widget = await this.pinCurrentEditor(uri, options);
+        if (widget) {
             return widget;
         }
+        widget = await this.replaceCurrentPreview(uri, options) || await this.openNewPreview(uri, options);
+        await this.editorManager.open(uri, options);
+        return widget;
+    }
 
-        if (!previousPreview) {
-            this.currentEditorPreview = super.open(uri, options) as Promise<EditorPreviewWidget>;
-        } else {
-            const childWidget = await this.editorManager.getOrCreateByUri(uri);
-            previousPreview.replaceEditorWidget(childWidget);
-            this.currentEditorPreview = Promise.resolve(previousPreview);
+    protected async pinCurrentEditor(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorWidget | EditorPreviewWidget | undefined> {
+        if (await this.editorManager.getByUri(uri)) {
+            const editorWidget = await this.editorManager.open(uri, options);
+            if (editorWidget.parent instanceof EditorPreviewWidget) {
+                if (!options.preview) {
+                    editorWidget.parent.pinEditorWidget();
+                }
+                return editorWidget.parent;
+            }
+            return editorWidget;
         }
+    }
 
-        const preview = await this.currentEditorPreview as EditorPreviewWidget;
-        this.editorManager.open(uri, options);
-        this.shell.revealWidget(preview.id);
-        return preview;
+    protected async replaceCurrentPreview(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget | undefined> {
+        const currentPreview = await this.currentEditorPreview;
+        if (currentPreview) {
+            const editorWidget = await this.editorManager.getOrCreateByUri(uri);
+            currentPreview.replaceEditorWidget(editorWidget);
+            return currentPreview;
+        }
+    }
+
+    protected openNewPreview(uri: URI, options: PreviewEditorOpenerOptions): Promise<EditorPreviewWidget> {
+        return this.currentEditorPreview = super.open(uri, options) as Promise<EditorPreviewWidget>;
     }
 
     protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): EditorPreviewWidgetOptions {

--- a/packages/editor-preview/src/browser/editor-preview-widget.ts
+++ b/packages/editor-preview/src/browser/editor-preview-widget.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 
 import {
-    ApplicationShell, BaseWidget,  DockPanel, Navigatable, PanelLayout, Saveable,
-     StatefulWidget, Title,  Widget, WidgetConstructionOptions, WidgetManager
+    ApplicationShell, BaseWidget, DockPanel, Navigatable, PanelLayout, Saveable,
+    StatefulWidget, Title, Widget, WidgetConstructionOptions, WidgetManager
 } from '@theia/core/lib/browser';
 import { Emitter, DisposableCollection } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
@@ -70,7 +70,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
         return this.pinned_;
     }
 
-    get saveable(): Saveable|undefined {
+    get saveable(): Saveable | undefined {
         if (this.editorWidget_) {
             return this.editorWidget_.saveable;
         }
@@ -80,14 +80,14 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
         return this.editorWidget_ && this.editorWidget_.getResourceUri();
     }
     createMoveToUri(resourceUri: URI): URI | undefined {
-        return this.editorWidget_ &&  this.editorWidget_.createMoveToUri(resourceUri);
+        return this.editorWidget_ && this.editorWidget_.createMoveToUri(resourceUri);
     }
 
     pinEditorWidget(): void {
         this.title.className = this.title.className.replace(PREVIEW_TITLE_CLASS, '');
         this.pinListeners.dispose();
         this.pinned_ = true;
-        this.onPinnedEmitter.fire({preview: this, editorWidget: this.editorWidget_!});
+        this.onPinnedEmitter.fire({ preview: this, editorWidget: this.editorWidget_! });
     }
 
     replaceEditorWidget(editorWidget: EditorWidget): void {
@@ -156,15 +156,15 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
                 }
             };
             parent.layoutModified.connect(layoutListener);
-            this.pinListeners.push({dispose: () => parent.layoutModified.disconnect(layoutListener)});
+            this.pinListeners.push({ dispose: () => parent.layoutModified.disconnect(layoutListener) });
 
-            const tabMovedListener = (w: Widget, args: {title: Title<Widget>}) => {
+            const tabMovedListener = (w: Widget, args: { title: Title<Widget> }) => {
                 if (args.title === this.title) {
                     this.pinEditorWidget();
                 }
             };
             tabBar.tabMoved.connect(tabMovedListener);
-            this.pinListeners.push({dispose: () => tabBar.tabMoved.disconnect(tabMovedListener)});
+            this.pinListeners.push({ dispose: () => tabBar.tabMoved.disconnect(tabMovedListener) });
 
             const attachDoubleClickListener = (attempt: number): number | undefined => {
                 const tabNode = tabBar.contentNode.children.item(tabBar.currentIndex);
@@ -173,7 +173,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
                 }
                 const dblClickListener = (event: Event) => this.pinEditorWidget();
                 tabNode.addEventListener('dblclick', dblClickListener);
-                this.pinListeners.push({dispose: () => tabNode.removeEventListener('dblclick', dblClickListener)});
+                this.pinListeners.push({ dispose: () => tabNode.removeEventListener('dblclick', dblClickListener) });
             };
             requestAnimationFrame(() => attachDoubleClickListener(0));
         }
@@ -190,7 +190,7 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
                 const width = parseInt(this.node.style.width || '');
                 const height = parseInt(this.node.style.height || '');
                 if (width && height) {
-                    this.editorWidget_.editor.setSize({width, height});
+                    this.editorWidget_.editor.setSize({ width, height });
                 }
             }
             MessageLoop.sendMessage(this.editorWidget_, msg);
@@ -211,9 +211,9 @@ export class EditorPreviewWidget extends BaseWidget implements ApplicationShell.
     }
 
     async restoreState(state: PreviewViewState): Promise<void> {
-        const {pinned, editorState, previewDescription} = state;
+        const { pinned, editorState, previewDescription } = state;
         if (!this.editorWidget_ && previewDescription) {
-            const {factoryId, options} = previewDescription;
+            const { factoryId, options } = previewDescription;
             const editorWidget = await this.widgetManager.getOrCreateWidget(factoryId, options) as EditorWidget;
             this.replaceEditorWidget(editorWidget);
         }

--- a/packages/editor/src/browser/editor-preferences.ts
+++ b/packages/editor/src/browser/editor-preferences.ts
@@ -21,15 +21,22 @@ import {
     PreferenceService,
     PreferenceContribution,
     PreferenceSchema,
-    PreferenceChangeEvent
+    PreferenceChangeEvent,
+    PreferenceSchemaProperties
 } from '@theia/core/lib/browser/preferences';
-import { isWindows, isOSX } from '@theia/core/lib/common/os';
+import { isWindows, isOSX, OS } from '@theia/core/lib/common/os';
 import { SUPPORTED_ENCODINGS } from './supported-encodings';
 
 const DEFAULT_WINDOWS_FONT_FAMILY = 'Consolas, \'Courier New\', monospace';
 const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospace';
 const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'monospace\', monospace, \'Droid Sans Fallback\'';
 
+const platform = {
+    isMacintosh: isOSX,
+    isLinux: OS.type() === OS.Type.Linux
+};
+
+// should be in sync with https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/config/editorOptions.ts#L2585
 export const EDITOR_FONT_DEFAULTS = {
     fontFamily: (
         isOSX ? DEFAULT_MAC_FONT_FAMILY : (isWindows ? DEFAULT_WINDOWS_FONT_FAMILY : DEFAULT_LINUX_FONT_FAMILY)
@@ -42,56 +49,988 @@ export const EDITOR_FONT_DEFAULTS = {
     letterSpacing: 0,
 };
 
+// should be in sync with https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/config/editorOptions.ts#L2600
+export const EDITOR_MODEL_DEFAULTS = {
+    tabSize: 4,
+    indentSize: 4,
+    insertSpaces: true,
+    detectIndentation: true,
+    trimAutoWhitespace: true,
+    largeFileOptimizations: true
+};
+
+// tslint:disable:no-null-keyword
+// should be in sync with https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/config/editorOptions.ts#L2612
+// 1. Copy
+// 2. Inline values
+export const EDITOR_DEFAULTS = {
+    inDiffEditor: false,
+    wordSeparators: '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?',
+    lineNumbersMinChars: 5,
+    lineDecorationsWidth: 10,
+    readOnly: false,
+    mouseStyle: 'text',
+    disableLayerHinting: false,
+    automaticLayout: false,
+    wordWrap: 'off',
+    wordWrapColumn: 80,
+    wordWrapMinified: true,
+    wrappingIndent: 1,
+    wordWrapBreakBeforeCharacters: '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋',
+    wordWrapBreakAfterCharacters: ' \t})]?|/&,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ”〉》」』】〕）］｝｣',
+    wordWrapBreakObtrusiveCharacters: '.',
+    autoClosingBrackets: 'languageDefined',
+    autoClosingQuotes: 'languageDefined',
+    autoSurround: 'languageDefined',
+    autoIndent: true,
+    dragAndDrop: true,
+    emptySelectionClipboard: true,
+    copyWithSyntaxHighlighting: true,
+    useTabStops: true,
+    multiCursorModifier: 'altKey',
+    multiCursorMergeOverlapping: true,
+    accessibilitySupport: 'auto',
+    showUnused: true,
+
+    viewInfo: {
+        extraEditorClassName: '',
+        disableMonospaceOptimizations: false,
+        rulers: [],
+        ariaLabel: 'Editor content',
+        renderLineNumbers: 1,
+        renderCustomLineNumbers: null,
+        cursorSurroundingLines: 0,
+        renderFinalNewline: true,
+        selectOnLineNumbers: true,
+        glyphMargin: true,
+        revealHorizontalRightPadding: 30,
+        roundedSelection: true,
+        overviewRulerLanes: 2,
+        overviewRulerBorder: true,
+        cursorBlinking: 1,
+        mouseWheelZoom: false,
+        cursorSmoothCaretAnimation: false,
+        cursorStyle: 1,
+        cursorWidth: 0,
+        hideCursorInOverviewRuler: false,
+        scrollBeyondLastLine: true,
+        scrollBeyondLastColumn: 5,
+        smoothScrolling: false,
+        stopRenderingLineAfter: 10000,
+        renderWhitespace: 'none',
+        renderControlCharacters: false,
+        fontLigatures: false,
+        renderIndentGuides: true,
+        highlightActiveIndentGuide: true,
+        renderLineHighlight: 'line',
+        scrollbar: {
+            vertical: 1,
+            horizontal: 1,
+            arrowSize: 11,
+            useShadows: true,
+            verticalHasArrows: false,
+            horizontalHasArrows: false,
+            horizontalScrollbarSize: 10,
+            horizontalSliderSize: 10,
+            verticalScrollbarSize: 14,
+            verticalSliderSize: 14,
+            handleMouseWheel: true,
+            mouseWheelScrollSensitivity: 1,
+            fastScrollSensitivity: 5,
+        },
+        minimap: {
+            enabled: true,
+            side: 'right',
+            showSlider: 'mouseover',
+            renderCharacters: true,
+            maxColumn: 120
+        },
+        fixedOverflowWidgets: false,
+    },
+
+    contribInfo: {
+        selectionClipboard: true,
+        hover: {
+            enabled: true,
+            delay: 300,
+            sticky: true
+        },
+        links: true,
+        contextmenu: true,
+        quickSuggestions: { other: true, comments: false, strings: false },
+        quickSuggestionsDelay: 10,
+        parameterHints: {
+            enabled: true,
+            cycle: false
+        },
+        formatOnType: false,
+        formatOnPaste: false,
+        suggestOnTriggerCharacters: true,
+        acceptSuggestionOnEnter: 'on',
+        acceptSuggestionOnCommitCharacter: true,
+        wordBasedSuggestions: true,
+        suggestSelection: 'recentlyUsed',
+        suggestFontSize: 0,
+        suggestLineHeight: 0,
+        tabCompletion: 'off',
+        suggest: {
+            filterGraceful: true,
+            snippets: 'inline',
+            snippetsPreventQuickSuggestions: true,
+            localityBonus: false,
+            shareSuggestSelections: false,
+            showIcons: true,
+            maxVisibleSuggestions: 12,
+            filteredTypes: Object.create(null)
+        },
+        gotoLocation: {
+            multiple: 'peek'
+        },
+        selectionHighlight: true,
+        occurrencesHighlight: true,
+        codeLens: true,
+        folding: true,
+        foldingStrategy: 'auto',
+        showFoldingControls: 'mouseover',
+        matchBrackets: true,
+        find: {
+            seedSearchStringFromSelection: true,
+            autoFindInSelection: false,
+            globalFindClipboard: false,
+            addExtraSpaceOnTop: true
+        },
+        colorDecorators: true,
+        lightbulbEnabled: true,
+        codeActionsOnSave: {},
+        codeActionsOnSaveTimeout: 750
+    },
+};
+// tslint:eanble:no-null-keyword
+
+// tslint:disable:max-line-length
+// should be in sync with https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/editor/common/config/commonEditorConfig.ts#L232
+// 1. Copy
+// 2. Find -> Use Regular Expressions -> nls\.localize\(.*, "(.*)"\) -> "$1"
+// 3. Find -> Use Regular Expressions -> nls\.localize\(.*, '(.*)'\) -> '$1'
+// 4. Apply `quotemark` quick fixes
+// 5. Fix the rest manually
+const codeEditorPreferenceProperties = {
+    'editor.fontFamily': {
+        'type': 'string',
+        'default': EDITOR_FONT_DEFAULTS.fontFamily,
+        'description': 'Controls the font family.'
+    },
+    'editor.fontWeight': {
+        'type': 'string',
+        'enum': ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700', '800', '900'],
+        'default': EDITOR_FONT_DEFAULTS.fontWeight,
+        'description': 'Controls the font weight.'
+    },
+    'editor.fontSize': {
+        'type': 'number',
+        'default': EDITOR_FONT_DEFAULTS.fontSize,
+        'description': 'Controls the font size in pixels.'
+    },
+    'editor.lineHeight': {
+        'type': 'number',
+        'default': EDITOR_FONT_DEFAULTS.lineHeight,
+        'description': 'Controls the line height. Use 0 to compute the line height from the font size.'
+    },
+    'editor.letterSpacing': {
+        'type': 'number',
+        'default': EDITOR_FONT_DEFAULTS.letterSpacing,
+        'description': 'Controls the letter spacing in pixels.'
+    },
+    'editor.lineNumbers': {
+        'type': 'string',
+        'enum': ['off', 'on', 'relative', 'interval'],
+        'enumDescriptions': [
+            'Line numbers are not rendered.',
+            'Line numbers are rendered as absolute number.',
+            'Line numbers are rendered as distance in lines to cursor position.',
+            'Line numbers are rendered every 10 lines.'
+        ],
+        'default': 'on',
+        'description': 'Controls the display of line numbers.'
+    },
+    'editor.cursorSurroundingLines': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.viewInfo.cursorSurroundingLines,
+        'description': "Controls the minimal number of visible leading and trailing lines surrounding the cursor. Known as 'scrollOff' or `scrollOffset` in some other editors."
+    },
+    'editor.renderFinalNewline': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.renderFinalNewline,
+        'description': 'Render last line number when the file ends with a newline.'
+    },
+    'editor.rulers': {
+        'type': 'array',
+        'items': {
+            'type': 'number'
+        },
+        'default': EDITOR_DEFAULTS.viewInfo.rulers,
+        'description': 'Render vertical rulers after a certain number of monospace characters. Use multiple values for multiple rulers. No rulers are drawn if array is empty.'
+    },
+    'editor.wordSeparators': {
+        'type': 'string',
+        'default': EDITOR_DEFAULTS.wordSeparators,
+        'description': 'Characters that will be used as word separators when doing word related navigations or operations.'
+    },
+    'editor.tabSize': {
+        'type': 'number',
+        'default': EDITOR_MODEL_DEFAULTS.tabSize,
+        'minimum': 1,
+        'markdownDescription': 'The number of spaces a tab is equal to. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.'
+    },
+    'editor.insertSpaces': {
+        'type': 'boolean',
+        'default': EDITOR_MODEL_DEFAULTS.insertSpaces,
+        'markdownDescription': 'Insert spaces when pressing `Tab`. This setting is overridden based on the file contents when `#editor.detectIndentation#` is on.'
+    },
+    'editor.detectIndentation': {
+        'type': 'boolean',
+        'default': EDITOR_MODEL_DEFAULTS.detectIndentation,
+        'markdownDescription': 'Controls whether `#editor.tabSize#` and `#editor.insertSpaces#` will be automatically detected when a file is opened based on the file contents.'
+    },
+    'editor.roundedSelection': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.roundedSelection,
+        'description': 'Controls whether selections should have rounded corners.'
+    },
+    'editor.scrollBeyondLastLine': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.scrollBeyondLastLine,
+        'description': 'Controls whether the editor will scroll beyond the last line.'
+    },
+    'editor.scrollBeyondLastColumn': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.viewInfo.scrollBeyondLastColumn,
+        'description': 'Controls the number of extra characters beyond which the editor will scroll horizontally.'
+    },
+    'editor.smoothScrolling': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.smoothScrolling,
+        'description': 'Controls whether the editor will scroll using an animation.'
+    },
+    'editor.minimap.enabled': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.minimap.enabled,
+        'description': 'Controls whether the minimap is shown.'
+    },
+    'editor.minimap.side': {
+        'type': 'string',
+        'enum': ['left', 'right'],
+        'default': EDITOR_DEFAULTS.viewInfo.minimap.side,
+        'description': 'Controls the side where to render the minimap.'
+    },
+    'editor.minimap.showSlider': {
+        'type': 'string',
+        'enum': ['always', 'mouseover'],
+        'default': EDITOR_DEFAULTS.viewInfo.minimap.showSlider,
+        'description': 'Controls whether the minimap slider is automatically hidden.'
+    },
+    'editor.minimap.renderCharacters': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.minimap.renderCharacters,
+        'description': 'Render the actual characters on a line as opposed to color blocks.'
+    },
+    'editor.minimap.maxColumn': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.viewInfo.minimap.maxColumn,
+        'description': 'Limit the width of the minimap to render at most a certain number of columns.'
+    },
+    'editor.hover.enabled': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.hover.enabled,
+        'description': 'Controls whether the hover is shown.'
+    },
+    'editor.hover.delay': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.contribInfo.hover.delay,
+        'description': 'Controls the delay in milliseconds after which the hover is shown.'
+    },
+    'editor.hover.sticky': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.hover.sticky,
+        'description': 'Controls whether the hover should remain visible when mouse is moved over it.'
+    },
+    'editor.find.seedSearchStringFromSelection': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.find.seedSearchStringFromSelection,
+        'description': 'Controls whether the search string in the Find Widget is seeded from the editor selection.'
+    },
+    'editor.find.autoFindInSelection': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.find.autoFindInSelection,
+        'description': 'Controls whether the find operation is carried out on selected text or the entire file in the editor.'
+    },
+    'editor.find.globalFindClipboard': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.find.globalFindClipboard,
+        'description': 'Controls whether the Find Widget should read or modify the shared find clipboard on macOS.',
+        'included': platform.isMacintosh
+    },
+    'editor.find.addExtraSpaceOnTop': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.'
+    },
+    'editor.wordWrap': {
+        'type': 'string',
+        'enum': ['off', 'on', 'wordWrapColumn', 'bounded'],
+        'markdownEnumDescriptions': [
+            'Lines will never wrap.',
+            'Lines will wrap at the viewport width.',
+            'Lines will wrap at `#editor.wordWrapColumn#`.',
+            'Lines will wrap at the minimum of viewport and `#editor.wordWrapColumn#`.',
+        ],
+        'default': EDITOR_DEFAULTS.wordWrap,
+        'description': 'Controls how lines should wrap.'
+    },
+    'editor.wordWrapColumn': {
+        'type': 'integer',
+        'default': EDITOR_DEFAULTS.wordWrapColumn,
+        'minimum': 1,
+        'markdownDescription': 'Controls the wrapping column of the editor when `#editor.wordWrap#` is `wordWrapColumn` or `bounded`.'
+    },
+    'editor.wrappingIndent': {
+        'type': 'string',
+        'enum': ['none', 'same', 'indent', 'deepIndent'],
+        enumDescriptions: [
+            'No indentation. Wrapped lines begin at column 1.',
+            'Wrapped lines get the same indentation as the parent.',
+            'Wrapped lines get +1 indentation toward the parent.',
+            'Wrapped lines get +2 indentation toward the parent.',
+        ],
+        'default': 'same',
+        'description': 'Controls the indentation of wrapped lines.',
+    },
+    'editor.mouseWheelScrollSensitivity': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.viewInfo.scrollbar.mouseWheelScrollSensitivity,
+        'markdownDescription': 'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.'
+    },
+    'editor.fastScrollSensitivity': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.viewInfo.scrollbar.fastScrollSensitivity,
+        'markdownDescription': 'Scrolling speed multiplier when pressing `Alt`.'
+    },
+    'editor.multiCursorModifier': {
+        'type': 'string',
+        'enum': ['ctrlCmd', 'alt'],
+        'markdownEnumDescriptions': [
+            'Maps to `Control` on Windows and Linux and to `Command` on macOS.',
+            'Maps to `Alt` on Windows and Linux and to `Option` on macOS.'
+        ],
+        'default': 'alt',
+        'markdownDescription': 'The modifier to be used to add multiple cursors with the mouse. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier. [Read more](https://code.visualstudio.com/docs/editor/codebasics#_multicursor-modifier).'
+    },
+    'editor.multiCursorMergeOverlapping': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.multiCursorMergeOverlapping,
+        'description': 'Merge multiple cursors when they are overlapping.'
+    },
+    'editor.quickSuggestions': {
+        'anyOf': [
+            {
+                type: 'boolean',
+            },
+            {
+                type: 'object',
+                properties: {
+                    strings: {
+                        type: 'boolean',
+                        default: false,
+                        description: 'Enable quick suggestions inside strings.'
+                    },
+                    comments: {
+                        type: 'boolean',
+                        default: false,
+                        description: 'Enable quick suggestions inside comments.'
+                    },
+                    other: {
+                        type: 'boolean',
+                        default: true,
+                        description: 'Enable quick suggestions outside of strings and comments.'
+                    },
+                }
+            }
+        ],
+        'default': EDITOR_DEFAULTS.contribInfo.quickSuggestions,
+        'description': 'Controls whether suggestions should automatically show up while typing.'
+    },
+    'editor.quickSuggestionsDelay': {
+        'type': 'integer',
+        'default': EDITOR_DEFAULTS.contribInfo.quickSuggestionsDelay,
+        'minimum': 0,
+        'description': 'Controls the delay in milliseconds after which quick suggestions will show up.'
+    },
+    'editor.parameterHints.enabled': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.parameterHints.enabled,
+        'description': 'Enables a pop-up that shows parameter documentation and type information as you type.'
+    },
+    'editor.parameterHints.cycle': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.parameterHints.cycle,
+        'description': 'Controls whether the parameter hints menu cycles or closes when reaching the end of the list.'
+    },
+    'editor.autoClosingBrackets': {
+        type: 'string',
+        enum: ['always', 'languageDefined', 'beforeWhitespace', 'never'],
+        enumDescriptions: [
+            '',
+            'Use language configurations to determine when to autoclose brackets.',
+            'Autoclose brackets only when the cursor is to the left of whitespace.',
+            '',
+
+        ],
+        'default': EDITOR_DEFAULTS.autoClosingBrackets,
+        'description': 'Controls whether the editor should automatically close brackets after the user adds an opening bracket.'
+    },
+    'editor.autoClosingQuotes': {
+        type: 'string',
+        enum: ['always', 'languageDefined', 'beforeWhitespace', 'never'],
+        enumDescriptions: [
+            '',
+            'Use language configurations to determine when to autoclose quotes.',
+            'Autoclose quotes only when the cursor is to the left of whitespace.',
+            '',
+        ],
+        'default': EDITOR_DEFAULTS.autoClosingQuotes,
+        'description': 'Controls whether the editor should automatically close quotes after the user adds an opening quote.'
+    },
+    'editor.autoSurround': {
+        type: 'string',
+        enum: ['languageDefined', 'brackets', 'quotes', 'never'],
+        enumDescriptions: [
+            'Use language configurations to determine when to automatically surround selections.',
+            'Surround with brackets but not quotes.',
+            'Surround with quotes but not brackets.',
+            ''
+        ],
+        'default': EDITOR_DEFAULTS.autoSurround,
+        'description': 'Controls whether the editor should automatically surround selections.'
+    },
+    'editor.formatOnType': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.formatOnType,
+        'description': 'Controls whether the editor should automatically format the line after typing.'
+    },
+    'editor.formatOnPaste': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.formatOnPaste,
+        'description': 'Controls whether the editor should automatically format the pasted content. A formatter must be available and the formatter should be able to format a range in a document.'
+    },
+    'editor.autoIndent': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.autoIndent,
+        'description': 'Controls whether the editor should automatically adjust the indentation when users type, paste or move lines. Extensions with indentation rules of the language must be available.'
+    },
+    'editor.suggestOnTriggerCharacters': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.suggestOnTriggerCharacters,
+        'description': 'Controls whether suggestions should automatically show up when typing trigger characters.'
+    },
+    'editor.acceptSuggestionOnEnter': {
+        'type': 'string',
+        'enum': ['on', 'smart', 'off'],
+        'default': EDITOR_DEFAULTS.contribInfo.acceptSuggestionOnEnter,
+        'markdownEnumDescriptions': [
+            '',
+            'Only accept a suggestion with `Enter` when it makes a textual change.',
+            ''
+        ],
+        'markdownDescription': 'Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.'
+    },
+    'editor.acceptSuggestionOnCommitCharacter': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.acceptSuggestionOnCommitCharacter,
+        'markdownDescription': 'Controls whether suggestions should be accepted on commit characters. For example, in JavaScript, the semi-colon (`;`) can be a commit character that accepts a suggestion and types that character.'
+    },
+    'editor.snippetSuggestions': {
+        'type': 'string',
+        'enum': ['top', 'bottom', 'inline', 'none'],
+        'enumDescriptions': [
+            'Show snippet suggestions on top of other suggestions.',
+            'Show snippet suggestions below other suggestions.',
+            'Show snippets suggestions with other suggestions.',
+            'Do not show snippet suggestions.',
+        ],
+        'default': EDITOR_DEFAULTS.contribInfo.suggest.snippets,
+        'description': 'Controls whether snippets are shown with other suggestions and how they are sorted.'
+    },
+    'editor.emptySelectionClipboard': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.emptySelectionClipboard,
+        'description': 'Controls whether copying without a selection copies the current line.'
+    },
+    'editor.copyWithSyntaxHighlighting': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.copyWithSyntaxHighlighting,
+        'description': 'Controls whether syntax highlighting should be copied into the clipboard.'
+    },
+    'editor.wordBasedSuggestions': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.wordBasedSuggestions,
+        'description': 'Controls whether completions should be computed based on words in the document.'
+    },
+    'editor.suggestSelection': {
+        'type': 'string',
+        'enum': ['first', 'recentlyUsed', 'recentlyUsedByPrefix'],
+        'markdownEnumDescriptions': [
+            'Always select the first suggestion.',
+            'Select recent suggestions unless further typing selects one, e.g. `console.| -> console.log` because `log` has been completed recently.',
+            'Select suggestions based on previous prefixes that have completed those suggestions, e.g. `co -> console` and `con -> const`.',
+        ],
+        'default': 'recentlyUsed',
+        'description': 'Controls how suggestions are pre-selected when showing the suggest list.'
+    },
+    'editor.suggestFontSize': {
+        'type': 'integer',
+        'default': 0,
+        'minimum': 0,
+        'markdownDescription': 'Font size for the suggest widget. When set to `0`, the value of `#editor.fontSize#` is used.'
+    },
+    'editor.suggestLineHeight': {
+        'type': 'integer',
+        'default': 0,
+        'minimum': 0,
+        'markdownDescription': 'Line height for the suggest widget. When set to `0`, the value of `#editor.lineHeight#` is used.'
+    },
+    'editor.tabCompletion': {
+        type: 'string',
+        default: 'off',
+        enum: ['on', 'off', 'onlySnippets'],
+        enumDescriptions: [
+            'Tab complete will insert the best matching suggestion when pressing tab.',
+            'Disable tab completions.',
+            "Tab complete snippets when their prefix match. Works best when 'quickSuggestions' aren't enabled.",
+        ],
+        description: 'Enables tab completions.'
+    },
+    'editor.suggest.filterGraceful': {
+        type: 'boolean',
+        default: true,
+        description: 'Controls whether filtering and sorting suggestions accounts for small typos.'
+    },
+    'editor.suggest.localityBonus': {
+        type: 'boolean',
+        default: false,
+        description: 'Controls whether sorting favours words that appear close to the cursor.'
+    },
+    'editor.suggest.shareSuggestSelections': {
+        type: 'boolean',
+        default: false,
+        markdownDescription: 'Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).'
+    },
+    'editor.suggest.snippetsPreventQuickSuggestions': {
+        type: 'boolean',
+        default: true,
+        description: 'Control whether an active snippet prevents quick suggestions.'
+    },
+    'editor.suggest.showIcons': {
+        type: 'boolean',
+        default: EDITOR_DEFAULTS.contribInfo.suggest.showIcons,
+        description: 'Controls whether to show or hide icons in suggestions.'
+    },
+    'editor.suggest.maxVisibleSuggestions': {
+        type: 'number',
+        default: EDITOR_DEFAULTS.contribInfo.suggest.maxVisibleSuggestions,
+        minimum: 1,
+        maximum: 15,
+        description: 'Controls how many suggestions IntelliSense will show before showing a scrollbar (maximum 15).'
+    },
+    'editor.suggest.filteredTypes': {
+        type: 'object',
+        default: { keyword: true, snippet: true },
+        markdownDescription: 'Controls whether some suggestion types should be filtered from IntelliSense. A list of suggestion types can be found here: https://code.visualstudio.com/docs/editor/intellisense#_types-of-completions.',
+        properties: {
+            method: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `method` suggestions.'
+            },
+            function: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `function` suggestions.'
+            },
+            constructor: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `constructor` suggestions.'
+            },
+            field: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `field` suggestions.'
+            },
+            variable: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `variable` suggestions.'
+            },
+            class: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `class` suggestions.'
+            },
+            struct: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `struct` suggestions.'
+            },
+            interface: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `interface` suggestions.'
+            },
+            module: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `module` suggestions.'
+            },
+            property: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `property` suggestions.'
+            },
+            event: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `event` suggestions.'
+            },
+            operator: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `operator` suggestions.'
+            },
+            unit: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `unit` suggestions.'
+            },
+            value: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `value` suggestions.'
+            },
+            constant: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `constant` suggestions.'
+            },
+            enum: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `enum` suggestions.'
+            },
+            enumMember: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `enumMember` suggestions.'
+            },
+            keyword: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `keyword` suggestions.'
+            },
+            text: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `text` suggestions.'
+            },
+            color: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `color` suggestions.'
+            },
+            file: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `file` suggestions.'
+            },
+            reference: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `reference` suggestions.'
+            },
+            customcolor: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `customcolor` suggestions.'
+            },
+            folder: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `folder` suggestions.'
+            },
+            typeParameter: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `typeParameter` suggestions.'
+            },
+            snippet: {
+                type: 'boolean',
+                default: true,
+                markdownDescription: 'When set to `false` IntelliSense never shows `snippet` suggestions.'
+            },
+        }
+    },
+    'editor.gotoLocation.multiple': {
+        description: "Controls the behavior of 'Go To' commands, like Go To Definition, when multiple target locations exist.",
+        type: 'string',
+        enum: ['peek', 'gotoAndPeek', 'goto'],
+        default: EDITOR_DEFAULTS.contribInfo.gotoLocation.multiple,
+        enumDescriptions: [
+            'Show peek view of the results (default)',
+            'Go to the primary result and show a peek view',
+            'Go to the primary result and enable peek-less navigation to others'
+        ]
+    },
+    'editor.selectionHighlight': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.selectionHighlight,
+        'description': 'Controls whether the editor should highlight matches similar to the selection.'
+    },
+    'editor.occurrencesHighlight': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.occurrencesHighlight,
+        'description': 'Controls whether the editor should highlight semantic symbol occurrences.'
+    },
+    'editor.overviewRulerLanes': {
+        'type': 'integer',
+        'default': 3,
+        'description': 'Controls the number of decorations that can show up at the same position in the overview ruler.'
+    },
+    'editor.overviewRulerBorder': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.overviewRulerBorder,
+        'description': 'Controls whether a border should be drawn around the overview ruler.'
+    },
+    'editor.cursorBlinking': {
+        'type': 'string',
+        'enum': ['blink', 'smooth', 'phase', 'expand', 'solid'],
+        'default': 'blink',
+        'description': 'Control the cursor animation style.'
+    },
+    'editor.mouseWheelZoom': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.mouseWheelZoom,
+        'markdownDescription': 'Zoom the font of the editor when using mouse wheel and holding `Ctrl`.'
+    },
+    'editor.cursorSmoothCaretAnimation': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.cursorSmoothCaretAnimation,
+        'description': 'Controls whether the smooth caret animation should be enabled.'
+    },
+    'editor.cursorStyle': {
+        'type': 'string',
+        'enum': ['block', 'block-outline', 'line', 'line-thin', 'underline', 'underline-thin'],
+        'default': 'line',
+        'description': 'Controls the cursor style.'
+    },
+    'editor.cursorWidth': {
+        'type': 'integer',
+        'default': EDITOR_DEFAULTS.viewInfo.cursorWidth,
+        'markdownDescription': 'Controls the width of the cursor when `#editor.cursorStyle#` is set to `line`.'
+    },
+    'editor.fontLigatures': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.fontLigatures,
+        'description': 'Enables/Disables font ligatures.'
+    },
+    'editor.hideCursorInOverviewRuler': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.hideCursorInOverviewRuler,
+        'description': 'Controls whether the cursor should be hidden in the overview ruler.'
+    },
+    'editor.renderWhitespace': {
+        'type': 'string',
+        'enum': ['none', 'boundary', 'selection', 'all'],
+        'enumDescriptions': [
+            '',
+            'Render whitespace characters except for single spaces between words.',
+            'Render whitespace characters only on selected text.',
+            ''
+        ],
+        default: EDITOR_DEFAULTS.viewInfo.renderWhitespace,
+        description: 'Controls how the editor should render whitespace characters.'
+    },
+    'editor.renderControlCharacters': {
+        'type': 'boolean',
+        default: EDITOR_DEFAULTS.viewInfo.renderControlCharacters,
+        description: 'Controls whether the editor should render control characters.'
+    },
+    'editor.renderIndentGuides': {
+        'type': 'boolean',
+        default: EDITOR_DEFAULTS.viewInfo.renderIndentGuides,
+        description: 'Controls whether the editor should render indent guides.'
+    },
+    'editor.highlightActiveIndentGuide': {
+        'type': 'boolean',
+        default: EDITOR_DEFAULTS.viewInfo.highlightActiveIndentGuide,
+        description: 'Controls whether the editor should highlight the active indent guide.'
+    },
+    'editor.renderLineHighlight': {
+        'type': 'string',
+        'enum': ['none', 'gutter', 'line', 'all'],
+        'enumDescriptions': [
+            '',
+            '',
+            '',
+            'Highlights both the gutter and the current line.',
+        ],
+        default: EDITOR_DEFAULTS.viewInfo.renderLineHighlight,
+        description: 'Controls how the editor should render the current line highlight.'
+    },
+    'editor.codeLens': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.codeLens,
+        'description': 'Controls whether the editor shows CodeLens.'
+    },
+    'editor.folding': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.folding,
+        'description': 'Controls whether the editor has code folding enabled.'
+    },
+    'editor.foldingStrategy': {
+        'type': 'string',
+        'enum': ['auto', 'indentation'],
+        'default': EDITOR_DEFAULTS.contribInfo.foldingStrategy,
+        'markdownDescription': 'Controls the strategy for computing folding ranges. `auto` uses a language specific folding strategy, if available. `indentation` uses the indentation based folding strategy.'
+    },
+    'editor.showFoldingControls': {
+        'type': 'string',
+        'enum': ['always', 'mouseover'],
+        'default': EDITOR_DEFAULTS.contribInfo.showFoldingControls,
+        'description': 'Controls whether the fold controls on the gutter are automatically hidden.'
+    },
+    'editor.matchBrackets': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.matchBrackets,
+        'description': 'Highlight matching brackets when one of them is selected.'
+    },
+    'editor.glyphMargin': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.viewInfo.glyphMargin,
+        'description': 'Controls whether the editor should render the vertical glyph margin. Glyph margin is mostly used for debugging.'
+    },
+    'editor.useTabStops': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.useTabStops,
+        'description': 'Inserting and deleting whitespace follows tab stops.'
+    },
+    'editor.trimAutoWhitespace': {
+        'type': 'boolean',
+        'default': EDITOR_MODEL_DEFAULTS.trimAutoWhitespace,
+        'description': 'Remove trailing auto inserted whitespace.'
+    },
+    'editor.stablePeek': {
+        'type': 'boolean',
+        'default': false,
+        'markdownDescription': 'Keep peek editors open even when double clicking their content or when hitting `Escape`.'
+    },
+    'editor.dragAndDrop': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.dragAndDrop,
+        'description': 'Controls whether the editor should allow moving selections via drag and drop.'
+    },
+    'editor.accessibilitySupport': {
+        'type': 'string',
+        'enum': ['auto', 'on', 'off'],
+        'enumDescriptions': [
+            'The editor will use platform APIs to detect when a Screen Reader is attached.',
+            'The editor will be permanently optimized for usage with a Screen Reader.',
+            'The editor will never be optimized for usage with a Screen Reader.',
+        ],
+        'default': EDITOR_DEFAULTS.accessibilitySupport,
+        'description': 'Controls whether the editor should run in a mode where it is optimized for screen readers.'
+    },
+    'editor.showUnused': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.showUnused,
+        'description': 'Controls fading out of unused code.'
+    },
+    'editor.links': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.links,
+        'description': 'Controls whether the editor should detect links and make them clickable.'
+    },
+    'editor.colorDecorators': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.colorDecorators,
+        'description': 'Controls whether the editor should render the inline color decorators and color picker.'
+    },
+    'editor.lightbulb.enabled': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.lightbulbEnabled,
+        'description': 'Enables the code action lightbulb in the editor.'
+    },
+    'editor.maxTokenizationLineLength': {
+        'type': 'integer',
+        'default': 20_000,
+        'description': 'Lines above this length will not be tokenized for performance reasons'
+    },
+    'editor.codeActionsOnSave': {
+        'type': 'object',
+        'properties': {
+            'source.organizeImports': {
+                'type': 'boolean',
+                'description': 'Controls whether organize imports action should be run on file save.'
+            },
+            'source.fixAll': {
+                'type': 'boolean',
+                'description': 'Controls whether auto fix action should be run on file save.'
+            }
+        },
+        'additionalProperties': {
+            'type': 'boolean'
+        },
+        'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSave,
+        'description': 'Code action kinds to be run on save.'
+    },
+    'editor.codeActionsOnSaveTimeout': {
+        'type': 'number',
+        'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSaveTimeout,
+        'description': 'Timeout in milliseconds after which the code actions that are run on save are cancelled.'
+    },
+    'editor.selectionClipboard': {
+        'type': 'boolean',
+        'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,
+        'description': 'Controls whether the Linux primary clipboard should be supported.',
+        'included': platform.isLinux
+    },
+    'diffEditor.renderSideBySide': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls whether the diff editor shows the diff side by side or inline.'
+    },
+    'diffEditor.ignoreTrimWhitespace': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls whether the diff editor shows changes in leading or trailing whitespace as diffs.'
+    },
+    'editor.largeFileOptimizations': {
+        'type': 'boolean',
+        'default': EDITOR_MODEL_DEFAULTS.largeFileOptimizations,
+        'description': 'Special handling for large files to disable certain memory intensive features.'
+    },
+    'diffEditor.renderIndicators': {
+        'type': 'boolean',
+        'default': true,
+        'description': 'Controls whether the diff editor shows +/- indicators for added/removed changes.'
+    }
+};
+// tslint:enable:max-line-length
+
 export const editorPreferenceSchema: PreferenceSchema = {
     'type': 'object',
     'scope': 'resource',
     'overridable': true,
     'properties': {
-        'editor.tabSize': {
-            'type': 'number',
-            'minimum': 1,
-            'default': 4,
-            'description': 'Configure the tab size in the editor.'
-        },
-        'editor.fontSize': {
-            'type': 'number',
-            'default': EDITOR_FONT_DEFAULTS.fontSize,
-            'description': 'Configure the editor font size.'
-        },
-        'editor.fontFamily': {
-            'type': 'string',
-            'default': EDITOR_FONT_DEFAULTS.fontFamily,
-            'description': 'Controls the font family.'
-        },
-        'editor.lineHeight': {
-            'type': 'number',
-            'default': EDITOR_FONT_DEFAULTS.lineHeight,
-            'description': 'Controls the line height. Use 0 to compute the line height from the font size.'
-        },
-        'editor.letterSpacing': {
-            'type': 'number',
-            'default': EDITOR_FONT_DEFAULTS.letterSpacing,
-            'description': 'Controls the letter spacing in pixels.'
-        },
-        'editor.lineNumbers': {
-            'enum': [
-                'on',
-                'off',
-                'relative',
-                'interval'
-            ],
-            'default': 'on',
-            'description': 'Control the rendering of line numbers.'
-        },
-        'editor.renderWhitespace': {
-            'enum': [
-                'none',
-                'boundary',
-                'all'
-            ],
-            'default': 'none',
-            'description': 'Control the rendering of whitespaces in the editor.'
-        },
+        ...(<PreferenceSchemaProperties>codeEditorPreferenceProperties),
         'editor.autoSave': {
             'enum': [
                 'on',
@@ -107,183 +1046,6 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'description': 'Configure the auto save delay in milliseconds.',
             overridable: false
         },
-        'editor.rulers': {
-            'type': 'array',
-            'default': [],
-            'description': 'Render vertical lines at the specified columns.'
-        },
-        'editor.wordSeparators': {
-            'type': 'string',
-            'default': "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/",
-            'description': 'A string containing the word separators used when doing word navigation.'
-        },
-        'editor.glyphMargin': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable the rendering of the glyph margin.'
-        },
-        'editor.roundedSelection': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Render the editor selection with rounded borders.'
-        },
-        'editor.minimap.enabled': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable or disable the minimap.'
-        },
-        'editor.minimap.showSlider': {
-            'enum': [
-                'mouseover',
-                'always'
-            ],
-            'default': 'mouseover',
-            'description': 'Controls whether the minimap slider is automatically hidden.'
-        },
-        'editor.minimap.renderCharacters': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Render the actual characters on a line (as opposed to color blocks).'
-        },
-        'editor.minimap.maxColumn': {
-            'type': 'number',
-            'default': 120,
-            'description': 'Limit the width of the minimap to render at most a certain number of columns.'
-        },
-        'editor.minimap.side': {
-            'enum': [
-                'right',
-                'left'
-            ],
-            'default': 'right',
-            'description': 'Control the side of the minimap in editor.'
-        },
-        'editor.overviewRulerLanes': {
-            'type': 'number',
-            'default': 2,
-            'description': 'The number of vertical lanes the overview ruler should render.'
-        },
-        'editor.overviewRulerBorder': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Controls if a border should be drawn around the overview ruler.'
-        },
-        'editor.cursorBlinking': {
-            'enum': [
-                'blink',
-                'smooth',
-                'phase',
-                'expand',
-                'solid'
-            ],
-            'default': 'blink',
-            'description': "Control the cursor animation style, possible values are 'blink', 'smooth', 'phase', 'expand' and 'solid'."
-        },
-        'editor.mouseWheelZoom': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl.'
-        },
-        'editor.cursorStyle': {
-            'enum': [
-                'line',
-                'block'
-            ],
-            'default': 'line',
-            'description': "Control the cursor style, either 'block' or 'line'."
-        },
-        'editor.fontLigatures': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable font ligatures.'
-        },
-        'editor.hideCursorInOverviewRuler': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Should the cursor be hidden in the overview ruler.'
-        },
-        'editor.scrollBeyondLastLine': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable that scrolling can go one screen size after the last line.'
-        },
-        'editor.wordWrap': {
-            'enum': [
-                'off',
-                'on',
-                'wordWrapColumn',
-                'bounded'
-            ],
-            'default': 'off',
-            'description': 'Control the wrapping of the editor.'
-        },
-        'editor.wordWrapColumn': {
-            'type': 'number',
-            'default': 80,
-            'description': 'Control the wrapping of the editor.'
-        },
-        'editor.wrappingIndent': {
-            'enum': [
-                'same',
-                'indent',
-                'deepIndent',
-                'none'
-            ],
-            'default': 'same',
-            'description': 'Control indentation of wrapped lines.'
-        },
-        'editor.links': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable detecting links and making them clickable.'
-        },
-        'editor.mouseWheelScrollSensitivity': {
-            'type': 'number',
-            'default': 1,
-            'description': 'A multiplier to be used on the `deltaX` and `deltaY` of mouse wheel scroll events.'
-        },
-        'editor.multiCursorModifier': {
-            'enum': [
-                'alt',
-                'ctrlCmd'
-            ],
-            'default': 'alt',
-            'description': 'The modifier to be used to add multiple cursors with the mouse.'
-        },
-        'editor.accessibilitySupport': {
-            'enum': [
-                'auto',
-                'on',
-                'off'
-            ],
-            'default': 'auto',
-            'description': "Configure the editor's accessibility support."
-        },
-        'editor.quickSuggestions': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable quick suggestions (shadow suggestions).'
-        },
-        'editor.quickSuggestionsDelay': {
-            'type': 'number',
-            'default': 500,
-            'description': 'Quick suggestions show delay (in ms).'
-        },
-        'editor.parameterHints': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enables parameter hints.'
-        },
-        'editor.autoClosingBrackets': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable auto closing brackets.'
-        },
-        'editor.autoIndent': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable auto indentation adjustment.'
-        },
         'editor.formatOnSave': {
             'type': 'boolean',
             'default': false,
@@ -293,217 +1055,6 @@ export const editorPreferenceSchema: PreferenceSchema = {
             'type': 'number',
             'default': 750,
             'description': 'Timeout in milliseconds after which the formatting that is run on file save is cancelled.'
-        },
-        'editor.formatOnType': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable format on type.'
-        },
-        'editor.formatOnPaste': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable format on paste.'
-        },
-        'editor.dragAndDrop': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Controls if the editor should allow to move selections via drag and drop.'
-        },
-        'editor.suggestOnTriggerCharacters': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable the suggestion box to pop-up on trigger characters.'
-        },
-        'editor.acceptSuggestionOnEnter': {
-            'enum': [
-                'on',
-                'smart',
-                'off'
-            ],
-            'default': 'on',
-            'description': 'Accept suggestions on ENTER.'
-        },
-        'editor.acceptSuggestionOnCommitCharacter': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Accept suggestions on provider defined characters.'
-        },
-        'editor.snippetSuggestions': {
-            'enum': [
-                'inline',
-                'top',
-                'bottom',
-                'none'
-            ],
-            'default': 'inline',
-            'description': 'Enable snippet suggestions.'
-        },
-        'editor.emptySelectionClipboard': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Copying without a selection copies the current line.'
-        },
-        'editor.wordBasedSuggestions': {
-            'type': 'boolean',
-            'default': true,
-            'description': "Enable word based suggestions. Defaults to 'true'."
-        },
-        'editor.selectionHighlight': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable selection highlight.'
-        },
-        'editor.occurrencesHighlight': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable semantic occurrences highlight.'
-        },
-        'editor.codeLens': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Show code lens.'
-        },
-        'editor.folding': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable code folding.'
-        },
-        'editor.foldingStrategy': {
-            'enum': [
-                'auto',
-                'indentation'
-            ],
-            'default': 'auto',
-            'description': 'Selects the folding strategy.'
-                + '\'auto\' uses the strategies contributed for the current document, \'indentation\' uses the indentation based folding strategy. '
-        },
-        'editor.showFoldingControls': {
-            'enum': [
-                'mouseover',
-                'always'
-            ],
-            'default': 'mouseover',
-            'description': 'Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter.'
-        },
-        'editor.matchBrackets': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable highlighting of matching brackets.'
-        },
-        'editor.renderControlCharacters': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable rendering of control characters.'
-        },
-        'editor.renderIndentGuides': {
-            'type': 'boolean',
-            'default': false,
-            'description': 'Enable rendering of indent guides.'
-        },
-        'editor.renderLineHighlight': {
-            'enum': [
-                'all',
-                'gutter',
-                'line',
-                'none'
-            ],
-            'default': 'all',
-            'description': 'Enable rendering of current line highlight.'
-        },
-        'editor.useTabStops': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Inserting and deleting whitespace follows tab stops.'
-        },
-        'editor.insertSpaces': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Using whitespaces to replace tabs when tabbing.'
-        },
-        'editor.colorDecorators': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable inline color decorators and color picker rendering.'
-        },
-        'editor.highlightActiveIndentGuide': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Enable highlighting of the active indent guide.'
-        },
-        'editor.iconsInSuggestions': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Render icons in suggestions box.'
-        },
-        'editor.showUnused': {
-            'type': 'boolean',
-            'default': true,
-            'description': 'Controls fading out of unused variables.',
-        },
-        'editor.scrollBeyondLastColumn': {
-            'type': 'number',
-            'default': 5,
-            'description': 'Enable that scrolling can go beyond the last column by a number of columns.'
-        },
-        'editor.suggestSelection': {
-            'enum': [
-                'first',
-                'recentlyUsed',
-                'recentlyUsedByPrefix'
-            ],
-            'default': 'first',
-            'description': 'The history mode for suggestions'
-        },
-        'editor.fontWeight': {
-            'enum': [
-                'normal',
-                'bold',
-                'bolder',
-                'lighter',
-                'initial',
-                'inherit',
-                '100',
-                '200',
-                '300',
-                '400',
-                '500',
-                '600',
-                '700',
-                '800',
-                '900'
-            ],
-            'default': EDITOR_FONT_DEFAULTS.fontWeight,
-            'description': 'Controls the editor\'s font weight.'
-        },
-        'diffEditor.renderSideBySide': {
-            'type': 'boolean',
-            'description': 'Render the differences in two side-by-side editors.',
-            'default': true
-        },
-        'diffEditor.ignoreTrimWhitespace': {
-            'type': 'boolean',
-            'description': 'Compute the diff by ignoring leading/trailing whitespace.',
-            'default': true
-        },
-        'diffEditor.renderIndicators': {
-            'type': 'boolean',
-            'description': 'Render +/- indicators for added/deleted changes.',
-            'default': true
-        },
-        'diffEditor.followsCaret': {
-            'type': 'boolean',
-            'description': 'Resets the navigator state when the user selects something in the editor.',
-            'default': true
-        },
-        'diffEditor.ignoreCharChanges': {
-            'type': 'boolean',
-            'description': 'Jump from line to line.',
-            'default': true
-        },
-        'diffEditor.alwaysRevealFirst': {
-            'type': 'boolean',
-            'description': 'Reveal first change.',
-            'default': true
         },
         'files.eol': {
             'type': 'string',
@@ -528,80 +1079,19 @@ export const editorPreferenceSchema: PreferenceSchema = {
     }
 };
 
-export interface EditorConfiguration {
-    'editor.tabSize': number
-    'editor.fontFamily': string
-    'editor.fontSize': number
-    'editor.fontWeight'?: 'normal' | 'bold' | 'bolder' | 'lighter' | 'initial'
-    | 'inherit' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'
+type CodeEditorPreferenceProperties = typeof codeEditorPreferenceProperties;
+export type CodeEditorConfiguration = {
+    [P in keyof CodeEditorPreferenceProperties]:
+    CodeEditorPreferenceProperties[P] extends { enum: string[] } ?
+    CodeEditorPreferenceProperties[P]['enum'][number] :
+    CodeEditorPreferenceProperties[P]['default'];
+};
+
+export interface EditorConfiguration extends CodeEditorConfiguration {
     'editor.autoSave': 'on' | 'off'
     'editor.autoSaveDelay': number
-    'editor.lineNumbers'?: 'on' | 'off'
-    'editor.renderWhitespace'?: 'none' | 'boundary' | 'all'
-    'editor.rulers'?: number[]
-    'editor.wordSeparators'?: string
-    'editor.glyphMargin'?: boolean
-    'editor.roundedSelection'?: boolean
-    'editor.minimap.enabled'?: boolean
-    'editor.minimap.showSlider'?: 'always' | 'mouseover'
-    'editor.minimap.renderCharacters'?: boolean
-    'editor.minimap.maxColumn'?: number
-    'editor.minimap.side'?: 'right' | 'left'
-    'editor.overviewRulerLanes'?: number
-    'editor.overviewRulerBorder'?: boolean
-    'editor.cursorBlinking'?: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid'
-    'editor.mouseWheelZoom'?: boolean
-    'editor.cursorStyle'?: 'line' | 'block'
-    'editor.fontLigatures'?: boolean
-    'editor.hideCursorInOverviewRuler'?: boolean
-    'editor.scrollBeyondLastLine'?: boolean
-    'editor.scrollBeyondLastColumn'?: number
-    'editor.wordWrap'?: 'off' | 'on' | 'wordWrapColumn' | 'bounded'
-    'editor.wordWrapColumn'?: number
-    'editor.wrappingIndent'?: 'none' | 'same' | 'indent' | 'deepIndent'
-    'editor.links'?: boolean
-    'editor.mouseWheelScrollSensitivity'?: number
-    'editor.multiCursorModifier'?: 'ctrlCmd' | 'alt'
-    'editor.accessibilitySupport'?: 'auto' | 'off' | 'on'
-    'editor.quickSuggestions'?: boolean
-    'editor.quickSuggestionsDelay'?: number
-    'editor.suggestSelection'?: 'first' | 'recentlyUsed' | 'recentlyUsedByPrefix'
-    'editor.iconsInSuggestions'?: boolean
-    'editor.parameterHints'?: boolean
-    'editor.autoClosingBrackets'?: boolean
-    'editor.autoIndent'?: boolean
-    'editor.formatOnType'?: boolean
     'editor.formatOnSave': boolean
     'editor.formatOnSaveTimeout': number
-    'editor.formatOnPaste'?: boolean
-    'editor.dragAndDrop'?: boolean
-    'editor.suggestOnTriggerCharacters'?: boolean
-    'editor.acceptSuggestionOnEnter'?: 'on' | 'smart' | 'off'
-    'editor.acceptSuggestionOnCommitCharacter'?: boolean
-    'editor.snippetSuggestions'?: 'top' | 'bottom' | 'inline' | 'none'
-    'editor.emptySelectionClipboard'?: boolean
-    'editor.wordBasedSuggestions'?: boolean
-    'editor.selectionHighlight'?: boolean
-    'editor.occurrencesHighlight'?: boolean
-    'editor.codeLens'?: boolean
-    'editor.folding'?: boolean
-    'editor.foldingStrategy'?: 'auto' | 'indentation'
-    'editor.showFoldingControls'?: 'always' | 'mouseover'
-    'editor.matchBrackets'?: boolean
-    'editor.renderControlCharacters'?: boolean
-    'editor.renderIndentGuides'?: boolean
-    'editor.highlightActiveIndentGuide'?: boolean
-    'editor.renderLineHighlight'?: 'none' | 'gutter' | 'line' | 'all'
-    'editor.useTabStops'?: boolean
-    'editor.insertSpaces': boolean
-    'editor.colorDecorators'?: boolean
-    'editor.showUnused'?: boolean
-    'diffEditor.renderSideBySide'?: boolean
-    'diffEditor.ignoreTrimWhitespace'?: boolean
-    'diffEditor.renderIndicators'?: boolean
-    'diffEditor.followsCaret'?: boolean
-    'diffEditor.ignoreCharChanges'?: boolean
-    'diffEditor.alwaysRevealFirst'?: boolean
     'files.eol': EndOfLinePreference
     'files.encoding': string
 }

--- a/packages/editor/src/browser/editor.ts
+++ b/packages/editor/src/browser/editor.ts
@@ -119,7 +119,7 @@ export interface MouseTarget {
     /**
      * The target element
      */
-    readonly element: Element;
+    readonly element?: Element;
     /**
      * The target type
      */

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -7,7 +7,7 @@
     "@theia/core": "^0.10.0",
     "@theia/languages": "^0.10.0",
     "@theia/monaco": "^0.10.0",
-    "vscode-json-languageserver": "^1.0.1"
+    "vscode-json-languageserver": "^1.2.1"
   },
   "devDependencies": {
     "@theia/ext-scripts": "^0.10.0"

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -9,7 +9,7 @@
     "@theia/workspace": "^0.10.0",
     "@typefox/monaco-editor-core": "^0.14.6",
     "@types/uuid": "^3.4.3",
-    "monaco-languageclient": "^0.9.1",
+    "monaco-languageclient": "next",
     "uuid": "^3.2.1"
   },
   "publishConfig": {

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -7,9 +7,9 @@
     "@theia/output": "^0.10.0",
     "@theia/process": "^0.10.0",
     "@theia/workspace": "^0.10.0",
-    "@typefox/monaco-editor-core": "^0.14.6",
+    "@typefox/monaco-editor-core": "^0.18.0-next",
     "@types/uuid": "^3.4.3",
-    "monaco-languageclient": "next",
+    "monaco-languageclient": "^0.10.2",
     "uuid": "^3.2.1"
   },
   "publishConfig": {

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -12,8 +12,8 @@
     "@theia/workspace": "^0.10.0",
     "deepmerge": "2.0.1",
     "jsonc-parser": "^2.0.2",
-    "monaco-css": "^2.0.1",
-    "monaco-html": "^2.0.2",
+    "monaco-css": "^2.5.0",
+    "monaco-html": "^2.5.2",
     "onigasm": "2.2.1",
     "vscode-textmate": "^4.0.1"
   },

--- a/packages/monaco/src/browser/monaco-bulk-edit-service.ts
+++ b/packages/monaco/src/browser/monaco-bulk-edit-service.ts
@@ -23,7 +23,7 @@ export class MonacoBulkEditService implements monaco.editor.IBulkEditService {
     @inject(MonacoWorkspace)
     protected readonly workspace: MonacoWorkspace;
 
-    apply(edit: monaco.languages.WorkspaceEdit): monaco.Promise<monaco.editor.IBulkEditResult> {
+    apply(edit: monaco.languages.WorkspaceEdit): Promise<monaco.editor.IBulkEditResult> {
         return this.workspace.applyBulkEdit(edit);
     }
 

--- a/packages/monaco/src/browser/monaco-command-service.ts
+++ b/packages/monaco/src/browser/monaco-command-service.ts
@@ -51,20 +51,16 @@ export class MonacoCommandService implements ICommandService {
     }
 
     // tslint:disable-next-line:no-any
-    executeCommand(commandId: any, ...args: any[]): monaco.Promise<any> {
+    async executeCommand(commandId: any, ...args: any[]): Promise<any> {
         const handler = this.commandRegistry.getActiveHandler(commandId, ...args);
         if (handler) {
-            try {
-                this._onWillExecuteCommand.fire({ commandId });
-                return monaco.Promise.wrap(handler.execute(...args));
-            } catch (err) {
-                return monaco.Promise.wrapError(err);
-            }
+            this._onWillExecuteCommand.fire({ commandId });
+            return handler.execute(...args);
         }
         if (this.delegate) {
             return this.delegate.executeCommand(commandId, ...args);
         }
-        return monaco.Promise.wrapError(new Error(`command '${commandId}' not found`));
+        throw new Error(`command '${commandId}' not found`);
     }
 
 }

--- a/packages/monaco/src/browser/monaco-context-menu.ts
+++ b/packages/monaco/src/browser/monaco-context-menu.ts
@@ -25,7 +25,7 @@ import { CommandRegistry } from '@phosphor/commands';
 @injectable()
 export class MonacoContextMenuService implements IContextMenuService {
 
-    constructor( @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer) {
+    constructor(@inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer) {
     }
 
     showContextMenu(delegate: IContextMenuDelegate): void {
@@ -35,29 +35,28 @@ export class MonacoContextMenuService implements IContextMenuService {
         if (delegate.hasOwnProperty('getKeyBinding')) {
             this.contextMenuRenderer.render(EDITOR_CONTEXT_MENU, anchor, () => delegate.onHide(false));
         } else {
-            delegate.getActions().then(actions => {
-                const commands = new CommandRegistry();
-                const menu = new Menu({
-                    commands
-                });
-
-                for (const action of actions) {
-                    const commandId = 'quickfix_' + actions.indexOf(action);
-                    commands.addCommand(commandId, {
-                        label: action.label,
-                        className: action.class,
-                        isToggled: () => action.checked,
-                        isEnabled: () => action.enabled,
-                        execute: () => action.run()
-                    });
-                    menu.addItem({
-                        type: 'command',
-                        command: commandId
-                    });
-                }
-                menu.aboutToClose.connect(() => delegate.onHide(false));
-                menu.open(anchor.x, anchor.y);
+            const actions = delegate.getActions();
+            const commands = new CommandRegistry();
+            const menu = new Menu({
+                commands
             });
+
+            for (const action of actions) {
+                const commandId = 'quickfix_' + actions.indexOf(action);
+                commands.addCommand(commandId, {
+                    label: action.label,
+                    className: action.class,
+                    isToggled: () => action.checked,
+                    isEnabled: () => action.enabled,
+                    execute: () => action.run()
+                });
+                menu.addItem({
+                    type: 'command',
+                    command: commandId
+                });
+            }
+            menu.aboutToClose.connect(() => delegate.onHide(false));
+            menu.open(anchor.x, anchor.y);
         }
     }
 

--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -14,12 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient';
 import URI from '@theia/core/lib/common/uri';
 import { Disposable } from '@theia/core/lib/common';
 import { Dimension, DiffNavigator, DeltaDecorationParams } from '@theia/editor/lib/browser';
 import { MonacoEditorModel } from './monaco-editor-model';
-import { MonacoEditor } from './monaco-editor';
+import { MonacoEditor, MonacoEditorServices } from './monaco-editor';
 import { MonacoDiffNavigatorFactory } from './monaco-diff-navigator-factory';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 
@@ -42,13 +41,12 @@ export class MonacoDiffEditor extends MonacoEditor {
         readonly node: HTMLElement,
         readonly originalModel: MonacoEditorModel,
         readonly modifiedModel: MonacoEditorModel,
-        protected readonly m2p: MonacoToProtocolConverter,
-        protected readonly p2m: ProtocolToMonacoConverter,
+        services: MonacoEditorServices,
         protected readonly diffNavigatorFactory: MonacoDiffNavigatorFactory,
         options?: MonacoDiffEditor.IOptions,
         override?: IEditorOverrideServices,
     ) {
-        super(uri, modifiedModel, node, m2p, p2m, options, override);
+        super(uri, modifiedModel, node, services, options, override);
         this.documents.add(originalModel);
         const original = originalModel.textEditorModel;
         const modified = modifiedModel.textEditorModel;

--- a/packages/monaco/src/browser/monaco-editor-model.ts
+++ b/packages/monaco/src/browser/monaco-editor-model.ts
@@ -206,8 +206,9 @@ export class MonacoEditorModel implements ITextEditorModel, TextEditorDocument {
         return this.model;
     }
 
-    load(): monaco.Promise<MonacoEditorModel> {
-        return monaco.Promise.wrap(this.resolveModel).then(() => this);
+    async load(): Promise<MonacoEditorModel> {
+        await this.resolveModel;
+        return this;
     }
 
     save(): Promise<void> {

--- a/packages/monaco/src/browser/monaco-editor-service.ts
+++ b/packages/monaco/src/browser/monaco-editor-service.ts
@@ -56,15 +56,33 @@ export class MonacoEditorService extends monaco.services.CodeEditorServiceImpl {
         return editor && editor.getControl();
     }
 
-    openCodeEditor(input: IResourceInput, source?: ICodeEditor, sideBySide?: boolean): monaco.Promise<CommonCodeEditor | undefined> {
+    async openCodeEditor(input: IResourceInput, source?: ICodeEditor, sideBySide?: boolean): Promise<CommonCodeEditor | undefined> {
         const uri = new URI(input.resource.toString());
         const openerOptions = this.createEditorOpenerOptions(input, source, sideBySide);
-        return monaco.Promise.wrap(open(this.openerService, uri, openerOptions).then(widget => {
-            if (widget instanceof EditorWidget && widget.editor instanceof MonacoEditor) {
-                return widget.editor.getControl();
+        const widget = await open(this.openerService, uri, openerOptions);
+        const editorWidget = await this.findEditorWidgetByUri(widget, uri.toString());
+        if (editorWidget && editorWidget.editor instanceof MonacoEditor) {
+            return editorWidget.editor.getControl();
+        }
+        return undefined;
+    }
+
+    protected async findEditorWidgetByUri(widget: object | undefined, uriAsString: string): Promise<EditorWidget | undefined> {
+        if (widget instanceof EditorWidget) {
+            if (widget.editor.uri.toString() === uriAsString) {
+                return widget;
             }
             return undefined;
-        }));
+        }
+        if (ApplicationShell.TrackableWidgetProvider.is(widget)) {
+            for (const childWidget of await widget.getTrackableWidgets()) {
+                const editorWidget = await this.findEditorWidgetByUri(childWidget, uriAsString);
+                if (editorWidget) {
+                    return editorWidget;
+                }
+            }
+        }
+        return undefined;
     }
 
     protected createEditorOpenerOptions(input: IResourceInput, source?: ICodeEditor, sideBySide?: boolean): EditorOpenerOptions {

--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -14,9 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { injectable, inject, unmanaged } from 'inversify';
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter, TextEdit } from 'monaco-languageclient';
 import { ElementExt } from '@phosphor/domutils';
 import URI from '@theia/core/lib/common/uri';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { DisposableCollection, Disposable, Emitter, Event } from '@theia/core/lib/common';
 import {
     Dimension,
@@ -43,11 +45,25 @@ import IEditorOverrideServices = monaco.editor.IEditorOverrideServices;
 import IStandaloneCodeEditor = monaco.editor.IStandaloneCodeEditor;
 import IIdentifiedSingleEditOperation = monaco.editor.IIdentifiedSingleEditOperation;
 import IBoxSizing = ElementExt.IBoxSizing;
-import SuggestController = monaco.suggestController.SuggestController;
-import CommonFindController = monaco.findController.CommonFindController;
-import RenameController = monaco.rename.RenameController;
 
-export class MonacoEditor implements TextEditor {
+@injectable()
+export class MonacoEditorServices {
+
+    @inject(MonacoToProtocolConverter)
+    protected readonly m2p: MonacoToProtocolConverter;
+
+    @inject(ProtocolToMonacoConverter)
+    protected readonly p2m: ProtocolToMonacoConverter;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    constructor(@unmanaged() services: MonacoEditorServices) {
+        Object.assign(this, services);
+    }
+}
+
+export class MonacoEditor extends MonacoEditorServices implements TextEditor {
 
     protected readonly toDispose = new DisposableCollection();
 
@@ -73,11 +89,11 @@ export class MonacoEditor implements TextEditor {
         readonly uri: URI,
         readonly document: MonacoEditorModel,
         readonly node: HTMLElement,
-        protected readonly m2p: MonacoToProtocolConverter,
-        protected readonly p2m: ProtocolToMonacoConverter,
+        services: MonacoEditorServices,
         options?: MonacoEditor.IOptions,
-        override?: IEditorOverrideServices,
+        override?: IEditorOverrideServices
     ) {
+        super(services);
         this.toDispose.pushAll([
             this.onCursorPositionChangedEmitter,
             this.onSelectionChangedEmitter,
@@ -150,13 +166,14 @@ export class MonacoEditor implements TextEditor {
             this.onFocusChangedEmitter.fire(this.isFocused())
         ));
         this.toDispose.push(codeEditor.onMouseDown(e => {
-            const { position, range } = e.target;
+            const { element, position, range } = e.target;
             this.onMouseDownEmitter.fire({
                 target: {
                     ...e.target,
+                    element: element || undefined,
                     mouseColumn: this.m2p.asPosition(undefined, e.target.mouseColumn).character,
-                    range: range && this.m2p.asRange(range),
-                    position: position && this.m2p.asPosition(position.lineNumber, position.column)
+                    range: range && this.m2p.asRange(range) || undefined,
+                    position: position && this.m2p.asPosition(position.lineNumber, position.column) || undefined
                 },
                 event: e.event.browserEvent
             });
@@ -187,7 +204,7 @@ export class MonacoEditor implements TextEditor {
     }
 
     get cursor(): Position {
-        const { lineNumber, column } = this.editor.getPosition();
+        const { lineNumber, column } = this.editor.getPosition()!;
         return this.m2p.asPosition(lineNumber, column);
     }
 
@@ -201,7 +218,7 @@ export class MonacoEditor implements TextEditor {
     }
 
     get selection(): Range {
-        return this.m2p.asRange(this.editor.getSelection());
+        return this.m2p.asRange(this.editor.getSelection()!);
     }
 
     set selection(selection: Range) {
@@ -256,8 +273,10 @@ export class MonacoEditor implements TextEditor {
 
     blur(): void {
         const node = this.editor.getDomNode();
-        const textarea = node.querySelector('textarea') as HTMLElement;
-        textarea.blur();
+        if (node) {
+            const textarea = node.querySelector('textarea') as HTMLElement;
+            textarea.blur();
+        }
     }
 
     isFocused({ strict }: { strict: boolean } = { strict: false }): boolean {
@@ -282,22 +301,21 @@ export class MonacoEditor implements TextEditor {
      * `true` if the suggest widget is visible in the editor. Otherwise, `false`.
      */
     isSuggestWidgetVisible(): boolean {
-        const widget = this.editor.getContribution<SuggestController>('editor.contrib.suggestController')._widget;
-        return widget ? widget.suggestWidgetVisible.get() : false;
+        return this.contextKeyService.match('suggestWidgetVisible', this.editor.getDomNode() || this.node);
     }
 
     /**
      * `true` if the find (and replace) widget is visible in the editor. Otherwise, `false`.
      */
     isFindWidgetVisible(): boolean {
-        return this.editor.getContribution<CommonFindController>('editor.contrib.findController')._findWidgetVisible.get();
+        return this.contextKeyService.match('findWidgetVisible', this.editor.getDomNode() || this.node);
     }
 
     /**
      * `true` if the name rename refactoring input HTML element is visible. Otherwise, `false`.
      */
     isRenameInputVisible(): boolean {
-        return this.editor.getContribution<RenameController>('editor.contrib.renameController')._renameInputVisible.get();
+        return this.contextKeyService.match('renameInputVisible', this.editor.getDomNode() || this.node);
     }
 
     dispose(): void {
@@ -362,7 +380,7 @@ export class MonacoEditor implements TextEditor {
         const configuration = this.editor.getConfiguration();
 
         const lineHeight = configuration.lineHeight;
-        const lineCount = this.editor.getModel().getLineCount();
+        const lineCount = this.editor.getModel()!.getLineCount();
         const contentHeight = lineHeight * lineCount;
 
         const horizontalScrollbarHeight = configuration.layoutInfo.horizontalScrollbarHeight;
@@ -386,12 +404,11 @@ export class MonacoEditor implements TextEditor {
         return !!action && action.isSupported();
     }
 
-    runAction(id: string): monaco.Promise<void> {
+    async runAction(id: string): Promise<void> {
         const action = this.editor.getAction(id);
         if (action && action.isSupported()) {
-            return action.run();
+            await action.run();
         }
-        return monaco.Promise.as(undefined);
     }
 
     get commandService(): monaco.commands.ICommandService {
@@ -420,7 +437,7 @@ export class MonacoEditor implements TextEditor {
         const start = toPosition(startLineNumber).lineNumber;
         const end = toPosition(endLineNumber).lineNumber;
         return this.editor
-            .getModel()
+            .getModel()!
             .getLinesDecorations(start, end)
             .map(this.toEditorDecoration.bind(this));
     }
@@ -460,7 +477,7 @@ export class MonacoEditor implements TextEditor {
     }
 
     storeViewState(): object {
-        return this.editor.saveViewState();
+        return this.editor.saveViewState()!;
     }
 
     restoreViewState(state: object): void {
@@ -475,11 +492,11 @@ export class MonacoEditor implements TextEditor {
     }
 
     async detectLanguage(): Promise<void> {
-        const filename = this.uri.path.toString();
         const modeService = monaco.services.StaticServices.modeService.get();
         const firstLine = this.document.textEditorModel.getLineContent(1);
-        const mode = await modeService.getOrCreateModeByFilenameOrFirstLine(filename, firstLine);
-        this.setLanguage(mode.getId());
+        const model = this.getControl().getModel();
+        const language = modeService.createByFilepathOrFirstLine(model && model.uri, firstLine);
+        this.setLanguage(language.languageIdentifier.language);
         this._languageAutoDetected = true;
     }
 

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -57,6 +57,7 @@ import { MonacoMimeService } from './monaco-mime-service';
 import { MimeService } from '@theia/core/lib/browser/mime-service';
 
 import debounce = require('lodash.debounce');
+import { MonacoEditorServices } from './monaco-editor';
 
 const deepmerge: (args: object[]) => object = require('deepmerge').default.all;
 
@@ -91,6 +92,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(MonacoEditorService).toSelf().inSingletonScope();
     bind(MonacoTextModelService).toSelf().inSingletonScope();
     bind(MonacoContextMenuService).toSelf().inSingletonScope();
+    bind(MonacoEditorServices).toSelf().inSingletonScope();
     bind(MonacoEditorProvider).toSelf().inSingletonScope();
     bind(MonacoCommandService).toSelf().inTransientScope();
     bind(MonacoCommandServiceFactory).toAutoFactory(MonacoCommandService);
@@ -152,7 +154,7 @@ export function createMonacoConfigurationService(container: interfaces.Container
 
     const initFromConfiguration = debounce(() => {
         const event = new monaco.services.ConfigurationChangeEvent();
-        event._source = monaco.services.ConfigurationTarget.DEFAULT;
+        event._source = 6 /* DEFAULT */;
         service._onDidChangeConfiguration.fire(event);
     });
     preferences.onPreferenceChanged(e => {
@@ -160,10 +162,12 @@ export function createMonacoConfigurationService(container: interfaces.Container
             initFromConfiguration();
         }
     });
-    preferences.onPreferencesChanged(changes => {
-        const event = new monaco.services.ConfigurationChangeEvent();
-        event.change(Object.keys(changes));
-        service._onDidChangeConfiguration.fire(event);
+    configurations.onDidChangeConfiguration(e => {
+        if (e.affectedSections) {
+            const event = new monaco.services.ConfigurationChangeEvent();
+            event.change(e.affectedSections);
+            service._onDidChangeConfiguration.fire(event);
+        }
     });
 
     return service;

--- a/packages/monaco/src/browser/monaco-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-keybinding.ts
@@ -43,14 +43,11 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
             const command = this.commands.validate(item.command);
             if (command) {
                 const raw = item.keybinding;
-                const keybinding = raw.type === monaco.keybindings.KeybindingType.Simple
-                    ? this.keyCode(raw as monaco.keybindings.SimpleKeybinding).toString()
+                const when = item.when && item.when.serialize();
+                const keybinding = raw instanceof monaco.keybindings.SimpleKeybinding
+                    ? this.keyCode(raw).toString()
                     : this.keySequence(raw as monaco.keybindings.ChordKeybinding).join(' ');
-                const isInDiffEditor = item.when && /(^|[^!])\bisInDiffEditor\b/gm.test(item.when.serialize());
-                const context = isInDiffEditor
-                    ? EditorKeybindingContexts.diffEditorTextFocus
-                    : EditorKeybindingContexts.strictEditorTextFocus;
-                registry.registerKeybinding({ command, keybinding, context });
+                registry.registerKeybinding({ command, keybinding, when });
             }
         }
 
@@ -91,9 +88,6 @@ export class MonacoKeybindingContribution implements KeybindingContribution {
     }
 
     protected keySequence(keybinding: monaco.keybindings.ChordKeybinding): KeySequence {
-        return [
-            this.keyCode(keybinding.firstPart),
-            this.keyCode(keybinding.chordPart)
-        ];
+        return keybinding.parts.map(part => this.keyCode(part));
     }
 }

--- a/packages/monaco/src/browser/monaco-loader.ts
+++ b/packages/monaco/src/browser/monaco-loader.ts
@@ -57,7 +57,6 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/editor/browser/editorExtensions',
                 'vs/editor/standalone/browser/simpleServices',
                 'vs/editor/standalone/browser/standaloneServices',
-                'vs/base/parts/quickopen/common/quickOpen',
                 'vs/base/parts/quickopen/browser/quickOpenWidget',
                 'vs/base/parts/quickopen/browser/quickOpenModel',
                 'vs/base/common/filters',
@@ -65,42 +64,39 @@ export function loadMonaco(vsRequire: any): Promise<void> {
                 'vs/base/common/platform',
                 'vs/editor/common/modes',
                 'vs/editor/contrib/suggest/suggest',
-                'vs/editor/contrib/suggest/suggestController',
-                'vs/editor/contrib/find/findController',
-                'vs/editor/contrib/rename/rename',
                 'vs/editor/contrib/snippet/snippetParser',
                 'vs/platform/configuration/common/configuration',
                 'vs/platform/configuration/common/configurationModels',
                 'vs/editor/browser/services/codeEditorService',
                 'vs/editor/browser/services/codeEditorServiceImpl',
                 'vs/platform/contextkey/common/contextkey',
-                'vs/platform/contextkey/browser/contextKeyService'
+                'vs/platform/contextkey/browser/contextKeyService',
+                'vs/base/common/errors'
             ], (css: any, html: any, commands: any, actions: any,
                 keybindingsRegistry: any, keybindingResolver: any, resolvedKeybinding: any, keybindingLabels: any,
-                keyCodes: any, mime: any, editorExtensions: any, simpleServices: any, standaloneServices: any, quickOpen: any, quickOpenWidget: any, quickOpenModel: any,
-                filters: any, styler: any, platform: any, modes: any, suggest: any, suggestController: any, findController: any, rename: any, snippetParser: any,
+                keyCodes: any, mime: any, editorExtensions: any, simpleServices: any, standaloneServices: any, quickOpenWidget: any, quickOpenModel: any,
+                filters: any, styler: any, platform: any, modes: any, suggest: any, snippetParser: any,
                 configuration: any, configurationModels: any,
                 codeEditorService: any, codeEditorServiceImpl: any,
-                contextKey: any, contextKeyService: any) => {
+                contextKey: any, contextKeyService: any,
+                error: any) => {
                     const global: any = self;
                     global.monaco.commands = commands;
                     global.monaco.actions = actions;
                     global.monaco.keybindings = Object.assign({}, keybindingsRegistry, keybindingResolver, resolvedKeybinding, keybindingLabels, keyCodes);
                     global.monaco.services = Object.assign({}, simpleServices, standaloneServices, configuration, configurationModels, codeEditorService, codeEditorServiceImpl);
-                    global.monaco.quickOpen = Object.assign({}, quickOpen, quickOpenWidget, quickOpenModel);
+                    global.monaco.quickOpen = Object.assign({}, quickOpenWidget, quickOpenModel);
                     global.monaco.filters = filters;
                     global.monaco.theme = styler;
                     global.monaco.platform = platform;
                     global.monaco.editorExtensions = editorExtensions;
                     global.monaco.modes = modes;
                     global.monaco.suggest = suggest;
-                    global.monaco.suggestController = suggestController;
-                    global.monaco.findController = findController;
-                    global.monaco.rename = rename;
                     global.monaco.snippetParser = snippetParser;
                     global.monaco.contextkey = contextKey;
                     global.monaco.contextKeyService = contextKeyService;
                     global.monaco.mime = mime;
+                    global.monaco.error = error;
                     resolve();
                 });
         });

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -20,7 +20,6 @@ import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { MonacoCommands } from './monaco-command';
 import { MonacoCommandRegistry } from './monaco-command-registry';
 import MenuRegistry = monaco.actions.MenuRegistry;
-import MenuId = monaco.actions.MenuId;
 
 export interface MonacoActionGroup {
     id: string;
@@ -75,7 +74,7 @@ export class MonacoEditorMenuContribution implements MenuContribution {
     ) { }
 
     registerMenus(registry: MenuModelRegistry): void {
-        for (const item of MenuRegistry.getMenuItems(MenuId.EditorContext)) {
+        for (const item of MenuRegistry.getMenuItems(7)) {
             const commandId = this.commands.validate(item.command.id);
             if (commandId) {
                 const menuPath = [...EDITOR_CONTEXT_MENU, (item.group || '')];

--- a/packages/monaco/src/browser/monaco-outline-contribution.ts
+++ b/packages/monaco/src/browser/monaco-outline-contribution.ts
@@ -97,10 +97,12 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
         const editor = this.editorManager.currentEditor;
         if (editor) {
             const model = MonacoEditor.get(editor)!.getControl().getModel();
-            this.toDisposeOnEditor.push(model.onDidChangeContent(() => {
-                this.roots = undefined; // Invalidate the previously resolved roots.
-                this.updateOutline();
-            }));
+            if (model) {
+                this.toDisposeOnEditor.push(model.onDidChangeContent(() => {
+                    this.roots = undefined; // Invalidate the previously resolved roots.
+                    this.updateOutline();
+                }));
+            }
             this.toDisposeOnEditor.push(editor.editor.onSelectionChanged(selection => this.updateOutline(selection)));
         }
         this.updateOutline();
@@ -145,7 +147,7 @@ export class MonacoOutlineContribution implements FrontendApplicationContributio
                     if (token.isCancellationRequested) {
                         return [];
                     }
-                    const nodes = this.createNodes(uri, symbols);
+                    const nodes = this.createNodes(uri, symbols || []);
                     this.roots.push(...nodes);
                 } catch {
                     /* collect symbols from other providers */

--- a/packages/monaco/src/browser/monaco-semantic-highlighting-service.ts
+++ b/packages/monaco/src/browser/monaco-semantic-highlighting-service.ts
@@ -79,7 +79,7 @@ export class MonacoSemanticHighlightingService extends SemanticHighlightingServi
     protected async model(uri: string | URI): Promise<monaco.editor.ITextModel | undefined> {
         const editor = await this.editor(uri);
         if (editor) {
-            return editor.getControl().getModel();
+            return editor.getControl().getModel() || undefined;
         }
         return undefined;
     }

--- a/packages/monaco/src/browser/monaco-status-bar-contribution.ts
+++ b/packages/monaco/src/browser/monaco-status-bar-contribution.ts
@@ -99,6 +99,6 @@ export class MonacoStatusBarContribution implements FrontendApplicationContribut
 
     protected getModel(editor: EditorWidget | undefined): monaco.editor.IModel | undefined {
         const monacoEditor = MonacoEditor.get(editor);
-        return monacoEditor && monacoEditor.getControl().getModel();
+        return monacoEditor && monacoEditor.getControl().getModel() || undefined;
     }
 }

--- a/packages/monaco/src/browser/monaco-text-model-service.ts
+++ b/packages/monaco/src/browser/monaco-text-model-service.ts
@@ -52,8 +52,8 @@ export class MonacoTextModelService implements monaco.editor.ITextModelService {
         return this._models.onDidCreate;
     }
 
-    createModelReference(raw: monaco.Uri | URI): monaco.Promise<monaco.editor.IReference<MonacoEditorModel>> {
-        return monaco.Promise.wrap(this._models.acquire(raw.toString()));
+    createModelReference(raw: monaco.Uri | URI): Promise<monaco.editor.IReference<MonacoEditorModel>> {
+        return this._models.acquire(raw.toString());
     }
 
     protected async loadModel(uri: URI): Promise<MonacoEditorModel> {

--- a/packages/monaco/src/browser/monaco-workspace.ts
+++ b/packages/monaco/src/browser/monaco-workspace.ts
@@ -268,7 +268,7 @@ export class MonacoWorkspace implements lang.Workspace {
         return true;
     }
 
-    async applyBulkEdit(workspaceEdit: monaco.languages.WorkspaceEdit, options?: EditorOpenerOptions): monaco.Promise<monaco.editor.IBulkEditResult> {
+    async applyBulkEdit(workspaceEdit: monaco.languages.WorkspaceEdit, options?: EditorOpenerOptions): Promise<monaco.editor.IBulkEditResult> {
         try {
             const unresolvedEditorEdits = this.groupEdits(workspaceEdit);
             const editorEdits = await this.openEditors(unresolvedEditorEdits, options);
@@ -278,7 +278,7 @@ export class MonacoWorkspace implements lang.Workspace {
             editorEdits.forEach(editorEdit => {
                 const editor = editorEdit.editor!;
                 const model = editor!.document.textEditorModel;
-                const currentSelections = editor!.getControl().getSelections();
+                const currentSelections = editor!.getControl().getSelections() || [];
                 const editOperations: monaco.editor.IIdentifiedSingleEditOperation[] = editorEdit.textEdits.map(edit => ({
                     identifier: undefined!,
                     forceMoveMarkers: false,

--- a/packages/monaco/src/browser/textmate/textmate-snippet-completion-provider.ts
+++ b/packages/monaco/src/browser/textmate/textmate-snippet-completion-provider.ts
@@ -33,9 +33,8 @@ export class TextmateSnippetCompletionProvider implements monaco.languages.Compl
                 documentation: {
                     value: '```' + this.mdLanguage + '\n' + this.replaceVariables(insertText) + '```'
                 },
-                insertText: {
-                    value: insertText
-                }
+                insertText: insertText,
+                range: undefined!
             });
         }
     }
@@ -46,9 +45,11 @@ export class TextmateSnippetCompletionProvider implements monaco.languages.Compl
 
     provideCompletionItems(document: monaco.editor.ITextModel,
         position: monaco.Position,
-        token: monaco.CancellationToken,
-        context: monaco.languages.CompletionContext): monaco.languages.CompletionItem[] {
-        return this.items;
+        context: monaco.languages.CompletionContext,
+        token: monaco.CancellationToken): monaco.languages.CompletionList {
+        return {
+            suggestions: this.items
+        };
     }
 }
 

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -71,6 +71,9 @@ export interface Range {
 export interface MarkdownString {
     value: string;
     isTrusted?: boolean;
+    uris?: {
+        [href: string]: UriComponents;
+    };
 }
 
 export interface SerializedDocumentFilter {
@@ -118,34 +121,36 @@ export interface CompletionContext {
     triggerCharacter?: string;
 }
 
+export enum CompletionItemInsertTextRule {
+    KeepWhitespace = 1,
+    InsertAsSnippet = 4
+}
+
 export interface Completion {
     label: string;
-    insertText: string;
-    type: CompletionType;
+    kind: CompletionItemKind;
     detail?: string;
     documentation?: string | MarkdownString;
-    filterText?: string;
     sortText?: string;
+    filterText?: string;
     preselect?: boolean;
-    noAutoAccept?: boolean;
+    insertText: string;
+    insertTextRules?: CompletionItemInsertTextRule;
+    range: Range;
     commitCharacters?: string[];
-    overwriteBefore?: number;
-    overwriteAfter?: number;
     additionalTextEdits?: SingleEditOperation[];
     command?: Command;
-    snippetType?: SnippetType;
 }
+
 export interface SingleEditOperation {
     range: Range;
-    text: string;
+    text: string | null;
     /**
      * This indicates that this operation has "insert" semantics.
      * i.e. forceMoveMarkers = true => if `range` is collapsed, all markers at the position will be moved.
      */
     forceMoveMarkers?: boolean;
 }
-
-export type SnippetType = 'internal' | 'textmate';
 
 export interface Command {
     id: string;
@@ -155,32 +160,34 @@ export interface Command {
     arguments?: any[];
 }
 
-export type CompletionType = 'method'
-    | 'function'
-    | 'constructor'
-    | 'field'
-    | 'variable'
-    | 'class'
-    | 'struct'
-    | 'interface'
-    | 'module'
-    | 'property'
-    | 'event'
-    | 'operator'
-    | 'unit'
-    | 'value'
-    | 'constant'
-    | 'enum'
-    | 'enum-member'
-    | 'keyword'
-    | 'snippet'
-    | 'text'
-    | 'color'
-    | 'file'
-    | 'reference'
-    | 'customcolor'
-    | 'folder'
-    | 'type-parameter';
+export enum CompletionItemKind {
+    Method = 0,
+    Function = 1,
+    Constructor = 2,
+    Field = 3,
+    Variable = 4,
+    Class = 5,
+    Struct = 6,
+    Interface = 7,
+    Module = 8,
+    Property = 9,
+    Event = 10,
+    Operator = 11,
+    Unit = 12,
+    Value = 13,
+    Constant = 14,
+    Enum = 15,
+    EnumMember = 16,
+    Keyword = 17,
+    Text = 18,
+    Color = 19,
+    File = 20,
+    Reference = 21,
+    Customcolor = 22,
+    Folder = 23,
+    TypeParameter = 24,
+    Snippet = 25
+}
 
 export class IdObject {
     id?: number;
@@ -191,6 +198,7 @@ export interface CompletionDto extends Completion {
 }
 
 export interface CompletionResultDto extends IdObject {
+    id: number;
     completions: CompletionDto[];
     incomplete?: boolean;
 }
@@ -229,7 +237,7 @@ export enum MarkerTag {
 }
 
 export interface ParameterInformation {
-    label: string;
+    label: string | [number, number];
     documentation?: string | MarkdownString;
 }
 
@@ -239,10 +247,17 @@ export interface SignatureInformation {
     parameters: ParameterInformation[];
 }
 
-export interface SignatureHelp {
+export interface SignatureHelp extends IdObject {
     signatures: SignatureInformation[];
     activeSignature: number;
     activeParameter: number;
+}
+
+export interface SignatureHelpContext {
+    triggerKind: theia.SignatureHelpTriggerKind;
+    triggerCharacter?: string;
+    isRetrigger: boolean;
+    activeSignatureHelp?: SignatureHelp;
 }
 
 export interface Hover {
@@ -312,7 +327,8 @@ export interface ReferenceContext {
 
 export interface DocumentLink {
     range: Range;
-    url?: string;
+    url?: UriComponents | string;
+    tooltip?: string;
 }
 
 export interface DocumentLinkProvider {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -43,7 +43,6 @@ import {
     Hover,
     DocumentHighlight,
     FormattingOptions,
-    SingleEditOperation as ModelSingleEditOperation,
     Definition,
     DefinitionLink,
     DocumentLink,
@@ -61,7 +60,8 @@ import {
     ColorPresentation,
     RenameLocation,
     FileMoveEvent,
-    FileWillMoveEvent
+    FileWillMoveEvent,
+    SignatureHelpContext
 } from './plugin-api-rpc-model';
 import { ExtPluginApi } from './plugin-ext-api-contribution';
 import { KeysToAnyValues, KeysToKeysToAnyValue } from './types';
@@ -793,7 +793,7 @@ export enum TrackedRangeStickiness {
 }
 export interface ContentDecorationRenderOptions {
     contentText?: string;
-    contentIconPath?: string | UriComponents;
+    contentIconPath?: UriComponents;
 
     border?: string;
     borderColor?: string | ThemeColor;
@@ -828,10 +828,10 @@ export interface ThemeDecorationRenderOptions {
     textDecoration?: string;
     cursor?: string;
     color?: string | ThemeColor;
-    opacity?: number;
+    opacity?: string;
     letterSpacing?: string;
 
-    gutterIconPath?: string | UriComponents;
+    gutterIconPath?: UriComponents;
     gutterIconSize?: string;
 
     overviewRulerColor?: string | ThemeColor;
@@ -1095,13 +1095,16 @@ export interface LanguagesExt {
     $provideTypeDefinition(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
     $provideDefinition(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Definition | DefinitionLink[] | undefined>;
     $provideReferences(handle: number, resource: UriComponents, position: Position, context: ReferenceContext, token: CancellationToken): Promise<Location[] | undefined>;
-    $provideSignatureHelp(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<SignatureHelp | undefined>;
+    $provideSignatureHelp(
+        handle: number, resource: UriComponents, position: Position, context: SignatureHelpContext, token: CancellationToken
+    ): Promise<SignatureHelp | undefined>;
+    $releaseSignatureHelp(handle: number, id: number): void;
     $provideHover(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<Hover | undefined>;
     $provideDocumentHighlights(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<DocumentHighlight[] | undefined>;
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents,
-        options: FormattingOptions, token: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
+        options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range,
-        options: FormattingOptions, token: CancellationToken): Promise<ModelSingleEditOperation[] | undefined>;
+        options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
     $provideOnTypeFormattingEdits(
         handle: number,
         resource: UriComponents,
@@ -1109,7 +1112,7 @@ export interface LanguagesExt {
         ch: string,
         options: FormattingOptions,
         token: CancellationToken
-    ): Promise<ModelSingleEditOperation[] | undefined>;
+    ): Promise<TextEdit[] | undefined>;
     $provideDocumentLinks(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentLink[] | undefined>;
     $resolveDocumentLink(handle: number, link: DocumentLink, token: CancellationToken): Promise<DocumentLink | undefined>;
     $provideCodeLenses(handle: number, resource: UriComponents, token: CancellationToken): Promise<CodeLensSymbol[] | undefined>;
@@ -1120,7 +1123,7 @@ export interface LanguagesExt {
         rangeOrSelection: Range | Selection,
         context: monaco.languages.CodeActionContext,
         token: CancellationToken
-    ): Promise<monaco.languages.CodeAction[]>;
+    ): Promise<monaco.languages.CodeAction[] | undefined>;
     $provideDocumentSymbols(handle: number, resource: UriComponents, token: CancellationToken): Promise<DocumentSymbol[] | undefined>;
     $provideWorkspaceSymbols(handle: number, query: string, token: CancellationToken): PromiseLike<SymbolInformation[]>;
     $resolveWorkspaceSymbol(handle: number, symbol: SymbolInformation, token: CancellationToken): PromiseLike<SymbolInformation>;
@@ -1146,7 +1149,7 @@ export interface LanguagesMain {
     $registerTypeDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerDefinitionProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerReferenceProvider(handle: number, selector: SerializedDocumentFilter[]): void;
-    $registerSignatureHelpProvider(handle: number, selector: SerializedDocumentFilter[], triggerCharacters: string[]): void;
+    $registerSignatureHelpProvider(handle: number, selector: SerializedDocumentFilter[], metadata: theia.SignatureHelpProviderMetadata): void;
     $registerHoverProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerDocumentHighlightProvider(handle: number, selector: SerializedDocumentFilter[]): void;
     $registerQuickFixProvider(handle: number, selector: SerializedDocumentFilter[], codeActionKinds?: string[]): void;

--- a/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
+++ b/packages/plugin-ext/src/main/browser/editors-and-documents-main.ts
@@ -94,7 +94,7 @@ export class EditorsAndDocumentsMain {
         const removedDocuments = delta.removedDocuments.map(d => d.textEditorModel.uri);
 
         for (const editor of delta.addedEditors) {
-            const textEditorMain = new TextEditorMain(editor.id, editor.editor.getControl().getModel(), editor.editor);
+            const textEditorMain = new TextEditorMain(editor.id, editor.editor.getControl().getModel()!, editor.editor);
             this.textEditors.set(editor.id, textEditorMain);
             addedEditors.push(textEditorMain);
         }
@@ -339,7 +339,7 @@ class EditorAndDocumentState {
 class EditorSnapshot {
     readonly id: string;
     constructor(readonly editor: MonacoEditor) {
-        this.id = `${editor.getControl().getId()},${editor.getControl().getModel().id}`;
+        this.id = `${editor.getControl().getId()},${editor.getControl().getModel()!.id}`;
     }
 }
 

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -270,7 +270,7 @@ export class TextEditorMain {
         if (!this.editor) {
             return;
         }
-        this.editor.getControl().setDecorations(key, ranges);
+        this.editor.getControl().setDecorations(key, ranges.map(option => Object.assign(option, { color: undefined })));
     }
 
     setDecorationsFast(key: string, _ranges: number[]): void {
@@ -349,7 +349,7 @@ export class TextEditorPropertiesMain {
     private static getSelectionsFromEditor(prevProperties: TextEditorPropertiesMain | undefined, editor: MonacoEditor): monaco.Selection[] {
         let result: monaco.Selection[] | undefined = undefined;
         if (editor) {
-            result = editor.getControl().getSelections();
+            result = editor.getControl().getSelections() || undefined;
         }
 
         if (!result && prevProperties) {

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -44,7 +44,7 @@ import {
     Hover,
     DocumentHighlight,
     Range,
-    SingleEditOperation,
+    TextEdit,
     FormattingOptions,
     Definition,
     DefinitionLink,
@@ -55,6 +55,7 @@ import {
     Location,
     ColorPresentation,
     RenameLocation,
+    SignatureHelpContext,
 } from '../common/plugin-api-rpc-model';
 import { CompletionAdapter } from './languages/completion';
 import { Diagnostics } from './languages/diagnostics';
@@ -225,7 +226,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     }
 
     $releaseCompletionItems(handle: number, id: number): void {
-        this.withAdapter(handle, CompletionAdapter, adapter => adapter.releaseCompletionItems(id));
+        this.withAdapter(handle, CompletionAdapter, async adapter => adapter.releaseCompletionItems(id));
     }
 
     registerCompletionItemProvider(selector: theia.DocumentSelector, provider: theia.CompletionItemProvider, triggerCharacters: string[]): theia.Disposable {
@@ -248,13 +249,19 @@ export class LanguagesExtImpl implements LanguagesExt {
     // ### Definition provider end
 
     // ### Signature help begin
-    $provideSignatureHelp(handle: number, resource: UriComponents, position: Position, token: theia.CancellationToken): Promise<SignatureHelp | undefined> {
-        return this.withAdapter(handle, SignatureHelpAdapter, adapter => adapter.provideSignatureHelp(URI.revive(resource), position, token));
+    $provideSignatureHelp(
+        handle: number, resource: UriComponents, position: Position, context: SignatureHelpContext, token: theia.CancellationToken
+    ): Promise<SignatureHelp | undefined> {
+        return this.withAdapter(handle, SignatureHelpAdapter, adapter => adapter.provideSignatureHelp(URI.revive(resource), position, token, context));
     }
 
-    registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, ...triggerCharacters: string[]): theia.Disposable {
+    $releaseSignatureHelp(handle: number, id: number): void {
+        this.withAdapter(handle, SignatureHelpAdapter, async adapter => adapter.releaseSignatureHelp(id));
+    }
+
+    registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, metadata: theia.SignatureHelpProviderMetadata): theia.Disposable {
         const callId = this.addNewAdapter(new SignatureHelpAdapter(provider, this.documents));
-        this.proxy.$registerSignatureHelpProvider(callId, this.transformDocumentSelector(selector), triggerCharacters);
+        this.proxy.$registerSignatureHelpProvider(callId, this.transformDocumentSelector(selector), metadata);
         return this.createDisposable(callId);
     }
     // ### Signature help end
@@ -341,7 +348,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     }
 
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents,
-        options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+        options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         return this.withAdapter(handle, DocumentFormattingAdapter, adapter => adapter.provideDocumentFormattingEdits(URI.revive(resource), options, token));
     }
     // ### Document Formatting Edit end
@@ -354,7 +361,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     }
 
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range,
-        options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+        options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         return this.withAdapter(handle, RangeFormattingAdapter, adapter => adapter.provideDocumentRangeFormattingEdits(URI.revive(resource), range, options, token));
     }
     // ### Document Range Formatting Edit end
@@ -371,7 +378,7 @@ export class LanguagesExtImpl implements LanguagesExt {
     }
 
     $provideOnTypeFormattingEdits(handle: number, resource: UriComponents, position: Position, ch: string,
-        options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+        options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         return this.withAdapter(handle, OnTypeFormattingAdapter, adapter => adapter.provideOnTypeFormattingEdits(URI.revive(resource), position, ch, options, token));
     }
     // ### On Type Formatting Edit end
@@ -413,7 +420,7 @@ export class LanguagesExtImpl implements LanguagesExt {
         rangeOrSelection: Range | Selection,
         context: monaco.languages.CodeActionContext,
         token: theia.CancellationToken
-    ): Promise<monaco.languages.CodeAction[]> {
+    ): Promise<monaco.languages.CodeAction[] | undefined> {
         return this.withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeAction(URI.revive(resource), rangeOrSelection, context, token));
     }
     // ### Code Actions Provider end

--- a/packages/plugin-ext/src/plugin/languages/code-action.ts
+++ b/packages/plugin-ext/src/plugin/languages/code-action.ts
@@ -36,7 +36,7 @@ export class CodeActionAdapter {
     ) { }
 
     provideCodeAction(resource: URI, rangeOrSelection: Range | Selection,
-        context: monaco.languages.CodeActionContext, token: theia.CancellationToken): Promise<monaco.languages.CodeAction[]> {
+        context: monaco.languages.CodeActionContext, token: theia.CancellationToken): Promise<monaco.languages.CodeAction[] | undefined> {
         const document = this.document.getDocumentData(resource);
         if (!document) {
             return Promise.reject(new Error(`There are no document for ${resource}`));
@@ -61,7 +61,7 @@ export class CodeActionAdapter {
 
         return Promise.resolve(this.provider.provideCodeActions(doc, ran, codeActionContext, token)).then(commandsOrActions => {
             if (!Array.isArray(commandsOrActions) || commandsOrActions.length === 0) {
-                return undefined!;
+                return undefined;
             }
             // TODO cache toDispose and dispose it
             const toDispose = new DisposableCollection();

--- a/packages/plugin-ext/src/plugin/languages/document-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/document-formatting.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import URI from 'vscode-uri/lib/umd';
-import { FormattingOptions, SingleEditOperation } from '../../common/plugin-api-rpc-model';
+import { FormattingOptions, TextEdit } from '../../common/plugin-api-rpc-model';
 
 export class DocumentFormattingAdapter {
 
@@ -27,7 +27,7 @@ export class DocumentFormattingAdapter {
         private readonly documents: DocumentsExtImpl
     ) { }
 
-    provideDocumentFormattingEdits(resource: URI, options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+    provideDocumentFormattingEdits(resource: URI, options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         const document = this.documents.getDocumentData(resource);
         if (!document) {
             return Promise.reject(new Error(`There are no document for ${resource}`));

--- a/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/on-type-formatting.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import URI from 'vscode-uri/lib/umd';
-import { FormattingOptions, SingleEditOperation } from '../../common/plugin-api-rpc-model';
+import { FormattingOptions, TextEdit } from '../../common/plugin-api-rpc-model';
 import { Position } from '../../common/plugin-api-rpc';
 
 export class OnTypeFormattingAdapter {
@@ -29,7 +29,7 @@ export class OnTypeFormattingAdapter {
     ) { }
 
     provideOnTypeFormattingEdits(resource: URI, position: Position, ch: string,
-        options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+        options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         const document = this.documents.getDocumentData(resource);
         if (!document) {
             return Promise.reject(new Error(`There are no document for ${resource}`));

--- a/packages/plugin-ext/src/plugin/languages/range-formatting.ts
+++ b/packages/plugin-ext/src/plugin/languages/range-formatting.ts
@@ -18,7 +18,7 @@ import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import URI from 'vscode-uri/lib/umd';
-import { FormattingOptions, SingleEditOperation, Range } from '../../common/plugin-api-rpc-model';
+import { FormattingOptions, TextEdit, Range } from '../../common/plugin-api-rpc-model';
 
 export class RangeFormattingAdapter {
 
@@ -27,7 +27,7 @@ export class RangeFormattingAdapter {
         private readonly documents: DocumentsExtImpl
     ) { }
 
-    provideDocumentRangeFormattingEdits(resource: URI, range: Range, options: FormattingOptions, token: theia.CancellationToken): Promise<SingleEditOperation[] | undefined> {
+    provideDocumentRangeFormattingEdits(resource: URI, range: Range, options: FormattingOptions, token: theia.CancellationToken): Promise<TextEdit[] | undefined> {
         const document = this.documents.getDocumentData(resource);
         if (!document) {
             return Promise.reject(new Error(`There are no document for ${resource}`));

--- a/packages/plugin-ext/src/plugin/languages/signature.ts
+++ b/packages/plugin-ext/src/plugin/languages/signature.ts
@@ -13,15 +13,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// copied and modified from https://github.com/TypeFox/vscode/blob/70b8db24a37fafc77247de7f7cb5bb0195120ed0/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L771
 
 import URI from 'vscode-uri/lib/umd';
 import * as theia from '@theia/plugin';
 import { DocumentsExtImpl } from '../documents';
 import * as Converter from '../type-converters';
 import { Position } from '../../common/plugin-api-rpc';
-import { SignatureHelp } from '../../common/plugin-api-rpc-model';
+import { SignatureHelp, SignatureHelpContext } from '../../common/plugin-api-rpc-model';
 
 export class SignatureHelpAdapter {
+
+    private idSequence = 1;
+    private readonly cache = new Map<number, theia.SignatureHelp>();
 
     constructor(
         private readonly delegate: theia.SignatureHelpProvider,
@@ -29,7 +38,7 @@ export class SignatureHelpAdapter {
 
     }
 
-    provideSignatureHelp(resource: URI, position: Position, token: theia.CancellationToken): Promise<SignatureHelp | undefined> {
+    async provideSignatureHelp(resource: URI, position: Position, token: theia.CancellationToken, context: SignatureHelpContext): Promise<SignatureHelp | undefined> {
         const documentData = this.documents.getDocumentData(resource);
         if (!documentData) {
             return Promise.reject(new Error(`There are no document for  ${resource}`));
@@ -37,8 +46,35 @@ export class SignatureHelpAdapter {
 
         const document = documentData.document;
         const zeroBasedPosition = Converter.toPosition(position);
+        const pluginHelpContext = this.reviveContext(context);
 
-        return Promise.resolve(this.delegate.provideSignatureHelp(document, zeroBasedPosition, token));
+        const value = await this.delegate.provideSignatureHelp(document, zeroBasedPosition, token, pluginHelpContext);
+        if (!value) {
+            return undefined;
+        }
+        const id = this.idSequence++;
+        this.cache.set(id, value);
+        return Converter.SignatureHelp.from(id, value);
+    }
+
+    private reviveContext(context: SignatureHelpContext): theia.SignatureHelpContext {
+        let activeSignatureHelp: theia.SignatureHelp | undefined = undefined;
+        if (context.activeSignatureHelp) {
+            const revivedSignatureHelp = Converter.SignatureHelp.to(context.activeSignatureHelp);
+            const saved = typeof context.activeSignatureHelp.id === 'number' && this.cache.get(context.activeSignatureHelp.id);
+            if (saved) {
+                activeSignatureHelp = saved;
+                activeSignatureHelp.activeSignature = revivedSignatureHelp.activeSignature;
+                activeSignatureHelp.activeParameter = revivedSignatureHelp.activeParameter;
+            } else {
+                activeSignatureHelp = revivedSignatureHelp;
+            }
+        }
+        return { ...context, activeSignatureHelp };
+    }
+
+    releaseSignatureHelp(id: number): void {
+        this.cache.delete(id);
     }
 
 }

--- a/packages/plugin-ext/src/plugin/markdown-string.ts
+++ b/packages/plugin-ext/src/plugin/markdown-string.ts
@@ -14,6 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { MarkdownString as IMarkdownString } from '../common/plugin-api-rpc-model';
+
 export class MarkdownString {
 
     value: string;
@@ -45,7 +47,7 @@ export class MarkdownString {
 }
 
 // tslint:disable-next-line:no-any
-export function isMarkdownString(thing: any): thing is MarkdownString {
+export function isMarkdownString(thing: any): thing is IMarkdownString {
     if (thing instanceof MarkdownString) {
         return true;
     } else if (thing && typeof thing === 'object') {

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -70,6 +70,7 @@ import {
     ParameterInformation,
     SignatureInformation,
     SignatureHelp,
+    SignatureHelpTriggerKind,
     Hover,
     DocumentHighlightKind,
     DocumentHighlight,
@@ -547,8 +548,20 @@ export function createAPIFactory(
             registerDefinitionProvider(selector: theia.DocumentSelector, provider: theia.DefinitionProvider): theia.Disposable {
                 return languagesExt.registerDefinitionProvider(selector, provider);
             },
-            registerSignatureHelpProvider(selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, ...triggerCharacters: string[]): theia.Disposable {
-                return languagesExt.registerSignatureHelpProvider(selector, provider, ...triggerCharacters);
+            registerSignatureHelpProvider(
+                selector: theia.DocumentSelector, provider: theia.SignatureHelpProvider, first?: string | theia.SignatureHelpProviderMetadata, ...remaining: string[]
+            ): theia.Disposable {
+                let metadata: theia.SignatureHelpProviderMetadata;
+                if (typeof first === 'object') {
+                    metadata = first;
+                } else {
+                    const triggerCharacters: string[] = [];
+                    metadata = { triggerCharacters, retriggerCharacters: [] };
+                    if (first) {
+                        triggerCharacters.push(first, ...remaining);
+                    }
+                }
+                return languagesExt.registerSignatureHelpProvider(selector, provider, metadata);
             },
             registerTypeDefinitionProvider(selector: theia.DocumentSelector, provider: theia.TypeDefinitionProvider): theia.Disposable {
                 return languagesExt.registerTypeDefinitionProvider(selector, provider);
@@ -793,6 +806,7 @@ export function createAPIFactory(
             ParameterInformation,
             SignatureInformation,
             SignatureHelp,
+            SignatureHelpTriggerKind,
             Hover,
             DocumentHighlightKind,
             DocumentHighlight,

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -141,7 +141,7 @@ export class TextEditorDecorationType implements theia.TextEditorDecorationType 
         this.key = TextEditorDecorationType.Keys.nextId();
         this.proxy = proxy;
         // tslint:disable-next-line:no-any
-        this.proxy.$registerTextEditorDecorationType(this.key, <any>options);
+        this.proxy.$registerTextEditorDecorationType(this.key, Converters.DecorationRenderOptions.from(options));
     }
 
     dispose(): void {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -26,11 +26,12 @@ import {
     ProcessTaskDto,
     PickOpenItem
 } from '../common/plugin-api-rpc';
+import * as rpc from '../common/plugin-api-rpc';
 import * as model from '../common/plugin-api-rpc-model';
 import * as theia from '@theia/plugin';
 import * as types from './types-impl';
 import { LanguageSelector, LanguageFilter, RelativePattern } from './languages';
-import { isMarkdownString } from './markdown-string';
+import { isMarkdownString, MarkdownString } from './markdown-string';
 import URI from 'vscode-uri';
 
 const SIDE_GROUP = -2;
@@ -121,6 +122,9 @@ export function toRange(range: model.Range): types.Range {
     return new types.Range(startLineNumber - 1, startColumn - 1, endLineNumber - 1, endColumn - 1);
 }
 
+export function fromRange(range: undefined): undefined;
+export function fromRange(range: theia.Range): model.Range;
+export function fromRange(range: theia.Range | undefined): model.Range | undefined;
 export function fromRange(range: theia.Range | undefined): model.Range | undefined {
     if (!range) {
         return undefined;
@@ -210,6 +214,12 @@ export function fromMarkdown(markup: theia.MarkdownString | theia.MarkedString):
     }
 }
 
+export function toMarkdown(value: model.MarkdownString): MarkdownString {
+    const ret = new MarkdownString(value.value);
+    ret.isTrusted = value.isTrusted;
+    return ret;
+}
+
 export function fromDocumentSelector(selector: theia.DocumentSelector | undefined): LanguageSelector | undefined {
     if (!selector) {
         return undefined;
@@ -244,72 +254,70 @@ function isRelativePattern(obj: {}): obj is theia.RelativePattern {
     return rp && typeof rp.base === 'string' && typeof rp.pattern === 'string';
 }
 
-export function fromCompletionItemKind(kind?: types.CompletionItemKind): model.CompletionType {
+export function fromCompletionItemKind(kind?: types.CompletionItemKind): model.CompletionItemKind {
     switch (kind) {
-        case types.CompletionItemKind.Method: return 'method';
-        case types.CompletionItemKind.Function: return 'function';
-        case types.CompletionItemKind.Constructor: return 'constructor';
-        case types.CompletionItemKind.Field: return 'field';
-        case types.CompletionItemKind.Variable: return 'variable';
-        case types.CompletionItemKind.Class: return 'class';
-        case types.CompletionItemKind.Interface: return 'interface';
-        case types.CompletionItemKind.Struct: return 'struct';
-        case types.CompletionItemKind.Module: return 'module';
-        case types.CompletionItemKind.Property: return 'property';
-        case types.CompletionItemKind.Unit: return 'unit';
-        case types.CompletionItemKind.Value: return 'value';
-        case types.CompletionItemKind.Constant: return 'constant';
-        case types.CompletionItemKind.Enum: return 'enum';
-        case types.CompletionItemKind.EnumMember: return 'enum-member';
-        case types.CompletionItemKind.Keyword: return 'keyword';
-        case types.CompletionItemKind.Snippet: return 'snippet';
-        case types.CompletionItemKind.Text: return 'text';
-        case types.CompletionItemKind.Color: return 'color';
-        case types.CompletionItemKind.File: return 'file';
-        case types.CompletionItemKind.Reference: return 'reference';
-        case types.CompletionItemKind.Folder: return 'folder';
-        case types.CompletionItemKind.Event: return 'event';
-        case types.CompletionItemKind.Operator: return 'operator';
-        case types.CompletionItemKind.TypeParameter: return 'type-parameter';
+        case types.CompletionItemKind.Method: return model.CompletionItemKind.Method;
+        case types.CompletionItemKind.Function: return model.CompletionItemKind.Function;
+        case types.CompletionItemKind.Constructor: return model.CompletionItemKind.Constructor;
+        case types.CompletionItemKind.Field: return model.CompletionItemKind.Field;
+        case types.CompletionItemKind.Variable: return model.CompletionItemKind.Variable;
+        case types.CompletionItemKind.Class: return model.CompletionItemKind.Class;
+        case types.CompletionItemKind.Interface: return model.CompletionItemKind.Interface;
+        case types.CompletionItemKind.Struct: return model.CompletionItemKind.Struct;
+        case types.CompletionItemKind.Module: return model.CompletionItemKind.Module;
+        case types.CompletionItemKind.Property: return model.CompletionItemKind.Property;
+        case types.CompletionItemKind.Unit: return model.CompletionItemKind.Unit;
+        case types.CompletionItemKind.Value: return model.CompletionItemKind.Value;
+        case types.CompletionItemKind.Constant: return model.CompletionItemKind.Constant;
+        case types.CompletionItemKind.Enum: return model.CompletionItemKind.Enum;
+        case types.CompletionItemKind.EnumMember: return model.CompletionItemKind.EnumMember;
+        case types.CompletionItemKind.Keyword: return model.CompletionItemKind.Keyword;
+        case types.CompletionItemKind.Snippet: return model.CompletionItemKind.Snippet;
+        case types.CompletionItemKind.Text: return model.CompletionItemKind.Text;
+        case types.CompletionItemKind.Color: return model.CompletionItemKind.Color;
+        case types.CompletionItemKind.File: return model.CompletionItemKind.File;
+        case types.CompletionItemKind.Reference: return model.CompletionItemKind.Reference;
+        case types.CompletionItemKind.Folder: return model.CompletionItemKind.Folder;
+        case types.CompletionItemKind.Event: return model.CompletionItemKind.Event;
+        case types.CompletionItemKind.Operator: return model.CompletionItemKind.Operator;
+        case types.CompletionItemKind.TypeParameter: return model.CompletionItemKind.TypeParameter;
     }
-    return 'property';
+    return model.CompletionItemKind.Property;
 }
 
-export function toCompletionItemKind(type?: model.CompletionType): types.CompletionItemKind {
-    if (type) {
-        switch (type) {
-            case 'method': return types.CompletionItemKind.Method;
-            case 'function': return types.CompletionItemKind.Function;
-            case 'constructor': return types.CompletionItemKind.Constructor;
-            case 'field': return types.CompletionItemKind.Field;
-            case 'variable': return types.CompletionItemKind.Variable;
-            case 'class': return types.CompletionItemKind.Class;
-            case 'interface': return types.CompletionItemKind.Interface;
-            case 'struct': return types.CompletionItemKind.Struct;
-            case 'module': return types.CompletionItemKind.Module;
-            case 'property': return types.CompletionItemKind.Property;
-            case 'unit': return types.CompletionItemKind.Unit;
-            case 'value': return types.CompletionItemKind.Value;
-            case 'constant': return types.CompletionItemKind.Constant;
-            case 'enum': return types.CompletionItemKind.Enum;
-            case 'enum-member': return types.CompletionItemKind.EnumMember;
-            case 'keyword': return types.CompletionItemKind.Keyword;
-            case 'snippet': return types.CompletionItemKind.Snippet;
-            case 'text': return types.CompletionItemKind.Text;
-            case 'color': return types.CompletionItemKind.Color;
-            case 'file': return types.CompletionItemKind.File;
-            case 'reference': return types.CompletionItemKind.Reference;
-            case 'folder': return types.CompletionItemKind.Folder;
-            case 'event': return types.CompletionItemKind.Event;
-            case 'operator': return types.CompletionItemKind.Operator;
-            case 'type-parameter': return types.CompletionItemKind.TypeParameter;
-        }
+export function toCompletionItemKind(kind?: model.CompletionItemKind): types.CompletionItemKind {
+    switch (kind) {
+        case model.CompletionItemKind.Method: return types.CompletionItemKind.Method;
+        case model.CompletionItemKind.Function: return types.CompletionItemKind.Function;
+        case model.CompletionItemKind.Constructor: return types.CompletionItemKind.Constructor;
+        case model.CompletionItemKind.Field: return types.CompletionItemKind.Field;
+        case model.CompletionItemKind.Variable: return types.CompletionItemKind.Variable;
+        case model.CompletionItemKind.Class: return types.CompletionItemKind.Class;
+        case model.CompletionItemKind.Interface: return types.CompletionItemKind.Interface;
+        case model.CompletionItemKind.Struct: return types.CompletionItemKind.Struct;
+        case model.CompletionItemKind.Module: return types.CompletionItemKind.Module;
+        case model.CompletionItemKind.Property: return types.CompletionItemKind.Property;
+        case model.CompletionItemKind.Unit: return types.CompletionItemKind.Unit;
+        case model.CompletionItemKind.Value: return types.CompletionItemKind.Value;
+        case model.CompletionItemKind.Constant: return types.CompletionItemKind.Constant;
+        case model.CompletionItemKind.Enum: return types.CompletionItemKind.Enum;
+        case model.CompletionItemKind.EnumMember: return types.CompletionItemKind.EnumMember;
+        case model.CompletionItemKind.Keyword: return types.CompletionItemKind.Keyword;
+        case model.CompletionItemKind.Snippet: return types.CompletionItemKind.Snippet;
+        case model.CompletionItemKind.Text: return types.CompletionItemKind.Text;
+        case model.CompletionItemKind.Color: return types.CompletionItemKind.Color;
+        case model.CompletionItemKind.File: return types.CompletionItemKind.File;
+        case model.CompletionItemKind.Reference: return types.CompletionItemKind.Reference;
+        case model.CompletionItemKind.Folder: return types.CompletionItemKind.Folder;
+        case model.CompletionItemKind.Event: return types.CompletionItemKind.Event;
+        case model.CompletionItemKind.Operator: return types.CompletionItemKind.Operator;
+        case model.CompletionItemKind.TypeParameter: return types.CompletionItemKind.TypeParameter;
     }
     return types.CompletionItemKind.Property;
 }
 
-export function fromTextEdit(edit: theia.TextEdit): model.SingleEditOperation {
-    return <model.SingleEditOperation>{
+export function fromTextEdit(edit: theia.TextEdit): model.TextEdit {
+    return {
         text: edit.newText,
         range: fromRange(edit.range)
     };
@@ -442,6 +450,60 @@ export function fromDocumentHighlight(documentHighlight: theia.DocumentHighlight
         range: fromRange(documentHighlight.range),
         kind: fromDocumentHighlightKind(documentHighlight.kind)
     };
+}
+
+export namespace ParameterInformation {
+    export function from(info: types.ParameterInformation): model.ParameterInformation {
+        return {
+            label: info.label,
+            documentation: info.documentation ? fromMarkdown(info.documentation) : undefined
+        };
+    }
+    export function to(info: model.ParameterInformation): types.ParameterInformation {
+        return {
+            label: info.label,
+            documentation: isMarkdownString(info.documentation) ? toMarkdown(info.documentation) : info.documentation
+        };
+    }
+}
+
+export namespace SignatureInformation {
+
+    export function from(info: types.SignatureInformation): model.SignatureInformation {
+        return {
+            label: info.label,
+            documentation: info.documentation ? fromMarkdown(info.documentation) : undefined,
+            parameters: info.parameters && info.parameters.map(ParameterInformation.from)
+        };
+    }
+
+    export function to(info: model.SignatureInformation): types.SignatureInformation {
+        return {
+            label: info.label,
+            documentation: isMarkdownString(info.documentation) ? toMarkdown(info.documentation) : info.documentation,
+            parameters: info.parameters && info.parameters.map(ParameterInformation.to)
+        };
+    }
+}
+
+export namespace SignatureHelp {
+
+    export function from(id: number, help: types.SignatureHelp): model.SignatureHelp {
+        return {
+            id,
+            activeSignature: help.activeSignature,
+            activeParameter: help.activeParameter,
+            signatures: help.signatures && help.signatures.map(SignatureInformation.from)
+        };
+    }
+
+    export function to(help: model.SignatureHelp): types.SignatureHelp {
+        return {
+            activeSignature: help.activeSignature,
+            activeParameter: help.activeParameter,
+            signatures: help.signatures && help.signatures.map(SignatureInformation.to)
+        };
+    }
 }
 
 export namespace KnownCommands {
@@ -894,4 +956,124 @@ export function quickPickItemToPickOpenItem(items: Item[]): PickOpenItem[] {
         });
     }
     return pickItems;
+}
+
+export namespace DecorationRenderOptions {
+    export function from(options: theia.DecorationRenderOptions): rpc.DecorationRenderOptions {
+        return {
+            isWholeLine: options.isWholeLine,
+            rangeBehavior: options.rangeBehavior ? DecorationRangeBehavior.from(options.rangeBehavior) : undefined,
+            overviewRulerLane: options.overviewRulerLane,
+            light: options.light ? ThemableDecorationRenderOptions.from(options.light) : undefined,
+            dark: options.dark ? ThemableDecorationRenderOptions.from(options.dark) : undefined,
+
+            backgroundColor: <string | types.ThemeColor>options.backgroundColor,
+            outline: options.outline,
+            outlineColor: <string | types.ThemeColor>options.outlineColor,
+            outlineStyle: options.outlineStyle,
+            outlineWidth: options.outlineWidth,
+            border: options.border,
+            borderColor: <string | types.ThemeColor>options.borderColor,
+            borderRadius: options.borderRadius,
+            borderSpacing: options.borderSpacing,
+            borderStyle: options.borderStyle,
+            borderWidth: options.borderWidth,
+            fontStyle: options.fontStyle,
+            fontWeight: options.fontWeight,
+            textDecoration: options.textDecoration,
+            cursor: options.cursor,
+            color: <string | types.ThemeColor>options.color,
+            opacity: options.opacity,
+            letterSpacing: options.letterSpacing,
+            gutterIconPath: options.gutterIconPath ? pathOrURIToURI(options.gutterIconPath) : undefined,
+            gutterIconSize: options.gutterIconSize,
+            overviewRulerColor: <string | types.ThemeColor>options.overviewRulerColor,
+            before: options.before ? ThemableDecorationAttachmentRenderOptions.from(options.before) : undefined,
+            after: options.after ? ThemableDecorationAttachmentRenderOptions.from(options.after) : undefined,
+        };
+    }
+}
+
+export namespace DecorationRangeBehavior {
+    export function from(value: types.DecorationRangeBehavior): rpc.TrackedRangeStickiness {
+        if (typeof value === 'undefined') {
+            return value;
+        }
+        switch (value) {
+            case types.DecorationRangeBehavior.OpenOpen:
+                return rpc.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges;
+            case types.DecorationRangeBehavior.ClosedClosed:
+                return rpc.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges;
+            case types.DecorationRangeBehavior.OpenClosed:
+                return rpc.TrackedRangeStickiness.GrowsOnlyWhenTypingBefore;
+            case types.DecorationRangeBehavior.ClosedOpen:
+                return rpc.TrackedRangeStickiness.GrowsOnlyWhenTypingAfter;
+        }
+    }
+}
+
+export namespace ThemableDecorationRenderOptions {
+    export function from(options: theia.ThemableDecorationRenderOptions): rpc.ThemeDecorationRenderOptions {
+        if (typeof options === 'undefined') {
+            return options;
+        }
+        return {
+            backgroundColor: <string | types.ThemeColor>options.backgroundColor,
+            outline: options.outline,
+            outlineColor: <string | types.ThemeColor>options.outlineColor,
+            outlineStyle: options.outlineStyle,
+            outlineWidth: options.outlineWidth,
+            border: options.border,
+            borderColor: <string | types.ThemeColor>options.borderColor,
+            borderRadius: options.borderRadius,
+            borderSpacing: options.borderSpacing,
+            borderStyle: options.borderStyle,
+            borderWidth: options.borderWidth,
+            fontStyle: options.fontStyle,
+            fontWeight: options.fontWeight,
+            textDecoration: options.textDecoration,
+            cursor: options.cursor,
+            color: <string | types.ThemeColor>options.color,
+            opacity: options.opacity,
+            letterSpacing: options.letterSpacing,
+            gutterIconPath: options.gutterIconPath ? pathOrURIToURI(options.gutterIconPath) : undefined,
+            gutterIconSize: options.gutterIconSize,
+            overviewRulerColor: <string | types.ThemeColor>options.overviewRulerColor,
+            before: options.before ? ThemableDecorationAttachmentRenderOptions.from(options.before) : undefined,
+            after: options.after ? ThemableDecorationAttachmentRenderOptions.from(options.after) : undefined,
+        };
+    }
+}
+
+export namespace ThemableDecorationAttachmentRenderOptions {
+    export function from(options: theia.ThemableDecorationAttachmentRenderOptions): rpc.ContentDecorationRenderOptions {
+        if (typeof options === 'undefined') {
+            return options;
+        }
+        return {
+            contentText: options.contentText,
+            contentIconPath: options.contentIconPath ? pathOrURIToURI(options.contentIconPath) : undefined,
+            border: options.border,
+            borderColor: <string | types.ThemeColor>options.borderColor,
+            fontStyle: options.fontStyle,
+            fontWeight: options.fontWeight,
+            textDecoration: options.textDecoration,
+            color: <string | types.ThemeColor>options.color,
+            backgroundColor: <string | types.ThemeColor>options.backgroundColor,
+            margin: options.margin,
+            width: options.width,
+            height: options.height,
+        };
+    }
+}
+
+export function pathOrURIToURI(value: string | URI): URI {
+    if (typeof value === 'undefined') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return URI.file(value);
+    } else {
+        return value;
+    }
 }

--- a/packages/plugin-ext/src/plugin/types-impl.ts
+++ b/packages/plugin-ext/src/plugin/types-impl.ts
@@ -819,10 +819,10 @@ export enum MarkerTag {
 }
 
 export class ParameterInformation {
-    label: string;
+    label: string | [number, number];
     documentation?: string | MarkdownString;
 
-    constructor(label: string, documentation?: string | MarkdownString) {
+    constructor(label: string | [number, number], documentation?: string | MarkdownString) {
         this.label = label;
         this.documentation = documentation;
     }
@@ -836,13 +836,24 @@ export class SignatureInformation {
     constructor(label: string, documentation?: string | MarkdownString) {
         this.label = label;
         this.documentation = documentation;
+        this.parameters = [];
     }
+}
+
+export enum SignatureHelpTriggerKind {
+    Invoke = 1,
+    TriggerCharacter = 2,
+    ContentChange = 3,
 }
 
 export class SignatureHelp {
     signatures: SignatureInformation[];
     activeSignature: number;
     activeParameter: number;
+
+    constructor() {
+        this.signatures = [];
+    }
 }
 
 export class Hover {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -12,7 +12,7 @@
     "@theia/monaco": "^0.10.0",
     "@theia/workspace": "^0.10.0",
     "command-exists": "^1.2.8",
-    "typescript-language-server": "^0.3.8"
+    "typescript-language-server": "^0.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,9 +785,10 @@
   dependencies:
     nan "2.10.0"
 
-"@typefox/monaco-editor-core@^0.14.6":
-  version "0.14.6"
-  resolved "https://registry.yarnpkg.com/@typefox/monaco-editor-core/-/monaco-editor-core-0.14.6.tgz#32e378f3430913504ea9c7063944444a04429892"
+"@typefox/monaco-editor-core@^0.18.0-next":
+  version "0.18.0-next.1"
+  resolved "https://registry.yarnpkg.com/@typefox/monaco-editor-core/-/monaco-editor-core-0.18.0-next.1.tgz#c31d3361215703b524065f460e1b4b6b714699db"
+  integrity sha512-l7uZbyLfXwh5b5YHv1U2T5KQAVrPTnUqklRd1HEI6ZBWGqw5ukXa5L17ATaVYRpCsy7ZtqyOQS2viWSS/goNFA==
 
 "@types/base64-arraybuffer@0.1.0":
   version "0.1.0"
@@ -7343,18 +7344,20 @@ moment@^2.10.6, moment@^2.21.0, moment@^2.6.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-monaco-css@^2.0.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/monaco-css/-/monaco-css-2.2.0.tgz#644e6e45d05f7704a4e1f563883bef4af9badb1f"
+monaco-css@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/monaco-css/-/monaco-css-2.5.0.tgz#eb173658306d6ae6a8d38c08df7f67ecba685f80"
+  integrity sha512-V5YuMysU5MbNMPlZxMfB4os/mx+nIH3emrl2zgQe7Iu77dQhODoUysd5OoZB9hzpFoRDZ/KFuEaFaib8/ziYRQ==
 
-monaco-html@^2.0.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/monaco-html/-/monaco-html-2.2.0.tgz#435f2f4ce6e5c7f707fb57e7c8a05b41e5cd1aa0"
+monaco-html@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/monaco-html/-/monaco-html-2.5.2.tgz#3e231ff50d024ed4f3c2d9fb075e77351f33508a"
+  integrity sha512-tugs+jHMtfInq/gMl5wXYoUs649rc5h6a/bbaK2+4MTx//iWUZ9mgTsgmbqqfbujEgHxxJHiGWTDIZjz8Ztx7g==
 
-monaco-languageclient@next:
-  version "0.9.0-next.1"
-  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.0-next.1.tgz#2a3c133f3b16c345aa3eba0738e7a0161cb2b05e"
-  integrity sha512-POZOxVsRBzqK14yfk66clEefTFR+Ahx77uhyhanmJG/pItBVX4E962N/uUwYZPGc4zO3FZ+Ef7tFFxbyIQXdAg==
+monaco-languageclient@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.10.2.tgz#d243964737b29fc20d542deca1835fa045cd19eb"
+  integrity sha512-ZfOm4jQyJzz7rHFIBfLiSM2tfgWoWXkumarLJPSqMFYyK1swIXwS8a8f8cwVZFkJ/aUO1GHcQXaaPZ1B5YtsLQ==
   dependencies:
     glob-to-regexp "^0.3.0"
     vscode-jsonrpc "^4.1.0-next"
@@ -10587,17 +10590,17 @@ typedoc@^0.15.0-0:
     typedoc-default-themes "^0.6.0-0"
     typescript "3.3.x"
 
-typescript-language-server@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.3.8.tgz#de69db5a4d96b3cd1e994d37a8981010237f6c00"
-  integrity sha512-ohi+libVtaJ0F8asuXeqYlrPV84AkbcpWsp5kBeO6XnCrilwQS+elDrJ+jPu2tfVy3CIUpUbUYUmg4Bq3CA/XQ==
+typescript-language-server@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/typescript-language-server/-/typescript-language-server-0.4.0.tgz#9b4aee8e001a69fcd152459a6cc1a08283db9193"
+  integrity sha512-K8jNOmDFn+QfrCh8ujby2pGDs5rpjYZQn+zvQnf42rxG4IHbfw5CHoMvbGkWPK/J5Gw8/l5K3i03kVZC2IBElg==
   dependencies:
     command-exists "1.2.6"
     commander "^2.11.0"
     fs-extra "^7.0.0"
     p-debounce "^1.0.0"
     tempy "^0.2.1"
-    vscode-languageserver "^4.4.0"
+    vscode-languageserver "^5.3.0-next"
     vscode-uri "^1.0.5"
 
 typescript@3.3.x:
@@ -10980,14 +10983,10 @@ vscode-json-languageservice@^3.3.0:
     vscode-nls "^4.1.1"
     vscode-uri "^2.0.3"
 
-vscode-jsonrpc@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
-
-vscode-jsonrpc@^4.1.0-next, vscode-jsonrpc@^4.1.0-next.2:
-  version "4.1.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz#3bd318910a48e631742b290975386e3dae685be3"
-  integrity sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg==
+vscode-jsonrpc@^4.1.0-next, vscode-jsonrpc@^4.1.0-next.3:
+  version "4.1.0-next.3"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
+  integrity sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==
 
 vscode-languageclient@^5.3.0-next:
   version "5.3.0-next.6"
@@ -10997,36 +10996,26 @@ vscode-languageclient@^5.3.0-next:
     semver "^5.5.0"
     vscode-languageserver-protocol "^3.15.0-next.6"
 
-vscode-languageserver-protocol@^3.10.3:
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.3.tgz#59841c9602a6a6baab68613c2a47760994657196"
+vscode-languageserver-protocol@^3.15.0-next.6, vscode-languageserver-protocol@^3.15.0-next.8:
+  version "3.15.0-next.8"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.8.tgz#5e3cc0ae143fe3364820249e32f6019ce974fa9e"
+  integrity sha512-9FigDhuYTUqX73IGKgJeyLmfXQJv9p3t22RF3peT+HM33uFiTZE3MUgHj4I9m/dKCDvuJt0yvbI27ut4hDoGRQ==
   dependencies:
-    vscode-jsonrpc "^3.6.2"
-    vscode-languageserver-types "^3.10.1"
+    vscode-jsonrpc "^4.1.0-next.3"
+    vscode-languageserver-types "^3.15.0-next.4"
 
-vscode-languageserver-protocol@^3.15.0-next.6:
-  version "3.15.0-next.6"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
-  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
+vscode-languageserver-types@^3.15.0-next, vscode-languageserver-types@^3.15.0-next.2, vscode-languageserver-types@^3.15.0-next.4:
+  version "3.15.0-next.4"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.4.tgz#9aae49844ef826ae656382facecc20664113c060"
+  integrity sha512-IKIWTdUPBnOtwznIrhxKnjVZ7hYxEzwZ3M2xmDi7OjjexuOM6LnGtoo1Dv4wYSik4epK4STEib6e8da2GxUsJA==
+
+vscode-languageserver@^5.3.0-next:
+  version "5.3.0-next.10"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.3.0-next.10.tgz#995fe8b57fc4eb9fea0d11762d3a803de4278995"
+  integrity sha512-QL7Fe1FT6PdLtVzwJeZ78pTic4eZbzLRy7yAQgPb9xalqqgZESR0+yDZPwJrM3E7PzOmwHBceYcJR54eQZ7Kng==
   dependencies:
-    vscode-jsonrpc "^4.1.0-next.2"
-    vscode-languageserver-types "^3.15.0-next.2"
-
-vscode-languageserver-types@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.10.1.tgz#d5d5f44f688a3b2aa9857dc53cb9cacca73fe35a"
-
-vscode-languageserver-types@^3.15.0-next, vscode-languageserver-types@^3.15.0-next.2:
-  version "3.15.0-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz#a0601332cdaafac21931f497bb080cfb8d73f254"
-  integrity sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==
-
-vscode-languageserver@^4.4.0:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-4.4.2.tgz#600ae9cc7a6ff1e84d93c7807840c2cb5b22821b"
-  dependencies:
-    vscode-languageserver-protocol "^3.10.3"
-    vscode-uri "^1.0.5"
+    vscode-languageserver-protocol "^3.15.0-next.8"
+    vscode-textbuffer "^1.0.0"
 
 vscode-languageserver@^5.3.0-next.8:
   version "5.3.0-next.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,659 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/core@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
+  integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helpers" "^7.5.5"
+    "@babel/parser" "^7.5.5"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
+  integrity sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+  dependencies:
+    "@babel/types" "^7.5.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-builder-binary-assignment-operator-visitor@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz#6b69628dfe4087798e0c4ed98e3d4a6b2fbd2f5f"
+  integrity sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==
+  dependencies:
+    "@babel/helper-explode-assignable-expression" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-call-delegate@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz#87c1f8ca19ad552a736a7a27b1c1fcf8b1ff1f43"
+  integrity sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
+"@babel/helper-define-map@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz#3dec32c2046f37e09b28c93eb0b103fd2a25d369"
+  integrity sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.5.5"
+    lodash "^4.17.13"
+
+"@babel/helper-explode-assignable-expression@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz#537fa13f6f1674df745b0c00ec8fe4e99681c8f6"
+  integrity sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-hoist-variables@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz#0298b5f25c8c09c53102d52ac4a98f773eb2850a"
+  integrity sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
+"@babel/helper-member-expression-to-functions@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz#1fb5b8ec4453a93c439ee9fe3aeea4a84b76b590"
+  integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
+  dependencies:
+    "@babel/types" "^7.5.5"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  integrity sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz#f84ff8a09038dcbca1fd4355661a500937165b4a"
+  integrity sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/types" "^7.5.5"
+    lodash "^4.17.13"
+
+"@babel/helper-optimise-call-expression@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
+  integrity sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-plugin-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
+  integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
+
+"@babel/helper-regex@^7.0.0", "@babel/helper-regex@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.5.5.tgz#0aa6824f7100a2e0e89c1527c23936c152cab351"
+  integrity sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==
+  dependencies:
+    lodash "^4.17.13"
+
+"@babel/helper-remap-async-to-generator@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz#361d80821b6f38da75bd3f0785ece20a88c5fe7f"
+  integrity sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-wrap-function" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-replace-supers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz#f84ce43df031222d2bad068d2626cb5799c34bc2"
+  integrity sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+
+"@babel/helper-simple-access@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
+  integrity sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==
+  dependencies:
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
+"@babel/helper-wrap-function@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
+  integrity sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/template" "^7.1.0"
+    "@babel/traverse" "^7.1.0"
+    "@babel/types" "^7.2.0"
+
+"@babel/helpers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.5.5.tgz#63908d2a73942229d1e6685bc2a0e730dde3b75e"
+  integrity sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==
+  dependencies:
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+
+"@babel/highlight@^7.0.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
+  integrity sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
+"@babel/parser@^7.4.4", "@babel/parser@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
+
+"@babel/plugin-proposal-async-generator-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz#b289b306669dce4ad20b0252889a15768c9d417e"
+  integrity sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+
+"@babel/plugin-proposal-dynamic-import@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz#e532202db4838723691b10a67b8ce509e397c506"
+  integrity sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+
+"@babel/plugin-proposal-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
+  integrity sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz#61939744f71ba76a3ae46b5eea18a54c16d22e58"
+  integrity sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
+"@babel/plugin-proposal-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
+  integrity sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz#501ffd9826c0b91da22690720722ac7cb1ca9c78"
+  integrity sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/plugin-syntax-async-generators@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
+  integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-dynamic-import@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
+  integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-json-strings@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
+  integrity sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-object-rest-spread@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
+  integrity sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
+  integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-arrow-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
+  integrity sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-async-to-generator@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz#89a3848a0166623b5bc481164b5936ab947e887e"
+  integrity sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
+"@babel/plugin-transform-block-scoped-functions@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
+  integrity sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-block-scoping@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.5.5.tgz#a35f395e5402822f10d2119f6f8e045e3639a2ce"
+  integrity sha512-82A3CLRRdYubkG85lKwhZB0WZoHxLGsJdux/cOVaJCJpvYFl1LVzAIFyRsa7CvXqW8rBM4Zf3Bfn8PHt5DP0Sg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.13"
+
+"@babel/plugin-transform-classes@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz#d094299d9bd680a14a2a0edae38305ad60fb4de9"
+  integrity sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    globals "^11.1.0"
+
+"@babel/plugin-transform-computed-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
+  integrity sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-destructuring@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz#f6c09fdfe3f94516ff074fe877db7bc9ef05855a"
+  integrity sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz#361a148bc951444312c69446d76ed1ea8e4450c3"
+  integrity sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/plugin-transform-duplicate-keys@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz#c5dbf5106bf84cdf691222c0974c12b1df931853"
+  integrity sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-exponentiation-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz#a63868289e5b4007f7054d46491af51435766008"
+  integrity sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-for-of@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
+  integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-function-name@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
+  integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
+  integrity sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-member-expression-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz#fa10aa5c58a2cb6afcf2c9ffa8cb4d8b3d489a2d"
+  integrity sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-amd@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz#ef00435d46da0a5961aa728a1d2ecff063e4fb91"
+  integrity sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-commonjs@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz#425127e6045231360858eeaa47a71d75eded7a74"
+  integrity sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz#e75266a13ef94202db2a0620977756f51d52d249"
+  integrity sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    babel-plugin-dynamic-import-node "^2.3.0"
+
+"@babel/plugin-transform-modules-umd@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz#7678ce75169f0877b8eb2235538c074268dd01ae"
+  integrity sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.5.tgz#9d269fd28a370258199b4294736813a60bbdd106"
+  integrity sha512-z7+2IsWafTBbjNsOxU/Iv5CvTJlr5w4+HGu1HovKYTtgJ362f7kBcQglkfmlspKKZ3bgrbSGvLfNx++ZJgCWsg==
+  dependencies:
+    regexp-tree "^0.1.6"
+
+"@babel/plugin-transform-new-target@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
+  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-super@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz#c70021df834073c65eb613b8679cc4a381d1a9f9"
+  integrity sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+
+"@babel/plugin-transform-parameters@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
+  integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.4.4"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-property-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz#03e33f653f5b25c4eb572c98b9485055b389e905"
+  integrity sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-regenerator@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz#629dc82512c55cee01341fb27bdfcb210354680f"
+  integrity sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==
+  dependencies:
+    regenerator-transform "^0.14.0"
+
+"@babel/plugin-transform-reserved-words@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
+  integrity sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz#a6331afbfc59189d2135b2e09474457a8e3d28bc"
+  integrity sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-shorthand-properties@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
+  integrity sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-spread@^7.2.0":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
+  integrity sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-sticky-regex@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz#a1e454b5995560a9c1e0d537dfc15061fd2687e1"
+  integrity sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.0.0"
+
+"@babel/plugin-transform-template-literals@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
+  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-typeof-symbol@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
+  integrity sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-unicode-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
+  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
+
+"@babel/preset-env@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.5.5.tgz#bc470b53acaa48df4b8db24a570d6da1fef53c9a"
+  integrity sha512-GMZQka/+INwsMz1A5UEql8tG015h5j/qjptpKY2gJ7giy8ohzU710YciJB5rcKsWGWHiW3RUnHib0E5/m3Tp3A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-dynamic-import" "^7.5.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.5.5"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.5.0"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.5.5"
+    "@babel/plugin-transform-classes" "^7.5.5"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.5.0"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.5.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.5.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.5.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.5.0"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.5"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.5.5"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.5"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.5.5"
+    browserslist "^4.6.0"
+    core-js-compat "^3.1.1"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
+
+"@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/template@^7.1.0", "@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
+  integrity sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -1146,6 +1799,16 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-loader@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -1157,6 +1820,13 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-dynamic-import-node@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
+  integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
+  dependencies:
+    object.assign "^4.1.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1827,6 +2497,15 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
+browserslist@^4.6.0, browserslist@^4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.6.tgz#6e4bf467cde520bc9dbdf3747dafa03531cec453"
+  integrity sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==
+  dependencies:
+    caniuse-lite "^1.0.30000984"
+    electron-to-chromium "^1.3.191"
+    node-releases "^1.1.25"
+
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
@@ -2031,6 +2710,11 @@ caniuse-api@^1.5.2:
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000877"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000877.tgz#29ea435fdbe8a671cc5b027a75e28a816c17c340"
+
+caniuse-lite@^1.0.30000984:
+  version "1.0.30000989"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
+  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2682,6 +3366,13 @@ conventional-recommended-bump@^1.2.1:
     meow "^3.3.0"
     object-assign "^4.0.1"
 
+convert-source-map@^1.1.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
+
 convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -2721,6 +3412,14 @@ copy-webpack-plugin@^4.5.0:
     minimatch "^3.0.4"
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
+
+core-js-compat@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.2.0.tgz#d7fcc4d695d66b069437bd9d9f411274ceb196d3"
+  integrity sha512-vQve8j3tGPPqIkrsK442hbVwDIGXcngLPnislJaCNJIG1aBWPD0IqRhpxEwjtUOYpzLap8xA7CoGlJBT1ZkcDA==
+  dependencies:
+    browserslist "^4.6.6"
+    semver "^6.3.0"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -3058,7 +3757,7 @@ debug@3.1.0, debug@^3.0.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.1:
+debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -3504,6 +4203,11 @@ electron-store@^2.0.0:
 electron-to-chromium@^1.2.7:
   version "1.3.58"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz#8267a4000014e93986d9d18c65a8b4022ca75188"
+
+electron-to-chromium@^1.3.191:
+  version "1.3.221"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.221.tgz#421a58ac8d1931c8df400d55c7f6fd621710da10"
+  integrity sha512-YbNA7KgCvLq9ZaEa7wpYP7IP4LrJ4+b36oeF1lYBSJ0zVGVN7uo3Ct9qDUm/M3VDOWj03RVgsMFF8PdL8UjhzA==
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -4093,6 +4797,15 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
 find-git-exec@0.0.1-alpha.2, find-git-exec@^0.0.1-alpha.2:
   version "0.0.1-alpha.2"
   resolved "https://registry.yarnpkg.com/find-git-exec/-/find-git-exec-0.0.1-alpha.2.tgz#02c266b3be6e411c19aa5fd6f813c96a73286fac"
@@ -4118,6 +4831,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
 
 first-chunk-stream@^2.0.0:
   version "2.0.0"
@@ -4529,6 +5249,11 @@ global-prefix@^1.0.1:
     ini "^1.3.4"
     is-windows "^1.0.1"
     which "^1.2.14"
+
+globals@^11.1.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -5491,7 +6216,12 @@ js-base64@^2.1.9:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.8.tgz#57a9b130888f956834aa40c5b165ba59c758f033"
 
-"js-tokens@^3.0.0 || ^4.0.0":
+js-levenshtein@^1.1.3:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
@@ -5601,6 +6331,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
@@ -5641,14 +6376,22 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonc-parser@^2.0.0-next.1, jsonc-parser@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.0.1.tgz#9d23cd2709714fff508a1a6679d82135bee1ae60"
+json5@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
 
 jsonc-parser@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.0.2.tgz#42fcf56d70852a043fadafde51ddb4a85649978d"
   integrity sha512-TSU435K5tEKh3g7bam1AFf+uZrISheoDsLlpmAo6wWZYqjsnd09lHYK1Qo+moK4Ikifev1Gdpa69g4NELKnCrQ==
+
+jsonc-parser@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.1.0.tgz#eb0d0c7a3c33048524ce3574c57c7278fb2f1bf3"
+  integrity sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w==
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -5953,6 +6696,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -6138,6 +6889,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -6213,6 +6969,14 @@ make-dir@^1.0.0, make-dir@^1.1.0:
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   dependencies:
     pify "^3.0.0"
+
+make-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -6587,14 +7351,14 @@ monaco-html@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/monaco-html/-/monaco-html-2.2.0.tgz#435f2f4ce6e5c7f707fb57e7c8a05b41e5cd1aa0"
 
-monaco-languageclient@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.1.tgz#dccd26ae0be4d1014395b406e924baae9f8eb9b5"
-  integrity sha512-mDwbYk67UVPf41RnhfMLRME08NsK2/JeqCkkhPL+wef6rZQNHRb/U2bMMuW/MVVM/yT2DYFy5f7cLNm63FYGMw==
+monaco-languageclient@next:
+  version "0.9.0-next.1"
+  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.0-next.1.tgz#2a3c133f3b16c345aa3eba0738e7a0161cb2b05e"
+  integrity sha512-POZOxVsRBzqK14yfk66clEefTFR+Ahx77uhyhanmJG/pItBVX4E962N/uUwYZPGc4zO3FZ+Ef7tFFxbyIQXdAg==
   dependencies:
     glob-to-regexp "^0.3.0"
-    vscode-base-languageclient "4.4.0"
-    vscode-jsonrpc "^3.6.2"
+    vscode-jsonrpc "^4.1.0-next"
+    vscode-languageclient "^5.3.0-next"
     vscode-uri "^1.0.5"
 
 moo-server@*, moo-server@1.3.x:
@@ -6818,6 +7582,13 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
+node-releases@^1.1.25:
+  version "1.1.26"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.26.tgz#f30563edc5c7dc20cf524cc8652ffa7be0762937"
+  integrity sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==
+  dependencies:
+    semver "^5.3.0"
+
 nomnom@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
@@ -7021,7 +7792,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.3:
+object.assign@^4.0.3, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -7204,11 +7975,25 @@ p-limit@^1.0.0, p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-map@^1.1.1, p-map@^1.2.0:
   version "1.2.0"
@@ -7237,6 +8022,11 @@ p-timeout@^2.0.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 package-json@^4.0.1:
   version "4.0.1"
@@ -7341,7 +8131,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5:
+path-parse@^1.0.5, path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -7419,6 +8209,11 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0, pinkie-promise@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -7440,6 +8235,13 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 pkg-up@^2.0.0:
   version "2.0.0"
@@ -8236,7 +9038,14 @@ reflect-metadata@^0.1.10:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
 
-regenerate@^1.2.1:
+regenerate-unicode-properties@^8.0.2:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz#ef51e0f0ea4ad424b77bf7cb41f3e015c70a3f0e"
+  integrity sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
+  dependencies:
+    regenerate "^1.4.0"
+
+regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
@@ -8244,12 +9053,24 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
 regenerator-transform@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
   dependencies:
     babel-runtime "^6.18.0"
     babel-types "^6.19.0"
+    private "^0.1.6"
+
+regenerator-transform@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
+  integrity sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
+  dependencies:
     private "^0.1.6"
 
 regex-cache@^0.4.2:
@@ -8264,6 +9085,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexp-tree@^0.1.6:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.11.tgz#c9c7f00fcf722e0a56c7390983a7a63dd6c272f3"
+  integrity sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==
 
 regexpu-core@^1.0.0:
   version "1.0.0"
@@ -8280,6 +9106,18 @@ regexpu-core@^2.0.0:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
+
+regexpu-core@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
+  integrity sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.0.2"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
 
 registry-auth-token@^3.0.1:
   version "3.3.2"
@@ -8298,9 +9136,21 @@ regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
 
+regjsgen@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.5.0.tgz#a7634dc08f89209c2049adda3525711fb97265dd"
+  integrity sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==
+
 regjsparser@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
+  dependencies:
+    jsesc "~0.5.0"
+
+regjsparser@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.0.tgz#f1e6ae8b7da2bae96c99399b868cd6c933a2ba9c"
+  integrity sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==
   dependencies:
     jsesc "~0.5.0"
 
@@ -8341,13 +9191,14 @@ replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request-light@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.3.tgz#a18635ec6dd92f8705c019c42ef645f684d94f7e"
+request-light@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.4.tgz#3cea29c126682e6bcadf7915353322eeba01a755"
+  integrity sha512-pM9Fq5jRnSb+82V7M97rp8FE9/YNeP2L9eckB4Szd7lyeclSIx02aIpPO/6e4m6Dy31+FBN/zkFMTd2HkNO3ow==
   dependencies:
     http-proxy-agent "^2.1.0"
     https-proxy-agent "^2.2.1"
-    vscode-nls "^3.2.2"
+    vscode-nls "^4.0.0"
 
 request-promise-core@1.1.1:
   version "1.1.1"
@@ -8439,6 +9290,13 @@ resolve@^1.1.6, resolve@^1.3.2:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.8.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
 
 responselike@1.0.2:
   version "1.0.2"
@@ -8643,10 +9501,15 @@ selenium-standalone@^6.15.4:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
-semver@^5.6.0:
+semver@^5.5.1, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -8928,7 +9791,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -9520,6 +10383,11 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -9818,6 +10686,29 @@ underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
+unicode-canonical-property-names-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
+  integrity sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
+
+unicode-match-property-ecmascript@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz#8ed2a32569961bce9227d09cd3ffbb8fed5f020c"
+  integrity sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^1.0.4"
+    unicode-property-aliases-ecmascript "^1.0.4"
+
+unicode-match-property-value-ecmascript@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
+  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
+
+unicode-property-aliases-ecmascript@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
+  integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -10063,65 +10954,102 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vscode-base-languageclient@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/vscode-base-languageclient/-/vscode-base-languageclient-4.4.0.tgz#07098fe42a986e8b65e47960de5ccf656aefe8d0"
-  dependencies:
-    vscode-languageserver-protocol "^3.10.0"
-
 vscode-debugprotocol@^1.32.0:
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.32.0.tgz#cca9eccb3f73ded5e525e01621a72ca2bb577dc3"
 
-vscode-json-languageserver@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageserver/-/vscode-json-languageserver-1.0.1.tgz#58bb0be82d816b50d71b3facfaffcae9a6587139"
+vscode-json-languageserver@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageserver/-/vscode-json-languageserver-1.2.1.tgz#c7b55d4c024036305f3dcc65bc14400f39d262e2"
+  integrity sha512-JijXG0VRnnzqdNL3TyjDKiKoQ3IA3+0zd/+eyeyBW7fZpxM4oK/eHTLKHAwen6dYcXdrjJwx8XtT+LWls40esQ==
   dependencies:
-    jsonc-parser "^2.0.0-next.1"
-    request-light "^0.2.2"
-    vscode-json-languageservice "^3.0.12"
-    vscode-languageserver "^4.0.0"
-    vscode-nls "^3.2.2"
-    vscode-uri "^1.0.3"
+    jsonc-parser "^2.1.0"
+    request-light "^0.2.4"
+    vscode-json-languageservice "^3.3.0"
+    vscode-languageserver "^5.3.0-next.8"
+    vscode-nls "^4.1.1"
+    vscode-uri "^2.0.1"
 
-vscode-json-languageservice@^3.0.12:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.1.5.tgz#4ebac4cadcaedd55ea2d0716259b50a89955e00e"
+vscode-json-languageservice@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.3.1.tgz#4ad2c82db849a7bbe54fcbf5c9b3a2ed26dc8fee"
+  integrity sha512-Qyvlrftexu1acvwbMt+CDehVrDZtFV1GAJrKdOCHQL9bWNhzI06KEiSd4iXR0NUOuAdroG/uU4wBkH6e5CcTXg==
   dependencies:
-    jsonc-parser "^2.0.1"
-    vscode-languageserver-types "^3.10.1"
-    vscode-nls "^3.2.4"
-    vscode-uri "^1.0.5"
+    jsonc-parser "^2.1.0"
+    vscode-languageserver-types "^3.15.0-next.2"
+    vscode-nls "^4.1.1"
+    vscode-uri "^2.0.3"
 
-vscode-jsonrpc@^3.6.0, vscode-jsonrpc@^3.6.2:
+vscode-jsonrpc@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
 
-vscode-languageserver-protocol@^3.10.0, vscode-languageserver-protocol@^3.10.3:
+vscode-jsonrpc@^4.1.0-next, vscode-jsonrpc@^4.1.0-next.2:
+  version "4.1.0-next.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz#3bd318910a48e631742b290975386e3dae685be3"
+  integrity sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg==
+
+vscode-languageclient@^5.3.0-next:
+  version "5.3.0-next.6"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.3.0-next.6.tgz#35e74882781158e8b111911c0953869d3df08777"
+  integrity sha512-DxT8+gkenjCjJV6ArcP75/AQfx6HP6m6kHIbacPCpffMeoE1YMLKj6ZixA9J87yr0fMtBmqumLmDeGe7MIF2bw==
+  dependencies:
+    semver "^5.5.0"
+    vscode-languageserver-protocol "^3.15.0-next.6"
+
+vscode-languageserver-protocol@^3.10.3:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.3.tgz#59841c9602a6a6baab68613c2a47760994657196"
   dependencies:
     vscode-jsonrpc "^3.6.2"
     vscode-languageserver-types "^3.10.1"
 
-vscode-languageserver-types@^3.10.0, vscode-languageserver-types@^3.10.1:
+vscode-languageserver-protocol@^3.15.0-next.6:
+  version "3.15.0-next.6"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz#a8aeb7e7dd65da8216b386db59494cdfd3215d92"
+  integrity sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==
+  dependencies:
+    vscode-jsonrpc "^4.1.0-next.2"
+    vscode-languageserver-types "^3.15.0-next.2"
+
+vscode-languageserver-types@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.10.1.tgz#d5d5f44f688a3b2aa9857dc53cb9cacca73fe35a"
 
-vscode-languageserver@^4.0.0, vscode-languageserver@^4.4.0:
+vscode-languageserver-types@^3.15.0-next, vscode-languageserver-types@^3.15.0-next.2:
+  version "3.15.0-next.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz#a0601332cdaafac21931f497bb080cfb8d73f254"
+  integrity sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ==
+
+vscode-languageserver@^4.4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-4.4.2.tgz#600ae9cc7a6ff1e84d93c7807840c2cb5b22821b"
   dependencies:
     vscode-languageserver-protocol "^3.10.3"
     vscode-uri "^1.0.5"
 
-vscode-nls@^3.2.2, vscode-nls@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-3.2.4.tgz#2166b4183c8aea884d20727f5449e62be69fd398"
+vscode-languageserver@^5.3.0-next.8:
+  version "5.3.0-next.8"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.3.0-next.8.tgz#12a4adf60374dbb93e153e08bdca5525f9b2029f"
+  integrity sha512-6vUb96wsRfrFqndril3gct/FBCSc24OxFZ2iz7kuEuXvLaIcEVOcSZIqQK8oFN7PdbAIaa9nnIpKSy4Yd15cIw==
+  dependencies:
+    vscode-languageserver-protocol "^3.15.0-next.6"
+    vscode-textbuffer "^1.0.0"
+    vscode-uri "^1.0.6"
+
+vscode-nls@^4.0.0, vscode-nls@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.1.tgz#f9916b64e4947b20322defb1e676a495861f133c"
+  integrity sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A==
 
 vscode-ripgrep@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.2.4.tgz#b3cfbe08ed13f6cf6b134147ea4d982970ab4f70"
+
+vscode-textbuffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textbuffer/-/vscode-textbuffer-1.0.0.tgz#1faee638c8e0e4131c8d5c353993a1874acda086"
+  integrity sha512-zPaHo4urgpwsm+PrJWfNakolRpryNja18SUip/qIIsfhuEqEIPEXMxHOlFPjvDC4JgTaimkncNW7UMXRJTY6ow==
 
 vscode-textmate@^4.0.1:
   version "4.0.1"
@@ -10129,16 +11057,22 @@ vscode-textmate@^4.0.1:
   dependencies:
     oniguruma "^7.0.0"
 
-vscode-uri@^1.0.3, vscode-uri@^1.0.5, vscode-uri@^1.0.8:
+vscode-uri@^1.0.5, vscode-uri@^1.0.6, vscode-uri@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
   integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
 
-vscode-ws-jsonrpc@^0.0.2-1:
-  version "0.0.2-2"
-  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.0.2-2.tgz#3d977ea40a2f47148ea8cfcbf077196ecd7fe3a2"
+vscode-uri@^2.0.1, vscode-uri@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.0.3.tgz#25e5f37f552fbee3cec7e5f80cef8469cefc6543"
+  integrity sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw==
+
+vscode-ws-jsonrpc@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.1.1.tgz#163ff05662635b4fd161ed132e112cec4d83f126"
+  integrity sha512-1O/FUORbb8dZAvh9AFF6HViLJ0Ja0RbF+sFRnUsoqkuKIRsXDDiiJpwYwT6fmglCLefE5afGPw9NoHvDVN/5yw==
   dependencies:
-    vscode-jsonrpc "^3.6.0"
+    vscode-jsonrpc "^4.1.0-next"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- upgrading to LSP 5.3.0
  - LSP dependencies are targeting es6 now, we are forced to use babel in order to transpile es6 to es5 classes for these dependencies
- upgrading to Monaco 0.17.0
  - [x] open a CQ for all copied code to align with latest vscode.d.ts - it was already covered by previous CQs
- [x] reference peek cannot be closed with `esc`
- [x] monaco configuration does not reflect editor preferences
- [x] fix editor preview tests
- [x] depends on https://github.com/TypeFox/monaco-languageclient/pull/174
- [x] https://github.com/theia-ide/theia/pull/5901#issuecomment-522919840
- [ ] https://github.com/theia-ide/theia/pull/5901#issuecomment-528796882
- [x] https://github.com/theia-ide/theia/pull/5901#issuecomment-529311130

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- test language features with native Theia extension:
  - test that features are available in the editor context menu and in quick command palette
  - a declaration is revealed when following the reference
  - focus belongs to a proper editor after following a reference (for internal and outside references, from editor to editor preview and view versa)
  - reference peek is still opened after following a reference (for internal and outside references, from editor to editor preview and view versa)
  - esc closes reference peek widget
  - completion items are properly resolved and inserted
  - focus belongs to a proper editor on peek definition (for internal and outside references, from editor to editor preview and view versa)
  - check that rename work inside the file and across files
  - check that arguments are proposed by the signature help
  - check that hover is present with properly rendered docs
  - check that symbol occurrences is highlighted when a declaration or reference is selected
  - check that go to (type|implementation) definition works properly, i.e. definition is revealed
  - check that code lens work properly
    - run/debug code lenses: https://github.com/kasecato/vscode-javadebug-sample
  - check that code actions work properly (quick fixes)
  - check that document and selection formatting work properly
  - check color provider with css colors
  - check link provider with links in html
  - check that folding ranges are properly provided for js, css and html
  - check go to symbol command
  - check open workspace symbol command
- test language features with VS Code extension:
  - typesctipt VS Code extension for testing: [ts_plugins.zip](https://github.com/theia-ide/theia/files/3513239/ts_plugins.zip)
  - to run it:
    - uninstall native typescript extension in example package.json
    - build the example app
    - unzip archive into plugins folder
    - start the example app
  - use the same checks as for native Theia extension
- test quick palette:
  - proper keys are displayed for the quick command palette, i.e. they are displayed and a corresponding Monaco command can be triggered by such keybinding
  - use sample vscode extension
  - use fuzzy search
- test vscode tree view (that context keys work properly)
- test plugin editor decorations, for example with power mode extension
- test debug console input editor
- test debug breakpoint editor
- test that preferences are propagated as config key values: change editor preferences and check whether they are reflected
- test language auto detection
- test `edit` menu with editor
- test `selection` menu with editor
- test editor context menu
- smoke test some VS Code extensions like go, python, just use editor for a bit, check backend and frontend logs for errors

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

