### PR TITLE
migrate layout from version 2 to 3

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -46,7 +46,7 @@ import {
     ApplicationShell, ApplicationShellOptions, DockPanelRenderer, TabBarRenderer,
     TabBarRendererFactory, ShellLayoutRestorer,
     SidePanelHandler, SidePanelHandlerFactory,
-    SplitPositionHandler, DockPanelRendererFactory
+    SplitPositionHandler, DockPanelRendererFactory, ApplicationShellLayoutMigration, ApplicationShellLayoutMigrationError
 } from './shell';
 import { StatusBar, StatusBarImpl } from './status-bar/status-bar';
 import { LabelParser } from './label-parser';
@@ -127,6 +127,16 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(OpenerService).toService(DefaultOpenerService);
     bind(HttpOpenHandler).toSelf().inSingletonScope();
     bind(OpenHandler).toService(HttpOpenHandler);
+
+    bindContributionProvider(bind, ApplicationShellLayoutMigration);
+    bind<ApplicationShellLayoutMigration>(ApplicationShellLayoutMigration).toConstantValue({
+        layoutVersion: 2.0,
+        onWillInflateLayout({ layoutVersion }): void {
+            throw ApplicationShellLayoutMigrationError.create(
+                `It is not possible to migrate layout of version ${layoutVersion} to version ${this.layoutVersion}.`
+            );
+        }
+    });
 
     bindContributionProvider(bind, WidgetFactory);
     bind(WidgetManager).toSelf().inSingletonScope();

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -20,7 +20,7 @@ import { MaybePromise } from '../common/types';
 import { KeybindingRegistry } from './keybinding';
 import { Widget } from './widgets';
 import { ApplicationShell } from './shell/application-shell';
-import { ShellLayoutRestorer } from './shell/shell-layout-restorer';
+import { ShellLayoutRestorer, ApplicationShellLayoutMigrationError } from './shell/shell-layout-restorer';
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { preventNavigation, parseCssTime } from './browser';
 import { CorePreferences } from './core-preferences';
@@ -229,7 +229,12 @@ export class FrontendApplication {
         try {
             return await this.layoutRestorer.restoreLayout(this);
         } catch (error) {
-            this.logger.error('Could not restore layout', error);
+            if (ApplicationShellLayoutMigrationError.is(error)) {
+                console.warn(error.message);
+                console.info('Initializing the defaut layout instead...');
+            } else {
+                console.error('Could not restore layout', error);
+            }
             return false;
         }
     }

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -45,7 +45,16 @@ const MAIN_AREA_CLASS = 'theia-app-main';
 /** The class name added to the bottom area panel. */
 const BOTTOM_AREA_CLASS = 'theia-app-bottom';
 
-const LAYOUT_DATA_VERSION = '3.0';
+export type ApplicationShellLayoutVersion =
+    /** layout versioning is introduced, unversiouned layout are not compatible */
+    2.0 |
+    /** view containers are introduced, backward compatible to 2.0 */
+    3.0;
+
+/**
+ * When a version is increased, make sure to introduce a migration (ApplicationShellLayoutMigration) to this version.
+ */
+export const applicationShellLayoutVersion: ApplicationShellLayoutVersion = 3.0;
 
 export const ApplicationShellOptions = Symbol('ApplicationShellOptions');
 export const DockPanelRendererFactory = Symbol('DockPanelRendererFactory');
