### PR TITLE
simplify plugin unzipping log info to one line 

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-file-handler.ts
@@ -37,10 +37,9 @@ export class PluginVsCodeFileHandler implements PluginDeployerFileHandler {
     }
 
     async handle(context: PluginDeployerFileHandlerContext): Promise<void> {
-        // need to unzip
-        console.log('unzipping the plugin', context.pluginEntry());
-
         const unpackedPath = path.resolve(this.unpackedFolder, path.basename(context.pluginEntry().path()));
+        console.log(`unzipping the VS Code extension '${path.basename(context.pluginEntry().path())}' to directory: ${unpackedPath}`);
+
         await context.unzip(context.pluginEntry().path(), unpackedPath);
         if (context.pluginEntry().path().endsWith('.tgz')) {
             const extensionPath = path.join(unpackedPath, 'package');

--- a/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
+++ b/packages/plugin-ext/src/main/node/handlers/plugin-theia-file-handler.ts
@@ -32,10 +32,9 @@ export class PluginTheiaFileHandler implements PluginDeployerFileHandler {
     }
 
     async handle(context: PluginDeployerFileHandlerContext): Promise<void> {
-        // need to unzip
-        console.log('unzipping the plugin', context.pluginEntry());
-
         const unpackedPath = path.resolve(this.unpackedFolder, path.basename(context.pluginEntry().path()));
+        console.log(`unzipping the plug-in '${path.basename(context.pluginEntry().path())}' to directory: ${unpackedPath}`);
+
         await context.unzip(context.pluginEntry().path(), unpackedPath);
 
         context.pluginEntry().updatePath(unpackedPath);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

fix: #6138

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Simplify plugin unzipping log info to one line :
![image](https://user-images.githubusercontent.com/35068357/64596042-c524b700-d3e5-11e9-8d98-6f4126f6dc6b.png)
* create plugins folder under Theia repo folder
* Google for an extension (*.vsix file) and download it to the plugins folder
* start Theia browser example
* check the log in terminal or console

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

