### PR TITLE
fix: snippet suggestion does not replace the input string

### DIFF
--- a/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
+++ b/packages/monaco/src/browser/monaco-snippet-suggest-provider.ts
@@ -13,28 +13,96 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import * as jsoncparser from 'jsonc-parser';
 import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileSystem, FileSystemError } from '@theia/filesystem/lib/common';
+import { CompletionTriggerKind } from '@theia/languages/lib/browser';
 
 @injectable()
 export class MonacoSnippetSuggestProvider implements monaco.modes.ISuggestSupport {
 
+    private static readonly _maxPrefix = 10000;
+
     @inject(FileSystem)
     protected readonly filesystem: FileSystem;
 
-    protected readonly snippets = new Map<string, MonacoSnippetSuggestion[]>();
+    protected readonly snippets = new Map<string, Snippet[]>();
     protected readonly pendingSnippets = new Map<string, Promise<void>[]>();
 
-    async provideCompletionItems(model: monaco.editor.ITextModel): Promise<monaco.modes.ISuggestResult> {
+    async provideCompletionItems(model: monaco.editor.ITextModel, position: monaco.Position,
+        context: monaco.modes.SuggestContext): Promise<monaco.modes.ISuggestResult | undefined> {
+
+        // copied and modified from https://github.com/microsoft/vscode/blob/master/src/vs/workbench/contrib/snippets/browser/snippetCompletionProvider.ts
+        if (position.column >= MonacoSnippetSuggestProvider._maxPrefix) {
+            return undefined;
+        }
+
+        if (context.triggerKind === CompletionTriggerKind.TriggerCharacter && context.triggerCharacter === ' ') {
+            // no snippets when suggestions have been triggered by space
+            return undefined;
+        }
+
         const languageId = model.getModeId(); // TODO: look up a language id at the position
         await this.loadSnippets(languageId);
-        const suggestions = this.snippets.get(languageId) || [];
+        const snippetsForLanguage = this.snippets.get(languageId) || [];
+
+        let suggestions: MonacoSnippetSuggestion[];
+        const pos = { lineNumber: position.lineNumber, column: 1 };
+        const lineOffsets: number[] = [];
+        const linePrefixLow = model.getLineContent(position.lineNumber).substr(0, position.column - 1).toLowerCase();
+        const endsInWhitespace = linePrefixLow.match(/\s$/);
+
+        while (pos.column < position.column) {
+            const word = model.getWordAtPosition(pos);
+            if (word) {
+                // at a word
+                lineOffsets.push(word.startColumn - 1);
+                pos.column = word.endColumn + 1;
+                if (word.endColumn - 1 < linePrefixLow.length && !/\s/.test(linePrefixLow[word.endColumn - 1])) {
+                    lineOffsets.push(word.endColumn - 1);
+                }
+            } else if (!/\s/.test(linePrefixLow[pos.column - 1])) {
+                // at a none-whitespace character
+                lineOffsets.push(pos.column - 1);
+                pos.column += 1;
+            } else {
+                // always advance!
+                pos.column += 1;
+            }
+        }
+
+        const availableSnippets = new Set<Snippet>();
+        snippetsForLanguage.forEach(availableSnippets.add, availableSnippets);
+        suggestions = [];
+        for (const start of lineOffsets) {
+            availableSnippets.forEach(snippet => {
+                if (this.isPatternInWord(linePrefixLow, start, linePrefixLow.length, snippet.prefix.toLowerCase(), 0, snippet.prefix.length)) {
+                    suggestions.push(new MonacoSnippetSuggestion(snippet,
+                        monaco.Range.fromPositions(this.newPositionWithDelta(position, 0, -(linePrefixLow.length - start)), position)));
+                    availableSnippets.delete(snippet);
+                }
+            });
+        }
+        if (endsInWhitespace || lineOffsets.length === 0) {
+            // add remaing snippets when the current prefix ends in whitespace or when no
+            // interesting positions have been found
+            availableSnippets.forEach(snippet => {
+                suggestions.push(new MonacoSnippetSuggestion(snippet, monaco.Range.fromPositions(position)));
+            });
+        }
+
+        // dismbiguate suggestions with same labels
+        suggestions.sort(MonacoSnippetSuggestion.compareByLabel);
         return { suggestions };
     }
 
-    resolveCompletionItem(_: monaco.editor.ITextModel, __: monaco.Position, item: monaco.modes.ISuggestion): monaco.modes.ISuggestion {
+    resolveCompletionItem(textModel: monaco.editor.ITextModel, position: monaco.Position, item: monaco.modes.ISuggestion): monaco.modes.ISuggestion {
         return item instanceof MonacoSnippetSuggestion ? item.resolve() : item;
     }
 
@@ -125,9 +193,29 @@ export class MonacoSnippetSuggestProvider implements monaco.modes.ISuggestSuppor
         for (const snippet of snippets) {
             for (const scope of snippet.scopes) {
                 const languageSnippets = this.snippets.get(scope) || [];
-                languageSnippets.push(new MonacoSnippetSuggestion(snippet));
+                languageSnippets.push(snippet);
                 this.snippets.set(scope, languageSnippets);
             }
+        }
+    }
+
+    isPatternInWord(patternLow: string, patternPos: number, patternLen: number, wordLow: string, wordPos: number, wordLen: number): boolean {
+        while (patternPos < patternLen && wordPos < wordLen) {
+            if (patternLow[patternPos] === wordLow[wordPos]) {
+                patternPos += 1;
+            }
+            wordPos += 1;
+        }
+        return patternPos === patternLen; // pattern must be exhausted
+    }
+
+    newPositionWithDelta(position: monaco.Position, deltaLineNumber: number = 0, deltaColumn: number = 0): monaco.Position {
+        const newLineNumber = position.lineNumber + deltaLineNumber;
+        const newColumn = position.column + deltaColumn;
+        if (newLineNumber === position.lineNumber && newColumn === position.column) {
+            return position;
+        } else {
+            return new monaco.Position(newLineNumber, newColumn);
         }
     }
 
@@ -167,18 +255,22 @@ export class MonacoSnippetSuggestion implements monaco.modes.ISuggestion {
     readonly label: string;
     readonly detail: string;
     readonly sortText: string;
+    readonly range: monaco.IRange;
     readonly noAutoAccept = true;
     readonly type: 'snippet' = 'snippet';
     readonly snippetType: 'textmate' = 'textmate';
+    readonly overwriteBefore?: number;
 
     insertText: string;
     documentation?: monaco.IMarkdownString;
 
-    constructor(protected readonly snippet: Snippet) {
+    constructor(protected readonly snippet: Snippet, range: monaco.IRange) {
         this.label = snippet.prefix;
         this.detail = `${snippet.description || snippet.name} (${snippet.source})`;
         this.insertText = snippet.body;
         this.sortText = `z-${snippet.prefix}`;
+        this.range = range;
+        this.overwriteBefore = this.range.endColumn - this.range.startColumn;
     }
 
     protected resolved = false;
@@ -189,6 +281,10 @@ export class MonacoSnippetSuggestion implements monaco.modes.ISuggestion {
             this.resolved = true;
         }
         return this;
+    }
+
+    static compareByLabel(a: MonacoSnippetSuggestion, b: MonacoSnippetSuggestion): number {
+        return a.label > b.label ? 1 : a.label < b.label ? -1 : 0;
     }
 
 }


### PR DESCRIPTION
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
fix https://github.com/theia-ide/theia/issues/5926: snippet suggestion does not replace the input string

- [x] a CQ for copied code: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20668 (please mark when it is resolved or labeled with `checkin` ready

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1.theia 0.9.0 with [redhat.java-0.46.0.vsix](https://github.com/redhat-developer/vscode-java/releases/download/v0.46.0/redhat.java-0.46.0.vsix)
2.open a maven project and edit a java file
3.type keyword like "if".
![image](https://user-images.githubusercontent.com/16164849/62987806-1f2c6e00-be74-11e9-9ab7-50b40eefde92.png)
4.select "ifelse" or other snippet suggestion.
5.without this patch whole suggested item body will be append to "if"  which is demonstrated in https://github.com/theia-ide/theia/issues/5926
![autocompletion1](https://user-images.githubusercontent.com/16164849/62924018-c57b6380-bde1-11e9-898c-d61e29714acf.gif)
6.with this patch "if" will  replaced by suggested item body.
![autocompletion2](https://user-images.githubusercontent.com/16164849/62934354-ea2e0600-bdf6-11e9-8ac4-41b6f4afac91.gif)
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

