### PR TITLE
fix #6046: workspace configuration contributed by VSCode extension an…

### DIFF
--- a/packages/core/src/browser/preferences/preference-service.ts
+++ b/packages/core/src/browser/preferences/preference-service.ts
@@ -89,6 +89,7 @@ export interface PreferenceService extends Disposable {
     overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined;
 
     resolve<T>(preferenceName: string, defaultValue?: T, resourceUri?: string): PreferenceResolveResult<T>;
+    validate(name: string, value: any): boolean;
 }
 
 /**
@@ -412,4 +413,7 @@ export class PreferenceServiceImpl implements PreferenceService, FrontendApplica
         };
     }
 
+    validate(name: string, value: any): boolean {
+        return this.schema.validate(name, value);
+    }
 }

--- a/packages/core/src/browser/preferences/test/mock-preference-service.ts
+++ b/packages/core/src/browser/preferences/test/mock-preference-service.ts
@@ -55,4 +55,7 @@ export class MockPreferenceService implements PreferenceService {
     overriddenPreferenceName(preferenceName: string): OverridePreferenceName | undefined {
         return undefined;
     }
+
+    // tslint:disable-next-line:no-any
+    validate(name: string, value: any): boolean { return true; }
 }

--- a/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
+++ b/packages/editor-preview/src/browser/editor-preview-manager.spec.ts
@@ -85,10 +85,12 @@ describe('editor-preview-manager', () => {
 
     it('should handle preview requests if editor.enablePreview enabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(true);
+        (mockPreference.validate as sinon.SinonStub).returns(true);
         expect(await previewManager.canHandle(new URI(), {preview: true})).to.be.greaterThan(0);
     });
     it('should not handle preview requests if editor.enablePreview disabled', async () => {
         (mockPreference.get as sinon.SinonStub).returns(false);
+        (mockPreference.validate as sinon.SinonStub).returns(true);
         expect(await previewManager.canHandle(new URI(), {preview: true})).to.equal(0);
     });
     it('should not handle requests that are not preview or currently being previewed', async () => {

--- a/packages/preferences/src/browser/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/browser/abstract-resource-preference-provider.ts
@@ -147,14 +147,9 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         if (typeof jsonData !== 'object') {
             return preferences;
         }
-        const uri = this.getUri();
         // tslint:disable-next-line:forin
         for (const preferenceName in jsonData) {
             const preferenceValue = jsonData[preferenceName];
-            if (!this.validate(preferenceName, preferenceValue)) {
-                console.warn(`Preference ${preferenceName} in ${uri} is invalid.`);
-                continue;
-            }
             if (this.schemaProvider.testOverrideValue(preferenceName, preferenceValue)) {
                 // tslint:disable-next-line:forin
                 for (const overriddenPreferenceName in preferenceValue) {
@@ -166,14 +161,6 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
             }
         }
         return preferences;
-    }
-
-    protected validate(preferenceName: string, preferenceValue: any): boolean {
-        // in case if preferences are loaded from .vscode folder we should load even invalid
-        if (this.configurations.getPath(this.getUri()) !== this.configurations.getPaths()[0]) {
-            return true;
-        }
-        return preferenceValue === undefined || this.schemaProvider.validate(preferenceName, preferenceValue);
     }
 
     protected parse(content: string): any {


### PR DESCRIPTION
…d provided by .theia/settins.json is sometimes wrongly filtered out

Signed-off-by: Cai Xuye <a1994846931931@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
fix #6046

For more information about this revision, please refer to https://github.com/theia-ide/theia/issues/6046#issuecomment-527330010

#### How to test
Test according to https://github.com/theia-ide/theia/issues/6046#issuecomment-527334904. In the fixed version, the start message should give you a correct value read from the workspace configuration.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

