### PR TITLE
Ensure terminate flags restart when restarting

### DIFF
--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -234,7 +234,7 @@ export class DebugSessionManager {
         if (await session.restart()) {
             return session;
         }
-        await session.terminate(!!restart);
+        await session.terminate(true);
         const { options, configuration } = session;
         configuration.__restart = restart;
         return this.start(options);


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

#### What it does
This PR ensures that the restart flag is always set to true when sending a `terminate` command to a debug adapter during a restart. The default is false.

This could also be fixed by passing `true` at the end of [this function call](doRestart), but I can't think of any situation where this flag should be set to false during a restart.

I'm also not sure what the config state is saving [here](https://github.com/theia-ide/theia/blob/master/packages/debug/src/browser/debug-session-manager.ts#L239), this change may make it redundant?

#### How to test
Implement `terminateRequest()` in a debug adapter and observe that `restart` in the arguments has the value `true` during a restart.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

