### PR TITLE
Add plugins resources provider contribution point

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -585,6 +585,25 @@ export interface MetadataProcessor {
     process(pluginMetadata: PluginMetadata): void;
 }
 
+/**
+ * Designed to retreive plugins resources from non default or remote location.
+ */
+export const PluginResourcesProvider = Symbol.for('ResourcesProvider');
+export interface PluginResourcesProvider {
+    /**
+     * Checks if this provider has resources for the given plugin.
+     * @param pluginId id of plugin to check presence of resources for
+     */
+    hasResources(pluginId: string): boolean;
+
+    /**
+     * Returns resource by given path or undefined if no resource exists.
+     * @param pluginId id of plugin that requests resource is for.
+     * @param resourcePath path to requested resource. Might be relative to plugin location
+     */
+    getResource(pluginId: string, resourcePath: string): Promise<Buffer | undefined>;
+}
+
 export function getPluginId(plugin: PluginPackage | PluginModel): string {
     return `${plugin.publisher}_${plugin.name}`.replace(/\W/g, '_');
 }


### PR DESCRIPTION
#### What it does
This PR adds contribution point into plugins resources endpoint. This allows advanced resources handling in case if resources of a plugin are located in another place or should be generated on the go.

#### How to test
Move a plugin resources into another folder and add simple implementation of `PluginResourcesProvider` contribution which just returns the resources.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

