### PR TITLE
Fix quick-pick initiated by the plugins not displaying with 1 item

### DIFF
--- a/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
+++ b/packages/core/src/browser/quick-open/quick-pick-service-impl.ts
@@ -38,7 +38,9 @@ export class QuickPickServiceImpl implements QuickPickService {
     async show(elements: (string | QuickPickItem<Object>)[], options?: QuickPickOptions): Promise<Object | undefined> {
         return new Promise<Object | undefined>(resolve => {
             this.items = this.toItems(elements, resolve);
-            if (this.items.length === 1) {
+            // Set `runIfSingle` to the value passed through options, else defaults to true.
+            const runIfSingle: boolean = (options && options.runIfSingle !== undefined) ? options.runIfSingle : true;
+            if (runIfSingle && this.items.length === 1) {
                 this.items[0].run(QuickOpenMode.OPEN);
                 return;
             }

--- a/packages/core/src/common/quick-pick-service.ts
+++ b/packages/core/src/common/quick-pick-service.ts
@@ -77,6 +77,12 @@ export interface QuickPickOptions {
      * The prefill value.
      */
     value?: string;
+
+    /**
+     * Determines if the quick pick with a single item should
+     * execute the item instead of displaying. The default is `true`.
+     */
+    runIfSingle?: boolean;
 }
 
 export const quickPickServicePath = '/services/quickPick';

--- a/packages/plugin-ext/src/main/browser/quick-open-main.ts
+++ b/packages/plugin-ext/src/main/browser/quick-open-main.ts
@@ -292,7 +292,8 @@ export class QuickOpenMainImpl implements QuickOpenMain, QuickOpenModel {
             title: options.title,
             totalSteps: options.totalSteps,
             ignoreFocusOut: options.ignoreFocusOut,
-            value: options.value
+            value: options.value,
+            runIfSingle: false,
         });
 
         const disposableListeners = new DisposableCollection();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6050

- fixes issue where `quick-pick` which were initiated by the plugins was
not displayed when it only contains a single item. The fix is to include
a new flag `runIfSingle` which is used to determine if the quick-pick
should display or execute the item.
- The default value for `runIfSingle` is set to `true`.
- The `plugin-ext` sets the `runIfSingle` to `false` so it always displays
the quick-pick regardless if an single item is present. This behavior is aligned
with previous versions of Theia and VSCode.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. test that quick-pick with 1 items contributed through the plugin system always displays:
1.1. clone the example https://github.com/i053322/quickpickexample
1.2. `cd quickpickexample && npm i && npm run compile`
1.3. copy the `quickpickexample` under the `plugins` folder
1.4. start the application, run the command `Hello World` (quick-pick should display)

2. verify that quick-pick with 1 item work as usual in the app
2.2. start the app (with a single workspace), run the command `New Terminal` (no quick-pick should be displayed)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>

