### PR TITLE
[preferences] Reject invalid preference schemas.

### DIFF
--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -135,6 +135,13 @@ export class PreferenceSchemaProvider extends PreferenceProvider {
     }
 
     protected doSetSchema(schema: PreferenceSchema): PreferenceProviderDataChange[] {
+        const ajv = new Ajv();
+        const valid = ajv.validateSchema(schema);
+        if (!valid) {
+            const errors = !!ajv.errors ? ajv.errorsText(ajv.errors) : 'unknown validation error';
+            console.error('An invalid preference schema was rejected: ' + errors);
+            return [];
+        }
         const scope = PreferenceScope.Default;
         const domain = this.getDomain();
         const changes: PreferenceProviderDataChange[] = [];


### PR DESCRIPTION
#### What it does
Fixes theia-ide/theia#6106

#### How to test

1. install rust vscode extension (0.6.1) (includes an invalid pref schema) and e.g. the python vscode extension
2. start the Theia application and see the rejection message for the invalid rust schema is logged, but more importantly it now should be possible to change python preferences (e.g. `python.pythonPath`) which was effectively a no-op before.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

