### PR TITLE
fire JSON schema changed event if an underlying in-memory resource is changed

### DIFF
--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -167,10 +167,11 @@ export class InMemoryResources implements ResourceResolver {
         return resource;
     }
 
-    resolve(uri: URI): MaybePromise<Resource> {
-        if (!this.resources.has(uri.toString())) {
-            throw new Error('Resource does not exist.');
+    resolve(uri: URI): Resource {
+        const uriString = uri.toString();
+        if (!this.resources.has(uriString)) {
+            throw new Error(`In memory '${uriString}' resource does not exist.`);
         }
-        return this.resources.get(uri.toString())!;
+        return this.resources.get(uriString)!;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6034: fire JSON schema changed event if an underlying in-memory resource is changed.

Otherwise JSON language server does not pick up content changes.

A bit off-topic:
I wonder why the host process has to be launched to recognize registered debuggers via metadata. Metadata from package.json should be recognized as soon as any VS Code extension is deployed. It could be that an extension code is not activated, but an extension still should contribute debug types and snippets for launch.json @tolusha Is it a bug?

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install [node](https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug) and [node2](https://marketplace.visualstudio.com/items?itemName=ms-vscode.node-debug2) vscode extensions instead of native node debug extension
- open launch.json file
- make sure that it has node launch configuration and it is recognized
- refresh the page several times with opened launch.json file
- each time check that node launch configuration is eventually (as soon as VS Code extensions are loaded) recognized properly

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

