### PR TITLE
[navigator] Added toolbar to disable auto sync

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar.tsx
@@ -124,7 +124,7 @@ export class TabBarToolbar extends ReactWidget {
             }
         }
         const command = this.commands.getCommand(item.command);
-        const iconClass = item.icon || (command && command.iconClass);
+        const iconClass = (typeof item.icon === 'function' && item.icon()) || item.icon || (command && command.iconClass);
         if (iconClass) {
             classNames.push(iconClass);
         }
@@ -266,7 +266,7 @@ export interface TabBarToolbarItem {
     /**
      * Optional icon for the item.
      */
-    readonly icon?: string;
+    readonly icon?: string | (() => string);
 
     /**
      * https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts

--- a/packages/navigator/src/browser/navigator-preferences.ts
+++ b/packages/navigator/src/browser/navigator-preferences.ts
@@ -22,16 +22,16 @@ import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceCo
 export const FileNavigatorConfigSchema: PreferenceSchema = {
     'type': 'object',
     properties: {
-        'navigator.autoReveal': {
+        'explorer.autoReveal': {
             type: 'boolean',
-            description: 'Selects file under editing in the navigator.',
+            description: 'Selects file under editing in the explorer.',
             default: true
         }
     }
 };
 
 export interface FileNavigatorConfiguration {
-    'navigator.autoReveal': boolean;
+    'explorer.autoReveal': boolean;
 }
 
 export const FileNavigatorPreferences = Symbol('NavigatorPreferences');


### PR DESCRIPTION
#### What it does
This adds a toolbar command to the navigator, that allows to easily disable the auto-sync between editor and navigator.

#### How to test
Open some editors and switch between them. 
See how the navigator reveals the corresponding items all the time.
Disable the new toolbar item in the navigator to disable the sync.
Switch between editors and see how the navigator stays as is.
Enable the new toolbar item and see how the navigator syncs again with the current editor.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)