### PR TITLE
Fix 'ps-tree' hoisted plugin warning

### DIFF
--- a/packages/plugin-dev/package.json
+++ b/packages/plugin-dev/package.json
@@ -13,7 +13,7 @@
     "@theia/preferences": "^0.9.0",
     "@theia/workspace": "^0.9.0",
     "@types/request": "^2.0.3",
-    "ps-tree": "1.1.0",
+    "ps-tree": "^1.2.0",
     "request": "^2.82.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3696,7 +3696,7 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-event-stream@=3.3.4, event-stream@~3.3.0:
+event-stream@=3.3.4:
   version "3.3.4"
   resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -7837,12 +7837,6 @@ ps-list@5.0.1:
   dependencies:
     pify "^3.0.0"
     tasklist "^3.1.0"
-
-ps-tree@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
-  dependencies:
-    event-stream "~3.3.0"
 
 ps-tree@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5922

- fix the warning displayed upon building the app
warning about a duplicate dependency being pulled with a
different version.
- fixes the `ps-tree` dependency between the `plugin-dev` and `plugin-ext`
extensions. (aligns the dependency version).

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>


