### PR TITLE
[vscode] parse view contribution "when" clause context

### DIFF
--- a/packages/core/src/browser/context-key-service.ts
+++ b/packages/core/src/browser/context-key-service.ts
@@ -22,6 +22,7 @@ export interface ContextKey<T> {
     reset(): void;
     get(): T | undefined;
 }
+
 export namespace ContextKey {
     // tslint:disable-next-line:no-any
     export const None: ContextKey<any> = Object.freeze({
@@ -52,6 +53,13 @@ export class ContextKeyService {
      */
     match(expression: string, context?: HTMLElement): boolean {
         return true;
+    }
+
+    /**
+     * It should be implemented by an extension, e.g. by the monaco extension.
+     */
+    parseKeys(expression: string): Set<string> {
+        return new Set<string>();
     }
 
 }

--- a/packages/monaco/src/browser/monaco-context-key-service.ts
+++ b/packages/monaco/src/browser/monaco-context-key-service.ts
@@ -58,4 +58,8 @@ export class MonacoContextKeyService extends ContextKeyService {
         return expression;
     }
 
+    parseKeys(expression: string): Set<string> {
+        return new Set<string>(monaco.contextkey.ContextKeyExpr.deserialize(expression).keys());
+    }
+
 }

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1119,6 +1119,7 @@ declare module monaco.contextKeyService {
 
 declare module monaco.contextkey {
     export class ContextKeyExpr {
+        keys(): string[];
         static deserialize(when: string): ContextKeyExpr;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
There is an `affects()` function of the `ContextKeyChangeEvent`: https://github.com/theia-ide/theia/blob/b0d8292226e4ca179ed6cfa8be4e47e354ff9f61/packages/core/src/browser/context-key-service.ts#L34-L36
which evaluates if the given set of context keys has a context key that was changed.
`PluginViewRegistry` listens to this event and passes `when` clause context from the view contribution:
https://github.com/theia-ide/theia/blob/b0d8292226e4ca179ed6cfa8be4e47e354ff9f61/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts#L144
The`when` clause context from the view contribution is a string which may be a composed expression e.g. `"when": "!config.githubPullRequests.showInSCM && config.git.enabled"`: https://github.com/microsoft/vscode-pull-request-github/blob/d91e778705cd5af0785c5a05184ebc550334b409/package.json#L182

A map with parsed `when` clauses was introduced to pass separate context keys to the `affects()` function of the `ContextKeyChangeEvent`.

fixes https://github.com/theia-ide/theia/issues/6015
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Remove `git` from `theia/examples/browser/package.json`.
2. Download [vscode git extension](https://github.com/che-incubator/vscode-git/releases/download/1.30.1/vscode-git-1.3.0.1.vsix).
3. Create `plugins` folder in Theia's root and paste the plugin to it.
4. Clone the [vscode github extension](https://github.com/microsoft/vscode-pull-request-github.git) and compile it.
5. Start the github plugin as a Hosted Plugin.
6. Click the GitHub icon.

Without this fix the GitHub panel is empty,
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

