### PR TITLE
[textmate] don't warn when same grammar is registered multiple times

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -416,6 +416,7 @@ export interface GrammarsContribution {
     language?: string;
     scope: string;
     grammar?: string | object;
+    grammarLocation?: string;
     embeddedLanguages?: ScopeMap;
     tokenTypes?: ScopeMap;
     injectTo?: string[];

--- a/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/grammars-reader.ts
@@ -46,6 +46,7 @@ export class GrammarsReader {
             scope: rawGrammar.scopeName,
             format: rawGrammar.path.endsWith('json') ? 'json' : 'plist',
             grammar: grammar,
+            grammarLocation: rawGrammar.path,
             injectTo: rawGrammar.injectTo,
             embeddedLanguages: rawGrammar.embeddedLanguages,
             tokenTypes: rawGrammar.tokenTypes

--- a/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-contribution-handler.ts
@@ -138,6 +138,7 @@ export class PluginContributionHandler {
                         return {
                             format: grammar.format,
                             content: grammar.grammar || '',
+                            location: grammar.grammarLocation
                         };
                     },
                     getInjections: (scopeName: string) =>


### PR DESCRIPTION
Fixes theia-ide/theia#6124

#### What it does
No more warnings when the same grammar is registered multiple times.

#### How to test
Remove textmate-grammars and install https://registry.npmjs.org/@theia/vscode-builtin-ini/-/vscode-builtin-ini-0.2.1.tgz in plugins folder

See how no warning is logged (if you do the same without this change there will be warning)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

