### PR TITLE
[plugin] Cache command arguments to safely pass the command over JSON-RPC

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -184,7 +184,7 @@ export interface CommandRegistryMain {
 }
 
 export interface CommandRegistryExt {
-    $executeCommand<T>(id: string, ...ars: any[]): PromiseLike<T>;
+    $executeCommand<T>(id: string, ...ars: any[]): PromiseLike<T | undefined>;
     registerArgumentProcessor(processor: ArgumentProcessor): void;
 }
 

--- a/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
+++ b/packages/plugin-ext/src/main/browser/view/tree-view-widget.tsx
@@ -127,7 +127,7 @@ export class PluginTree extends TreeImpl {
             contextValue: item.contextValue
         };
         const node = this.getNode(item.id);
-        if (item.collapsibleState !== TreeViewItemCollapsibleState.None) {
+        if (item.collapsibleState !== undefined && item.collapsibleState !== TreeViewItemCollapsibleState.None) {
             if (CompositeTreeViewNode.is(node)) {
                 return Object.assign(node, update);
             }
@@ -141,13 +141,14 @@ export class PluginTree extends TreeImpl {
             }, update);
         }
         if (TreeViewNode.is(node)) {
-            return Object.assign(node, update);
+            return Object.assign(node, update, { command: item.command });
         }
         return Object.assign({
             id: item.id,
             parent,
             visible: true,
-            selected: false
+            selected: false,
+            command: item.command
         }, update);
     }
 

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -174,7 +174,7 @@ export function createAPIFactory(
     return function (plugin: InternalPlugin): typeof theia {
         const commands: typeof theia.commands = {
             // tslint:disable-next-line:no-any
-            registerCommand(command: theia.CommandDescription, handler?: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any): Disposable {
+            registerCommand(command: theia.CommandDescription, handler?: <T>(...args: any[]) => T | Thenable<T | undefined>, thisArg?: any): Disposable {
                 return commandRegistry.registerCommand(command, handler, thisArg);
             },
             // tslint:disable-next-line:no-any


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->
#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Pass command to tree item in the tree-view-widget
- Cache command arguments to safely pass the command over JSON-RPC:
Currently tree item command doesn't provide arguments at all, they are overwritten to `id`:
https://github.com/theia-ide/theia/blob/f718cb3461eaf1a7de90c679d31cdbeafe485708/packages/plugin-ext/src/plugin/tree/tree-views.ts#L247-L249
The converter caches the command in the plugin side so the tree-view passes the command with id in arguments. This prevents `JSON circular structure` error and real arguments are available when the command is executed in the plugin side.
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Clone sample plugin: https://github.com/vinokurig/Test.git and compile it
2. Start the plugin as a Hosted Plugin
3. Open the tree-view (list icon on the left panel):
![screenshot-localhost-3030-2019 08 16-18-01-11](https://user-images.githubusercontent.com/7668752/63177092-de894c00-c04f-11e9-9a46-c67d0848a3ed.png)

4. click the `label` item
**See** A message from argument's field is shown.

The argument object contains a reference to itself: https://github.com/vinokurig/Test/blob/cdd7548fd1d1d3f22ba263017a80ef8a6192ac52/src/nodeDependencies.ts#L18-L20
so the command was safely converted and passed over JSON-RPC without an error.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

