### PR TITLE
ESLint VS Code extension installation fails #6118

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -185,7 +185,7 @@ export interface PluginPackageLanguageContributionConfiguration {
 export interface PluginTaskDefinitionContribution {
     type: string;
     required: string[];
-    properties: {
+    properties?: {
         [name: string]: {
             type: string;
             description?: string;

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -384,12 +384,13 @@ export class TheiaPluginScanner implements PluginScanner {
     }
 
     private readTaskDefinition(pluginName: string, definitionContribution: PluginTaskDefinitionContribution): TaskDefinition {
+        const propertyKeys = definitionContribution.properties ? Object.keys(definitionContribution.properties) : [];
         return {
             taskType: definitionContribution.type,
             source: pluginName,
             properties: {
                 required: definitionContribution.required,
-                all: Object.keys(definitionContribution.properties)
+                all: propertyKeys
             }
         };
     }


### PR DESCRIPTION
Made taskdefinition.properties optional
Return an empty array if undefinied

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
Fixes issue #6118 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Install ESLint VS Code plugin (Deploy plugin by id => vscode:extension/dbaeumer.vscode-eslint)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

