### PR TITLE
support removing all data from tasks.json

### DIFF
--- a/packages/task/src/browser/task-configurations.ts
+++ b/packages/task/src/browser/task-configurations.ts
@@ -329,11 +329,15 @@ export class TaskConfigurations implements Disposable {
                     if (this.rawTaskConfigurations.has(rootFolderUri)) {
                         this.rawTaskConfigurations.delete(rootFolderUri);
                     }
-                    const tasks = rawTasks['tasks'].map((t: TaskCustomization | TaskConfiguration) =>
-                        Object.assign(t, { _source: t.source || this.getSourceFolderFromConfigUri(uri) })
-                    );
-                    this.rawTaskConfigurations.set(rootFolderUri, tasks);
-                    return tasks;
+                    if (rawTasks && rawTasks['tasks']) {
+                        const tasks = rawTasks['tasks'].map((t: TaskCustomization | TaskConfiguration) =>
+                            Object.assign(t, { _source: t.source || this.getSourceFolderFromConfigUri(uri) })
+                        );
+                        this.rawTaskConfigurations.set(rootFolderUri, tasks);
+                        return tasks;
+                    } else {
+                        return [];
+                    }
                 }
             } catch (err) {
                 console.error(`Error(s) reading config file: ${uri}`);


### PR DESCRIPTION
- When all data are removed from tasks.json, or data in tasks.json is
corrupted, Theia fails to update tasks that have been loaded into the
memory. This pull request fixes this bug.
- fixes #6032

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test

- Open a workspace that has: at least one detected task, and a tasks.json where at least one detected task is customized
- Open the "Run task"
  - Expected: The customized detected tasks should be displayed as "Configured tasks".
- Remove all data from tasks.json. Save changes.
- Open the "Run task" again
  - Expected: all detected tasks should be displayed as "detected tasks", as the customizations have been removed from tasks.json

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
