### PR TITLE
support alternative commands in context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.11.0
+
+Breaking changes:
+
+- [core][plugin] support alternative commands in context menus [6069](https://github.com/theia-ide/theia/pull/6069)
+
 ## v0.10.0
 
 - [vscode] added env variable substitution support [#5811](https://github.com/theia-ide/theia/pull/5811)

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -84,6 +84,7 @@ import { ProgressService } from '../common/progress-service';
 import { DispatchingProgressClient } from './progress-client';
 import { ProgressStatusBarItem } from './progress-status-bar-item';
 import { TabBarDecoratorService, TabBarDecorator } from './shell/tab-bar-decorator';
+import { ContextMenuContext } from './menu/context-menu-context';
 
 export const frontendApplicationModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     const themeService = ThemeService.get();
@@ -283,6 +284,8 @@ export const frontendApplicationModule = new ContainerModule((bind, unbind, isBo
     bind(ProgressStatusBarItem).toSelf().inSingletonScope();
     bind(ProgressClient).toService(DispatchingProgressClient);
     bind(ProgressService).toSelf().inSingletonScope();
+
+    bind(ContextMenuContext).toSelf().inSingletonScope();
 });
 
 export function bindMessageService(bind: interfaces.Bind): interfaces.BindingWhenOnSyntax<MessageService> {

--- a/packages/core/src/browser/menu/context-menu-context.ts
+++ b/packages/core/src/browser/menu/context-menu-context.ts
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (C) 2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { OS } from '../../common/os';
+
+@injectable()
+export class ContextMenuContext {
+
+    protected _altPressed = false;
+    get altPressed(): boolean {
+        return this._altPressed;
+    }
+
+    protected setAltPressed(altPressed: boolean): void {
+        this._altPressed = altPressed;
+    }
+
+    resetAltPressed(): void {
+        this.setAltPressed(false);
+    }
+
+    constructor() {
+        document.addEventListener('keydown', e => this.setAltPressed(e.altKey || (OS.type() !== OS.Type.OSX && e.shiftKey)), true);
+        document.addEventListener('keyup', () => this.resetAltPressed(), true);
+    }
+
+}

--- a/packages/core/src/common/menu.ts
+++ b/packages/core/src/common/menu.ts
@@ -21,6 +21,11 @@ import { ContributionProvider } from './contribution-provider';
 
 export interface MenuAction {
     commandId: string
+    /**
+     * In addition to the mandatory command property, an alternative command can be defined.
+     * It will be shown and invoked when pressing Alt while opening a menu.
+     */
+    alt?: string;
     label?: string
     icon?: string
     order?: string
@@ -228,10 +233,17 @@ export class CompositeMenuNode implements MenuNode {
 }
 
 export class ActionMenuNode implements MenuNode {
+
+    readonly altNode: ActionMenuNode | undefined;
+
     constructor(
         public readonly action: MenuAction,
         protected readonly commands: CommandRegistry
-    ) { }
+    ) {
+        if (action.alt) {
+            this.altNode = new ActionMenuNode({ commandId: action.alt }, commands);
+        }
+    }
 
     get id(): string {
         return this.action.commandId;

--- a/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
+++ b/packages/core/src/electron-browser/menu/electron-context-menu-renderer.ts
@@ -20,9 +20,13 @@ import { inject, injectable } from 'inversify';
 import { MenuPath } from '../../common';
 import { ContextMenuRenderer, Anchor, RenderContextMenuOptions } from '../../browser';
 import { ElectronMainMenuFactory } from './electron-main-menu-factory';
+import { ContextMenuContext } from '../../browser/menu/context-menu-context';
 
 @injectable()
 export class ElectronContextMenuRenderer implements ContextMenuRenderer {
+
+    @inject(ContextMenuContext)
+    protected readonly context: ContextMenuContext;
 
     constructor(@inject(ElectronMainMenuFactory) private menuFactory: ElectronMainMenuFactory) {
     }
@@ -31,6 +35,8 @@ export class ElectronContextMenuRenderer implements ContextMenuRenderer {
         const { menuPath, args, onHide } = RenderContextMenuOptions.resolve(arg, arg2, arg3);
         const menu = this.menuFactory.createContextMenu(menuPath, args);
         menu.popup({});
+        // native context menu stops the event loop, so there is no keyboard events
+        this.context.resetAltPressed();
         if (onHide) {
             onHide();
         }

--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -100,6 +100,7 @@ export interface PluginPackageCommand {
 
 export interface PluginPackageMenu {
     command: string;
+    alt?: string;
     group?: string;
     when?: string;
 }
@@ -518,6 +519,7 @@ export type IconUrl = string | { light: string; dark: string; };
  */
 export interface Menu {
     command: string;
+    alt?: string;
     group?: string;
     when?: string;
 }

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -302,6 +302,7 @@ export class TheiaPluginScanner implements PluginScanner {
     private readMenu(rawMenu: PluginPackageMenu): Menu {
         const result: Menu = {
             command: rawMenu.command,
+            alt: rawMenu.alt,
             group: rawMenu.group,
             when: rawMenu.when
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- fix #4162: If a user presses `alt` (mac) or `shift` (linux + win) while opening the context menu then alternative commands should be displayed.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- install https://github.com/akosyakov/vscode-alt-sample/blob/master/vscode-alt-sample-0.0.1.vsix under plugins folder
- open a context menu with alternative command and without for the navigator, you should see `Hello World (Primary)` or `Hello World (Alt)`: https://github.com/akosyakov/vscode-alt-sample/blob/master/package.json#L20-L38
- try in browser and electron

Notice:
- it's aligned with VS Code, not native behaviour, i.e. switch can happen only while opening, not when context menu is opened. Native behaviour is not possible to implement on Electron, since event loop is stopped while context menu is opened and there are no events.
- it works only for context menus, no for toolbar or main menu! It's aligned with VS Code as well.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

