### PR TITLE
[explorer] implement 'more' toolbar item for the explorer

### DIFF
--- a/packages/git/src/browser/diff/git-diff-contribution.ts
+++ b/packages/git/src/browser/diff/git-diff-contribution.ts
@@ -20,8 +20,8 @@ import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { injectable, inject } from 'inversify';
 import { GitDiffWidget, GIT_DIFF } from './git-diff-widget';
 import { open, OpenerService } from '@theia/core/lib/browser';
-import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
-import { UriCommandHandler, UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { NavigatorContextMenu, FileNavigatorContribution } from '@theia/navigator/lib/browser/navigator-contribution';
+import { UriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { GitQuickOpenService } from '../git-quick-open-service';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
@@ -29,6 +29,9 @@ import URI from '@theia/core/lib/common/uri';
 import { GIT_RESOURCE_SCHEME } from '../git-resource';
 import { Git } from '../../common';
 import { GitRepositoryProvider } from '../git-repository-provider';
+import { WorkspaceRootUriAwareCommandHandler } from '@theia/workspace/lib/browser/workspace-commands';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 export namespace GitDiffCommands {
     export const OPEN_FILE_DIFF: Command = {
@@ -38,8 +41,21 @@ export namespace GitDiffCommands {
     };
 }
 
+export namespace ScmNavigatorMoreToolbarGroups {
+    export const SCM = '3_navigator_scm';
+}
+
 @injectable()
-export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget> {
+export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget> implements TabBarToolbarContribution {
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(FileNavigatorContribution)
+    protected readonly fileNavigatorContribution: FileNavigatorContribution;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     constructor(
         @inject(SelectionService) protected readonly selectionService: SelectionService,
@@ -68,7 +84,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
     }
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(GitDiffCommands.OPEN_FILE_DIFF, this.newUriAwareCommandHandler({
+        commands.registerCommand(GitDiffCommands.OPEN_FILE_DIFF, this.newWorkspaceRootUriAwareCommandHandler({
             isVisible: uri => !!this.repositoryProvider.findRepository(uri),
             isEnabled: uri => !!this.repositoryProvider.findRepository(uri),
             execute: async fileUri => {
@@ -101,6 +117,15 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         }));
     }
 
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        this.fileNavigatorContribution.registerMoreToolbarItem({
+            id: GitDiffCommands.OPEN_FILE_DIFF.id,
+            command: GitDiffCommands.OPEN_FILE_DIFF.id,
+            tooltip: GitDiffCommands.OPEN_FILE_DIFF.label,
+            group: ScmNavigatorMoreToolbarGroups.SCM,
+        });
+    }
+
     async showWidget(options: Git.Options.Diff): Promise<GitDiffWidget> {
         const widget = await this.widget;
         await widget.setContent(options);
@@ -109,8 +134,7 @@ export class GitDiffContribution extends AbstractViewContribution<GitDiffWidget>
         });
     }
 
-    protected newUriAwareCommandHandler(handler: UriCommandHandler<URI>): UriAwareCommandHandler<URI> {
-        return new UriAwareCommandHandler(this.selectionService, handler);
+    protected newWorkspaceRootUriAwareCommandHandler(handler: UriCommandHandler<URI>): WorkspaceRootUriAwareCommandHandler {
+        return new WorkspaceRootUriAwareCommandHandler(this.workspaceService, this.selectionService, handler);
     }
-
 }

--- a/packages/git/src/browser/diff/git-diff-frontend-module.ts
+++ b/packages/git/src/browser/diff/git-diff-frontend-module.ts
@@ -18,6 +18,7 @@ import { interfaces } from 'inversify';
 import { GitDiffContribution } from './git-diff-contribution';
 import { WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
 import { GitDiffWidget, GIT_DIFF } from './git-diff-widget';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 
 import '../../../src/browser/style/diff.css';
 
@@ -30,5 +31,6 @@ export function bindGitDiffModule(bind: interfaces.Bind): void {
     }));
 
     bindViewContribution(bind, GitDiffContribution);
+    bind(TabBarToolbarContribution).toService(GitDiffContribution);
 
 }

--- a/packages/workspace/src/browser/workspace-commands.ts
+++ b/packages/workspace/src/browser/workspace-commands.ts
@@ -447,16 +447,27 @@ export class WorkspaceRootUriAwareCommandHandler extends UriAwareCommandHandler<
         super(selectionService, handler);
     }
 
-    protected getUri(): URI | undefined {
-        const uri = super.getUri();
-        if (this.workspaceService.isMultiRootWorkspaceEnabled) {
-            return uri;
-        }
+    // tslint:disable-next-line: no-any
+    public isEnabled(...args: any[]): boolean {
+        return super.isEnabled(...args) && !!this.workspaceService.tryGetRoots().length;
+    }
+
+    // tslint:disable-next-line: no-any
+    public isVisible(...args: any[]): boolean {
+        return super.isVisible(...args) && !!this.workspaceService.tryGetRoots().length;
+    }
+
+    // tslint:disable-next-line: no-any
+    protected getUri(...args: any[]): URI | undefined {
+        const uri = super.getUri(...args);
+        // If the URI is available, return it immediately.
         if (uri) {
             return uri;
         }
-        const root = this.workspaceService.tryGetRoots()[0];
-        return root && new URI(root.uri);
+        // Return the first root if available.
+        if (!!this.workspaceService.tryGetRoots().length) {
+            return new URI(this.workspaceService.tryGetRoots()[0].uri);
+        }
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #5951
Fixes #6010

- Added a new toolbar item for the `explorer` which consists of mutliple commands.
- Adjusted the `WorkspaceRootUriAwareCommandHandler` to better handle commands which
can be used by the workspace root in both a single and multi-root workspace.
- Added the command `New File` to the toolbar item.
- Added the command `New Folder` to the toolbar item.
- Added the command `Add Folder to Workspace...` to the toolbar item.
- Added the command `Compare With...` to the toolbar item.

_Available Toolbar Item Commands_
- `New File`
- `New Folder`
- `Add Folder to Workspace...`
- `Compare With...`

<div align='center'>

<img width="567" alt="Screen Shot 2019-08-21 at 3 40 20 PM" src="https://user-images.githubusercontent.com/40359487/63463200-afe1eb80-c42a-11e9-9ab6-697e792c7cea.png">


</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. test the following commands in a single-root workspace
1.1. `New File`: creates a new file at the root if no selection is present, else it creates it at the selection.
1.2. `New Folder`: creates a new folder at the root if no selection is present, else it creates it at the selection
1.3. `Add Folder to Workspace...`: adds a folder to the workspace
1.4 `Compare With...`: if no selection it uses the root, else it uses the selection. prompts the user to select a branch to compare to

2. test the following commands in a multi-root workspace (**with roots**)
2.1. `New File`: creates a new file at the **first** root if no selection is present, else it creates it at the selection.
2.2. `New Folder`: creates a new folder at the **first** root if no selection is present, else it creates it at the selection
2.3. `Add Folder to Workspace...`: adds a folder to the workspace

3. test the following command in a multi-root workspace (**without any roots**)
3.1 `Add Folder to Workspace...`: adds a folder to the workspace


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

_Single-Root Workspace_

| Command | Toolbar | Selection |
|:---|:---:|:---:|
| `New File` | ✅ |  ✅ |
| `New Folder` | ✅| ✅|
| `Add Folder to Workspace...` | ✅| ✅|
| `Compare With...` | ✅| ✅|

_Multi-Root Workspace_

| Command | Toolbar | Selection |
|:---|:---:|:---:|
| `New File` | ✅<br /> (adds to first root) |  ✅ |
| `New Folder` | ✅<br /> (adds to first root) | ✅|
| `Add Folder to Workspace...` | ✅| ✅|
| `Compare With...` | ✅| ✅|

_Multi-Root Workspace (no roots)_

<div align='center'>

<img width="549" alt="Screen Shot 2019-08-21 at 4 07 50 PM" src="https://user-images.githubusercontent.com/40359487/63464726-d81f1980-c42d-11e9-8733-e200a6f6831f.png">

</div>

<br />

| Command | Toolbar | Selection |
|:---|:---:|:---:|
| `Add Folder to Workspace...` | ✅| ✅|

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

