### PR TITLE
Fix clumsy suggest dropdown from form inputs

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -291,9 +291,14 @@ export class KeybindingWidget extends ReactWidget {
     protected renderSearch(): React.ReactNode {
         return <div>
             <div className='search-kb-container'>
-                <input id='search-kb'
+                <input
+                    id='search-kb'
                     className={(this.items.length > 0) ? '' : 'no-kb'}
-                    type='text' placeholder='Search keybindings' onKeyUp={this.searchKeybindings}></input >
+                    type='text'
+                    placeholder='Search keybindings'
+                    autoComplete='off'
+                    onKeyUp={this.searchKeybindings}
+                />
             </div>
         </div>;
     }

--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -367,6 +367,7 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
             size={1}
             placeholder='Search'
             defaultValue={this.searchTerm}
+            autoComplete='off'
             onKeyUp={this.search}
             onFocus={this.handleFocusSearchInputBox}
             onBlur={this.handleBlurSearchInputBox}


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #4074

- fixes annoying issue with the search input present in the
`search-in-workspace` widget which displays a browser specific
auto-suggestion based on previous form history. The suggestion
is now disabled using the `autoComplete: 'off' prop.
- fixes a similar issue with the `keyboard shortcuts` widget as well.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- currently (master) when double clicking an input that previously had input, an auto-suggestion dropdown was displayed.
- with this PR, the autoComplete is turned off resulting in no more clumsy input
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
