### PR TITLE
Update editor tabbar captions for better multi-root support

### DIFF
--- a/packages/editor/src/browser/editor-widget-factory.ts
+++ b/packages/editor/src/browser/editor-widget-factory.ts
@@ -50,7 +50,7 @@ export class EditorWidgetFactory implements WidgetFactory {
             newEditor.title.closable = true;
             newEditor.title.label = this.labelProvider.getName(uri);
             newEditor.title.iconClass = icon + ' file-icon';
-            newEditor.title.caption = this.labelProvider.getLongName(uri);
+            newEditor.title.caption = uri.path.toString();
             return newEditor;
         });
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5921

- updated the editor's caption (used for tabbars) in order
to better support multi-root workspaces, and align with VSCode.
Currently, when in a multi-root workspace there is no way to
easily distinguish which root the file resides in. With this
change the entire path is displayed, similarly to the explorer.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open a single-root workspace, open an editor, and highlight over the tabbar (the entire path should be displayed as the html title)
2. open a multi-root workspace, open an editor, and highlight over the tabbar (the entire path should be displayed as the html title)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
