### PR TITLE
add focus style to items in getting started page

### DIFF
--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -63,7 +63,6 @@ html, body {
     border: none;
     color: var(--theia-accent-color1);
     font-weight: 500;
-    outline: 0;
     text-decoration: none;
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
fix: #6157
![image](https://user-images.githubusercontent.com/35068357/64684116-18b30580-d4b7-11e9-80a4-a768563cf00b.png)


#### How to test
* open `Getting Started` page
* press `tab` to select one item and press `enter` to click it

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

