### PR TITLE
wip: [task] fix 'run selected text' not spawning terminals when one is closed

### DIFF
--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -438,16 +438,17 @@ export class TaskService implements TaskConfigurationClient {
         const endLine = this.editorManager.currentEditor.editor.selection.end.line;
         const endCharacter = this.editorManager.currentEditor.editor.selection.end.character;
         let selectedRange: Range = Range.create(startLine, startCharacter, endLine, endCharacter);
-        // if no text is selected, default to selecting entire line
+        // If no text is currently selected, default to selecting the entire line.
         if (startLine === endLine && startCharacter === endCharacter) {
             selectedRange = Range.create(startLine, 0, endLine + 1, 0);
         }
         const selectedText: string = this.editorManager.currentEditor.editor.document.getText(selectedRange).trimRight() + '\n';
+        // Get the current terminal if it exists, else create a new one.
         let terminal = this.terminalService.currentTerminal;
         if (!terminal) {
             terminal = <TerminalWidget>await this.terminalService.newTerminal(<TerminalWidgetFactoryOptions>{ created: new Date().toString() });
             await terminal.start();
-            this.terminalService.activateTerminal(terminal);
+            this.terminalService.open(terminal);
         }
         terminal.sendText(selectedText);
     }

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -120,6 +120,7 @@ export class TerminalFrontendContribution implements TerminalService, CommandCon
     @postConstruct()
     protected init(): void {
         this.shell.currentChanged.connect(() => this.updateCurrentTerminal());
+        this.shell.currentChanged.disconnect(() => this.updateCurrentTerminal());
         this.widgetManager.onDidCreateWidget(({ widget }) => {
             if (widget instanceof TerminalWidget) {
                 this.updateCurrentTerminal();

--- a/packages/terminal/src/node/terminal-server.spec.ts
+++ b/packages/terminal/src/node/terminal-server.spec.ts
@@ -24,7 +24,7 @@ import { ITerminalServer } from '../common/terminal-protocol';
 
 const expect = chai.expect;
 
-describe('TermninalServer', function (): void {
+describe('TerminalServer', function (): void {
 
     this.timeout(5000);
     let terminalServer: ITerminalServer;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6027

- fixes an issue when attempting to run the command `Run Selected Text` when
a previously opened terminal is closed. Before the change, the terminal was never created
again which is a bug. With the change, a listener is added to the `TerminalFrontendContribution` to listen to disconnections of terminals to the shell and update the current terminal
when appropriate.
- fix a minor typo in the `terminal-server-spec`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open a workspace
2. open a file which contains a command that will generate output when executed by the command `Run Selected Text` (ex: `ls`)
3. the command should spawn a terminal with the output
4. close the terminal
5. re-run step 2, a new terminal should be spawned (previously nothing was created)
6. close the terminal
7. open a terminal manually (ex: <kbd>ctrl</kbd>+<kbd>`</kbd> on Linux)
8. re-run step 2, the newly manually created terminal should be used for the output

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>