### PR TITLE
Add 'title' for widgets in the sidebar

### DIFF
--- a/packages/core/src/browser/shell/side-panel-toolbar.ts
+++ b/packages/core/src/browser/shell/side-panel-toolbar.ts
@@ -97,6 +97,7 @@ export class SidePanelToolbar extends BaseWidget {
         if (this.titleContainer && title) {
             this._toolbarTitle = title;
             this.titleContainer.innerHTML = this._toolbarTitle.label;
+            this.titleContainer.title = this._toolbarTitle.caption || this._toolbarTitle.label;
             this.update();
         }
     }

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -846,8 +846,13 @@ export class ViewContainerPart extends BaseWidget {
         const title = document.createElement('span');
         title.classList.add('label', 'noselect');
         const updateTitle = () => title.innerText = this.wrapped.title.label;
+        const updateCaption = () => title.title = this.wrapped.title.caption || this.wrapped.title.label;
         updateTitle();
-        disposable.push(this.onTitleChanged(updateTitle));
+        updateCaption();
+        disposable.pushAll([
+            this.onTitleChanged(updateTitle),
+            this.onTitleChanged(updateCaption)
+        ]);
         header.appendChild(title);
         return {
             header,

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CommonCommands, CorePreferences } from '@theia/core/lib/browser';
+import { CommonCommands, CorePreferences, LabelProvider } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeModel, TreeNode,
@@ -43,6 +43,8 @@ export const CLASS = 'theia-Files';
 export class FileNavigatorWidget extends FileTreeWidget {
 
     @inject(CorePreferences) protected readonly corePreferences: CorePreferences;
+
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
 
     @inject(NavigatorContextKeyService)
     protected readonly contextKeyService: NavigatorContextKeyService;
@@ -106,12 +108,15 @@ export class FileNavigatorWidget extends FileTreeWidget {
                 const rootNode = this.model.root.children[0];
                 if (WorkspaceRootNode.is(rootNode)) {
                     this.title.label = rootNode.name;
+                    this.title.caption = this.labelProvider.getLongName(rootNode.uri);
                 }
             } else {
                 this.title.label = this.model.root.name;
+                this.title.caption = this.title.label;
             }
+        } else {
+            this.title.caption = this.title.label;
         }
-        this.title.caption = this.title.label;
     }
 
     protected enableDndOnMainPanel(): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- added `title` to widgets present in the sidebar by using the widget's caption.
- adjusted the `explorer` to display the workpace uri path when hovering over
the widget's title.

_Examples: (when hovering the title)_

<img width="480" alt="Screen Shot 2019-08-14 at 12 27 48 PM" src="https://user-images.githubusercontent.com/40359487/63038478-447aa580-be8f-11e9-83a3-371c3ce42d07.png">


<img width="480" alt="Screen Shot 2019-08-14 at 12 29 50 PM" src="https://user-images.githubusercontent.com/40359487/63038473-40e71e80-be8f-11e9-969d-fe7f3acc2611.png">


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- test with as many widgets as possible.
- hover over the title for widgets present in the sidebar (a html title should now be displayed)
- hovering over the `explorer` title should display the workspace uri path when in a single-root


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
