### PR TITLE
Do not use clang-format for typescript code

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -10,5 +10,6 @@
   "[jsonc]": {
     "editor.tabSize": 2
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "clang-format.language.typescript.enable": false    
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,6 @@
         "editor.tabSize": 2
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "files.insertFinalNewline": true
+    "files.insertFinalNewline": true,
+    "clang-format.language.typescript.enable": false    
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,50 +4,50 @@
 // - Linux: $HOME/.config/Code/User/settings.json
 // - Mac: $HOME/Library/Application Support/Code/User/settings.json
 {
-    "tslint.enable": true,
-    "editor.formatOnSave": true,
-    "search.exclude": {
-        "**/node_modules": true,
-        "**/lib": true,
-        "**/coverage": true
-    },
-    "lcov.path": [
-        "packages/core/coverage/lcov.info",
-        "packages/cpp/coverage/lcov.info",
-        "packages/editor/coverage/lcov.info",
-        "packages/filesystem/coverage/lcov.info",
-        "packages/extension-manager/coverage/lcov.info",
-        "packages/go/coverage/lcov.info",
-        "packages/java/coverage/lcov.info",
-        "packages/languages/coverage/lcov.info",
-        "packages/monaco/coverage/lcov.info",
-        "packages/navigator/coverage/lcov.info",
-        "packages/keymaps/coverage/lcov.info",
-        "packages/preferences/coverage/lcov.info",
-        "packages/process/coverage/lcov.info",
-        "packages/python/coverage/lcov.info",
-        "packages/terminal/coverage/lcov.info",
-        "packages/workspace/coverage/lcov.info",
-        "packages/task/coverage/lcov.info",
-        "packages/monaco-textmate/coverage/lcov.info"
-    ],
-    "lcov.watch": [
-        {
-            "pattern": "**/*.spec.ts",
-            "command": "yarn test:theia"
-        }
-    ],
-    "editor.insertSpaces": true,
-    "[typescript]": {
-        "editor.tabSize": 4
-    },
-    "[json]": {
-        "editor.tabSize": 2
-    },
-    "[jsonc]": {
-        "editor.tabSize": 2
-    },
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "files.insertFinalNewline": true,
-    "clang-format.language.typescript.enable": false    
+  "tslint.enable": true,
+  "editor.formatOnSave": true,
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/lib": true,
+    "**/coverage": true
+  },
+  "lcov.path": [
+    "packages/core/coverage/lcov.info",
+    "packages/cpp/coverage/lcov.info",
+    "packages/editor/coverage/lcov.info",
+    "packages/filesystem/coverage/lcov.info",
+    "packages/extension-manager/coverage/lcov.info",
+    "packages/go/coverage/lcov.info",
+    "packages/java/coverage/lcov.info",
+    "packages/languages/coverage/lcov.info",
+    "packages/monaco/coverage/lcov.info",
+    "packages/navigator/coverage/lcov.info",
+    "packages/keymaps/coverage/lcov.info",
+    "packages/preferences/coverage/lcov.info",
+    "packages/process/coverage/lcov.info",
+    "packages/python/coverage/lcov.info",
+    "packages/terminal/coverage/lcov.info",
+    "packages/workspace/coverage/lcov.info",
+    "packages/task/coverage/lcov.info",
+    "packages/monaco-textmate/coverage/lcov.info"
+  ],
+  "lcov.watch": [
+    {
+      "pattern": "**/*.spec.ts",
+      "command": "yarn test:theia"
+    }
+  ],
+  "editor.insertSpaces": true,
+  "[typescript]": {
+    "editor.tabSize": 4
+  },
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.tabSize": 2
+  },
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "files.insertFinalNewline": true,
+  "clang-format.language.typescript.enable": false
 }


### PR DESCRIPTION
clang-format applies its own formatting, disregarding the formatting
options specified in e.g. vscode settings.

Signed-off-by: Nathan Ridge <zeratul976@hotmail.com>