### PR TITLE
Disable format-on-save in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,6 @@
 // - Mac: $HOME/Library/Application Support/Code/User/settings.json
 {
     "tslint.enable": true,
-    "editor.formatOnSave": true,
     "search.exclude": {
         "**/node_modules": true,
         "**/lib": true,


### PR DESCRIPTION
As discussed on Spectrum:

https://spectrum.chat/theia/dev/formatter-workflow~a168b15c-5258-416f-944b-53504d740ec6?m=MTU2NTkzNjczMTE3OQ==

Signed-off-by: Nathan Ridge <zeratul976@hotmail.com>
