### PR TITLE
[debug] Download vscode debug extensions from elsewhere

### DIFF
--- a/packages/debug-nodejs/package.json
+++ b/packages/debug-nodejs/package.json
@@ -49,7 +49,7 @@
     "extends": "../../configs/nyc.json"
   },
   "adapters": {
-    "node-debug": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/node-debug/1.35.3/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage",
-    "node-debug2": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/node-debug2/1.33.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+    "node-debug": "https://github.com/theia-ide/vscode-node-debug/releases/download/v1.35.3/node-debug-1.35.3.vsix",
+    "node-debug2": "https://github.com/theia-ide/vscode-node-debug2/releases/download/v1.33.0/node-debug2-1.33.0.vsix"
   }
 }

--- a/packages/java-debug/package.json
+++ b/packages/java-debug/package.json
@@ -50,6 +50,6 @@
     "extends": "../../configs/nyc.json"
   },
   "adapters": {
-    "java-debug": "https://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/vscjava/extension/vscode-java-debug/0.15.0/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
+    "java-debug": "https://github.com/microsoft/vscode-java-debug/releases/download/0.15.0/vscode-java-debug-0.15.0.vsix"
   }
 }


### PR DESCRIPTION
This patch is a minimal fix for #6111, presented as a less extreme alternative to PR #6113. Instead of removing the `@theia/debug-nodejs` and `@theia/java-debug` theia extensions without advance warning to our adopters that may be using them, it instead fetches the underlying debug adapters from alternate sources. 

It downloads the Java debug adapter from the component's GH releases and node-debug / node-debug2 from our fork of these components, since the .vsix files are not available from upstream repos releases.

The longer-term solution is, as was recently briefly discussed, to have our own public registry for extensions.

Note: The alternate sources are 3 GH repo releases. This is not ideal either since it could exacerbate the "GH API rate limit" issues we have had. However the size of all 3 extensions together is a relatively modest  ~4MB, so I think that with a GH token set, it should not cause issues in our CI. 

Note2: untested at the time of this PR creation, other than looking at the download folders and confirming that the content appears ok at a glance.

cc: @svenefftinge @akosyakov @AlexTugarev @kittaakos 