### PR TITLE
[git diff] fix the git-diff widget header details alignment

### DIFF
--- a/packages/git/src/browser/diff/git-diff-widget.tsx
+++ b/packages/git/src/browser/diff/git-diff-widget.tsx
@@ -153,6 +153,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
 
     protected renderPathHeader(): React.ReactNode {
         return this.renderHeaderRow({
+            classNames: ['diff-header'],
             name: 'path',
             value: this.renderPath()
         });
@@ -171,6 +172,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
 
     protected renderRevisionHeader(): React.ReactNode {
         return this.renderHeaderRow({
+            classNames: ['diff-header'],
             name: 'revision: ',
             value: this.renderRevision()
         });
@@ -193,7 +195,7 @@ export class GitDiffWidget extends GitNavigableListWidget<GitFileChangeNode> imp
     }
     protected doRenderToolbar(...children: React.ReactNode[]): React.ReactNode {
         return this.renderHeaderRow({
-            classNames: ['space-between'],
+            classNames: ['diff-nav', 'space-between'],
             name: 'Files changed',
             value: <div className='lrBtns'>{...children}</div>
         });

--- a/packages/git/src/browser/style/diff.css
+++ b/packages/git/src/browser/style/diff.css
@@ -44,11 +44,26 @@
     flex-direction: row;
 }
 
+.theia-git .header-row.diff-header,
+.theia-git .header-row.diff-nav {
+    margin-bottom: 10px;
+}
+
 .theia-git .header-value {
     margin: 9px 0px 5px 5px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.theia-git .diff-header .header-value {
+    align-self: center;
+    margin: 0px;
+}
+
+.theia-git .diff-header .theia-header {
+    align-self: center;
+    padding-right: 5px;
 }
 
 .theia-git .gitItem.diff-file {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #5996

- fixes the `git-diff` widget header details but updating the css
specifically for the `git-diff` widget header. Originally the `path` and
`revision` details were not aligned properly and it has been resolved
so that they are displayed inline with their values.

| Before | After |
|:---:|:---:|
|<img width="489" alt="Screen Shot 2019-08-20 at 7 49 38 PM" src="https://user-images.githubusercontent.com/40359487/63392209-b406fe00-c383-11e9-8aa5-8c1d73974d2a.png">|<img width="490" alt="Screen Shot 2019-08-20 at 7 46 28 PM" src="https://user-images.githubusercontent.com/40359487/63392219-bbc6a280-c383-11e9-8dd3-e5825fa07424.png">|

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open the application with a given workspace (example: `theia`)
2. right-click on the `packages/` folder in the explorer and select `Compare With...`
3. when prompted, select a branch
4. verify that the alignment for `path`, `revision` and for `files changed` is correct in the `git-diff` header

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
