### PR TITLE
Execute tasks via keybindings.

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -553,10 +553,10 @@ export class KeybindingRegistry {
                 } else {
                     const command = this.commandRegistry.getCommand(binding.command);
                     if (command) {
-                        const commandHandler = this.commandRegistry.getActiveHandler(command.id);
+                        const commandHandler = this.commandRegistry.getActiveHandler(command.id, binding.args);
 
                         if (commandHandler) {
-                            commandHandler.execute();
+                            commandHandler.execute(binding.args);
                         }
 
                         /* Note that if a keybinding is in context but the command is

--- a/packages/core/src/common/keybinding.ts
+++ b/packages/core/src/common/keybinding.ts
@@ -29,4 +29,10 @@ export interface Keybinding {
      * https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts
      */
     when?: string;
+
+    /**
+     * Specified when the command has arguments that are passed to the command handler.
+     */
+    // tslint:disable-next-line no-any
+    args?: any;
 }

--- a/packages/keymaps/src/browser/keymaps-parser.ts
+++ b/packages/keymaps/src/browser/keymaps-parser.ts
@@ -35,10 +35,11 @@ export const keymapsSchema = {
             },
             when: {
                 type: 'string'
-            }
+            },
+            args: {}
         },
         required: ['command', 'keybinding'],
-        optional: ['context', 'when'],
+        optional: ['context', 'when', 'args'],
         additionalProperties: false
     }
 };

--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -37,6 +37,11 @@ export namespace TaskCommands {
         label: 'Run Task...'
     };
 
+    export const WORKBENCH_RUN_TASK: Command = {
+        id: 'workbench.action.tasks.runTask',
+        category: TASK_CATEGORY
+    };
+
     export const TASK_RUN_LAST: Command = {
         id: 'task:run:last',
         category: TASK_CATEGORY,
@@ -173,6 +178,19 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
     }
 
     registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(
+            TaskCommands.WORKBENCH_RUN_TASK,
+            {
+                isEnabled: () => true,
+                execute: async (label: string) => {
+                    const didExecute = await this.taskService.runTaskByLabel(label);
+                    if (!didExecute) {
+                        this.quickOpenTask.open();
+                    }
+                }
+            }
+        );
+
         registry.registerCommand(
             TaskCommands.TASK_RUN,
             {

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -398,6 +398,17 @@ export class TaskService implements TaskConfigurationClient {
         }
     }
 
+    async runTaskByLabel(taskLabel: string): Promise<boolean> {
+        const tasks: TaskConfiguration[] = await this.getTasks();
+        for (const task of tasks) {
+            if (task.label === taskLabel) {
+                await this.runTask(task);
+                return true;
+            }
+        }
+        return false;
+    }
+
     private async removeProblemMarks(option?: RunTaskOption): Promise<void> {
         if (option && option.customization) {
             const matchersFromOption = option.customization.problemMatcher || [];


### PR DESCRIPTION
Signed-off-by: Jason Attwood <jason_attwood@hotmail.co.uk>

#### What it does
This addresses issue #5870 , allowing for shortcuts to be made to run tasks.

#### How to test
Create any tasks (or use the default ones that are provided at the bottom [here](https://www.npmjs.com/package/@theia/task))
Create a keybinding for that task in the following format:
```
{
        "keybinding": "ctrl+alt+s",
        "command": "workbench.action.tasks.runTask",
        "args": "[Task] Echo a string"
}
```
the args is the label of the task to execute.

#### Review checklist
- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers
- [x] as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

