### PR TITLE
fix #5917: normalize the path of terminal link before openning it

### DIFF
--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -87,7 +87,7 @@ export abstract class NavigatableWidgetOpenHandler<W extends NavigatableWidget> 
     }
 
     protected serializeUri(uri: URI): string {
-        return uri.withoutFragment().toString();
+        return uri.withoutFragment().normalizePath().toString();
     }
 
 }

--- a/packages/core/src/common/path.spec.ts
+++ b/packages/core/src/common/path.spec.ts
@@ -153,4 +153,98 @@ describe('Path', () => {
         });
     }
 
+    assertNormalize({
+        from: '/',
+        expectation: '/'
+    });
+
+    assertNormalize({
+        from: '/c://',
+        expectation: '/c:/'
+    });
+
+    assertNormalize({
+        from: '/foo',
+        expectation: '/foo'
+    });
+
+    assertNormalize({
+        from: '/foo/',
+        expectation: '/foo/'
+    });
+
+    assertNormalize({
+        from: '/foo/bar',
+        expectation: '/foo/bar'
+    });
+
+    assertNormalize({
+        from: '/foo/../file.txt',
+        expectation: '/file.txt'
+    });
+
+    assertNormalize({
+        from: '/foo/bar/../file.txt',
+        expectation: '/foo/file.txt'
+    });
+
+    assertNormalize({
+        from: '/foo/../../file.txt',
+        expectation: '/file.txt'
+    });
+
+    assertNormalize({
+        from: '',
+        expectation: '.'
+    });
+
+    assertNormalize({
+        from: '.',
+        expectation: '.'
+    });
+
+    assertNormalize({
+        from: '..',
+        expectation: '..'
+    });
+
+    assertNormalize({
+        from: './foo',
+        expectation: 'foo'
+    });
+
+    assertNormalize({
+        from: './foo/./.',
+        expectation: 'foo'
+    });
+
+    assertNormalize({
+        from: './foo/',
+        expectation: 'foo/'
+    });
+
+    assertNormalize({
+        from: '../foo',
+        expectation: '../foo'
+    });
+
+    assertNormalize({
+        from: 'foo/..',
+        expectation: '.'
+    });
+
+    assertNormalize({
+        from: 'foo/bar/../../../',
+        expectation: '../'
+    });
+
+    function assertNormalize({ from, expectation }: {
+        from: string,
+        expectation: string
+    }): void {
+        it(`path ${from} should be normalized as ${expectation}`, () => {
+            assert.deepStrictEqual(new Path(from).normalize().toString(), expectation);
+        });
+    }
+
 });

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -177,4 +177,32 @@ export class Path {
         }
         return -1;
     }
+
+    normalize(): Path {
+        const trailingSlash = this.raw.endsWith('/');
+        const pathArray = this.toString().split('/');
+        const resultArray: string[] = [];
+        pathArray.forEach((value, index) => {
+            if (!value || value === '.') {
+                return;
+            }
+            if (value === '..') {
+                if (resultArray.length && resultArray[resultArray.length - 1] !== '..') {
+                    resultArray.pop();
+                } else if (!this.isAbsolute) {
+                    resultArray.push('..');
+                }
+            } else {
+                resultArray.push(value);
+            }
+        });
+        if (resultArray.length === 0) {
+            if (this.isRoot) {
+                return new Path('/');
+            } else {
+                return new Path('.');
+            }
+        }
+        return new Path((this.isAbsolute ? '/' : '') + resultArray.join('/') + (trailingSlash ? '/' : ''));
+    }
 }

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -164,6 +164,13 @@ export default class URI {
         return this.withFragment('');
     }
 
+    /**
+     * return a new URI replacing the current with its normalized path
+     */
+    normalizePath(): URI {
+        return this.withPath(this.path.normalize());
+    }
+
     get scheme(): string {
         return this.codeUri.scheme;
     }


### PR DESCRIPTION
Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Normalize the paths of file links contributed by terminals to avoid opening multiple editors for the same file.

#### How to test
1. Create a new file, e.g. named package.json and open it
2. Print some file links in the terminal, for example:
  - run `echo "./package.json"`
  - run `echo ".///package.json"`
  - run `echo "../${parent}/package.json"`
  - run `echo "/${absolute/path/to/package.json}"`
3. Ctrl/cmd+click open these links and see if they all activate the same editor opened in step 1

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

