### PR TITLE
[tree] RETURN should not expand nodes #1142

### DIFF
--- a/packages/core/src/browser/tree/tree-model.ts
+++ b/packages/core/src/browser/tree/tree-model.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017 TypeFox and others.
+ * Copyright (C) 2017-2019 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -345,9 +345,7 @@ export class TreeModelImpl implements TreeModel, SelectionProvider<ReadonlyArray
     }
 
     protected doOpenNode(node: TreeNode): void {
-        if (ExpandableTreeNode.is(node)) {
-            this.toggleNodeExpansion(node);
-        }
+        // do nothing (in particular do not expand the node)
     }
 
     selectParent(): void {


### PR DESCRIPTION
The default behaviour for RETURN is set to not expand a tree item in a tree (Naviator, File Dialog, Marker Tree)

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

The fix disables the expanding of a node on pressing the RETURN key in a tree (Naviator, File Dialog, Marker Tree)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

