### PR TITLE
add force refresh button in navigator

### DIFF
--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -44,6 +44,12 @@ export namespace FileNavigatorCommands {
         id: 'navigator.toggle.hidden.files',
         label: 'Toggle Hidden Files'
     };
+    export const REFRESH_NAVIGATOR: Command = {
+        id: 'navigator.refresh',
+        category: 'File',
+        label: 'Refresh in Explorer',
+        iconClass: 'refresh'
+    };
     export const COLLAPSE_ALL: Command = {
         id: 'navigator.collapse.all',
         category: 'File',
@@ -158,6 +164,11 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         });
         registry.registerCommand(FileNavigatorCommands.COLLAPSE_ALL, {
             execute: widget => this.withWidget(widget, () => this.collapseFileNavigatorTree()),
+            isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
+            isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
+        });
+        registry.registerCommand(FileNavigatorCommands.REFRESH_NAVIGATOR, {
+            execute: widget => this.withWidget(widget, () => this.refreshWorkspace()),
             isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
             isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
         });
@@ -318,10 +329,16 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     async registerToolbarItems(toolbarRegistry: TabBarToolbarRegistry): Promise<void> {
         toolbarRegistry.registerItem({
+            id: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
+            command: FileNavigatorCommands.REFRESH_NAVIGATOR.id,
+            tooltip: 'Refresh Explorer',
+            priority: 0,
+        });
+        toolbarRegistry.registerItem({
             id: FileNavigatorCommands.COLLAPSE_ALL.id,
             command: FileNavigatorCommands.COLLAPSE_ALL.id,
             tooltip: 'Collapse All',
-            priority: 0,
+            priority: 1,
         });
     }
 
@@ -371,6 +388,14 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         if (SelectableTreeNode.is(firstChild)) {
             model.selectNode(firstChild);
         }
+    }
+
+    /**
+     * force refresh workspace in navigator
+     */
+    async refreshWorkspace(): Promise<void> {
+        const { model } = await this.widget;
+        await model.refresh();
     }
 
     private readonly toDisposeAddRemoveFolderActions = new DisposableCollection();


### PR DESCRIPTION
#### What it does
add a force-refresh button on the toolbar in nagigator as pointed in #5885
![image](https://user-images.githubusercontent.com/35068357/62988164-e9888480-be75-11e9-9b5f-a4826b6c8e4b.png)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
It's hard to test, because file watcher will called `fileChanged` function, and auto refresh the file tree.
There are two ways to test it:
* First one is  check the websocket request in devtools:
when click force-refresh button, it will send `getFileStat` request to backend and receive a file node message.
![force refresh](https://user-images.githubusercontent.com/35068357/62988449-12f5e000-be77-11e9-92b3-79ac68587516.gif)
* Another way to test :
1. change the value of `fs.inotify.max_user_watches` to default value(8192) to diable the file wathcer.
`echo fs.inotify.max_user_watches=8192| sudo tee -a /etc/sysctl.conf && sudo sysctl -p`
2. start theia app and open a large project (such as theia workspace) in browser.
3. create a new file or folder and click refresh button.
![force refresh 2](https://user-images.githubusercontent.com/35068357/62989048-1be7b100-be79-11e9-91ae-82101e15b59c.gif)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

