### PR TITLE
Seperated the font color of the output view in themes.

### DIFF
--- a/packages/core/src/browser/style/variables-bright.useable.css
+++ b/packages/core/src/browser/style/variables-bright.useable.css
@@ -260,4 +260,7 @@ is not optimized for dense, information rich UIs.
   --theia-ansi-cyan-background-color: darkcyan;
   --theia-ansi-white-background-color: #BDBDBD;
 
+  /* Output */
+  --theia-output-font-color: var(--theia-ui-font-color1);
+  
 }

--- a/packages/core/src/browser/style/variables-dark.useable.css
+++ b/packages/core/src/browser/style/variables-dark.useable.css
@@ -260,4 +260,7 @@ is not optimized for dense, information rich UIs.
   --theia-ansi-cyan-background-color: #218D8D;
   --theia-ansi-white-background-color: #707070;
 
+  /* Output */
+  --theia-output-font-color: var(--theia-ui-font-color1);
+
 }

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -16,7 +16,7 @@
 
  #outputView {
 	font-size: var(--theia-ui-font-size1);
-    color: var(--theia-ui-font-color1);
+    color: var(--theia-output-font-color);
 }
 
 #outputView #outputContents {


### PR DESCRIPTION
#### What it does
It uses a different font color variable for font color in output view. 
Currently the css variable `--theia-ui-font-color1` is used in output view as well as in other widgets. So there is no chance for individual coloring. Which would be useful in case when using different backgrounds.

#### How to test
Change value for the new variable `--theia-output-font-color`. There should be a different font color in the output view compared to other widgets.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

