### PR TITLE
Fix menu bar color.

### DIFF
--- a/packages/core/src/browser/style/menus.css
+++ b/packages/core/src/browser/style/menus.css
@@ -30,7 +30,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-MenuBar {
+.p-Widget.p-MenuBar {
   padding-left: 5px;
   background: var(--theia-menu-color0);
   color: var(--theia-ui-bar-font-color1);


### PR DESCRIPTION
#### What it does
Since the font color is now set generally for widgets the menu bar did not get its individual color anymore.
The css rule got refined to be not overwritten by the p-widget rule.

#### How to test
Use a different font color for the menu. For that in theme variable css which you are currently using (e.g. `variables-dark.useable.css`) change the variable `--theia-ui-bar-font-color1` (used by the menu bar). Before that change it had no effect. 
After the change the menu bar has an individual font color again.  

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

