### PR TITLE
fix the debug stop button remains opaque

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -147,7 +147,7 @@
 }
 
 .debug-toolbar .debug-action.theia-mod-disabled {
-    opacity: 0.5;
+    opacity: 0.5 !important;
     user-select: none;
     pointer-events: none;
 }


### PR DESCRIPTION
Fix https://github.com/theia-ide/theia/issues/5930

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
When the debug button is clicked, it remains opaque and will be
transparent only after another click event occurred in the same page.
This commit is going to override opacity style of `:focus` css class.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Please follow the `Reproduction Steps` in the original issue and check if it is fixed.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

