### PR TITLE
[workspace] `workspace.supportMultiRootWorkspace` is enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Breaking changes:
 
 - [core][plugin] support alternative commands in context menus [6069](https://github.com/theia-ide/theia/pull/6069)
+- [workspace] switched `workspace.supportMultiRootWorkspace` to enabled by default [#6089](https://github.com/theia-ide/theia/pull/6089)
 
 ## v0.10.0
 

--- a/packages/workspace/src/browser/workspace-preferences.ts
+++ b/packages/workspace/src/browser/workspace-preferences.ts
@@ -27,14 +27,14 @@ export const workspacePreferenceSchema: PreferenceSchema = {
     type: 'object',
     properties: {
         'workspace.preserveWindow': {
-            description: 'Enable opening workspaces in current window',
+            description: 'Enable opening workspaces in current window.',
             type: 'boolean',
             default: false
         },
         'workspace.supportMultiRootWorkspace': {
-            description: 'Enable the multi-root workspace support to test this feature internally',
+            description: 'Controls whether multi-root workspace support is enabled.',
             type: 'boolean',
-            default: false
+            default: true
         }
     }
 };


### PR DESCRIPTION
#### What it does
Enables `workspace.supportMultiRootWorkspace` by default.

Fixes theia-ide/theia#6088

#### How to test
Start theia and see how multiroot workspaces are enabled.
E.g. `Save workspace as ...` menu item is enabled.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

