### PR TITLE
[task] update 'run selected text' isVisible and isEnabled handling

### DIFF
--- a/packages/task/src/browser/task-frontend-contribution.ts
+++ b/packages/task/src/browser/task-frontend-contribution.ts
@@ -28,6 +28,7 @@ import { TaskService } from './task-service';
 import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { TaskSchemaUpdater } from './task-schema-updater';
 import { TaskConfiguration, TaskWatcher } from '../common';
+import { EditorManager } from '@theia/editor/lib/browser';
 
 export namespace TaskCommands {
     const TASK_CATEGORY = 'Task';
@@ -91,6 +92,9 @@ const TASKS_STORAGE_KEY = 'tasks';
 export class TaskFrontendContribution implements CommandContribution, MenuContribution, KeybindingContribution, FrontendApplicationContribution, QuickOpenContribution {
     @inject(QuickOpenTask)
     protected readonly quickOpenTask: QuickOpenTask;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
 
     @inject(FrontendApplication)
     protected readonly app: FrontendApplication;
@@ -222,7 +226,8 @@ export class TaskFrontendContribution implements CommandContribution, MenuContri
         registry.registerCommand(
             TaskCommands.TASK_RUN_TEXT,
             {
-                isEnabled: () => true,
+                isVisible: () => !!this.editorManager.currentEditor,
+                isEnabled: () => !!this.editorManager.currentEditor,
                 execute: () => this.taskService.runSelectedText()
             }
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6017

- previously the command `Task: Run Selected Text` was always
enabled and visible which lead to a poor user experience when
no editor was currently opened. The handling for `isVisible` and
`isEnabled` was updated to determine if an editor is currently opened
using the `EditorManager`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- open a workspace
- with no file opened, click the `Task` menu and verify if the menu item `Run Selected Text` is disabled
- open an editor
- click the `Task` menu and verify that the menu item `Run Selected Text` is enabled
- execute the command successfully

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

