### PR TITLE
[problems] add a preference to control tree problem decorators

### DIFF
--- a/packages/markers/src/browser/problem/problem-preferences.ts
+++ b/packages/markers/src/browser/problem/problem-preferences.ts
@@ -20,7 +20,12 @@ import { createPreferenceProxy, PreferenceProxy, PreferenceService, PreferenceCo
 export const ProblemConfigSchema: PreferenceSchema = {
     'type': 'object',
     'properties': {
-        'problem.decorations.tabbar.enabled': {
+        'problems.decorations.enabled': {
+            'type': 'boolean',
+            'description': 'Show problem decorators (diagnostic markers) in tree widgets.',
+            'default': true,
+        },
+        'problems.decorations.tabbar.enabled': {
             'type': 'boolean',
             'description': 'Show problem decorators (diagnostic markers) in the tab bars.',
             'default': true
@@ -29,7 +34,8 @@ export const ProblemConfigSchema: PreferenceSchema = {
 };
 
 export interface ProblemConfiguration {
-    'problem.decorations.tabbar.enabled': boolean
+    'problems.decorations.enabled': boolean,
+    'problems.decorations.tabbar.enabled': boolean
 }
 
 export const ProblemPreferences = Symbol('ProblemPreferences');

--- a/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
+++ b/packages/markers/src/browser/problem/problem-tabbar-decorator.ts
@@ -68,7 +68,7 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
      */
     protected async handlePreferenceChange(event: PreferenceChangeEvent<ProblemConfiguration>): Promise<void> {
         const { preferenceName } = event;
-        if (preferenceName === 'problem.decorations.tabbar.enabled') {
+        if (preferenceName === 'problems.decorations.tabbar.enabled') {
             this.fireDidChangeDecorations();
         }
     }
@@ -79,7 +79,7 @@ export class ProblemTabBarDecorator implements TabBarDecorator {
      */
     protected collectDecorators(titles: Title<Widget>[]): Map<string, WidgetDecoration.Data> {
         const result: Map<string, Marker<Diagnostic>> = new Map();
-        if (this.preferences['problem.decorations.tabbar.enabled']) {
+        if (this.preferences['problems.decorations.tabbar.enabled']) {
             const markers = this.groupMarkersByURI(this.collectMarkers());
             for (const title of titles) {
                 // Ensure `title.caption` does not contain illegal characters for URI.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6019

- added a new preference to control whether to enable/disable
problem decorators (diagnostic markers) in tree widgets.
- updated the `problems.decorations.tabbar.enabled` preference name.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- open a workspace
- open a file and create an error
- the explorer tree decoration should be enabled for the file
- open the preferences widget, and disable the preference `problems.decorations.enabled`
- the explorer decorations should be turned off
- re-enable the preference `problems.decorations.enabled`
- the explorer decorations should be turned on 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
