### PR TITLE
add fetchTasks() and executeTask() to tasks API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.11.0
 
+- [task] added `tasks.fetchTasks()` and `tasks.executeTask()` to plugins API [#6058](https://github.com/theia-ide/theia/pull/6058)
+
 Breaking changes:
 
 - [core][plugin] support alternative commands in context menus [6069](https://github.com/theia-ide/theia/pull/6069)
@@ -72,8 +74,8 @@ Breaking changes:
 - [task] fixed the problem where a detected task can be customized more than once [#5777](https://github.com/theia-ide/theia/pull/5777)
 - [task] notified clients of TaskDefinitionRegistry on change [#5915](https://github.com/theia-ide/theia/pull/5915)
 - [task] updated `isVisible` and `isEnabled` handling for `Run Selected Text` [#6018](https://github.com/theia-ide/theia/pull/6018)
-- [tasks] added support for removing all data from tasks.json [#6033](https://github.com/theia-ide/theia/pull/6033)
-- [tasks] updated compare task to use task definitions [#5975](https://github.com/theia-ide/theia/pull/5975)
+- [task] added support for removing all data from tasks.json [#6033](https://github.com/theia-ide/theia/pull/6033)
+- [task] updated compare task to use task definitions [#5975](https://github.com/theia-ide/theia/pull/5975)
 - [terminal] added a preference `terminal.integrated.scrollback` to control the terminal scrollback [#5783](https://github.com/theia-ide/theia/pull/5783)
 - [vscode] added support for `command` variable substitution [#5835](https://github.com/theia-ide/theia/pull/5835)
 - [vscode] added support for `config` variable substitution [#5835](https://github.com/theia-ide/theia/pull/5835)

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1313,6 +1313,8 @@ export interface TasksExt {
 
 export interface TasksMain {
     $registerTaskProvider(handle: number, type: string): void;
+    $fetchTasks(taskVersion: string | undefined, taskType: string | undefined): Promise<TaskDto[]>;
+    $executeTask(taskDto: TaskDto): Promise<TaskExecutionDto | undefined>;
     $taskExecutions(): Promise<TaskExecutionDto[]>;
     $unregister(handle: number): void;
     $terminateTask(id: number): void;

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -676,6 +676,14 @@ export function createAPIFactory(
                 return tasksExt.registerTaskProvider(type, provider);
             },
 
+            fetchTasks(filter?: theia.TaskFilter): Thenable<theia.Task[]> {
+                return tasksExt.fetchTasks(filter);
+            },
+
+            executeTask(task: theia.Task): Thenable<theia.TaskExecution> {
+                return tasksExt.executeTask(task);
+            },
+
             get taskExecutions(): ReadonlyArray<theia.TaskExecution> {
                 return tasksExt.taskExecutions;
             },

--- a/packages/plugin-ext/src/plugin/tasks/tasks.ts
+++ b/packages/plugin-ext/src/plugin/tasks/tasks.ts
@@ -109,6 +109,26 @@ export class TasksExtImpl implements TasksExt {
         return this.createDisposable(callId);
     }
 
+    async fetchTasks(filter?: theia.TaskFilter): Promise<theia.Task[]> {
+        const taskVersion = filter ? filter.version : undefined;
+        const taskType = filter ? filter.type : undefined;
+        const taskDtos = await this.proxy.$fetchTasks(taskVersion, taskType);
+        return taskDtos.map(dto => converter.toTask(dto));
+    }
+
+    async executeTask(task: theia.Task): Promise<theia.TaskExecution> {
+        const taskDto = converter.fromTask(task);
+        if (taskDto) {
+            const executionDto = await this.proxy.$executeTask(taskDto);
+            if (executionDto) {
+                const taskExecution = this.getTaskExecution(executionDto);
+                return taskExecution;
+            }
+            throw new Error('Run task config does not return after being started');
+        }
+        throw new Error('Task was not successfully transformed into a task config');
+    }
+
     $provideTasks(handle: number, token?: theia.CancellationToken): Promise<TaskDto[] | undefined> {
         const adapter = this.adaptersMap.get(handle);
         if (adapter) {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -8253,6 +8253,19 @@ declare module '@theia/plugin' {
         exitCode: number;
     }
 
+    export interface TaskFilter {
+		/**
+		 * The task version as used in the tasks.json file.
+		 * The string support the package.json semver notation.
+		 */
+        version?: string;
+
+        /**
+         * The type of tasks to return.
+         */
+        type?: string;
+    }
+
     export namespace tasks {
 
         /**
@@ -8263,6 +8276,23 @@ declare module '@theia/plugin' {
          * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
          */
         export function registerTaskProvider(type: string, provider: TaskProvider): Disposable;
+
+        /**
+         * Fetches all tasks available in the systems. This includes tasks
+         * from `tasks.json` files as well as tasks from task providers
+         * contributed through extensions and plugins.
+         *
+         * @param filter a filter to filter the return tasks.
+         */
+        export function fetchTasks(filter?: TaskFilter): PromiseLike<Task[]>;
+
+        /**
+		 * Executes a task that is managed by VS Code. The returned
+		 * task execution can be used to terminate the task.
+		 *
+		 * @param task the task to execute
+		 */
+        export function executeTask(task: Task): PromiseLike<TaskExecution>;
 
         /**
          * The currently active task executions or an empty array.

--- a/packages/task/src/browser/task-service.ts
+++ b/packages/task/src/browser/task-service.ts
@@ -291,7 +291,7 @@ export class TaskService implements TaskConfigurationClient {
     /**
      * Run the last executed task.
      */
-    async runLastTask(): Promise<void> {
+    async runLastTask(): Promise<TaskInfo | undefined> {
         if (!this.lastTask) {
             return;
         }
@@ -303,7 +303,7 @@ export class TaskService implements TaskConfigurationClient {
      * Runs a task, by the source and label of the task configuration.
      * It looks for configured and detected tasks.
      */
-    async run(source: string, taskLabel: string): Promise<void> {
+    async run(source: string, taskLabel: string): Promise<TaskInfo | undefined> {
         let task = await this.getProvidedTask(source, taskLabel);
         const customizationObject: TaskCustomization = { type: '' };
         if (!task) { // if a detected task cannot be found, search from tasks.json
@@ -345,12 +345,12 @@ export class TaskService implements TaskConfigurationClient {
                 resolvedMatchers.push(resolvedMatcher);
             }
         }
-        this.runTask(task, {
+        return this.runTask(task, {
             customization: { ...customizationObject, ...{ problemMatcher: resolvedMatchers } }
         });
     }
 
-    async runTask(task: TaskConfiguration, option?: RunTaskOption): Promise<void> {
+    async runTask(task: TaskConfiguration, option?: RunTaskOption): Promise<TaskInfo | undefined> {
         const source = task._source;
         const taskLabel = task.label;
         if (option && option.customization) {
@@ -400,6 +400,8 @@ export class TaskService implements TaskConfigurationClient {
         if (typeof taskInfo.terminalId === 'number') {
             this.attach(taskInfo.terminalId, taskInfo.taskId);
         }
+
+        return taskInfo;
     }
 
     async runTaskByLabel(taskLabel: string): Promise<boolean> {


### PR DESCRIPTION
- This pull request adds the support of executing a vscode.Task, and fetching tasks by type and schema version to the plugins API.
- resolved #5342

Signed-off-by: Liang Huang <liang.huang@ericsson.com>

#### How to test

This pull request can be tested with adding a vscode extension to Theia:

```ts
import * as vscode from 'vscode';

export function activate(context: vscode.ExtensionContext) {

	console.log('Congratulations, your extension "fetchtest" is now active!');

	let disposable = vscode.commands.registerCommand('extension.helloWorld', () => {
		// The code you place here will be executed every time your command is executed

		// Display a message box to the user
		vscode.window.showInformationMessage('Test Fetch Task and Execute Task!');

		// vscode.tasks.fetchTasks({ type: 'shell' }).then((value) => {
		// 	console.log('shell fulfilled', value);
		// }, (reason) => {
		// 	console.log('rejected', reason);
		// });

		vscode.tasks.fetchTasks({ type: 'npm' }).then((fetchedTasks) => {
			console.log('npm tasks found: ', fetchedTasks.length);
			for (const task of fetchedTasks) {
				console.log('\n\nlooking at ', task.name, '\n\n');
				vscode.tasks.executeTask(task);
			}
		}, (reason) => {
			console.log('fetch task was rejected', reason);
		});

		// const myTask = new vscode.Task(
		// 	{ type: 'shell' }, // task definition
		// 	vscode.TaskScope.Workspace,
		// 	'test',
		// 	'testExtension',
		// 	new vscode.ShellExecution('ls -alR', { cwd: '/home/elaihau/dev' })
		// );
		// vscode.tasks.executeTask(myTask);
	});

	context.subscriptions.push(disposable);
}

export function deactivate() { }
```

- the extension can be locally packaged by `vsce` https://code.visualstudio.com/api/working-with-extensions/publishing-extension
- the extension, when added as a plugin, should add a command `Test Fetch Task and Execute Task` to Theia
- by running the command contributed by the extension, we are able to test if the tasks can be fetched by the new API, also, if the fetched tasks can be run.

**For reviewer's convenience I uploaded the source code** of my extension to https://github.com/elaihau/fetchtest

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)


