### PR TITLE
add `enter` key event handler and focus style  to `open button`  in navigator

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -130,17 +130,14 @@ button.theia-button, .theia-button {
     min-width: 65px;
     outline: none;
     cursor: pointer;
-    padding-left: 9px;
-    padding-right: 9px;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding: 4px 9px;
     margin-left: calc(var(--theia-ui-padding)*2);
     border-radius: 1px;
     box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2), 0px 1px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 1px -2px rgba(0, 0, 0, 0.12);
     transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-button.theia-button:hover, .theia-button:hover {
+button.theia-button:hover, .theia-button:hover, .theia-button:focus {
   background-color: var(--theia-ui-button-color-hover);
 }
 

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -188,6 +188,8 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             isVisible: () => true
         });
         registry.registerCommand(FileNavigatorCommands.TOGGLE_AUTO_REVEAL, {
+            isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
+            isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened),
             execute: () => {
                 const autoReveal = !this.fileNavigatorPreferences['explorer.autoReveal'];
                 this.preferenceService.set('explorer.autoReveal', autoReveal, PreferenceScope.User);

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -18,7 +18,7 @@ import { injectable, inject, postConstruct } from 'inversify';
 import { Message } from '@phosphor/messaging';
 import URI from '@theia/core/lib/common/uri';
 import { CommandService, SelectionService } from '@theia/core/lib/common';
-import { CommonCommands, CorePreferences, LabelProvider, ViewContainerTitleOptions } from '@theia/core/lib/browser';
+import { CommonCommands, CorePreferences, LabelProvider, ViewContainerTitleOptions, Key } from '@theia/core/lib/browser';
 import {
     ContextMenuRenderer, ExpandableTreeNode,
     TreeProps, TreeModel, TreeNode,
@@ -215,6 +215,11 @@ export class FileNavigatorWidget extends FileTreeWidget {
         this.commandService.executeCommand(WorkspaceCommands.OPEN_FOLDER.id);
     }
 
+    protected readonly keyUpHandler = (e: React.KeyboardEvent) => {
+        if (Key.ENTER.keyCode === e.keyCode) {
+            (e.target as HTMLElement).click();
+        }
+    }
     /**
      * Instead of rendering the file resources from the workspace, we render a placeholder
      * button when the workspace root is not yet set.
@@ -223,11 +228,13 @@ export class FileNavigatorWidget extends FileTreeWidget {
         let openButton;
 
         if (this.canOpenWorkspaceFileAndFolder) {
-            openButton = <button className='open-workspace-button' title='Select a folder or a workspace-file to open as your workspace' onClick={this.openWorkspace}>
+            openButton = <button className='theia-button open-workspace-button' title='Select a folder or a workspace-file to open as your workspace'
+                onClick={this.openWorkspace} onKeyUp={this.keyUpHandler}>
                 Open Workspace
             </button>;
         } else {
-            openButton = <button className='open-workspace-button' title='Select a folder as your workspace root' onClick={this.openFolder}>
+            openButton = <button className='theia-button open-workspace-button' title='Select a folder as your workspace root' onClick={this.openFolder}
+                onKeyUp={this.keyUpHandler}>
                 Open Folder
             </button>;
         }

--- a/packages/navigator/src/browser/style/index.css
+++ b/packages/navigator/src/browser/style/index.css
@@ -38,18 +38,9 @@
 }
 
 .p-Widget .open-workspace-button {
-    border: 1px solid var(--theia-border-color1);
-    color: var(--theia-ui-font-color1);
-    font-size: var(--theia-ui-font-size1);
-    border-radius: 0;
-    background-color: var(--theia-accent-color3);
-    outline: none;
-    cursor: pointer;
-    padding-left: 12px;
-    padding-right: 12px;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    padding: 4px 12px;
     width: calc(100% - var(--theia-ui-padding)*4);
+    margin-left: 0;
 }
 
 .navigator-tab-icon {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
fix: #6140 
1. add `button:focus` style when the button is focused (the same with `button:hover`)
2. hide `more tool` item on the toolbar in navigator when the workspace is empty.

#### How to test
1.open theia browser and close workspace
2.open `Explorer` sidebar, and press `tab` key to select `open workspace button`
3.press `enter` key to open `open workspace` dialog

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

