### PR TITLE
[vscode] vscode.extension.contributes.configuration can be array

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -63,7 +63,7 @@ export namespace PluginPackage {
  * This interface describes a package.json contribution section object.
  */
 export interface PluginPackageContribution {
-    configuration?: RecursivePartial<PreferenceSchema>;
+    configuration?: RecursivePartial<PreferenceSchema> | RecursivePartial<PreferenceSchema>[];
     configurationDefaults?: RecursivePartial<PreferenceSchemaProperties>;
     languages?: PluginPackageLanguageContribution[];
     grammars?: PluginPackageGrammarsContribution[];
@@ -388,7 +388,7 @@ export interface PluginModel {
  * This interface describes some static plugin contributions.
  */
 export interface PluginContribution {
-    configuration?: PreferenceSchema;
+    configuration?: PreferenceSchema | PreferenceSchema[];
     configurationDefaults?: PreferenceSchemaProperties;
     languages?: LanguageContribution[];
     grammars?: GrammarsContribution[];

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -122,8 +122,18 @@ export class TheiaPluginScanner implements PluginScanner {
 
         const contributions: PluginContribution = {};
         if (rawPlugin.contributes.configuration) {
-            const config = this.readConfiguration(rawPlugin.contributes.configuration, rawPlugin.packagePath);
-            contributions.configuration = config;
+            if (Array.isArray(rawPlugin.contributes.configuration)) {
+                contributions.configuration = [];
+                for (const c of rawPlugin.contributes.configuration) {
+                    const config = this.readConfiguration(c, rawPlugin.packagePath);
+                    if (config) {
+                        contributions.configuration.push(config);
+                    }
+                }
+            } else {
+                const config = this.readConfiguration(rawPlugin.contributes.configuration, rawPlugin.packagePath);
+                contributions.configuration = config;
+            }
         }
         const configurationDefaults = rawPlugin.contributes.configurationDefaults;
         contributions.configurationDefaults = PreferenceSchemaProperties.is(configurationDefaults) ? configurationDefaults : undefined;

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -83,7 +83,13 @@ export class PluginContributionHandler {
 
     handleContributions(contributions: PluginContribution): void {
         if (contributions.configuration) {
-            this.updateConfigurationSchema(contributions.configuration);
+            if (Array.isArray(contributions.configuration)) {
+                for (const config of contributions.configuration) {
+                    this.updateConfigurationSchema(config);
+                }
+            } else {
+                this.updateConfigurationSchema(contributions.configuration);
+            }
         }
         if (contributions.configurationDefaults) {
             this.updateDefaultOverridesSchema(contributions.configurationDefaults);


### PR DESCRIPTION
#### What it does
Many VS Code extensions contribute the configuration object wrapped in an array.
See https://github.com/microsoft/vscode/blob/master/src/vs/workbench/api/common/configurationExtensionPoint.ts#L131-L137

Fixes #6072
#### How to test
1. start the application with the following [tomcat](https://marketplace.visualstudio.com/items?itemName=adashen.vscode-tomcat) vscode extension
2. open the preferences using the menu item `File` > `Settings` > `Open Preferences`
3. there should be a new category **Tomcat** with the preferences:
3.1. `tomcat.workspace`
3.2. `tomcat.restart_when_http(s)_port_change`

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)