### PR TITLE
register language features even if a language is not registered

### DIFF
--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -9,7 +9,7 @@
     "@theia/workspace": "^0.10.0",
     "@typefox/monaco-editor-core": "^0.14.6",
     "@types/uuid": "^3.4.3",
-    "monaco-languageclient": "^0.9.0",
+    "monaco-languageclient": "^0.9.1",
     "uuid": "^3.2.1"
   },
   "publishConfig": {

--- a/packages/monaco/src/typings/monaco/index.d.ts
+++ b/packages/monaco/src/typings/monaco/index.d.ts
@@ -1139,3 +1139,29 @@ declare module monaco.mime {
 
     export function clearTextMimes(onlyUserConfigured?: boolean): void;
 }
+
+/**
+ * overloading languages register functions to accept LanguageSelector,
+ * check that all register functions passing a selector to registries:
+ * https://github.com/TypeFox/vscode/blob/c1dd5c86b7e1e55223831b1beb73f017bb19af94/src/vs/editor/standalone/browser/standaloneLanguages.ts#L325
+ */
+declare module monaco.languages {
+    export function registerReferenceProvider(selector: monaco.modes.LanguageSelector, provider: ReferenceProvider): IDisposable;
+    export function registerRenameProvider(selector: monaco.modes.LanguageSelector, provider: RenameProvider): IDisposable;
+    export function registerSignatureHelpProvider(selector: monaco.modes.LanguageSelector, provider: SignatureHelpProvider): IDisposable;
+    export function registerHoverProvider(selector: monaco.modes.LanguageSelector, provider: HoverProvider): IDisposable;
+    export function registerDocumentSymbolProvider(selector: monaco.modes.LanguageSelector, provider: DocumentSymbolProvider): IDisposable;
+    export function registerDocumentHighlightProvider(selector: monaco.modes.LanguageSelector, provider: DocumentHighlightProvider): IDisposable;
+    export function registerDefinitionProvider(selector: monaco.modes.LanguageSelector, provider: DefinitionProvider): IDisposable;
+    export function registerImplementationProvider(selector: monaco.modes.LanguageSelector, provider: ImplementationProvider): IDisposable;
+    export function registerTypeDefinitionProvider(selector: monaco.modes.LanguageSelector, provider: TypeDefinitionProvider): IDisposable;
+    export function registerCodeLensProvider(selector: monaco.modes.LanguageSelector, provider: CodeLensProvider): IDisposable;
+    export function registerCodeActionProvider(selector: monaco.modes.LanguageSelector, provider: CodeActionProvider): IDisposable;
+    export function registerDocumentFormattingEditProvider(selector: monaco.modes.LanguageSelector, provider: DocumentFormattingEditProvider): IDisposable;
+    export function registerDocumentRangeFormattingEditProvider(selector: monaco.modes.LanguageSelector, provider: DocumentRangeFormattingEditProvider): IDisposable;
+    export function registerOnTypeFormattingEditProvider(selector: monaco.modes.LanguageSelector, provider: OnTypeFormattingEditProvider): IDisposable;
+    export function registerLinkProvider(selector: monaco.modes.LanguageSelector, provider: LinkProvider): IDisposable;
+    export function registerCompletionItemProvider(selector: monaco.modes.LanguageSelector, provider: CompletionItemProvider): IDisposable;
+    export function registerColorProvider(selector: monaco.modes.LanguageSelector, provider: DocumentColorProvider): IDisposable;
+    export function registerFoldingRangeProvider(selector: monaco.modes.LanguageSelector, provider: FoldingRangeProvider): IDisposable;
+}

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -315,7 +315,9 @@ export function fromTextEdit(edit: theia.TextEdit): model.SingleEditOperation {
     };
 }
 
-export function fromLanguageSelector(selector: theia.DocumentSelector): LanguageSelector | undefined {
+export function fromLanguageSelector(selector: undefined): undefined;
+export function fromLanguageSelector(selector: theia.DocumentSelector): LanguageSelector;
+export function fromLanguageSelector(selector: undefined | theia.DocumentSelector): undefined | LanguageSelector {
     if (!selector) {
         return undefined;
     } else if (Array.isArray(selector)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6587,9 +6587,10 @@ monaco-html@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/monaco-html/-/monaco-html-2.2.0.tgz#435f2f4ce6e5c7f707fb57e7c8a05b41e5cd1aa0"
 
-monaco-languageclient@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.0.tgz#4b65684e277edab07625e76eb3d3d93e8f2130fa"
+monaco-languageclient@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/monaco-languageclient/-/monaco-languageclient-0.9.1.tgz#dccd26ae0be4d1014395b406e924baae9f8eb9b5"
+  integrity sha512-mDwbYk67UVPf41RnhfMLRME08NsK2/JeqCkkhPL+wef6rZQNHRb/U2bMMuW/MVVM/yT2DYFy5f7cLNm63FYGMw==
   dependencies:
     glob-to-regexp "^0.3.0"
     vscode-base-languageclient "4.4.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix #6143: There is no a guarantee that a language is registered by the time when a language feature is registered. Before with the bad timing a language can be registered too late leading to missing language features. Now language features will be registered regardless whether a language is registered.

TODO:
- [x] release monaco-languageclient 0.9.1 and cherry pick the fix for 0.10.2
- [x] tested with typescript VS Code extension

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- uninstall textmate grammars
- install built-in vscode extension contributing languages, i.e. for typescript
- use native and VS Code extensions contributing language smartness for installed built-in extensions
- start Theia
- test that language smartness is there

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

