### PR TITLE
fix bug: CompletionResultDto does not have a property named _id

### DIFF
--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -113,7 +113,7 @@ export class LanguagesMainImpl implements LanguagesMain {
                         suggestions: result.completions,
                         incomplete: result.incomplete,
                         // tslint:disable-next-line:no-any
-                        dispose: () => this.proxy.$releaseCompletionItems(handle, (<any>result)._id)
+                        dispose: () => this.proxy.$releaseCompletionItems(handle, result.id!)
                     };
                 }),
             resolveCompletionItem: supportsResolveDetails


### PR DESCRIPTION
Signed-off-by: xieyuanhu <xieyuanhuata@163.com>

#### What it does
fix #6012 

#### How to test
show log into debug console
##before:
![release_id](https://user-images.githubusercontent.com/50982164/63484349-d4dd6980-c4d1-11e9-8c89-e7a88f125c61.PNG)
##after
![update1](https://user-images.githubusercontent.com/50982164/63484277-a1024400-c4d1-11e9-8a2b-6817a9cf6cf0.PNG)
![update2](https://user-images.githubusercontent.com/50982164/63484286-a3fd3480-c4d1-11e9-9a32-0f240181fb22.PNG)


#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

