### PR TITLE
core: fix logic in `getToggledHandler`

### DIFF
--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -337,7 +337,7 @@ export class CommandRegistry implements CommandService {
         if (handlers) {
             for (const handler of handlers) {
                 try {
-                    if (handler.isToggled && handler.isToggled(...args)) {
+                    if (!handler.isToggled || handler.isToggled(...args)) {
                         return handler;
                     }
                 } catch (error) {


### PR DESCRIPTION
#### What it does
Fix logic issue when looking for a toggled command handler.

Follow up of https://github.com/theia-ide/theia/pull/5894#pullrequestreview-273209552

#### How to test
Register a command handler not defining a `isToggle` function.
Before this patch it would not be shown as toggled.
With this patch it should be shown as toggled.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
