### PR TITLE
Git diff list uses the perfect scroll bar now.

### DIFF
--- a/packages/git/src/browser/git-navigable-list-widget.tsx
+++ b/packages/git/src/browser/git-navigable-list-widget.tsx
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { SELECTED_CLASS, Key } from '@theia/core/lib/browser';
+import { SELECTED_CLASS, Key, Widget } from '@theia/core/lib/browser';
 import { GitFileStatus, Repository, GitFileChange } from '../common';
 import URI from '@theia/core/lib/common/uri';
 import { GitRepositoryProvider } from './git-repository-provider';
@@ -61,9 +61,17 @@ export abstract class GitNavigableListWidget<T extends { selected?: boolean }> e
         (async () => {
             const selected = this.node.getElementsByClassName(SELECTED_CLASS)[0];
             if (selected) {
-                ElementExt.scrollIntoViewIfNeeded(this.node, selected);
+                const container = document.getElementById(this.scrollContainer);
+                if (container) {
+                    ElementExt.scrollIntoViewIfNeeded(container, selected);
+                }
             }
         })();
+    }
+
+    protected onResize(msg: Widget.ResizeMessage): void {
+        super.onResize(msg);
+        this.update();
     }
 
     protected getStatusCaption(status: GitFileStatus, staged?: boolean): string {

--- a/packages/git/src/browser/style/history.css
+++ b/packages/git/src/browser/style/history.css
@@ -100,6 +100,7 @@
 
 .theia-git .git-diff-container .listContainer {
     flex: 1;
+    position: relative;
 }
 
 .theia-git .git-diff-container .listContainer .commitList {


### PR DESCRIPTION
#### What it does
The ListContainer of the GitDiff View uses the PerfectScrollbar instead of the browser native scrollbar now. 
It fixes also an error which caused that sometimes, after resizing vertically, elements at the lower end weren't selectable anymore.
See https://github.com/gitpod-io/gitpod/issues/757

#### How to test
Use a repository where are enough different files between two branches and use the Git Diff command to open these changes.    
The scrollbar of the git diff widget should show the same scrollbar in all browsers.
All elements should be selectable even after resizing. 

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

