### PR TITLE
fix plugins are not loaded when staring theia without internet access

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -31,6 +31,7 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
         const result: PluginModel = {
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
+            uniqueId: `${this.VSCODE_PREFIX}${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,
             publisher: plugin.publisher,
             version: plugin.version,
@@ -63,6 +64,6 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
      * to an array of deployable extension dependencies
      */
     private getDeployableDependencies(dependencies: string[]): string[] {
-        return dependencies.map(dep => this.VSCODE_PREFIX + dep);
+        return dependencies.map(dep => this.VSCODE_PREFIX + dep.toLowerCase());
     }
 }

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -132,6 +132,7 @@ export const emptyPlugin: Plugin = {
     },
     model: {
         id: 'emptyPlugin',
+        uniqueId: 'emptyPlugin',
         name: 'emptyPlugin',
         publisher: 'Theia',
         version: 'empty',

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -363,6 +363,7 @@ export interface PluginDeployerDirectoryHandlerContext {
  */
 export interface PluginModel {
     id: string;
+    uniqueId: string;
     name: string;
     publisher: string;
     version: string;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -86,6 +86,7 @@ export class TheiaPluginScanner implements PluginScanner {
         const result: PluginModel = {
             // see id definition: https://github.com/microsoft/vscode/blob/15916055fe0cb9411a5f36119b3b012458fe0a1d/src/vs/platform/extensions/common/extensions.ts#L167-L169
             id: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
+            uniqueId: `${plugin.publisher.toLowerCase()}.${plugin.name.toLowerCase()}`,
             name: plugin.name,
             publisher: plugin.publisher,
             version: plugin.version,

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -115,7 +115,7 @@ export class PluginDeployerImpl implements PluginDeployer {
         const queue = [...pluginEntries];
         while (queue.length) {
             const current = queue.shift()!;
-            if (visited.has(current)) {
+            if (visited.has(current) || pluginsToDeploy.has(current)) {
                 continue;
             }
             visited.add(current);
@@ -131,8 +131,8 @@ export class PluginDeployerImpl implements PluginDeployer {
 
             for (const deployerEntry of pluginDeployerEntries) {
                 const metadata = await this.pluginDeployerHandler.getPluginMetadata(deployerEntry);
-                if (metadata && !pluginsToDeploy.has(metadata.model.id)) {
-                    pluginsToDeploy.set(metadata.model.id, deployerEntry);
+                if (metadata && !pluginsToDeploy.has(metadata.model.uniqueId)) {
+                    pluginsToDeploy.set(metadata.model.uniqueId, deployerEntry);
                     if (metadata.model.extensionDependencies) {
                         queue.push(...metadata.model.extensionDependencies);
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
fix https://github.com/theia-ide/theia/issues/6055
If all the vscode entensions dependencies(listed in the extensionDependencies field of vscode extension)
are already downloaded to local directory before staring theia, then there is no need to download them
from the remote(vscode marketplace) during the theia starting process.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1 download two vscode plugins from vscode marketplac

-  [vscjava.vscode-java-dependency](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency)
- [redhat.java](https://marketplace.visualstudio.com/items?itemName=redhat.java)

2 copy these two plugins to `plugins` directory
3 then start theia(`cd examples/browser; yarn start`), and check if all of the vscode extensins can be loaded successfully

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

