### PR TITLE
fix 5956: normalize path only for URI with file scheme in Navigatable…

### DIFF
--- a/packages/core/src/browser/navigatable.ts
+++ b/packages/core/src/browser/navigatable.ts
@@ -87,7 +87,11 @@ export abstract class NavigatableWidgetOpenHandler<W extends NavigatableWidget> 
     }
 
     protected serializeUri(uri: URI): string {
-        return uri.withoutFragment().normalizePath().toString();
+        if (uri.scheme === 'file') {
+            return uri.withoutFragment().normalizePath().toString();
+        } else {
+            return uri.withoutFragment().toString();
+        }
     }
 
 }

--- a/packages/core/src/common/path.ts
+++ b/packages/core/src/common/path.ts
@@ -178,6 +178,9 @@ export class Path {
         return -1;
     }
 
+    /*
+     * return a normalized Path, resolving '..' and '.' segments
+     */
     normalize(): Path {
         const trailingSlash = this.raw.endsWith('/');
         const pathArray = this.toString().split('/');

--- a/packages/core/src/common/uri.ts
+++ b/packages/core/src/common/uri.ts
@@ -165,7 +165,7 @@ export default class URI {
     }
 
     /**
-     * return a new URI replacing the current with its normalized path
+     * return a new URI replacing the current with its normalized path, resolving '..' and '.' segments
      */
     normalizePath(): URI {
         return this.withPath(this.path.normalize());


### PR DESCRIPTION
…Widget

Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixed #5956.

#### How to test
As stated in #5956 
1. open git history
2. open commit
3. open diff editor
4. check whether the title of the diff widget is correct

Or test it by
1. select two files
2. right click and choose `Compare with Each Other`
3. check whether the title of the diff widget is correct

Also, follow **How to Test** in https://github.com/theia-ide/theia/pull/5918 and see if it still works.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
