### PR TITLE
Display leading and trailing whitespaces in search-in-workspace results

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-result-tree-widget.tsx
@@ -649,7 +649,7 @@ export class SearchInWorkspaceResultTreeWidget extends TreeWidget {
         const replaceTerm = this._replaceTerm !== '' && this._showReplaceButtons ? <span className='replace-term'>{this._replaceTerm}</span> : '';
         const className = `match${this._showReplaceButtons ? ' strike-through' : ''}`;
         return <React.Fragment>
-            <span className={className}> {node.lineText.substr(node.character - 1, node.length)}</span>
+            <span className={className}>{node.lineText.substr(node.character - 1, node.length)}</span>
             {replaceTerm}
         </React.Fragment>;
     }

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -255,6 +255,7 @@
     background: var(--theia-word-highlight-match-color1);
     display: inline-block;
     line-height: normal;
+    white-space: pre;
 }
 
 .t-siw-search-container .resultLine .match.strike-through {

--- a/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
+++ b/packages/search-in-workspace/src/node/ripgrep-search-in-workspace-server.slow-spec.ts
@@ -77,6 +77,7 @@ const getRootPathFromName = (name: string) => {
     const names: { [file: string]: string } = {
         carrots: rootDirA,
         potatoes: rootDirA,
+        pastas: rootDirA,
         regexes: rootDirA,
         small: `${rootDirA}/small`,
         'file:with:some:colons': rootDirA,
@@ -110,6 +111,8 @@ Carrot is a funny word.
 Potatoes, unlike carrots, are generally not orange.  But sweet potatoes are,
 it's very confusing.
 `);
+
+    createTestFile('pastas', 'pasta pasta');
 
     createTestFile('regexes', `\
 aaa hello. x h3lo y hell0h3lllo
@@ -230,6 +233,34 @@ function compareSearchResults(expected: SearchInWorkspaceResult[], actual: Searc
 
 describe('ripgrep-search-in-workspace-server', function (): void {
     this.timeout(10000);
+
+    it('should return 1 result when searching for " pasta", respecting the leading whitespace', done => {
+        const pattern = ' pasta';
+
+        const client = new ResultAccumulator(() => {
+            const expected: SearchInWorkspaceResult[] = [
+                { root: rootDirAUri, fileUri: 'pastas', line: 1, character: 6, length: pattern.length, lineText: '' },
+            ];
+            compareSearchResults(expected, client.results);
+            done();
+        });
+        ripgrepServer.setClient(client);
+        ripgrepServer.search(pattern, [rootDirAUri]);
+    });
+
+    it('should return 1 result when searching for "pasta", respecting the trailing whitespace', done => {
+        const pattern = 'pasta ';
+
+        const client = new ResultAccumulator(() => {
+            const expected: SearchInWorkspaceResult[] = [
+                { root: rootDirAUri, fileUri: 'pastas', line: 1, character: 1, length: pattern.length, lineText: '' },
+            ];
+            compareSearchResults(expected, client.results);
+            done();
+        });
+        ripgrepServer.setClient(client);
+        ripgrepServer.search(pattern, [rootDirAUri]);
+    });
 
     // Try some simple patterns with different case.
     it('should return 7 results when searching for "carrot"', done => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5987

- fixed an issue where leading and trailing whitespaces were not being displayed
from the `search-in-workspace` result tree leading to confusion and overall an
annoying behavior.
- added an additional test to `ripgrep-search-in-workspace-server.slow-spec.ts` which
tests the result of a search including a trailing whitespace.
- added an additional test to `ripgrep-search-in-workspace-server.slow-spec.ts` which
tests the result of a search including a leading whitespace.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- open an example workspace (ex: `theia/packages/bunyan`)
- open the search-in-workspace widget (_view_ menu + _search_ menu item)
- perform a search with a leading whitespace (the search results should display the leading whitespace as well)
- perform a search with a trailing whitespace (the search results should display the trailing whitespace as well)
- perform the leading and trailing whitespace searches again with the `replace` functionality enabled (click the toggle replace icon (small triangle) and enter a replace term) - the leading and trailing whitespaces should also be displayed with the strikethrough)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
