### PR TITLE
fix #5927: plugin ext file path error

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -50,8 +50,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
 
             const localPath = this.pluginsIdsFiles.get(pluginId);
             if (localPath) {
-                const fileToServe = path.join(localPath, filePath);
-                res.sendFile(fileToServe, { root: localPath }, (error: Error) => {
+                res.sendFile(filePath, { root: localPath }, (error: Error) => {
                     res.status(404).send(`No such file for plugin with id '${escape_html(pluginId)}'.`);
                 });
             } else {


### PR DESCRIPTION
#### What it does
fix: #5927

![image](https://user-images.githubusercontent.com/10203793/62929770-bb5f6200-bded-11e9-99cf-04cc944b96fd.png)

#### How to test
- Press F1
- Deploy Plugin By Id
- input ext install ms-kubernetes-tools.vscode-kubernetes-tools
- until install finish
- refresh theia
- the ext logo show correct

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

