### PR TITLE
[plugin] Add missing return statements

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
@@ -89,10 +89,12 @@ export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
             request(options, (error, response, body) => {
                 if (error) {
                     reject(error);
+                    return;
                 } else if (response.statusCode === 200) {
                     const extension = body.results[0].extensions[0];
                     if (!extension) {
                         reject(new Error('No extension'));
+                        return;
                     }
                     let asset;
                     if (wantedExtensionVersion !== undefined) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add missing return statements to `VsCodePluginDeployerResolver`.
Since https://github.com/theia-ide/theia/commit/2d4c8457c09cc6ca37fc5480d14eb080a74ed85a was merged Plugins install their dependent plugins automatically.
[VsCode Github plugin](https://github.com/microsoft/vscode-pull-request-github)  includes built in vscode git extension in it's dependent extensions which is not present in the vscode marketplace. This causes an error witch is not properly handled. The `return` statement in the catch error section allows to skip the installation of dependent extension in case of failure.    

fixes https://github.com/eclipse/che/issues/14319
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Remove `git` from `theia/examples/browser/package.json`.
2. Download [vscode git extension](https://github.com/che-incubator/vscode-git/releases/download/1.30.1/vscode-git-1.3.0.1.vsix).
3. Download [vscode github-pull-request extension](https://github.com/microsoft/vscode-pull-request-github/releases/download/v0.8.0/vscode-pull-request-github-0.8.0.vsix).
4. Create `plugins` folder in Theia's root and paste the downloaded plugins to it.
5. Start Theia

Without the fix the vscode git and Github plugins fail to start.
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

