### PR TITLE
Remove hover background on the scm inline actions

### DIFF
--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -252,10 +252,6 @@
     align-items: center;
 }
 
-.theia-scm-inline-action:hover {
-    background: var(--theia-content-font-color3);
-}
-
 .theia-scm-inline-action .open-file {
     height: 16px;
     width: 12px;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes #6075

Remove the hover background over the `scm` inline actions
so that it is consistent with other views (ex: `search-in-workspace`),
toolbar items, and is aligned with VSCode.

<div align='center'>

![Peek 2019-09-03 07-10](https://user-images.githubusercontent.com/40359487/64168654-003d4e00-ce1a-11e9-935e-b754eca0c08f.gif)


</div>

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. open a workspace under git source control (ex: theia)
2. make some temporary changes on a file
3. open the scm view (View > SCM)
4. highlight over the change, there should not be a hover background anymore

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>