@@ -516,7 +525,7 @@ export class ApplicationShell extends Widget {
      */
     getLayoutData(): ApplicationShell.LayoutData {
         return {
-            version: LAYOUT_DATA_VERSION,
+            version: applicationShellLayoutVersion,
             mainPanel: this.mainPanel.saveLayout(),
             bottomPanel: {
                 config: this.bottomPanel.saveLayout(),
@@ -561,7 +570,7 @@ export class ApplicationShell extends Widget {
      * Apply a shell layout that has been previously created with `getLayoutData`.
      */
     async setLayoutData(layoutData: ApplicationShell.LayoutData): Promise<void> {
-        const { mainPanel, bottomPanel, leftPanel, rightPanel, activeWidgetId } = this.getValidatedLayoutData(layoutData);
+        const { mainPanel, bottomPanel, leftPanel, rightPanel, activeWidgetId } = layoutData;
         if (leftPanel) {
             this.leftPanelHandler.setLayoutData(leftPanel);
             await this.registerWithFocusTracker(leftPanel);
@@ -596,13 +605,6 @@ export class ApplicationShell extends Widget {
         if (activeWidgetId) {
             this.activateWidget(activeWidgetId);
         }
-    }
-
-    protected getValidatedLayoutData(layoutData: ApplicationShell.LayoutData): ApplicationShell.LayoutData {
-        if (layoutData.version !== LAYOUT_DATA_VERSION) {
-            throw new Error(`Saved workbench layout (version ${layoutData.version || 'unknown'}) is incompatible with the current (${LAYOUT_DATA_VERSION})`);
-        }
-        return layoutData;
     }
 
     /**
@@ -1585,7 +1587,7 @@ export namespace ApplicationShell {
      * Data to save and load the application shell layout.
      */
     export interface LayoutData {
-        version?: string,
+        version?: string | ApplicationShellLayoutVersion,
         mainPanel?: DockPanel.ILayoutConfig;
         bottomPanel?: BottomPanelLayoutData;
         leftPanel?: SidePanel.LayoutData;

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -14,15 +14,17 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { injectable, inject } from 'inversify';
+import { injectable, inject, named } from 'inversify';
 import { Widget } from '@phosphor/widgets';
 import { FrontendApplication } from '../frontend-application';
 import { WidgetManager, WidgetConstructionOptions } from '../widget-manager';
 import { StorageService } from '../storage-service';
 import { ILogger } from '../../common/logger';
 import { CommandContribution, CommandRegistry } from '../../common/command';
-import { ApplicationShell } from './application-shell';
 import { ThemeService } from '../theming';
+import { ContributionProvider } from '../../common/contribution-provider';
+import { MaybePromise } from '../../common/types';
+import { ApplicationShell, applicationShellLayoutVersion, ApplicationShellLayoutVersion } from './application-shell';
 
 /**
  * A contract for widgets that want to store and restore their inner state, between sessions.
@@ -47,15 +49,79 @@ export namespace StatefulWidget {
     }
 }
 
-interface WidgetDescription {
+export interface WidgetDescription {
     constructionOptions: WidgetConstructionOptions,
     innerWidgetState?: string | object
 }
+
+export interface ApplicationShellLayoutMigrationContext {
+    /**
+     * A resolved version of a current layout.
+     */
+    layoutVersion: number
+    /**
+     * A layout to be inflated.
+     */
+    layout: ApplicationShell.LayoutData
+    /**
+     * A parent widget is to be inflated. `undefined` if the application shell
+     */
+    parent?: Widget
+}
+
+export interface ApplicationShellLayoutMigrationError extends Error {
+    code: 'ApplicationShellLayoutMigrationError'
+}
+export namespace ApplicationShellLayoutMigrationError {
+    const code: ApplicationShellLayoutMigrationError['code'] = 'ApplicationShellLayoutMigrationError';
+    export function create(message?: string): ApplicationShellLayoutMigrationError {
+        return Object.assign(new Error(
+            `Could not migrate layout to version ${applicationShellLayoutVersion}.` + (message ? '\n' + message : '')
+        ), { code });
+    }
+    export function is(error: Error | undefined): error is ApplicationShellLayoutMigrationError {
+        return !!error && 'code' in error && error['code'] === code;
+    }
+}
+
+export const ApplicationShellLayoutMigration = Symbol('ApplicationShellLayoutMigration');
+export interface ApplicationShellLayoutMigration {
+    /**
+     * A target migration version.
+     */
+    readonly layoutVersion: ApplicationShellLayoutVersion;
+
+    /**
+     * A migration can transform layout before it will be inflated.
+     *
+     * @throws `ApplicationShellLayoutMigrationError` if a layout cannot be migrated,
+     * in this case the default layout will be initialized.
+     */
+    onWillInflateLayout?(context: ApplicationShellLayoutMigrationContext): MaybePromise<void>;
+
+    /**
+     * A migration can transform the given description before it will be inflated.
+     *
+     * @returns a migrated widget description, or `undefined`
+     * @throws `ApplicationShellLayoutMigrationError` if a widget description cannot be migrated,
+     * in this case the default layout will be initialized.
+     */
+    onWillInflateWidget?(desc: WidgetDescription, context: ApplicationShellLayoutMigrationContext): MaybePromise<WidgetDescription | undefined>;
+}
+
+const resetLayoutCommand = {
+    id: 'reset.layout',
+    category: 'View',
+    label: 'Reset Workbench Layout'
+};
 
 @injectable()
 export class ShellLayoutRestorer implements CommandContribution {
     private storageKey = 'layout';
     private shouldStoreLayout: boolean = true;
+
+    @inject(ContributionProvider) @named(ApplicationShellLayoutMigration)
+    protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -63,18 +129,14 @@ export class ShellLayoutRestorer implements CommandContribution {
         @inject(StorageService) protected storageService: StorageService) { }
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({
-            id: 'reset.layout',
-            category: 'View',
-            label: 'Reset Workbench Layout'
-        }, {
-                execute: async () => {
-                    this.shouldStoreLayout = false;
-                    this.storageService.setData(this.storageKey, undefined);
-                    ThemeService.get().reset(); // Theme service cannot use DI, so the current theme ID is stored elsewhere. Hence the explicit reset.
-                    window.location.reload(true);
-                }
-            });
+        commands.registerCommand(resetLayoutCommand, {
+            execute: async () => {
+                this.shouldStoreLayout = false;
+                this.storageService.setData(this.storageKey, undefined);
+                ThemeService.get().reset(); // Theme service cannot use DI, so the current theme ID is stored elsewhere. Hence the explicit reset.
+                window.location.reload(true);
+            }
+        });
     }
 
     storeLayout(app: FrontendApplication): void {
@@ -147,18 +209,58 @@ export class ShellLayoutRestorer implements CommandContribution {
     /**
      * Creates the layout data from its string representation.
      */
-    protected inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
-        const pending: Promise<Widget | undefined>[] = [];
-        const result = JSON.parse(layoutData, (property: string, value) => {
+    protected async inflate(layoutData: string): Promise<ApplicationShell.LayoutData> {
+        const parseContext = new ShellLayoutRestorer.ParseContext();
+        const layout = this.parse<ApplicationShell.LayoutData>(layoutData, parseContext);
+
+        // tslint:disable-next-line:no-any
+        let layoutVersion: number | any;
+        try {
+            layoutVersion = 'version' in layout && Number(layout.version);
+        } catch { /* no-op */ }
+        if (typeof layoutVersion !== 'number' || Number.isNaN(layoutVersion)) {
+            throw new Error('could not resolve a layout version');
+        }
+        if (layoutVersion !== applicationShellLayoutVersion) {
+            if (layoutVersion < applicationShellLayoutVersion) {
+                console.warn(`Layout version ${layoutVersion} is behind current layout version ${applicationShellLayoutVersion}, trying to migrate...`);
+            } else {
+                console.warn(`Layout version ${layoutVersion} is ahead current layout version ${applicationShellLayoutVersion}, trying to load anyway...`);
+            }
+            console.info(`Please use '${resetLayoutCommand.label}' command if the layout looks bogus.`);
+        }
+
+        const migrations = this.migrations.getContributions()
+            .filter(m => m.layoutVersion > layoutVersion && m.layoutVersion <= applicationShellLayoutVersion)
+            .sort((m, m2) => m.layoutVersion - m2.layoutVersion);
+        if (migrations.length) {
+            console.info(`Found ${migrations.length} migrations from layout version ${layoutVersion} to version ${applicationShellLayoutVersion}, migrating...`);
+        }
+
+        const context = { layout, layoutVersion, migrations };
+        await this.fireWillInflateLayout(context);
+        await parseContext.inflate(context);
+        return layout;
+    }
+
+    protected async fireWillInflateLayout(context: ShellLayoutRestorer.InflateContext): Promise<void> {
+        for (const migration of context.migrations) {
+            if (migration.onWillInflateLayout) {
+                // don't catch exceptions, if one migrarion fails all should fail.
+                await migration.onWillInflateLayout(context);
+            }
+        }
+    }
+
+    protected parse<T>(layoutData: string, parseContext: ShellLayoutRestorer.ParseContext): T {
+        return JSON.parse(layoutData, (property: string, value) => {
             if (this.isWidgetsProperty(property)) {
                 const widgets: (Widget | undefined)[] = [];
                 const descs = (value as WidgetDescription[]);
                 for (let i = 0; i < descs.length; i++) {
-                    const promise = this.convertToWidget(descs[i]);
-                    pending.push(promise.then(widget => {
-                        widgets[i] = widget;
-                        return widget;
-                    }));
+                    parseContext.push(async context => {
+                        widgets[i] = await this.convertToWidget(descs[i], context);
+                    });
                 }
                 return widgets;
             } else if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -166,11 +268,9 @@ export class ShellLayoutRestorer implements CommandContribution {
                 const copy: any = {};
                 for (const p in value) {
                     if (this.isWidgetProperty(p)) {
-                        const promise = this.convertToWidget(value[p]);
-                        pending.push(promise.then(widget => {
-                            copy[p] = widget;
-                            return widget;
-                        }));
+                        parseContext.push(async context => {
+                            copy[p] = await this.convertToWidget(value[p], context);
+                        });
                     } else {
                         copy[p] = value[p];
                     }
@@ -179,29 +279,79 @@ export class ShellLayoutRestorer implements CommandContribution {
             }
             return value;
         });
-        return Promise.all(pending).then(() => result);
     }
 
-    private convertToWidget(desc: WidgetDescription): Promise<Widget | undefined> {
-        if (desc.constructionOptions) {
-            return this.widgetManager.getOrCreateWidget(desc.constructionOptions.factoryId, desc.constructionOptions.options)
-                .then(async widget => {
-                    if (StatefulWidget.is(widget) && desc.innerWidgetState !== undefined) {
-                        try {
-                            const oldState = typeof desc.innerWidgetState === 'string' ? await this.inflate(desc.innerWidgetState) : desc.innerWidgetState;
-                            widget.restoreState(oldState);
-                        } catch (err) {
-                            this.logger.warn(`Couldn't restore widget state for ${widget.id}. Error: ${err} `);
-                        }
+    protected async fireWillInflateWidget(desc: WidgetDescription, context: ShellLayoutRestorer.InflateContext): Promise<WidgetDescription> {
+        for (const migration of context.migrations) {
+            if (migration.onWillInflateWidget) {
+                // don't catch exceptions, if one migrarion fails all should fail.
+                const migrated = await migration.onWillInflateWidget(desc, context);
+                if (migrated) {
+                    if (migrated.innerWidgetState && typeof migrated.innerWidgetState !== 'string') {
+                        // in order to inflate nested widgets
+                        migrated.innerWidgetState = JSON.stringify(migrated.innerWidgetState);
                     }
-                    return widget;
-                }, err => {
-                    this.logger.warn(`Couldn't restore widget for ${desc.constructionOptions.factoryId}. Error: ${err} `);
-                    return undefined;
-                });
-        } else {
-            return Promise.resolve(undefined);
+                    desc = migrated;
+                }
+            }
+        }
+        return desc;
+    }
+
+    protected async convertToWidget(desc: WidgetDescription, context: ShellLayoutRestorer.InflateContext): Promise<Widget | undefined> {
+        if (!desc.constructionOptions) {
+            return undefined;
+        }
+        try {
+            desc = await this.fireWillInflateWidget(desc, context);
+            const widget = await this.widgetManager.getOrCreateWidget(desc.constructionOptions.factoryId, desc.constructionOptions.options);
+            if (StatefulWidget.is(widget) && desc.innerWidgetState !== undefined) {
+                try {
+                    let oldState;
+                    if (typeof desc.innerWidgetState === 'string') {
+                        const parseContext = new ShellLayoutRestorer.ParseContext();
+                        oldState = this.parse(desc.innerWidgetState, parseContext);
+                        await parseContext.inflate({ ...context, parent: widget });
+                    } else {
+                        oldState = desc.innerWidgetState;
+                    }
+                    widget.restoreState(oldState);
+                } catch (e) {
+                    if (ApplicationShellLayoutMigrationError.is(e)) {
+                        throw e;
+                    }
+                    this.logger.warn(`Couldn't restore widget state for ${widget.id}. Error: ${e} `);
+                }
+            }
+            return widget;
+        } catch (e) {
+            if (ApplicationShellLayoutMigrationError.is(e)) {
+                throw e;
+            }
+            this.logger.warn(`Couldn't restore widget for ${desc.constructionOptions.factoryId}. Error: ${e} `);
+            return undefined;
         }
     }
 
+}
+export namespace ShellLayoutRestorer {
+    export class ParseContext {
+        protected readonly toInflate: Inflate[] = [];
+
+        push(toInflate: Inflate): void {
+            this.toInflate.push(toInflate);
+        }
+
+        async inflate(context: InflateContext): Promise<void> {
+            const pending: Promise<void>[] = [];
+            while (this.toInflate.length) {
+                pending.push(this.toInflate.pop()!(context));
+            }
+            await Promise.all(pending);
+        }
+    }
+    export type Inflate = (context: InflateContext) => Promise<void>;
+    export interface InflateContext extends ApplicationShellLayoutMigrationContext {
+        readonly migrations: ApplicationShellLayoutMigration[];
+    }
 }

--- a/packages/markers/src/browser/problem/problem-frontend-module.ts
+++ b/packages/markers/src/browser/problem/problem-frontend-module.ts
@@ -14,18 +14,19 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import '../../../src/browser/style/index.css';
+
 import { ContainerModule } from 'inversify';
 import { ProblemWidget, PROBLEMS_WIDGET_ID } from './problem-widget';
 import { ProblemContribution } from './problem-contribution';
 import { createProblemWidget } from './problem-container';
-import { FrontendApplicationContribution, bindViewContribution } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, bindViewContribution, ApplicationShellLayoutMigration } from '@theia/core/lib/browser';
 import { ProblemManager } from './problem-manager';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { NavigatorTreeDecorator } from '@theia/navigator/lib/browser/navigator-decorator-service';
 import { ProblemDecorator } from './problem-decorator';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-
-import '../../../src/browser/style/index.css';
+import { ProblemLayoutVersion3Migration } from './problem-layout-migrations';
 
 export default new ContainerModule(bind => {
     bind(ProblemManager).toSelf().inSingletonScope();
@@ -37,6 +38,7 @@ export default new ContainerModule(bind => {
         id: PROBLEMS_WIDGET_ID,
         createWidget: () => context.container.get<ProblemWidget>(ProblemWidget)
     }));
+    bind(ApplicationShellLayoutMigration).to(ProblemLayoutVersion3Migration).inSingletonScope();
 
     bindViewContribution(bind, ProblemContribution);
     bind(FrontendApplicationContribution).toService(ProblemContribution);

--- a/packages/markers/src/browser/problem/problem-layout-migrations.ts
+++ b/packages/markers/src/browser/problem/problem-layout-migrations.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { ApplicationShellLayoutMigration, WidgetDescription } from '@theia/core/lib/browser/shell/shell-layout-restorer';
+import { PROBLEM_KIND } from '../../common/problem-marker';
+import { PROBLEMS_WIDGET_ID } from './problem-widget';
+
+@injectable()
+export class ProblemLayoutVersion3Migration implements ApplicationShellLayoutMigration {
+    readonly layoutVersion = 3.0;
+    onWillInflateWidget(desc: WidgetDescription): WidgetDescription | undefined {
+        if (desc.constructionOptions.factoryId === PROBLEM_KIND) {
+            desc.constructionOptions.factoryId = PROBLEMS_WIDGET_ID;
+            return desc;
+        }
+        return undefined;
+    }
+}

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -17,8 +17,12 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from 'inversify';
-import { KeybindingContext, bindViewContribution, FrontendApplicationContribution, ViewContainer } from '@theia/core/lib/browser';
-import { FileNavigatorWidget, FILE_NAVIGATOR_ID, EXPLORER_VIEW_CONTAINER_ID } from './navigator-widget';
+import {
+    KeybindingContext, bindViewContribution,
+    FrontendApplicationContribution, ViewContainer,
+    ApplicationShellLayoutMigration
+} from '@theia/core/lib/browser';
+import { FileNavigatorWidget, FILE_NAVIGATOR_ID, EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget';
 import { NavigatorActiveContext } from './navigator-keybinding-context';
 import { FileNavigatorContribution } from './navigator-contribution';
 import { createFileNavigatorWidget } from './navigator-container';
@@ -28,6 +32,7 @@ import { FileNavigatorFilter } from './navigator-filter';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { NavigatorDiff } from './navigator-diff';
+import { NavigatorLayoutVersion3Migration } from './navigator-layout-migrations';
 
 export default new ContainerModule(bind => {
     bindFileNavigatorPreferences(bind);
@@ -52,11 +57,7 @@ export default new ContainerModule(bind => {
         id: EXPLORER_VIEW_CONTAINER_ID,
         createWidget: async () => {
             const viewContainer = container.get<ViewContainer.Factory>(ViewContainer.Factory)({ id: EXPLORER_VIEW_CONTAINER_ID });
-            viewContainer.setTitleOptions({
-                label: 'Explorer',
-                iconClass: 'navigator-tab-icon',
-                closeable: true
-            });
+            viewContainer.setTitleOptions(EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS);
             const widget = await container.get(WidgetManager).getOrCreateWidget(FILE_NAVIGATOR_ID);
             viewContainer.addWidget(widget, {
                 canHide: false,
@@ -65,6 +66,7 @@ export default new ContainerModule(bind => {
             return viewContainer;
         }
     }));
+    bind(ApplicationShellLayoutMigration).to(NavigatorLayoutVersion3Migration).inSingletonScope();
 
     bind(NavigatorDiff).toSelf().inSingletonScope();
 });

--- a/packages/navigator/src/browser/navigator-layout-migrations.ts
+++ b/packages/navigator/src/browser/navigator-layout-migrations.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { ApplicationShellLayoutMigration, WidgetDescription, ApplicationShellLayoutMigrationContext } from '@theia/core/lib/browser/shell/shell-layout-restorer';
+import { FILE_NAVIGATOR_ID, EXPLORER_VIEW_CONTAINER_ID, EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS } from './navigator-widget';
+
+@injectable()
+export class NavigatorLayoutVersion3Migration implements ApplicationShellLayoutMigration {
+    readonly layoutVersion = 3.0;
+    onWillInflateWidget(desc: WidgetDescription, { parent }: ApplicationShellLayoutMigrationContext): WidgetDescription | undefined {
+        if (desc.constructionOptions.factoryId === FILE_NAVIGATOR_ID && !parent) {
+            return {
+                constructionOptions: {
+                    factoryId: EXPLORER_VIEW_CONTAINER_ID
+                },
+                innerWidgetState: {
+                    parts: [
+                        {
+                            widget: {
+                                constructionOptions: {
+                                    factoryId: FILE_NAVIGATOR_ID
+                                },
+                                innerWidgetState: desc.innerWidgetState
+                            },
+                            partId: {
+                                factoryId: FILE_NAVIGATOR_ID
+                            },
+                            collapsed: false,
+                            hidden: false
+                        }
+                    ],
+                    title: EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS
+                }
+            };
+        }
+        return undefined;
+    }
+}

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CommonCommands, CorePreferences, LabelProvider } from '@theia/core/lib/browser';
+import { CommonCommands, CorePreferences, LabelProvider, ViewContainerTitleOptions } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeModel, TreeNode,
@@ -36,6 +36,12 @@ import { NavigatorContextKeyService } from './navigator-context-key-service';
 
 export const FILE_NAVIGATOR_ID = 'files';
 export const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
+export const EXPLORER_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
+    label: 'Explorer',
+    iconClass: 'navigator-tab-icon',
+    closeable: true
+};
+
 export const LABEL = 'No folder opened';
 export const CLASS = 'theia-Files';
 

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -21,7 +21,8 @@ import {
     StatusBar,
     StatusBarAlignment,
     StatusBarEntry,
-    KeybindingRegistry
+    KeybindingRegistry,
+    ViewContainerTitleOptions
 } from '@theia/core/lib/browser';
 import { CommandRegistry, Disposable, DisposableCollection, CommandService } from '@theia/core/lib/common';
 import { ContextKeyService, ContextKey } from '@theia/core/lib/browser/context-key-service';
@@ -33,6 +34,11 @@ import { ScmRepository } from './scm-repository';
 
 export const SCM_WIDGET_FACTORY_ID = ScmWidget.ID;
 export const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
+export const SCM_VIEW_CONTAINER_TITLE_OPTIONS: ViewContainerTitleOptions = {
+    label: 'Source Control',
+    iconClass: 'scm-tab-icon',
+    closeable: true
+};
 
 export namespace SCM_COMMANDS {
     export const CHANGE_REPOSITORY = {

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -15,9 +15,13 @@
  ********************************************************************************/
 
 import { ContainerModule } from 'inversify';
-import { bindViewContribution, FrontendApplicationContribution, WidgetFactory, ViewContainer, WidgetManager } from '@theia/core/lib/browser';
+import {
+    bindViewContribution, FrontendApplicationContribution,
+    WidgetFactory, ViewContainer,
+    WidgetManager, ApplicationShellLayoutMigration
+} from '@theia/core/lib/browser';
 import { ScmService } from './scm-service';
-import { SCM_WIDGET_FACTORY_ID, ScmContribution, SCM_VIEW_CONTAINER_ID } from './scm-contribution';
+import { SCM_WIDGET_FACTORY_ID, ScmContribution, SCM_VIEW_CONTAINER_ID, SCM_VIEW_CONTAINER_TITLE_OPTIONS } from './scm-contribution';
 
 import { ScmWidget } from './scm-widget';
 import '../../src/browser/style/index.css';
@@ -28,6 +32,7 @@ import { ScmNavigatorDecorator } from './decorations/scm-navigator-decorator';
 import { ScmDecorationsService } from './decorations/scm-decorations-service';
 import { ScmAvatarService } from './scm-avatar-service';
 import { ScmContextKeyService } from './scm-context-key-service';
+import { ScmLayoutVersion3Migration } from './scm-layout-migrations';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -45,11 +50,7 @@ export default new ContainerModule(bind => {
                 id: SCM_VIEW_CONTAINER_ID,
                 progressLocationId: 'scm'
             });
-            viewContainer.setTitleOptions({
-                label: 'Source Control',
-                iconClass: 'scm-tab-icon',
-                closeable: true
-            });
+            viewContainer.setTitleOptions(SCM_VIEW_CONTAINER_TITLE_OPTIONS);
             const widget = await container.get(WidgetManager).getOrCreateWidget(SCM_WIDGET_FACTORY_ID);
             viewContainer.addWidget(widget, {
                 canHide: false,
@@ -58,6 +59,7 @@ export default new ContainerModule(bind => {
             return viewContainer;
         }
     })).inSingletonScope();
+    bind(ApplicationShellLayoutMigration).to(ScmLayoutVersion3Migration).inSingletonScope();
 
     bind(ScmQuickOpenService).toSelf().inSingletonScope();
     bindViewContribution(bind, ScmContribution);

--- a/packages/scm/src/browser/scm-layout-migrations.ts
+++ b/packages/scm/src/browser/scm-layout-migrations.ts
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { ApplicationShellLayoutMigration, WidgetDescription, ApplicationShellLayoutMigrationContext } from '@theia/core/lib/browser/shell/shell-layout-restorer';
+import { SCM_VIEW_CONTAINER_TITLE_OPTIONS, SCM_VIEW_CONTAINER_ID, SCM_WIDGET_FACTORY_ID } from './scm-contribution';
+
+@injectable()
+export class ScmLayoutVersion3Migration implements ApplicationShellLayoutMigration {
+    readonly layoutVersion = 3.0;
+    onWillInflateWidget(desc: WidgetDescription, { parent }: ApplicationShellLayoutMigrationContext): WidgetDescription | undefined {
+        if (desc.constructionOptions.factoryId === 'scm' && !parent) {
+            return {
+                constructionOptions: {
+                    factoryId: SCM_VIEW_CONTAINER_ID
+                },
+                innerWidgetState: {
+                    parts: [
+                        {
+                            widget: {
+                                constructionOptions: {
+                                    factoryId: SCM_WIDGET_FACTORY_ID
+                                },
+                                innerWidgetState: desc.innerWidgetState
+                            },
+                            partId: {
+                                factoryId: SCM_WIDGET_FACTORY_ID
+                            },
+                            collapsed: false,
+                            hidden: false
+                        }
+                    ],
+                    title: SCM_VIEW_CONTAINER_TITLE_OPTIONS
+                }
+            };
+        }
+        return undefined;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #5950:
- introduced layout migration points
- implemented migration point for version 2 to discard all unversioned layouts (for backward compatibility)
- implemented scm migration point for version 3 to wrap scm widget into view container
- implemented explorer migration point for version 3 to wrap explorer widget into view container

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- get Theia before view containers from fe938acc3aec8fc563bda46bf9c129d9d90c2c32 commit
- open some workspace with it and customize the layout, especially explorer and scm views
- open the same workspace with Theia from this PR, the layout should be restored properly and you should see that some migrations were found in the dev console
- after that reload Theia again to check that Theia from this PR does not apply any migrations to already migrated (latest) layout

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

