### PR TITLE
tolerate missing internet access while deploying plugins

### DIFF
--- a/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
+++ b/packages/plugin-ext-vscode/src/node/scanner-vscode.ts
@@ -63,6 +63,6 @@ export class VsCodePluginScanner extends TheiaPluginScanner implements PluginSca
      * to an array of deployable extension dependencies
      */
     private getDeployableDependencies(dependencies: string[]): string[] {
-        return dependencies.map(dep => this.VSCODE_PREFIX + dep);
+        return dependencies.map(dep => this.VSCODE_PREFIX + dep.toLowerCase());
     }
 }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -377,6 +377,10 @@ export interface PluginModel {
         backend?: string;
     };
     contributes?: PluginContribution;
+    /**
+     * The deployable form of extensionDependencies from package.json,
+     * i.e. not `publisher.name`, but `vscode:extension/publisher.name`.
+     */
     extensionDependencies?: string[];
 }
 

--- a/packages/plugin-ext/src/plugin/plugin-manager.ts
+++ b/packages/plugin-ext/src/plugin/plugin-manager.ts
@@ -192,7 +192,7 @@ export class PluginManagerExtImpl implements PluginManagerExt, PluginManager {
             loading = (async () => {
                 if (plugin.rawModel.extensionDependencies) {
                     for (const dependencyId of plugin.rawModel.extensionDependencies) {
-                        const dependency = this.registry.get(dependencyId);
+                        const dependency = this.registry.get(dependencyId.toLowerCase());
                         if (dependency) {
                             await this.loadPlugin(dependency, configStorage, visited);
                         } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #6055: 
  - check whether a plugin is already to be deployed by an id
  - fix to use canonical plugin ids to resolve and activate plugins
  - make sure that dependencies only resolved after listed plugin entries
  - don't fail the entire deployment if a resolution of a single plugin entry failed
- closes https://github.com/theia-ide/theia/pull/6056 (superseded)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1 download two vscode plugins from vscode marketplac

-  [vscjava.vscode-java-dependency](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-dependency)
- [redhat.java](https://marketplace.visualstudio.com/items?itemName=redhat.java)

2 copy these two plugins to `plugins` directory
3 then start theia(`cd examples/browser; yarn start`), and check if all of the vscode extensins can be loaded successfully


#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

