### PR TITLE
[file-search] Fixed Windows file search inconsistencies

### DIFF
--- a/packages/file-search/src/browser/quick-file-open.ts
+++ b/packages/file-search/src/browser/quick-file-open.ts
@@ -329,7 +329,7 @@ export class QuickFileOpenService implements QuickOpenModel, QuickOpenHandler {
             label: this.labelProvider.getName(uri),
             iconClass: await this.labelProvider.getIcon(uri) + ' file-icon',
             description,
-            tooltip: uri.path.toString(),
+            tooltip: this.labelProvider.getLongName(uri),
             uri: uri,
             hidden: false,
             run: this.getRunFunction(uri)

--- a/packages/file-search/src/common/file-search-service.ts
+++ b/packages/file-search/src/common/file-search-service.ts
@@ -25,7 +25,7 @@ export interface FileSearchService {
 
     /**
      * finds files by a given search pattern.
-     * @return the matching paths, relative to the given `options.rootUri`.
+     * @return the matching file uris
      */
     find(searchPattern: string, options: FileSearchService.Options, cancellationToken?: CancellationToken): Promise<string[]>;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Before:
![windows-before](https://user-images.githubusercontent.com/12599255/63597076-89e85280-c5b4-11e9-8250-a22bb86b791a.png)
Note:
- Labels for found files were relative paths from the workspace root containing backslashes.
- Descriptions were the decoded path part of the workspace root URI.

After:
![windows-after](https://user-images.githubusercontent.com/12599255/63597102-98cf0500-c5b4-11e9-9d2e-d5bf5e321bd1.png)

Linux (for comparison):
![linux-after](https://user-images.githubusercontent.com/12599255/63597338-227ed280-c5b5-11e9-949b-a6788e4990c8.png)

Also, allow Windows users to use both forwards or back slashes as path separators (same behaviour as VS code).

Fixes #1591

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- Use CTRLCMD+P file quick-open on Windows and compare with Linux / Mac.
- Test on Windows using both forwards and back slash as path separator.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

