### PR TITLE
support active/focused view or panel `when` clause context

### DIFF
--- a/packages/core/src/browser/shell/side-panel-handler.ts
+++ b/packages/core/src/browser/shell/side-panel-handler.ts
@@ -71,7 +71,7 @@ export class SidePanelHandler {
      * The widget container is a dock panel in `single-document` mode, which means that the panel
      * cannot be split.
      */
-    dockPanel: DockPanel;
+    dockPanel: TheiaDockPanel;
     /**
      * The panel that contains the tab bar and the dock panel. This one is hidden whenever the dock
      * panel is empty.

--- a/packages/core/src/browser/view-container.ts
+++ b/packages/core/src/browser/view-container.ts
@@ -146,7 +146,7 @@ export class ViewContainer extends BaseWidget implements StatefulWidget, Applica
         ]);
         if (this.options.progressLocationId) {
             const onProgress = this.progressLocationService.onProgress(this.options.progressLocationId);
-            this.toDispose.push(new ProgressBar({ container: this.node, insertMode: 'prepend'}, onProgress));
+            this.toDispose.push(new ProgressBar({ container: this.node, insertMode: 'prepend' }, onProgress));
         }
     }
 
@@ -658,8 +658,10 @@ export class ViewContainerPart extends BaseWidget {
     protected readonly body: HTMLElement;
     protected readonly collapsedEmitter = new Emitter<boolean>();
     protected readonly contextMenuEmitter = new Emitter<MouseEvent>();
-    protected readonly onVisibilityChangedEmitter = new Emitter<boolean>();
-    readonly onVisibilityChanged = this.onVisibilityChangedEmitter.event;
+    /**
+     * @deprecated since 0.11.0, use `onDidChangeVisibility` instead
+     */
+    readonly onVisibilityChanged = this.onDidChangeVisibility;
     protected readonly onTitleChangedEmitter = new Emitter<void>();
     readonly onTitleChanged = this.onTitleChangedEmitter.event;
     protected readonly onDidFocusEmitter = new Emitter<this>();
@@ -699,7 +701,6 @@ export class ViewContainerPart extends BaseWidget {
             disposable,
             this.collapsedEmitter,
             this.contextMenuEmitter,
-            this.onVisibilityChangedEmitter,
             this.onTitleChangedEmitter,
             this.registerContextMenu(),
             this.onDidFocusEmitter,
@@ -979,20 +980,6 @@ export class ViewContainerPart extends BaseWidget {
             this.header.focus();
         } else {
             this.wrapped.activate();
-        }
-    }
-
-    setFlag(flag: Widget.Flag): void {
-        super.setFlag(flag);
-        if (flag === Widget.Flag.IsVisible) {
-            this.onVisibilityChangedEmitter.fire(this.isVisible);
-        }
-    }
-
-    clearFlag(flag: Widget.Flag): void {
-        super.clearFlag(flag);
-        if (flag === Widget.Flag.IsVisible) {
-            this.onVisibilityChangedEmitter.fire(this.isVisible);
         }
     }
 

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -43,10 +43,13 @@ export class BaseWidget extends Widget {
     readonly onScrollYReachEnd: Event<void> = this.onScrollYReachEndEmitter.event;
     protected readonly onScrollUpEmitter = new Emitter<void>();
     readonly onScrollUp: Event<void> = this.onScrollUpEmitter.event;
+    protected readonly onDidChangeVisibilityEmitter = new Emitter<boolean>();
+    readonly onDidChangeVisibility = this.onDidChangeVisibilityEmitter.event;
 
     protected readonly toDispose = new DisposableCollection(
         this.onScrollYReachEndEmitter,
-        this.onScrollUpEmitter
+        this.onScrollUpEmitter,
+        this.onDidChangeVisibilityEmitter
     );
     protected readonly toDisposeOnDetach = new DisposableCollection();
     protected scrollBar?: PerfectScrollbar;
@@ -148,6 +151,20 @@ export class BaseWidget extends Widget {
 
     protected addClipboardListener<K extends 'cut' | 'copy' | 'paste'>(element: HTMLElement, type: K, listener: EventListenerOrEventListenerObject<K>): void {
         this.toDisposeOnDetach.push(addClipboardListener(element, type, listener));
+    }
+
+    setFlag(flag: Widget.Flag): void {
+        super.setFlag(flag);
+        if (flag === Widget.Flag.IsVisible) {
+            this.onDidChangeVisibilityEmitter.fire(this.isVisible);
+        }
+    }
+
+    clearFlag(flag: Widget.Flag): void {
+        super.clearFlag(flag);
+        if (flag === Widget.Flag.IsVisible) {
+            this.onDidChangeVisibilityEmitter.fire(this.isVisible);
+        }
     }
 }
 

--- a/packages/output/src/browser/output-widget.tsx
+++ b/packages/output/src/browser/output-widget.tsx
@@ -38,6 +38,7 @@ export class OutputWidget extends ReactWidget {
         this.title.iconClass = 'fa output-tab-icon';
         this.title.closable = true;
         this.addClass('theia-output');
+        this.node.tabIndex = 0;
     }
 
     @postConstruct()

--- a/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
+++ b/packages/plugin-ext/src/main/browser/view/view-context-key-service.ts
@@ -30,6 +30,35 @@ export class ViewContextKeyService {
         return this._viewItem;
     }
 
+    protected _activeViewlet: ContextKey<string>;
+    /**
+     * Viewlet is a tab in the left area in VS Code. Active means visible in this context.
+     *
+     * In VS Code there can be only one visible viewlet at any time.
+     * It is not true for Theia, since views can be relayouted to different areas.
+     * So only last visible view will be an active viewlet.
+     */
+    get activeViewlet(): ContextKey<string> {
+        return this._activeViewlet;
+    }
+
+    protected _activePanel: ContextKey<string>;
+    /**
+     * Panel is a tab in the bottom area in VS Code. Active means visible in this context.
+     *
+     * In VS Code there can be only one visible panel at any time.
+     * It is not true for Theia, since views can be relayouted to different areas.
+     * So only last visible view will be an active panel.
+     */
+    get activePanel(): ContextKey<string> {
+        return this._activePanel;
+    }
+
+    protected _focusedView: ContextKey<string>;
+    get focusedView(): ContextKey<string> {
+        return this._focusedView;
+    }
+
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
 
@@ -37,6 +66,9 @@ export class ViewContextKeyService {
     protected init(): void {
         this._view = this.contextKeyService.createKey('view', '');
         this._viewItem = this.contextKeyService.createKey('viewItem', '');
+        this._activeViewlet = this.contextKeyService.createKey('activeViewlet', '');
+        this._activePanel = this.contextKeyService.createKey('activePanel', '');
+        this._focusedView = this.contextKeyService.createKey('focusedView', '');
     }
 
     match(expression: string | undefined): boolean {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #4104: support active/focused view or panel `when` clause context

See https://code.visualstudio.com/docs/getstarted/keybindings#_activefocused-view-or-panel-when-clause-context for requirements. **Important**: in this context _active_ means _visible_, not _focused_ as usual. 

In VS Code there are viewlets, panels and views:
  - viewlet is a tab in the left area (explorer, scm, search, debug, etc.)
  - panel is a tab in the bottom area (terminals, markers, output, debug console, etc.)
  - view is a part in the viewlet, e.g. files and outline are views in the explorer viewlet

**Important difference** to Theia that VS Code does not allow to move individual viewlets or panels to other areas. It means that there is always only one visible viewlet or panel in VS Code, but in Theia it can be that several viewlets and panels widgets are visible. **This PR implements the difference by setting context keys to last focused visible viewlet or panel widget.**

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install https://github.com/akosyakov/vscode-view-when-sample/blob/master/vscode-view-when-sample-0.0.1.vsix
- to test `activeViewlet` and `activePanel`: open quick command palette and type `Test` you should see commands visible in the current context https://github.com/akosyakov/vscode-view-when-sample/blob/dd61713e5124d10e744d02d0694f177b3d46af3f/package.json#L69-L109
- to test `focusedView`: focus contributed `nodeDependencies` view in the explorer tab and type `ctrlcmd+f1`, it should trigger a notification bound to this keybinding when this view is focused: https://github.com/akosyakov/vscode-view-when-sample/blob/dd61713e5124d10e744d02d0694f177b3d46af3f/package.json#L112-L118

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

