### PR TITLE
notify clients of TaskDefinitionRegistry on change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [task] fixed the problem where a detected task can be customized more than once [#5777](https://github.com/theia-ide/theia/pull/5777)
 - [task] displayed the customized tasks as "configured tasks" in the task quick open [#5777](https://github.com/theia-ide/theia/pull/5777)
 - [task] allowed users to override any task properties other than the ones used in the task definition [#5777](https://github.com/theia-ide/theia/pull/5777)
+- [task] notified clients of TaskDefinitionRegistry on change [#5915](https://github.com/theia-ide/theia/pull/5915)
 - [outline] added `OutlineViewTreeModel` for the outline view tree widget [#5687](https://github.com/theia-ide/theia/pull/5687)
 
 Breaking changes:
@@ -17,6 +18,7 @@ Breaking changes:
 - [plugin] files from 'plugin-ext/src/api' moved to 'plugin-ext/src/common', renamed 'model.ts' to 'plugin-api-rpc-model.ts', 'plugin-api.ts' to 'plugin-api-rpc.ts'
 - [task] ensure that plugin tasks are registered before accessing them [5869](https://github.com/theia-ide/theia/pull/5869)
   - `TaskProviderRegistry` and `TaskResolverRegistry` are promisified
+- [task] removed `filterDuplicates()` from `TaskConfigurations` class [#5915](https://github.com/theia-ide/theia/pull/5915)
 - [shell][plugin] integrated view containers and views [#5665](https://github.com/theia-ide/theia/pull/5665)
   - `Source Control` and `Explorer` are view containers now and previous layout data cannot be loaded for them. Because of it the layout is completely reset.
 - [vscode] complete support of variable substitution [#5835](https://github.com/theia-ide/theia/pull/5835)

--- a/packages/task/src/browser/task-definition-registry.ts
+++ b/packages/task/src/browser/task-definition-registry.ts
@@ -15,6 +15,7 @@
  ********************************************************************************/
 
 import { injectable } from 'inversify';
+import { Event, Emitter } from '@theia/core/lib/common';
 import { TaskConfiguration, TaskCustomization, TaskDefinition } from '../common';
 
 @injectable()
@@ -22,6 +23,11 @@ export class TaskDefinitionRegistry {
 
     // task type - array of task definitions
     private definitions: Map<string, TaskDefinition[]> = new Map();
+
+    protected readonly onDidRegisterTaskDefinitionEmitter = new Emitter<void>();
+    get onDidRegisterTaskDefinition(): Event<void> {
+        return this.onDidRegisterTaskDefinitionEmitter.event;
+    }
 
     /**
      * Finds the task definition(s) from the registry with the given `taskType`.
@@ -70,5 +76,6 @@ export class TaskDefinitionRegistry {
     register(definition: TaskDefinition): void {
         const taskType = definition.taskType;
         this.definitions.set(taskType, [...this.getDefinitions(taskType), definition]);
+        this.onDidRegisterTaskDefinitionEmitter.fire(undefined);
     }
 }


### PR DESCRIPTION
- In current theia, task definitions from plugins are registered after the initialization of the task extension, causing task-loading, which counts on the existence of task definitions, not to function correctly. With changes in this pull request, events are emitted so that the clients of TaskDefinitionRegistry are notified and therefore have the flexibility to re-organize the loaded tasks.

Signed-off-by: Liang Huang <liang.huang@ericsson.com>


#### How to test
1. Have a detected task prepared.
- What I did in this step is having `npm` extension installed in Theia, and adding at least one `npm` script, so that the project has a few detected npm tasks. Reload Theia frontend (example-browser).

2. Customize one detected task by adding an object in `tasks.json`, e.g., 
```json
        {
            "type": "npm",
            "script": "lint",
            "problemMatcher": [
                "$eslint-stylish"
            ]
        }
```

3. Run the customized task.

What happened: the problem matcher, although defined in `tasks.json`, does not parse the task output, and therefore warnings and errors of the task did not show up in the problems view

What should happen: warnings and errors of the task, if any, should be displayed as markers in the problems view
 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
